### PR TITLE
Fix AI Enhance and tool test errors

### DIFF
--- a/packages/backend/src/ai/ai.controller.ts
+++ b/packages/backend/src/ai/ai.controller.ts
@@ -2,18 +2,24 @@ import {
   Controller,
   Post,
   Body,
+  Req,
   UseGuards,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { AiService } from './ai.service';
+import { UsersService } from '../users/users.service';
 
 @ApiTags('AI')
 @ApiBearerAuth()
 @UseGuards(AuthGuard('jwt'))
 @Controller('api/ai')
 export class AiController {
-  constructor(private readonly aiService: AiService) {}
+  constructor(
+    private readonly aiService: AiService,
+    private readonly usersService: UsersService,
+  ) {}
 
   @Post('generate-tools')
   @ApiOperation({
@@ -37,22 +43,28 @@ export class AiController {
   @Post('improve-description')
   @ApiOperation({ summary: 'AI-improve a tool description for LLM consumption' })
   async improveDescription(
+    @Req() req: any,
     @Body()
     dto: {
       toolName: string;
       currentDescription: string;
-      apiContext: string;
-      provider: 'anthropic' | 'openai';
-      apiKey: string;
+      apiContext?: string;
     },
   ) {
+    const user = await this.usersService.findById(req.user.sub);
+    if (!user?.aiProvider || !user?.aiApiKey) {
+      throw new BadRequestException(
+        'AI provider not configured. Go to Settings to set up your AI provider and API key.',
+      );
+    }
+
     return {
       description: await this.aiService.improveToolDescription(
         dto.toolName,
         dto.currentDescription,
-        dto.apiContext,
-        dto.provider,
-        dto.apiKey,
+        dto.apiContext || '',
+        user.aiProvider as 'anthropic' | 'openai',
+        user.aiApiKey,
       ),
     };
   }

--- a/packages/backend/src/ai/ai.module.ts
+++ b/packages/backend/src/ai/ai.module.ts
@@ -3,8 +3,10 @@ import { AiService } from './ai.service';
 import { AiController } from './ai.controller';
 import { ClaudeProvider } from './providers/claude.provider';
 import { OpenaiProvider } from './providers/openai.provider';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [AiController],
   providers: [AiService, ClaudeProvider, OpenaiProvider],
   exports: [AiService],

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -251,8 +251,9 @@ export class RestEngine {
       if (typeof value === 'string' && value.startsWith('$')) {
         // Reference to a param: "$paramName" → params.paramName
         const paramName = value.substring(1);
-        if (params[paramName] !== undefined) {
-          result[key] = params[paramName];
+        const paramValue = params[paramName];
+        if (paramValue !== undefined && paramValue !== '') {
+          result[key] = paramValue;
         }
       } else {
         result[key] = value;

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -262,7 +262,7 @@ export default function ConnectorDetailPage() {
     setEnhancingToolId(toolId);
     try {
       const result: any = await ai.improveDescription(
-        { name: toolName, description: toolDescription, connectorName: connector?.name },
+        { toolName, currentDescription: toolDescription, apiContext: connector?.name || '' },
         token,
       );
       if (result?.description) {


### PR DESCRIPTION
## Summary
- **AI Enhance**: read AI provider/apiKey from user profile instead of requiring them in request body; fix frontend field name mismatch (`name`→`toolName`, `description`→`currentDescription`, `connectorName`→`apiContext`)
- **Tool Test**: filter out empty string params in `mapParams()` to prevent sending invalid empty query parameters to external APIs (causing 500 errors)

## Test plan
- [ ] Configure AI provider in Settings, then click AI Enhance on a tool — should work without errors
- [ ] Run Test on a tool with empty params — should not send empty query params to the API