### PR TITLE
feat: multi-MCP server endpoints and OAuth fix

### DIFF
--- a/packages/backend/prisma/migrations/20260303_multi_mcp_servers/migration.sql
+++ b/packages/backend/prisma/migrations/20260303_multi_mcp_servers/migration.sql
@@ -1,0 +1,70 @@
+-- AlterTable: Add mcpServerId to API keys
+ALTER TABLE "mcp_api_keys" ADD COLUMN "mcp_server_id" TEXT;
+
+-- AlterTable: Evolve McpServerConfig (remove unused fields, add slug/description)
+ALTER TABLE "mcp_server_configs" DROP COLUMN IF EXISTS "auth_config",
+DROP COLUMN IF EXISTS "auth_type",
+DROP COLUMN IF EXISTS "endpoint",
+DROP COLUMN IF EXISTS "transport",
+ADD COLUMN "description" TEXT,
+ADD COLUMN "slug" TEXT NOT NULL DEFAULT 'default',
+ALTER COLUMN "name" SET DEFAULT 'Default';
+
+-- CreateTable: MCP Server ↔ Connector pivot
+CREATE TABLE "mcp_server_connectors" (
+    "id" TEXT NOT NULL,
+    "mcp_server_id" TEXT NOT NULL,
+    "connector_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "mcp_server_connectors_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcp_server_connectors_mcp_server_id_connector_id_key" ON "mcp_server_connectors"("mcp_server_id", "connector_id");
+
+-- ── Data Migration ──────────────────────────────────────────────────────────
+-- For each user who has no MCP server yet, create a default one
+INSERT INTO "mcp_server_configs" ("id", "user_id", "name", "slug", "is_active", "created_at", "updated_at")
+SELECT
+  gen_random_uuid()::text,
+  u."id",
+  'Default',
+  'default',
+  true,
+  NOW(),
+  NOW()
+FROM "users" u
+WHERE NOT EXISTS (
+  SELECT 1 FROM "mcp_server_configs" s WHERE s."user_id" = u."id"
+);
+
+-- Assign all connectors to their owner's default MCP server
+INSERT INTO "mcp_server_connectors" ("id", "mcp_server_id", "connector_id", "created_at")
+SELECT
+  gen_random_uuid()::text,
+  s."id",
+  c."id",
+  NOW()
+FROM "connectors" c
+JOIN "mcp_server_configs" s ON s."user_id" = c."user_id" AND s."slug" = 'default';
+
+-- Link existing API keys to their owner's default MCP server
+UPDATE "mcp_api_keys" k
+SET "mcp_server_id" = s."id"
+FROM "mcp_server_configs" s
+WHERE s."user_id" = k."user_id" AND s."slug" = 'default';
+
+-- ── End Data Migration ──────────────────────────────────────────────────────
+
+-- CreateIndex: unique constraint on (userId, slug)
+CREATE UNIQUE INDEX "mcp_server_configs_user_id_slug_key" ON "mcp_server_configs"("user_id", "slug");
+
+-- AddForeignKey
+ALTER TABLE "mcp_api_keys" ADD CONSTRAINT "mcp_api_keys_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_server_configs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mcp_server_connectors" ADD CONSTRAINT "mcp_server_connectors_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_server_configs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mcp_server_connectors" ADD CONSTRAINT "mcp_server_connectors_connector_id_fkey" FOREIGN KEY ("connector_id") REFERENCES "connectors"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -118,14 +118,16 @@ model ToolRoleAccess {
 // ── Per-User MCP API Keys ───────────────────────────────────────────────────
 
 model McpApiKey {
-  id         String    @id @default(cuid())
-  userId     String    @map("user_id")
-  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  key        String    @unique
-  name       String    // label: "Claude Desktop", "Cursor", etc.
-  isActive   Boolean   @default(true) @map("is_active")
-  lastUsedAt DateTime? @map("last_used_at")
-  createdAt  DateTime  @default(now()) @map("created_at")
+  id          String           @id @default(cuid())
+  userId      String           @map("user_id")
+  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mcpServerId String?          @map("mcp_server_id")
+  mcpServer   McpServerConfig? @relation(fields: [mcpServerId], references: [id], onDelete: SetNull)
+  key         String           @unique
+  name        String           // label: "Claude Desktop", "Cursor", etc.
+  isActive    Boolean          @default(true) @map("is_active")
+  lastUsedAt  DateTime?        @map("last_used_at")
+  createdAt   DateTime         @default(now()) @map("created_at")
 
   @@map("mcp_api_keys")
 }
@@ -181,9 +183,10 @@ model Connector {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  tools     McpTool[]
-  resources McpResource[]
-  prompts   McpPrompt[]
+  tools      McpTool[]
+  resources  McpResource[]
+  prompts    McpPrompt[]
+  mcpServers McpServerConnector[]
 
   @@map("connectors")
 }
@@ -278,22 +281,35 @@ model McpServerConfig {
   userId String @map("user_id")
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  name      String @default("My MCP Server")
-  version   String @default("1.0.0")
-  isActive  Boolean @default(true) @map("is_active")
-
-  // MCP client authentication
-  authType   AuthType @default(BEARER_TOKEN) @map("auth_type")
-  authConfig String?  @map("auth_config") // encrypted
-
-  // Transport configuration
-  transport String @default("streamable-http")
-  endpoint  String @default("/mcp")
+  name        String  @default("Default")
+  slug        String  @default("default")
+  description String? @db.Text
+  version     String  @default("1.0.0")
+  isActive    Boolean @default(true) @map("is_active")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  connectors McpServerConnector[]
+  apiKeys    McpApiKey[]
+
+  @@unique([userId, slug])
   @@map("mcp_server_configs")
+}
+
+// ── MCP Server ↔ Connector (many-to-many) ───────────────────────────────────
+
+model McpServerConnector {
+  id          String          @id @default(cuid())
+  mcpServerId String          @map("mcp_server_id")
+  mcpServer   McpServerConfig @relation(fields: [mcpServerId], references: [id], onDelete: Cascade)
+  connectorId String          @map("connector_id")
+  connector   Connector       @relation(fields: [connectorId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([mcpServerId, connectorId])
+  @@map("mcp_server_connectors")
 }
 
 // ── Audit Log ───────────────────────────────────────────────────────────────

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { AuditModule } from './audit/audit.module';
 import { HealthModule } from './health/health.module';
 import { SettingsModule } from './settings/settings.module';
 import { RolesModule } from './roles/roles.module';
+import { McpServersModule } from './mcp-servers/mcp-servers.module';
 import { PrismaModule } from './common/prisma.module';
 import { RedisModule } from './common/redis.module';
 import { McpAuthMiddleware } from './auth/mcp-auth.middleware';
@@ -108,6 +109,7 @@ if (useOAuth) {
     HealthModule,
     SettingsModule,
     RolesModule,
+    McpServersModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/packages/backend/src/audit/audit.controller.ts
+++ b/packages/backend/src/audit/audit.controller.ts
@@ -16,16 +16,20 @@ export class AuditController {
   @ApiQuery({ name: 'offset', required: false, type: Number })
   @ApiQuery({ name: 'toolId', required: false, type: String })
   @ApiQuery({ name: 'status', required: false, enum: ['SUCCESS', 'ERROR', 'TIMEOUT'] })
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'connectorId', required: false, type: String })
   async listInvocations(
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
     @Query('toolId') toolId?: string,
     @Query('status') status?: 'SUCCESS' | 'ERROR' | 'TIMEOUT',
+    @Query('search') search?: string,
+    @Query('connectorId') connectorId?: string,
   ) {
     return this.auditService.getRecentInvocations(
       limit ? parseInt(limit, 10) : 100,
       offset ? parseInt(offset, 10) : 0,
-      { toolId, status: status as any },
+      { toolId, status: status as any, search, connectorId },
     );
   }
 

--- a/packages/backend/src/audit/audit.service.ts
+++ b/packages/backend/src/audit/audit.service.ts
@@ -44,11 +44,22 @@ export class AuditService {
   async getRecentInvocations(
     limit = 100,
     offset = 0,
-    filters?: { toolId?: string; status?: InvocationStatus },
+    filters?: {
+      toolId?: string;
+      status?: InvocationStatus;
+      search?: string;
+      connectorId?: string;
+    },
   ) {
     const where: any = {};
     if (filters?.toolId) where.toolId = filters.toolId;
     if (filters?.status) where.status = filters.status;
+    if (filters?.search) {
+      where.tool = { name: { contains: filters.search, mode: 'insensitive' } };
+    }
+    if (filters?.connectorId) {
+      where.tool = { ...where.tool, connectorId: filters.connectorId };
+    }
 
     return this.prisma.toolInvocation.findMany({
       where,
@@ -56,7 +67,13 @@ export class AuditService {
       skip: offset,
       orderBy: { createdAt: 'desc' },
       include: {
-        tool: { select: { name: true, connectorId: true } },
+        tool: {
+          select: {
+            name: true,
+            connectorId: true,
+            connector: { select: { name: true, type: true } },
+          },
+        },
       },
     });
   }

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -21,6 +21,7 @@ import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
+import { McpServersService } from '../mcp-servers/mcp-servers.service';
 import { PrismaService } from '../common/prisma.service';
 import { EmailService } from '../settings/email.service';
 import { Roles, RolesGuard } from './roles.guard';
@@ -92,6 +93,7 @@ export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly usersService: UsersService,
+    private readonly mcpServersService: McpServersService,
     private readonly prisma: PrismaService,
     private readonly emailService: EmailService,
     private readonly configService: ConfigService,
@@ -159,6 +161,9 @@ export class AuthController {
       name: dto.name,
       role: role as any,
     });
+
+    // Create default MCP server for new user
+    await this.mcpServersService.createDefaultForUser(user.id);
 
     const token = this.authService.generateToken({
       sub: user.id,
@@ -294,6 +299,9 @@ export class AuthController {
       name: dto.name,
       role: invite.role,
     });
+
+    // Create default MCP server for new user
+    await this.mcpServersService.createDefaultForUser(user.id);
 
     // Assign MCP role if specified
     if (invite.mcpRoleId) {

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -14,12 +14,14 @@ import { PrismaOAuthStore } from './prisma-oauth.store';
 import { ClientCredentialsMiddleware } from './client-credentials.middleware';
 import { UsersModule } from '../users/users.module';
 import { SettingsModule } from '../settings/settings.module';
+import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 
 @Global()
 @Module({
   imports: [
     UsersModule,
     SettingsModule,
+    McpServersModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/packages/backend/src/auth/mcp-auth-exception.filter.ts
+++ b/packages/backend/src/auth/mcp-auth-exception.filter.ts
@@ -1,0 +1,61 @@
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+/**
+ * Exception filter that intercepts UnauthorizedException on MCP routes
+ * and adds the required WWW-Authenticate header for MCP OAuth discovery.
+ *
+ * The MCP spec (RFC 9728) requires the server to respond with:
+ *   401 + WWW-Authenticate: Bearer resource_metadata="<url>"
+ *
+ * Without this header, MCP clients (e.g. Claude Desktop) cannot discover
+ * the authorization server and fail with a generic connection error.
+ *
+ * This filter is needed because @rekog/mcp-nest's McpAuthJwtGuard throws
+ * a plain UnauthorizedException without setting the header.
+ */
+@Catch(UnauthorizedException)
+export class McpAuthExceptionFilter implements ExceptionFilter {
+  catch(exception: UnauthorizedException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const response = ctx.getResponse<Response>();
+
+    if (response.headersSent) return;
+
+    // Only modify behavior for MCP routes
+    if (request.path === '/mcp' || request.path.startsWith('/mcp/')) {
+      const proto =
+        (request.headers['x-forwarded-proto'] as string) ||
+        (request.secure ? 'https' : 'http');
+      const host =
+        (request.headers['x-forwarded-host'] as string) ||
+        request.headers.host;
+      const baseUrl = host
+        ? `${proto}://${host}`
+        : process.env.SERVER_URL || 'http://localhost:4000';
+
+      const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+
+      response.setHeader(
+        'WWW-Authenticate',
+        `Bearer resource_metadata="${resourceMetadataUrl}"`,
+      );
+      response.status(401).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Authentication required.' },
+        id: null,
+      });
+    } else {
+      // Default NestJS behavior for non-MCP routes
+      const status = exception.getStatus();
+      const exceptionResponse = exception.getResponse();
+      response.status(status).json(exceptionResponse);
+    }
+  }
+}

--- a/packages/backend/src/auth/mcp-auth.middleware.ts
+++ b/packages/backend/src/auth/mcp-auth.middleware.ts
@@ -38,7 +38,7 @@ export class McpAuthMiddleware implements NestMiddleware {
     if (apiKey?.startsWith('mcp_')) {
       const user = await this.mcpApiKeysService.resolveUserByKey(apiKey);
       if (user) {
-        (req as any).user = { sub: user.id, email: user.email, role: user.role, mcpRoleId: user.mcpRoleId };
+        (req as any).user = { sub: user.id, email: user.email, role: user.role, mcpRoleId: user.mcpRoleId, mcpServerId: user.mcpServerId };
         return next();
       }
       // Invalid per-user key — fall through to 401

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -1,0 +1,109 @@
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
+import { McpApiKeysService } from '../roles/mcp-api-keys.service';
+
+/**
+ * Combined auth guard for per-server MCP endpoints (/mcp/:serverId).
+ *
+ * Handles all auth modes (none, legacy, oauth2, both) in a single guard,
+ * so we don't depend on middleware configuration in AppModule.
+ *
+ * Auth methods (checked in order):
+ *   1. X-API-Key header → per-user MCP key (mcp_...) or static MCP_API_KEY
+ *   2. Bearer token → JWT (OAuth) or static MCP_BEARER_TOKEN
+ *   3. If auth mode is 'none' → allow all
+ */
+@Injectable()
+export class McpCombinedAuthGuard implements CanActivate {
+  private readonly logger = new Logger(McpCombinedAuthGuard.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly authService: AuthService,
+    private readonly mcpApiKeysService: McpApiKeysService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+
+    const mode = this.configService.get<string>('MCP_AUTH_MODE') || 'none';
+    const configuredApiKey = this.configService.get<string>('MCP_API_KEY');
+    const mcpBearerToken = this.configService.get<string>('MCP_BEARER_TOKEN');
+
+    const apiKey = req.headers['x-api-key'] as string | undefined;
+    const authHeader = req.headers['authorization'] as string | undefined;
+
+    // 1. Check per-user MCP API key (mcp_... prefix)
+    if (apiKey?.startsWith('mcp_')) {
+      const user = await this.mcpApiKeysService.resolveUserByKey(apiKey);
+      if (user) {
+        req.user = {
+          sub: user.id,
+          email: user.email,
+          role: user.role,
+          mcpRoleId: user.mcpRoleId,
+          mcpServerId: user.mcpServerId,
+        };
+        return true;
+      }
+      // Invalid key — continue to check other methods
+    }
+
+    // 2. Check static API key (legacy mode)
+    if (apiKey && configuredApiKey && apiKey === configuredApiKey) {
+      return true;
+    }
+
+    // 3. Check Bearer token (JWT or static)
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.substring(7);
+
+      // Static MCP bearer token
+      if (mcpBearerToken && token === mcpBearerToken) {
+        return true;
+      }
+
+      // JWT token (OAuth or legacy JWT)
+      try {
+        const payload = this.authService.verifyToken(token);
+        req.user = payload;
+        return true;
+      } catch {
+        // Invalid JWT — continue
+      }
+    }
+
+    // 4. If auth mode is 'none', allow all
+    if (mode === 'none') {
+      return true;
+    }
+
+    // 5. If no auth is configured at all (dev mode), allow
+    if (!configuredApiKey && !mcpBearerToken && mode !== 'oauth2') {
+      return true;
+    }
+
+    // Auth failed — build proper WWW-Authenticate header for MCP OAuth flow
+    // The MCP spec requires resource_metadata pointing to the protected resource metadata
+    const proto =
+      (req.headers['x-forwarded-proto'] as string) ||
+      (req.secure ? 'https' : 'http');
+    const host =
+      (req.headers['x-forwarded-host'] as string) || req.headers.host;
+    const baseUrl = host ? `${proto}://${host}` : (this.configService.get<string>('SERVER_URL') || 'http://localhost:4000');
+    const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer realm="AnythingToMCP MCP Server", resource_metadata="${resourceMetadataUrl}"`,
+    );
+    res.status(401).json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Authentication required.' },
+      id: null,
+    });
+    return false;
+  }
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '@nestjs/config';
 import cookieParser from 'cookie-parser';
 import { json, urlencoded } from 'express';
 import { AppModule } from './app.module';
+import { McpAuthExceptionFilter } from './auth/mcp-auth-exception.filter';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -31,6 +32,9 @@ async function bootstrap() {
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT') || 4000;
   const corsOrigin = configService.get<string>('CORS_ORIGIN') || '*';
+
+  // Add WWW-Authenticate header to MCP 401 responses for OAuth discovery
+  app.useGlobalFilters(new McpAuthExceptionFilter());
 
   // Global validation
   app.useGlobalPipes(
@@ -77,7 +81,8 @@ async function bootstrap() {
   await app.listen(port);
   logger.log(`AnythingToMCP backend running on: http://localhost:${port}`);
   logger.log(`Swagger docs: http://localhost:${port}/api/docs`);
-  logger.log(`MCP endpoint: http://localhost:${port}/mcp`);
+  logger.log(`MCP endpoint (global): http://localhost:${port}/mcp`);
+  logger.log(`MCP endpoint (per-server): http://localhost:${port}/mcp/:serverId`);
 }
 
 bootstrap();

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -1,0 +1,255 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Req,
+  Res,
+  Body,
+  UseGuards,
+  Logger,
+} from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpCombinedAuthGuard } from '../auth/mcp-combined-auth.guard';
+import { McpServersService } from '../mcp-servers/mcp-servers.service';
+import { ToolRegistry } from './tool-registry';
+import { DynamicMcpTools } from './dynamic-mcp-tools';
+import { RolesService } from '../roles/roles.service';
+
+/**
+ * Per-server MCP endpoint controller.
+ *
+ * Handles POST/GET/DELETE at /mcp/:serverId, creating a fresh MCP server
+ * per request that only exposes tools from connectors assigned to that server.
+ *
+ * This solves the single-endpoint limitation of @rekog/mcp-nest by giving
+ * each MCP server its own unique URL that clients like Claude Desktop
+ * can connect to independently (via OAuth or API key).
+ */
+@Controller('mcp')
+@SkipThrottle()
+@UseGuards(McpCombinedAuthGuard)
+export class McpEndpointController {
+  private readonly logger = new Logger(McpEndpointController.name);
+
+  constructor(
+    private readonly mcpServersService: McpServersService,
+    private readonly toolRegistry: ToolRegistry,
+    private readonly toolExecutor: DynamicMcpTools,
+    private readonly rolesService: RolesService,
+  ) {}
+
+  @Post(':serverId')
+  async handlePost(
+    @Param('serverId') serverId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+    @Body() body: unknown,
+  ) {
+    await this.handleMcpRequest(serverId, req, res, body);
+  }
+
+  @Get(':serverId')
+  async handleGet(
+    @Param('serverId') serverId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    // Stateless mode: GET is not supported
+    res.status(405).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Method not allowed in stateless mode' },
+      id: null,
+    });
+  }
+
+  @Delete(':serverId')
+  async handleDelete(
+    @Param('serverId') serverId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    // Stateless mode: DELETE is not supported
+    res.status(405).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Method not allowed in stateless mode' },
+      id: null,
+    });
+  }
+
+  private async handleMcpRequest(
+    serverId: string,
+    req: Request,
+    res: Response,
+    body: unknown,
+  ) {
+    // 1. Resolve the MCP server
+    const mcpServerConfig = await this.mcpServersService.findById(serverId);
+    if (!mcpServerConfig) {
+      return res.status(404).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'MCP server not found' },
+        id: null,
+      });
+    }
+
+    if (!mcpServerConfig.isActive) {
+      return res.status(403).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'MCP server is inactive' },
+        id: null,
+      });
+    }
+
+    // 2. Get connector IDs assigned to this server
+    const connectorIds = await this.mcpServersService.getConnectorIds(serverId);
+
+    // 3. Filter tools to only those from assigned connectors
+    const allTools = this.toolRegistry.getAllTools();
+    const serverTools = allTools.filter((t) => connectorIds.includes(t.connectorId));
+
+    // 4. Further filter by role-based access if user is identified
+    const user = (req as any).user;
+    let allowedToolIds: string[] | null = null;
+    if (user?.sub) {
+      allowedToolIds = await this.rolesService.getAllowedToolIds(user.sub);
+    }
+
+    // 5. Create a per-request MCP server with only the assigned tools
+    const mcpServer = new McpServer(
+      { name: mcpServerConfig.name, version: mcpServerConfig.version || '1.0.0' },
+    );
+
+    for (const tool of serverTools) {
+      // Skip tools not allowed by role
+      if (allowedToolIds !== null && !allowedToolIds.includes(tool.id)) {
+        continue;
+      }
+
+      const schema = this.stripEnvVarParams(tool.parameters, tool.connectorConfig.envVars);
+      const zodShape = this.jsonSchemaToZodShape(schema);
+
+      mcpServer.tool(tool.name, tool.description, zodShape, async (args: any) => {
+        const result = await this.toolExecutor.executeTool(tool.name, args);
+        return result;
+      });
+    }
+
+    // 6. Create transport and handle the request
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // stateless mode
+      enableJsonResponse: true,
+    });
+
+    try {
+      await mcpServer.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } catch (error: any) {
+      this.logger.error(`Error handling MCP request for server ${serverId}: ${error.message}`);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    } finally {
+      // Clean up stateless server
+      try {
+        await transport.close();
+        await mcpServer.close();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  /**
+   * Convert a JSON Schema to a Zod raw shape for McpServer.tool() registration.
+   */
+  private jsonSchemaToZodShape(schema: Record<string, unknown>): Record<string, z.ZodType> {
+    const properties = schema?.properties as Record<string, any> | undefined;
+    if (!properties) return {};
+
+    const required = (schema?.required as string[]) || [];
+    const shape: Record<string, z.ZodType> = {};
+
+    for (const [key, prop] of Object.entries(properties)) {
+      let zodType: z.ZodType;
+
+      switch (prop.type) {
+        case 'string':
+          zodType = prop.enum
+            ? z.enum(prop.enum as [string, ...string[]])
+            : z.string();
+          break;
+        case 'number':
+        case 'integer':
+          zodType = z.number();
+          break;
+        case 'boolean':
+          zodType = z.boolean();
+          break;
+        case 'array':
+          zodType = z.array(z.any());
+          break;
+        case 'object':
+          zodType = z.record(z.string(), z.any());
+          break;
+        default:
+          zodType = z.any();
+      }
+
+      if (prop.description) {
+        zodType = zodType.describe(prop.description);
+      }
+
+      if (prop.default !== undefined) {
+        zodType = zodType.default(prop.default);
+      }
+
+      if (!required.includes(key)) {
+        zodType = zodType.optional();
+      }
+
+      shape[key] = zodType;
+    }
+
+    return shape;
+  }
+
+  /**
+   * Remove parameters covered by connector env vars.
+   */
+  private stripEnvVarParams(
+    schema: Record<string, unknown>,
+    envVars?: Record<string, string>,
+  ): Record<string, unknown> {
+    if (!envVars || Object.keys(envVars).length === 0) return schema;
+
+    const properties = schema.properties as Record<string, unknown> | undefined;
+    if (!properties) return schema;
+
+    const envKeys = new Set(Object.keys(envVars));
+    const newProperties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(properties)) {
+      if (!envKeys.has(key)) {
+        newProperties[key] = value;
+      }
+    }
+
+    const required = (schema.required as string[]) || [];
+    const newRequired = required.filter((k) => !envKeys.has(k));
+
+    return {
+      ...schema,
+      properties: newProperties,
+      ...(newRequired.length > 0 ? { required: newRequired } : {}),
+    };
+  }
+}

--- a/packages/backend/src/mcp-server/mcp-server.module.ts
+++ b/packages/backend/src/mcp-server/mcp-server.module.ts
@@ -2,12 +2,15 @@ import { Module } from '@nestjs/common';
 import { McpServerService } from './mcp-server.service';
 import { ToolRegistry } from './tool-registry';
 import { DynamicMcpTools } from './dynamic-mcp-tools';
+import { McpEndpointController } from './mcp-endpoint.controller';
+import { McpCombinedAuthGuard } from '../auth/mcp-combined-auth.guard';
 import { RestEngine } from '../connectors/engines/rest.engine';
 import { GraphqlEngine } from '../connectors/engines/graphql.engine';
 import { SoapEngine } from '../connectors/engines/soap.engine';
 import { McpClientEngine } from '../connectors/engines/mcp-client.engine';
 import { DatabaseEngine } from '../connectors/engines/database.engine';
 import { WebhookEngine } from '../connectors/engines/webhook.engine';
+import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 
 const ENGINES = [
   RestEngine,
@@ -19,7 +22,9 @@ const ENGINES = [
 ];
 
 @Module({
-  providers: [McpServerService, ToolRegistry, DynamicMcpTools, ...ENGINES],
+  imports: [McpServersModule],
+  controllers: [McpEndpointController],
+  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, ...ENGINES],
   exports: [McpServerService, ToolRegistry],
 })
 export class McpServerModule {}

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -8,6 +8,7 @@ import { decrypt } from '../common/crypto/encryption.util';
 import { ToolRegistry } from './tool-registry';
 import { DynamicMcpTools } from './dynamic-mcp-tools';
 import { RolesService } from '../roles/roles.service';
+import { McpServersService } from '../mcp-servers/mcp-servers.service';
 
 @Injectable()
 export class McpServerService implements OnModuleInit {
@@ -22,6 +23,7 @@ export class McpServerService implements OnModuleInit {
     private readonly moduleRef: ModuleRef,
     private readonly configService: ConfigService,
     private readonly rolesService: RolesService,
+    private readonly mcpServersService: McpServersService,
   ) {
     this.encryptionKey =
       this.configService.get<string>('ENCRYPTION_KEY') ||
@@ -174,6 +176,21 @@ export class McpServerService implements OnModuleInit {
                 content: [{ type: 'text' as const, text: JSON.stringify({ error: `Access denied: you do not have permission to use '${name}'.` }) }],
                 isError: true,
               };
+            }
+          }
+
+          // Check MCP server scoping — if the API key is tied to a server,
+          // only allow tools from connectors assigned to that server
+          if (user.mcpServerId) {
+            const tool = this.toolRegistry.getTool(name);
+            if (tool) {
+              const allowedConnectorIds = await this.mcpServersService.getConnectorIds(user.mcpServerId);
+              if (!allowedConnectorIds.includes(tool.connectorId)) {
+                return {
+                  content: [{ type: 'text' as const, text: JSON.stringify({ error: `Tool '${name}' is not available on this MCP server.` }) }],
+                  isError: true,
+                };
+              }
             }
           }
         }

--- a/packages/backend/src/mcp-servers/mcp-servers.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.controller.ts
@@ -1,0 +1,116 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { IsString, IsOptional, IsBoolean, IsArray } from 'class-validator';
+import { McpServersService } from './mcp-servers.service';
+
+class CreateMcpServerDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  slug?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+class UpdateMcpServerDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  slug?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}
+
+class AssignConnectorsDto {
+  @IsArray()
+  @IsString({ each: true })
+  connectorIds: string[];
+}
+
+@ApiTags('MCP Servers')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'))
+@Controller('api/mcp-servers')
+export class McpServersController {
+  constructor(private readonly mcpServersService: McpServersService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List MCP servers for current user' })
+  async list(@Req() req: any) {
+    return this.mcpServersService.findAllByUser(req.user.sub);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new MCP server' })
+  async create(@Req() req: any, @Body() dto: CreateMcpServerDto) {
+    return this.mcpServersService.create(req.user.sub, dto);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get MCP server detail' })
+  async get(@Req() req: any, @Param('id') id: string) {
+    const server = await this.mcpServersService.findById(id);
+    if (!server) throw new NotFoundException('MCP server not found');
+    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    return server;
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update MCP server' })
+  async update(@Req() req: any, @Param('id') id: string, @Body() dto: UpdateMcpServerDto) {
+    const server = await this.mcpServersService.findById(id);
+    if (!server) throw new NotFoundException('MCP server not found');
+    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    return this.mcpServersService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete MCP server' })
+  async delete(@Req() req: any, @Param('id') id: string) {
+    const server = await this.mcpServersService.findById(id);
+    if (!server) throw new NotFoundException('MCP server not found');
+    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    await this.mcpServersService.delete(id);
+    return { message: 'MCP server deleted' };
+  }
+
+  @Put(':id/connectors')
+  @ApiOperation({ summary: 'Assign connectors to MCP server' })
+  async assignConnectors(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: AssignConnectorsDto,
+  ) {
+    const server = await this.mcpServersService.findById(id);
+    if (!server) throw new NotFoundException('MCP server not found');
+    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    await this.mcpServersService.assignConnectors(id, dto.connectorIds);
+    return { message: 'Connectors assigned' };
+  }
+}

--- a/packages/backend/src/mcp-servers/mcp-servers.module.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { McpServersService } from './mcp-servers.service';
+import { McpServersController } from './mcp-servers.controller';
+
+@Module({
+  providers: [McpServersService],
+  controllers: [McpServersController],
+  exports: [McpServersService],
+})
+export class McpServersModule {}

--- a/packages/backend/src/mcp-servers/mcp-servers.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+
+@Injectable()
+export class McpServersService {
+  private readonly logger = new Logger(McpServersService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAllByUser(userId: string) {
+    return this.prisma.mcpServerConfig.findMany({
+      where: { userId },
+      include: {
+        _count: { select: { connectors: true, apiKeys: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async findById(id: string) {
+    return this.prisma.mcpServerConfig.findUnique({
+      where: { id },
+      include: {
+        connectors: {
+          include: {
+            connector: {
+              select: { id: true, name: true, type: true, isActive: true },
+            },
+          },
+        },
+        apiKeys: {
+          select: {
+            id: true,
+            name: true,
+            key: true,
+            isActive: true,
+            lastUsedAt: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+        _count: { select: { connectors: true, apiKeys: true } },
+      },
+    });
+  }
+
+  async create(userId: string, data: { name: string; slug?: string; description?: string }) {
+    const slug = data.slug || this.generateSlug(data.name);
+    return this.prisma.mcpServerConfig.create({
+      data: {
+        userId,
+        name: data.name,
+        slug,
+        description: data.description,
+      },
+      include: {
+        _count: { select: { connectors: true, apiKeys: true } },
+      },
+    });
+  }
+
+  async update(id: string, data: { name?: string; slug?: string; description?: string; isActive?: boolean }) {
+    return this.prisma.mcpServerConfig.update({
+      where: { id },
+      data,
+      include: {
+        _count: { select: { connectors: true, apiKeys: true } },
+      },
+    });
+  }
+
+  async delete(id: string) {
+    await this.prisma.mcpServerConfig.delete({ where: { id } });
+  }
+
+  async assignConnectors(serverId: string, connectorIds: string[]) {
+    // Replace all: delete existing, insert new
+    await this.prisma.$transaction([
+      this.prisma.mcpServerConnector.deleteMany({
+        where: { mcpServerId: serverId },
+      }),
+      ...connectorIds.map((connectorId) =>
+        this.prisma.mcpServerConnector.create({
+          data: { mcpServerId: serverId, connectorId },
+        }),
+      ),
+    ]);
+  }
+
+  async getConnectorIds(serverId: string): Promise<string[]> {
+    const rows = await this.prisma.mcpServerConnector.findMany({
+      where: { mcpServerId: serverId },
+      select: { connectorId: true },
+    });
+    return rows.map((r) => r.connectorId);
+  }
+
+  async createDefaultForUser(userId: string) {
+    // Check if user already has a default server (idempotent)
+    const existing = await this.prisma.mcpServerConfig.findFirst({
+      where: { userId, slug: 'default' },
+    });
+    if (existing) return existing;
+
+    return this.prisma.mcpServerConfig.create({
+      data: {
+        userId,
+        name: 'Default',
+        slug: 'default',
+      },
+    });
+  }
+
+  private generateSlug(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      || 'server';
+  }
+}

--- a/packages/backend/src/roles/mcp-api-keys.controller.ts
+++ b/packages/backend/src/roles/mcp-api-keys.controller.ts
@@ -10,12 +10,16 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
-import { IsString } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator';
 import { McpApiKeysService } from './mcp-api-keys.service';
 
 class CreateKeyDto {
   @IsString()
   name: string;
+
+  @IsOptional()
+  @IsString()
+  mcpServerId?: string;
 }
 
 @ApiTags('MCP API Keys')
@@ -40,7 +44,7 @@ export class McpApiKeysController {
   @ApiOperation({ summary: 'Generate a new MCP API key' })
   async generateKey(@Req() req: any, @Body() dto: CreateKeyDto) {
     // Returns the full key — user must save it, it won't be shown again
-    return this.keysService.generate(req.user.sub, dto.name);
+    return this.keysService.generate(req.user.sub, dto.name, dto.mcpServerId);
   }
 
   @Post(':id/revoke')

--- a/packages/backend/src/roles/mcp-api-keys.service.ts
+++ b/packages/backend/src/roles/mcp-api-keys.service.ts
@@ -12,12 +12,12 @@ export class McpApiKeysService {
    * Generate a new MCP API key for a user.
    * Key format: mcp_<32 random hex chars>
    */
-  async generate(userId: string, name: string) {
+  async generate(userId: string, name: string, mcpServerId?: string) {
     const key = `mcp_${randomBytes(32).toString('hex')}`;
 
     return this.prisma.mcpApiKey.create({
-      data: { userId, key, name },
-      select: { id: true, key: true, name: true, isActive: true, createdAt: true },
+      data: { userId, key, name, mcpServerId: mcpServerId || null },
+      select: { id: true, key: true, name: true, isActive: true, mcpServerId: true, createdAt: true },
     });
   }
 
@@ -30,8 +30,9 @@ export class McpApiKeysService {
         isActive: true,
         lastUsedAt: true,
         createdAt: true,
-        // Show only last 8 chars of key for display
         key: true,
+        mcpServerId: true,
+        mcpServer: { select: { id: true, name: true } },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -77,6 +78,6 @@ export class McpApiKeysService {
       data: { lastUsedAt: new Date() },
     }).catch(() => {});
 
-    return record.user;
+    return { ...record.user, mcpServerId: record.mcpServerId };
   }
 }

--- a/packages/frontend/src/app/admin/roles/page.tsx
+++ b/packages/frontend/src/app/admin/roles/page.tsx
@@ -192,7 +192,7 @@ export default function AdminRolesPage() {
         title="MCP Role Management"
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full space-y-6">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full space-y-6">
         {msg && (
           <div className="p-3 rounded-md bg-[var(--info-bg)] text-[var(--info-text)] text-sm border border-[var(--info-border)]">
             {msg}

--- a/packages/frontend/src/app/admin/settings/page.tsx
+++ b/packages/frontend/src/app/admin/settings/page.tsx
@@ -99,7 +99,7 @@ export default function AdminSettingsPage() {
         title="Admin Settings"
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
         <div className="space-y-6">
           {/* SMTP Configuration */}
           <div className="border border-[var(--border)] rounded-lg p-6">

--- a/packages/frontend/src/app/admin/users/page.tsx
+++ b/packages/frontend/src/app/admin/users/page.tsx
@@ -124,7 +124,7 @@ export default function AdminUsersPage() {
         }
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
         {msg && (
           <div className="mb-4 p-3 rounded-md bg-[var(--info-bg)] text-[var(--info-text)] text-sm border border-[var(--info-border)]">
             {msg}

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -313,12 +313,12 @@ export default function ConnectorDetailPage() {
         ]}
         title={connector.name}
         actions={
-          <div className="flex gap-2">
+          <div className="flex gap-2 flex-wrap">
             <button
               onClick={handleTest}
               className="border border-[var(--border)] px-3 py-1.5 rounded text-sm hover:bg-[var(--accent)]"
             >
-              Test Connection
+              Test
             </button>
             <button
               onClick={() => setEditing(!editing)}
@@ -336,7 +336,7 @@ export default function ConnectorDetailPage() {
         }
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 space-y-6 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 space-y-6 flex-1 w-full">
         {msg && (
           <div className="p-3 rounded-md bg-[var(--info-bg)] text-[var(--info-text)] text-sm border border-[var(--info-border)]">
             {msg}
@@ -442,7 +442,7 @@ export default function ConnectorDetailPage() {
               </button>
             </div>
           ) : (
-            <div className="grid grid-cols-2 gap-4 text-sm">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
               <div>
                 <p className="text-[var(--muted-foreground)]">Name</p>
                 <p className="font-medium">{connector.name}</p>
@@ -550,11 +550,11 @@ export default function ConnectorDetailPage() {
 
         {/* Tools Section */}
         <div className="border border-[var(--border)] rounded-lg p-6">
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
             <h3 className="text-lg font-medium">
               MCP Tools ({toolList.length})
             </h3>
-            <div className="flex gap-2">
+            <div className="flex gap-2 flex-wrap">
               <button
                 onClick={() => setShowImport(!showImport)}
                 className="border border-[var(--border)] px-3 py-1.5 rounded text-sm hover:bg-[var(--accent)]"
@@ -671,28 +671,28 @@ export default function ConnectorDetailPage() {
                     />
                   ) : (
                     <div className="border border-[var(--border)] rounded-md p-3 hover:border-[var(--ring)] transition-colors">
-                      <div className="flex items-center justify-between">
+                      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                         <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2">
-                            <span className="font-medium text-sm font-mono">{tool.name}</span>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-medium text-sm font-mono break-all">{tool.name}</span>
                             {tool.endpointMapping?.method && (
-                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--info-bg)] text-[var(--info-text)] font-mono">
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--info-bg)] text-[var(--info-text)] font-mono flex-shrink-0">
                                 {tool.endpointMapping.method}
                               </span>
                             )}
                             <span
-                              className={`text-xs px-1.5 py-0.5 rounded ${tool.isEnabled ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}
+                              className={`text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${tool.isEnabled ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}
                             >
                               {tool.isEnabled ? 'enabled' : 'disabled'}
                             </span>
                           </div>
-                          <p className="text-xs text-[var(--muted-foreground)] mt-0.5 truncate">
+                          <p className="text-xs text-[var(--muted-foreground)] mt-0.5 line-clamp-2 sm:truncate">
                             {tool.description}
                           </p>
                           {/* Show mapping summary */}
-                          <div className="flex gap-3 mt-1.5 text-[10px] text-[var(--muted-foreground)]">
+                          <div className="flex gap-3 mt-1.5 text-[10px] text-[var(--muted-foreground)] flex-wrap">
                             {tool.endpointMapping?.path && (
-                              <span className="font-mono">{tool.endpointMapping.path}</span>
+                              <span className="font-mono break-all">{tool.endpointMapping.path}</span>
                             )}
                             {tool.parameters?.properties && (() => {
                               const allParams = Object.keys(tool.parameters.properties);
@@ -717,7 +717,7 @@ export default function ConnectorDetailPage() {
                             )}
                           </div>
                         </div>
-                        <div className="flex gap-2 ml-4">
+                        <div className="flex gap-2 flex-wrap sm:flex-nowrap sm:ml-4 flex-shrink-0">
                           <button
                             onClick={() => {
                               if (testingToolId === tool.id) {

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -116,7 +116,7 @@ export default function NewConnectorPage() {
         title="New Connector"
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
         <h2 className="text-lg font-medium mb-2">Choose connector type</h2>
         <p className="text-sm text-[var(--muted-foreground)] mb-6">Select the type of API you want to connect to.</p>
 

--- a/packages/frontend/src/app/connectors/page.tsx
+++ b/packages/frontend/src/app/connectors/page.tsx
@@ -187,7 +187,7 @@ export default function ConnectorsPage() {
         }
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
         {msg && (
           <div className="mb-4 p-3 rounded-md bg-[var(--info-bg)] text-[var(--info-text)] text-sm border border-[var(--info-border)] flex items-center justify-between">
             <span>{msg}</span>

--- a/packages/frontend/src/app/logs/page.tsx
+++ b/packages/frontend/src/app/logs/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/lib/auth-context';
-import { audit } from '@/lib/api';
+import { audit, connectors as connectorsApi } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
 import { Footer } from '@/components/footer';
 
@@ -11,7 +11,25 @@ export default function LogsPage() {
   const [logs, setLogs] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<string>('');
+  const [search, setSearch] = useState('');
+  const [connectorFilter, setConnectorFilter] = useState<string>('');
+  const [connectors, setConnectors] = useState<any[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
+  // Debounced search
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Load connectors for filter dropdown
+  useEffect(() => {
+    if (!token) return;
+    connectorsApi.list(token).then(setConnectors).catch(() => {});
+  }, [token]);
+
+  // Load logs
   useEffect(() => {
     if (!token) return;
     setLoading(true);
@@ -19,15 +37,26 @@ export default function LogsPage() {
       .invocations(token, {
         limit: 200,
         ...(statusFilter ? { status: statusFilter } : {}),
+        ...(debouncedSearch ? { search: debouncedSearch } : {}),
+        ...(connectorFilter ? { connectorId: connectorFilter } : {}),
       })
       .then(setLogs)
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [token, statusFilter]);
+  }, [token, statusFilter, debouncedSearch, connectorFilter]);
 
   const formatTime = (ts: string) => {
     const d = new Date(ts);
     return d.toLocaleString();
+  };
+
+  const formatJson = (data: any) => {
+    if (!data) return '-';
+    try {
+      return JSON.stringify(data, null, 2);
+    } catch {
+      return String(data);
+    }
   };
 
   return (
@@ -37,30 +66,56 @@ export default function LogsPage() {
         title="Logs"
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3 mb-6">
+          <div className="relative flex-1">
+            <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--muted-foreground)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search tool name..."
+              className="w-full border border-[var(--input)] rounded-md pl-10 pr-3 py-2 text-sm bg-[var(--background)]"
+            />
+          </div>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+          >
+            <option value="">All statuses</option>
+            <option value="SUCCESS">Success</option>
+            <option value="ERROR">Error</option>
+            <option value="TIMEOUT">Timeout</option>
+          </select>
+          <select
+            value={connectorFilter}
+            onChange={(e) => setConnectorFilter(e.target.value)}
+            className="border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+          >
+            <option value="">All connectors</option>
+            {connectors.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+
         <div className="border border-[var(--border)] rounded-lg">
-          <div className="p-4 border-b border-[var(--border)] flex items-center justify-between">
+          <div className="p-4 border-b border-[var(--border)]">
             <h3 className="font-medium">Tool Invocation Logs ({logs.length})</h3>
-            <div className="flex gap-2">
-              <select
-                value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
-                className="border border-[var(--input)] rounded-md px-2 py-1 text-sm bg-[var(--background)]"
-              >
-                <option value="">All statuses</option>
-                <option value="SUCCESS">Success</option>
-                <option value="ERROR">Error</option>
-                <option value="TIMEOUT">Timeout</option>
-              </select>
-            </div>
           </div>
 
-          <div className="overflow-x-auto">
+          {/* Desktop table */}
+          <div className="hidden sm:block overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-[var(--border)] text-left bg-[var(--muted)]">
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Time</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Tool</th>
+                  <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Connector</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Status</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Duration</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Client</th>
@@ -69,38 +124,136 @@ export default function LogsPage() {
               <tbody>
                 {loading ? (
                   <tr>
-                    <td colSpan={5} className="px-4 py-8 text-center text-[var(--muted-foreground)]">
+                    <td colSpan={6} className="px-4 py-8 text-center text-[var(--muted-foreground)]">
                       <div className="inline-block w-5 h-5 border-2 border-[var(--brand)] border-t-transparent rounded-full animate-spin mb-2"></div>
                       <p>Loading logs...</p>
                     </td>
                   </tr>
                 ) : logs.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="px-4 py-12 text-center text-[var(--muted-foreground)]">
-                      <p className="text-sm">No invocations yet. Tools will be logged here once MCP clients start using them.</p>
+                    <td colSpan={6} className="px-4 py-12 text-center text-[var(--muted-foreground)]">
+                      <p className="text-sm">No invocations found.</p>
                     </td>
                   </tr>
                 ) : (
                   logs.map((log) => (
-                    <tr key={log.id} className="border-b border-[var(--border)] hover:bg-[var(--accent)] transition-colors">
-                      <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{formatTime(log.createdAt)}</td>
-                      <td className="px-4 py-3 font-medium font-mono text-xs">{log.tool?.name || log.toolId}</td>
-                      <td className="px-4 py-3">
-                        <span className={`px-2 py-0.5 rounded text-xs font-medium ${
-                          log.status === 'SUCCESS' ? 'bg-[var(--success-bg)] text-[var(--success-text)]' :
-                          log.status === 'ERROR' ? 'bg-[var(--destructive-bg)] text-[var(--destructive-text)]' :
-                          'bg-[var(--warning-bg)] text-[var(--warning-text)]'
-                        }`}>
-                          {log.status}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.durationMs ? `${log.durationMs}ms` : '-'}</td>
-                      <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.clientInfo || '-'}</td>
-                    </tr>
+                    <>
+                      <tr
+                        key={log.id}
+                        onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
+                        className="border-b border-[var(--border)] hover:bg-[var(--accent)] transition-colors cursor-pointer"
+                      >
+                        <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs whitespace-nowrap">{formatTime(log.createdAt)}</td>
+                        <td className="px-4 py-3 font-medium font-mono text-xs">{log.tool?.name || log.toolId}</td>
+                        <td className="px-4 py-3 text-xs text-[var(--muted-foreground)]">
+                          {log.tool?.connector?.name || '-'}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`px-2 py-0.5 rounded text-xs font-medium ${
+                            log.status === 'SUCCESS' ? 'bg-[var(--success-bg)] text-[var(--success-text)]' :
+                            log.status === 'ERROR' ? 'bg-[var(--destructive-bg)] text-[var(--destructive-text)]' :
+                            'bg-[var(--warning-bg)] text-[var(--warning-text)]'
+                          }`}>
+                            {log.status}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.durationMs ? `${log.durationMs}ms` : '-'}</td>
+                        <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.clientInfo || '-'}</td>
+                      </tr>
+                      {expandedId === log.id && (
+                        <tr key={`${log.id}-detail`}>
+                          <td colSpan={6} className="px-4 py-4 bg-[var(--muted)]/50 border-b border-[var(--border)]">
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-full">
+                              <div>
+                                <h4 className="text-xs font-medium mb-2 text-[var(--muted-foreground)] uppercase tracking-wide">Input Parameters</h4>
+                                <pre className="bg-[var(--background)] border border-[var(--border)] rounded-md p-3 text-xs font-mono overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all">
+                                  {formatJson(log.input)}
+                                </pre>
+                              </div>
+                              <div>
+                                <h4 className="text-xs font-medium mb-2 text-[var(--muted-foreground)] uppercase tracking-wide">
+                                  {log.status === 'ERROR' ? 'Error' : 'Output'}
+                                </h4>
+                                <pre className="bg-[var(--background)] border border-[var(--border)] rounded-md p-3 text-xs font-mono overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-all">
+                                  {log.error || formatJson(log.output)}
+                                </pre>
+                              </div>
+                            </div>
+                            {(log.clientInfo || log.userId) && (
+                              <div className="mt-3 flex gap-4 text-xs text-[var(--muted-foreground)]">
+                                {log.clientInfo && <span>Client: {log.clientInfo}</span>}
+                                {log.userId && <span>User: {log.userId}</span>}
+                                {log.tool?.connector && <span>Connector: {log.tool.connector.name} ({log.tool.connector.type})</span>}
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </>
                   ))
                 )}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile card layout */}
+          <div className="sm:hidden divide-y divide-[var(--border)]">
+            {loading ? (
+              <div className="px-4 py-8 text-center text-[var(--muted-foreground)]">
+                <div className="inline-block w-5 h-5 border-2 border-[var(--brand)] border-t-transparent rounded-full animate-spin mb-2"></div>
+                <p>Loading logs...</p>
+              </div>
+            ) : logs.length === 0 ? (
+              <div className="px-4 py-12 text-center text-[var(--muted-foreground)]">
+                <p className="text-sm">No invocations found.</p>
+              </div>
+            ) : (
+              logs.map((log) => (
+                <div key={log.id}>
+                  <button
+                    onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
+                    className="w-full text-left px-4 py-3 hover:bg-[var(--accent)] transition-colors"
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="font-mono text-xs font-medium truncate flex-1 mr-2">{log.tool?.name || log.toolId}</span>
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${
+                        log.status === 'SUCCESS' ? 'bg-[var(--success-bg)] text-[var(--success-text)]' :
+                        log.status === 'ERROR' ? 'bg-[var(--destructive-bg)] text-[var(--destructive-text)]' :
+                        'bg-[var(--warning-bg)] text-[var(--warning-text)]'
+                      }`}>
+                        {log.status}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]">
+                      <span>{formatTime(log.createdAt)}</span>
+                      {log.durationMs && <span>{log.durationMs}ms</span>}
+                    </div>
+                  </button>
+                  {expandedId === log.id && (
+                    <div className="px-4 py-3 bg-[var(--muted)]/50 space-y-3">
+                      <div>
+                        <h4 className="text-xs font-medium mb-1 text-[var(--muted-foreground)] uppercase tracking-wide">Input</h4>
+                        <pre className="bg-[var(--background)] border border-[var(--border)] rounded-md p-2 text-xs font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">
+                          {formatJson(log.input)}
+                        </pre>
+                      </div>
+                      <div>
+                        <h4 className="text-xs font-medium mb-1 text-[var(--muted-foreground)] uppercase tracking-wide">
+                          {log.status === 'ERROR' ? 'Error' : 'Output'}
+                        </h4>
+                        <pre className="bg-[var(--background)] border border-[var(--border)] rounded-md p-2 text-xs font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">
+                          {log.error || formatJson(log.output)}
+                        </pre>
+                      </div>
+                      <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)]">
+                        {log.clientInfo && <span>Client: {log.clientInfo}</span>}
+                        {log.tool?.connector && <span>Connector: {log.tool.connector.name}</span>}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))
+            )}
           </div>
         </div>
       </main>

--- a/packages/frontend/src/app/mcp-server/[id]/page.tsx
+++ b/packages/frontend/src/app/mcp-server/[id]/page.tsx
@@ -1,0 +1,582 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth-context';
+import { mcpServers, connectors as connectorsApi, mcpKeys } from '@/lib/api';
+import { NavBar } from '@/components/nav-bar';
+import { Footer } from '@/components/footer';
+
+export default function McpServerDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { token } = useAuth();
+  const router = useRouter();
+
+  const [server, setServer] = useState<any>(null);
+  const [allConnectors, setAllConnectors] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Edit state
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [saveMsg, setSaveMsg] = useState('');
+
+  // API key state
+  const [newKeyName, setNewKeyName] = useState('');
+  const [generatedKey, setGeneratedKey] = useState('');
+  const [keyMsg, setKeyMsg] = useState('');
+
+  // Connector assignment state
+  const [assignedIds, setAssignedIds] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  const [copied, setCopied] = useState('');
+
+  useEffect(() => {
+    if (!token || !id) return;
+    Promise.all([
+      mcpServers.get(id, token),
+      connectorsApi.list(token),
+    ]).then(([srv, conns]) => {
+      setServer(srv);
+      setEditName(srv.name);
+      setEditDescription(srv.description || '');
+      setAllConnectors(conns);
+      setAssignedIds(new Set(srv.connectors?.map((c: any) => c.connector.id) || []));
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, [token, id]);
+
+  const apiUrl = typeof window !== 'undefined'
+    ? `${window.location.protocol}//${window.location.hostname}:4000`
+    : 'http://localhost:4000';
+
+  const handleSave = async () => {
+    if (!token || !id) return;
+    try {
+      const updated = await mcpServers.update(id, {
+        name: editName.trim(),
+        description: editDescription.trim() || undefined,
+      }, token);
+      setServer((prev: any) => ({ ...prev, ...updated }));
+      setSaveMsg('Saved');
+      setTimeout(() => setSaveMsg(''), 2000);
+    } catch (err: any) {
+      setSaveMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleToggleActive = async () => {
+    if (!token || !id || !server) return;
+    try {
+      const updated = await mcpServers.update(id, { isActive: !server.isActive }, token);
+      setServer((prev: any) => ({ ...prev, ...updated }));
+    } catch {}
+  };
+
+  const handleToggleConnector = (connectorId: string) => {
+    setAssignedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(connectorId)) next.delete(connectorId);
+      else next.add(connectorId);
+      return next;
+    });
+  };
+
+  const handleSaveConnectors = async () => {
+    if (!token || !id) return;
+    setSaving(true);
+    try {
+      await mcpServers.assignConnectors(id, Array.from(assignedIds), token);
+      setSaveMsg('Connectors updated');
+      setTimeout(() => setSaveMsg(''), 2000);
+    } catch (err: any) {
+      setSaveMsg(`Error: ${err.message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleGenerateKey = async () => {
+    if (!token || !newKeyName.trim()) return;
+    try {
+      const result = await mcpKeys.generate(newKeyName.trim(), token, id);
+      setGeneratedKey(result.key);
+      setNewKeyName('');
+      setKeyMsg('Key generated! Copy it now — it will not be shown again.');
+      // Reload server to refresh key list
+      const srv = await mcpServers.get(id, token);
+      setServer(srv);
+    } catch (err: any) {
+      setKeyMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleRevokeKey = async (keyId: string) => {
+    if (!token) return;
+    try {
+      await mcpKeys.revoke(keyId, token);
+      const srv = await mcpServers.get(id, token);
+      setServer(srv);
+      setKeyMsg('Key revoked');
+    } catch (err: any) {
+      setKeyMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleDeleteKey = async (keyId: string) => {
+    if (!token || !confirm('Delete this API key permanently?')) return;
+    try {
+      await mcpKeys.delete(keyId, token);
+      const srv = await mcpServers.get(id, token);
+      setServer(srv);
+      setKeyMsg('Key deleted');
+    } catch (err: any) {
+      setKeyMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleDeleteServer = async () => {
+    if (!token || !id || !confirm('Delete this MCP server? API keys will be unlinked.')) return;
+    try {
+      await mcpServers.delete(id, token);
+      router.push('/mcp-server');
+    } catch {}
+  };
+
+  const handleCopy = (text: string, label: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(label);
+    setTimeout(() => setCopied(''), 2000);
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[var(--background)] flex flex-col">
+        <NavBar breadcrumbs={[{ label: 'MCP Servers', href: '/mcp-server' }]} title="Loading..." />
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
+          <div className="animate-pulse space-y-6">
+            <div className="h-8 bg-[var(--muted)] rounded w-1/3" />
+            <div className="h-40 bg-[var(--muted)] rounded" />
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!server) {
+    return (
+      <div className="min-h-screen bg-[var(--background)] flex flex-col">
+        <NavBar breadcrumbs={[{ label: 'MCP Servers', href: '/mcp-server' }]} title="Not Found" />
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full text-center">
+          <p className="text-[var(--muted-foreground)]">MCP server not found.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  const endpointUrl = `${apiUrl}/mcp/${id}`;
+
+  const claudeConfigOAuth = `{
+  "mcpServers": {
+    "${server.slug || 'my-server'}": {
+      "type": "url",
+      "url": "${endpointUrl}"
+    }
+  }
+}`;
+
+  const claudeConfigApiKey = `{
+  "mcpServers": {
+    "${server.slug || 'my-server'}": {
+      "type": "url",
+      "url": "${endpointUrl}",
+      "headers": {
+        "X-API-Key": "YOUR_MCP_API_KEY"
+      }
+    }
+  }
+}`;
+
+  // Tools from assigned connectors
+  const assignedConnectors = allConnectors.filter((c) => assignedIds.has(c.id));
+  const toolsList = assignedConnectors.flatMap((c) =>
+    (c.tools || []).map((t: any) => ({ ...t, connectorName: c.name, connectorType: c.type })),
+  );
+
+  return (
+    <div className="min-h-screen bg-[var(--background)] flex flex-col">
+      <NavBar
+        breadcrumbs={[
+          { label: 'Dashboard', href: '/' },
+          { label: 'MCP Servers', href: '/mcp-server' },
+        ]}
+        title={server.name}
+        actions={
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleActive}
+              className={`px-3 py-1.5 rounded-md text-xs font-medium border ${
+                server.isActive
+                  ? 'border-[var(--success)] text-[var(--success)] hover:bg-[var(--success-bg)]'
+                  : 'border-[var(--muted-foreground)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]'
+              }`}
+            >
+              {server.isActive ? 'Active' : 'Inactive'}
+            </button>
+            <button
+              onClick={handleDeleteServer}
+              className="border border-[var(--destructive)] text-[var(--destructive)] px-3 py-1.5 rounded-md text-xs font-medium hover:bg-[var(--destructive-bg)]"
+            >
+              Delete
+            </button>
+          </div>
+        }
+      />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 space-y-6 flex-1 w-full">
+        {/* Server Info */}
+        <div className="border border-[var(--border)] rounded-lg p-6">
+          <h3 className="text-lg font-medium mb-4">Server Settings</h3>
+          <div className="space-y-4 max-w-md">
+            <div>
+              <label className="block text-sm font-medium mb-1">Name</label>
+              <input
+                type="text"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Slug</label>
+              <input
+                type="text"
+                value={server.slug}
+                disabled
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--muted)] opacity-70 font-mono"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Description</label>
+              <input
+                type="text"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                placeholder="What this MCP server is for"
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+              />
+            </div>
+            {saveMsg && (
+              <p className={`text-sm ${saveMsg.startsWith('Error') ? 'text-[var(--destructive)]' : 'text-[var(--success)]'}`}>
+                {saveMsg}
+              </p>
+            )}
+            <button
+              onClick={handleSave}
+              className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+
+        {/* Connection Config */}
+        <div className="border border-[var(--border)] rounded-lg p-6">
+          <h3 className="text-lg font-medium mb-4">Connect Your MCP Client</h3>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm text-[var(--muted-foreground)] mb-1">MCP Endpoint</label>
+              <div className="flex gap-2">
+                <code className="flex-1 bg-[var(--muted)] px-3 py-2 rounded text-sm font-mono break-all">{endpointUrl}</code>
+                <button
+                  onClick={() => handleCopy(endpointUrl, 'endpoint')}
+                  className="border border-[var(--border)] px-3 py-2 rounded text-xs hover:bg-[var(--accent)] flex-shrink-0"
+                >
+                  {copied === 'endpoint' ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+              <p className="text-xs text-[var(--muted-foreground)] mt-1">
+                Each MCP server has its own unique endpoint. Only tools from assigned connectors are exposed.
+              </p>
+            </div>
+
+            {/* OAuth config (Claude Desktop, ChatGPT, Cursor) */}
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-sm font-medium">OAuth (Claude Desktop, ChatGPT, Cursor)</h4>
+                <button
+                  onClick={() => handleCopy(claudeConfigOAuth, 'claude-oauth')}
+                  className="text-xs text-[var(--brand)] hover:underline"
+                >
+                  {copied === 'claude-oauth' ? 'Copied!' : 'Copy config'}
+                </button>
+              </div>
+              <pre className="bg-[var(--muted)] p-4 rounded text-xs overflow-x-auto font-mono">{claudeConfigOAuth}</pre>
+              <p className="text-xs text-[var(--muted-foreground)] mt-2">
+                The client will auto-discover OAuth endpoints and prompt you to log in.
+                Requires <code className="font-mono bg-[var(--muted)] px-1 rounded">MCP_AUTH_MODE=oauth2</code> or <code className="font-mono bg-[var(--muted)] px-1 rounded">both</code>.
+              </p>
+            </div>
+
+            {/* API Key config */}
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-sm font-medium">API Key (Claude Code, custom clients)</h4>
+                <button
+                  onClick={() => handleCopy(claudeConfigApiKey, 'claude-apikey')}
+                  className="text-xs text-[var(--brand)] hover:underline"
+                >
+                  {copied === 'claude-apikey' ? 'Copied!' : 'Copy config'}
+                </button>
+              </div>
+              <pre className="bg-[var(--muted)] p-4 rounded text-xs overflow-x-auto font-mono">{claudeConfigApiKey}</pre>
+              <p className="text-xs text-[var(--muted-foreground)] mt-2">
+                Replace <code className="font-mono bg-[var(--muted)] px-1 rounded">YOUR_MCP_API_KEY</code> with a key generated below.
+                Requires <code className="font-mono bg-[var(--muted)] px-1 rounded">MCP_AUTH_MODE=legacy</code> or <code className="font-mono bg-[var(--muted)] px-1 rounded">both</code>.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Assigned Connectors */}
+        <div className="border border-[var(--border)] rounded-lg p-6">
+          <h3 className="text-lg font-medium mb-4">
+            Assigned Connectors ({assignedIds.size})
+          </h3>
+          <p className="text-sm text-[var(--muted-foreground)] mb-4">
+            Select which connectors expose their tools through this MCP server.
+          </p>
+          {allConnectors.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)]">No connectors available. Create a connector first.</p>
+          ) : (
+            <>
+              <div className="flex gap-2 mb-3">
+                <button
+                  onClick={() => setAssignedIds(new Set(allConnectors.map((c) => c.id)))}
+                  className="border border-[var(--border)] px-3 py-1 rounded-md text-xs hover:bg-[var(--accent)]"
+                >
+                  Select All
+                </button>
+                <button
+                  onClick={() => setAssignedIds(new Set())}
+                  className="border border-[var(--border)] px-3 py-1 rounded-md text-xs hover:bg-[var(--accent)]"
+                >
+                  Deselect All
+                </button>
+              </div>
+              <div className="space-y-2 mb-4">
+                {allConnectors.map((c) => (
+                  <label
+                    key={c.id}
+                    className="flex items-center gap-3 p-3 rounded-lg bg-[var(--muted)]/50 hover:bg-[var(--accent)]/50 cursor-pointer transition-colors"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={assignedIds.has(c.id)}
+                      onChange={() => handleToggleConnector(c.id)}
+                      className="rounded"
+                    />
+                    <div className="flex-1">
+                      <span className="text-sm font-medium">{c.name}</span>
+                      <span className="text-xs text-[var(--muted-foreground)] ml-2">{c.type}</span>
+                    </div>
+                    <span className="text-xs text-[var(--muted-foreground)]">
+                      {(c.tools || []).length} tools
+                    </span>
+                  </label>
+                ))}
+              </div>
+              <button
+                onClick={handleSaveConnectors}
+                disabled={saving}
+                className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save Connector Assignments'}
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* API Keys */}
+        <div className="border border-[var(--border)] rounded-lg p-6">
+          <h3 className="text-lg font-medium mb-4">API Keys</h3>
+          <p className="text-sm text-[var(--muted-foreground)] mb-4">
+            Generate API keys scoped to this MCP server. Only tools from assigned connectors will be available.
+          </p>
+
+          <div className="space-y-3 mb-4">
+            <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
+              <div className="flex-1 sm:max-w-sm">
+                <label className="block text-sm font-medium mb-1">Key Label</label>
+                <input
+                  type="text"
+                  value={newKeyName}
+                  onChange={(e) => setNewKeyName(e.target.value)}
+                  placeholder="e.g. Claude Desktop, Cursor"
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                />
+              </div>
+              <button
+                onClick={handleGenerateKey}
+                disabled={!newKeyName.trim()}
+                className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
+              >
+                Generate Key
+              </button>
+            </div>
+
+            {generatedKey && (
+              <div className="border border-[var(--success-border)] bg-[var(--success-bg)] rounded-md p-3">
+                <p className="text-xs font-medium text-[var(--success-text)] mb-1">
+                  Copy this key now! It will not be shown again.
+                </p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 text-xs font-mono bg-[var(--background)] px-3 py-2 rounded border border-[var(--border)] select-all break-all">
+                    {generatedKey}
+                  </code>
+                  <button
+                    onClick={() => { navigator.clipboard.writeText(generatedKey); setKeyMsg('Copied!'); }}
+                    className="border border-[var(--border)] px-3 py-1.5 rounded text-xs hover:bg-[var(--accent)]"
+                  >
+                    Copy
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {keyMsg && (
+              <p className={`text-sm ${keyMsg.startsWith('Error') ? 'text-[var(--destructive)]' : 'text-[var(--success)]'}`}>
+                {keyMsg}
+              </p>
+            )}
+          </div>
+
+          {/* Key list */}
+          {server.apiKeys && server.apiKeys.length > 0 && (
+            <>
+              {/* Desktop table */}
+              <div className="hidden sm:block border border-[var(--border)] rounded-lg overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-[var(--muted)]">
+                    <tr>
+                      <th className="text-left px-4 py-2 font-medium text-xs">Label</th>
+                      <th className="text-left px-4 py-2 font-medium text-xs">Key</th>
+                      <th className="text-left px-4 py-2 font-medium text-xs">Status</th>
+                      <th className="text-left px-4 py-2 font-medium text-xs">Last Used</th>
+                      <th className="text-right px-4 py-2 font-medium text-xs">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {server.apiKeys.map((k: any) => (
+                      <tr key={k.id} className="border-t border-[var(--border)]">
+                        <td className="px-4 py-2 text-sm">{k.name}</td>
+                        <td className="px-4 py-2 font-mono text-xs text-[var(--muted-foreground)]">
+                          mcp_{'*'.repeat(24)}{k.key.slice(-8)}
+                        </td>
+                        <td className="px-4 py-2">
+                          <span className={`text-xs px-1.5 py-0.5 rounded ${k.isActive ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}>
+                            {k.isActive ? 'active' : 'revoked'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 text-xs text-[var(--muted-foreground)]">
+                          {k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : 'never'}
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          <div className="flex gap-1 justify-end">
+                            {k.isActive && (
+                              <button
+                                onClick={() => handleRevokeKey(k.id)}
+                                className="border border-[var(--border)] px-2 py-1 rounded text-xs hover:bg-[var(--accent)]"
+                              >
+                                Revoke
+                              </button>
+                            )}
+                            <button
+                              onClick={() => handleDeleteKey(k.id)}
+                              className="border border-[var(--destructive)] text-[var(--destructive)] px-2 py-1 rounded text-xs hover:bg-[var(--destructive-bg)]"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {/* Mobile card layout */}
+              <div className="sm:hidden space-y-3">
+                {server.apiKeys.map((k: any) => (
+                  <div key={k.id} className="border border-[var(--border)] rounded-lg p-3 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">{k.name}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${k.isActive ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}>
+                        {k.isActive ? 'active' : 'revoked'}
+                      </span>
+                    </div>
+                    <p className="font-mono text-xs text-[var(--muted-foreground)] break-all">
+                      mcp_{'*'.repeat(16)}{k.key.slice(-8)}
+                    </p>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-[var(--muted-foreground)]">
+                        Last used: {k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : 'never'}
+                      </span>
+                      <div className="flex gap-1">
+                        {k.isActive && (
+                          <button
+                            onClick={() => handleRevokeKey(k.id)}
+                            className="border border-[var(--border)] px-2 py-1 rounded text-xs hover:bg-[var(--accent)]"
+                          >
+                            Revoke
+                          </button>
+                        )}
+                        <button
+                          onClick={() => handleDeleteKey(k.id)}
+                          className="border border-[var(--destructive)] text-[var(--destructive)] px-2 py-1 rounded text-xs hover:bg-[var(--destructive-bg)]"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Active Tools */}
+        <div className="border border-[var(--border)] rounded-lg p-6">
+          <h3 className="text-lg font-medium mb-4">Active Tools ({toolsList.length})</h3>
+          {toolsList.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              No tools available. Assign connectors with enabled tools above.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {toolsList.map((t: any) => (
+                <div key={t.id} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 p-3 bg-[var(--muted)] rounded-lg">
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <span className={`w-2 h-2 rounded-full flex-shrink-0 ${t.isEnabled ? 'bg-[var(--success)]' : 'bg-[var(--muted-foreground)]'}`} />
+                    <span className="font-mono text-sm font-medium break-all">{t.name}</span>
+                  </div>
+                  <div className="flex items-center justify-between sm:justify-end gap-2 pl-4 sm:pl-0">
+                    <span className="text-xs text-[var(--muted-foreground)] truncate">
+                      {t.connectorName}
+                    </span>
+                    <span className={`text-xs px-2 py-0.5 rounded flex-shrink-0 ${t.isEnabled ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}>
+                      {t.isEnabled ? 'enabled' : 'disabled'}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/packages/frontend/src/app/mcp-server/page.tsx
+++ b/packages/frontend/src/app/mcp-server/page.tsx
@@ -1,153 +1,201 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
-import { connectors } from '@/lib/api';
+import { mcpServers } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
 import { Footer } from '@/components/footer';
 
-export default function McpServerPage() {
+export default function McpServerListPage() {
   const { token } = useAuth();
-  const [toolsList, setToolsList] = useState<any[]>([]);
-  const [copied, setCopied] = useState('');
+  const router = useRouter();
+  const [servers, setServers] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('');
 
   useEffect(() => {
     if (!token) return;
-    connectors.list(token).then((list) => {
-      const allTools: any[] = [];
-      for (const c of list) {
-        for (const t of c.tools || []) {
-          allTools.push({ ...t, connectorName: c.name, connectorType: c.type });
-        }
-      }
-      setToolsList(allTools);
-    }).catch(() => {});
+    mcpServers.list(token).then(setServers).catch(() => {}).finally(() => setLoading(false));
   }, [token]);
 
-  const apiUrl = typeof window !== 'undefined'
-    ? `${window.location.protocol}//${window.location.hostname}:4000`
-    : 'http://localhost:4000';
-
-  const handleCopy = (text: string, label: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(label);
-    setTimeout(() => setCopied(''), 2000);
+  const handleCreate = async () => {
+    if (!token || !newName.trim()) return;
+    setCreating(true);
+    try {
+      const server = await mcpServers.create(
+        { name: newName.trim(), description: newDescription.trim() || undefined },
+        token,
+      );
+      setServers((prev) => [...prev, server]);
+      setNewName('');
+      setNewDescription('');
+      setShowCreate(false);
+      router.push(`/mcp-server/${server.id}`);
+    } catch {
+    } finally {
+      setCreating(false);
+    }
   };
 
-  const claudeConfig = `{
-  "mcpServers": {
-    "anything-to-mcp": {
-      "type": "url",
-      "url": "${apiUrl}/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_TOKEN"
-      }
-    }
-  }
-}`;
+  const filtered = servers.filter((s) => {
+    if (search && !s.name.toLowerCase().includes(search.toLowerCase()) && !(s.slug || '').toLowerCase().includes(search.toLowerCase()) && !(s.description || '').toLowerCase().includes(search.toLowerCase())) return false;
+    if (statusFilter === 'active' && !s.isActive) return false;
+    if (statusFilter === 'inactive' && s.isActive) return false;
+    return true;
+  });
 
   return (
     <div className="min-h-screen bg-[var(--background)] flex flex-col">
       <NavBar
         breadcrumbs={[{ label: 'Dashboard', href: '/' }]}
-        title="MCP Server"
+        title="MCP Servers"
+        actions={
+          <button
+            onClick={() => setShowCreate(true)}
+            className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90"
+          >
+            + New MCP Server
+          </button>
+        }
       />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 space-y-6 flex-1 w-full">
-        {/* Server Status */}
-        <div className="border border-[var(--border)] rounded-lg p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-medium">Server Status</h3>
-            <span className="flex items-center gap-2 text-sm text-[var(--success)] font-medium">
-              <span className="w-2 h-2 bg-[var(--success)] rounded-full animate-pulse"></span>
-              Running
-            </span>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-[var(--muted-foreground)] mb-1">MCP Endpoint (Streamable HTTP)</label>
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 space-y-6 flex-1 w-full">
+        {/* Create dialog */}
+        {showCreate && (
+          <div className="border border-[var(--brand)] rounded-lg p-6 bg-[var(--background)]">
+            <h3 className="text-lg font-medium mb-4">Create MCP Server</h3>
+            <div className="space-y-3 max-w-md">
+              <div>
+                <label className="block text-sm font-medium mb-1">Name</label>
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="e.g. Production, Development, Sales Tools"
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Description (optional)</label>
+                <input
+                  type="text"
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                  placeholder="What this MCP server is for"
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                />
+              </div>
               <div className="flex gap-2">
-                <code className="flex-1 bg-[var(--muted)] px-3 py-2 rounded text-sm font-mono">{apiUrl}/mcp</code>
                 <button
-                  onClick={() => handleCopy(`${apiUrl}/mcp`, 'endpoint')}
-                  className="border border-[var(--border)] px-3 py-2 rounded text-xs hover:bg-[var(--accent)]"
+                  onClick={handleCreate}
+                  disabled={!newName.trim() || creating}
+                  className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
                 >
-                  {copied === 'endpoint' ? 'Copied!' : 'Copy'}
+                  {creating ? 'Creating...' : 'Create'}
+                </button>
+                <button
+                  onClick={() => { setShowCreate(false); setNewName(''); setNewDescription(''); }}
+                  className="border border-[var(--border)] px-4 py-2 rounded-md text-sm hover:bg-[var(--accent)]"
+                >
+                  Cancel
                 </button>
               </div>
             </div>
-            <div>
-              <label className="block text-sm text-[var(--muted-foreground)] mb-1">Server Name</label>
-              <code className="block bg-[var(--muted)] px-3 py-2 rounded text-sm font-mono">anything-to-mcp v0.1.0</code>
-            </div>
           </div>
-        </div>
+        )}
 
-        {/* Connect Your MCP Client */}
-        <div className="border border-[var(--border)] rounded-lg p-6">
-          <h3 className="text-lg font-medium mb-4">Connect Your MCP Client</h3>
-
-          <div className="space-y-4">
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <h4 className="text-sm font-medium">Claude Desktop / Claude Code</h4>
-                <button
-                  onClick={() => handleCopy(claudeConfig, 'claude')}
-                  className="text-xs text-[var(--brand)] hover:underline"
-                >
-                  {copied === 'claude' ? 'Copied!' : 'Copy config'}
-                </button>
-              </div>
-              <pre className="bg-[var(--muted)] p-4 rounded text-xs overflow-x-auto font-mono">{claudeConfig}</pre>
+        {/* Search & filters */}
+        {!loading && servers.length > 0 && (
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="relative flex-1">
+              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--muted-foreground)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search MCP servers..."
+                className="w-full border border-[var(--input)] rounded-md pl-10 pr-3 py-2 text-sm bg-[var(--background)]"
+              />
             </div>
-
-            <div>
-              <h4 className="text-sm font-medium mb-2">Cursor IDE</h4>
-              <div className="bg-[var(--muted)] p-4 rounded text-sm">
-                <p>Settings &rarr; MCP &rarr; Add Server &rarr; URL: <code className="font-mono text-xs">{apiUrl}/mcp</code></p>
-              </div>
-            </div>
-
-            <div>
-              <h4 className="text-sm font-medium mb-2">API Key / Token</h4>
-              <p className="text-sm text-[var(--muted-foreground)]">
-                Set <code className="font-mono text-xs bg-[var(--muted)] px-1.5 py-0.5 rounded">MCP_BEARER_TOKEN</code> or{' '}
-                <code className="font-mono text-xs bg-[var(--muted)] px-1.5 py-0.5 rounded">MCP_API_KEY</code>{' '}
-                in your server&apos;s environment variables to secure the MCP endpoint.
-              </p>
-            </div>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+            >
+              <option value="">All statuses</option>
+              <option value="active">Active</option>
+              <option value="inactive">Inactive</option>
+            </select>
           </div>
-        </div>
+        )}
 
-        {/* Active Tools */}
-        <div className="border border-[var(--border)] rounded-lg p-6">
-          <h3 className="text-lg font-medium mb-4">Active Tools ({toolsList.length})</h3>
-          {toolsList.length === 0 ? (
-            <div className="text-center py-8">
-              <p className="text-[var(--muted-foreground)] text-sm">
-                No tools configured yet. Add a connector and import its spec to generate MCP tools.
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {toolsList.map((t) => (
-                <div key={t.id} className="flex items-center justify-between p-3 bg-[var(--muted)] rounded-lg">
-                  <div className="flex items-center gap-3">
-                    <span className={`w-2 h-2 rounded-full flex-shrink-0 ${t.isEnabled ? 'bg-[var(--success)]' : 'bg-[var(--muted-foreground)]'}`} />
-                    <span className="font-mono text-sm font-medium">{t.name}</span>
-                    <span className="text-xs text-[var(--muted-foreground)]">
-                      {t.connectorName} / {t.connectorType}
+        {/* Server list */}
+        {loading ? (
+          <div className="space-y-3">
+            {[1, 2].map((i) => (
+              <div key={i} className="border border-[var(--border)] rounded-lg p-6 animate-pulse">
+                <div className="h-5 bg-[var(--muted)] rounded w-1/4 mb-3" />
+                <div className="h-4 bg-[var(--muted)] rounded w-1/2" />
+              </div>
+            ))}
+          </div>
+        ) : servers.length === 0 ? (
+          <div className="text-center py-16">
+            <p className="text-[var(--muted-foreground)] mb-4">No MCP servers configured yet.</p>
+            <button
+              onClick={() => setShowCreate(true)}
+              className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90"
+            >
+              Create your first MCP Server
+            </button>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-[var(--muted-foreground)]">No MCP servers match your search.</p>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {filtered.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => router.push(`/mcp-server/${s.id}`)}
+                className="border border-[var(--border)] rounded-lg p-4 sm:p-6 text-left hover:border-[var(--brand)] hover:bg-[var(--accent)]/50 transition-colors"
+              >
+                <div className="flex items-start sm:items-center justify-between gap-2 mb-2">
+                  <div className="flex items-center gap-2 flex-wrap min-w-0">
+                    <h3 className="text-base sm:text-lg font-medium">{s.name}</h3>
+                    <span className="text-xs font-mono text-[var(--muted-foreground)] bg-[var(--muted)] px-2 py-0.5 rounded">
+                      {s.slug}
                     </span>
                   </div>
-                  <span className={`text-xs px-2 py-0.5 rounded ${t.isEnabled ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}>
-                    {t.isEnabled ? 'enabled' : 'disabled'}
+                  <span className={`flex items-center gap-1.5 text-xs font-medium flex-shrink-0 ${s.isActive ? 'text-[var(--success)]' : 'text-[var(--muted-foreground)]'}`}>
+                    <span className={`w-2 h-2 rounded-full ${s.isActive ? 'bg-[var(--success)]' : 'bg-[var(--muted-foreground)]'}`} />
+                    {s.isActive ? 'Active' : 'Inactive'}
                   </span>
                 </div>
-              ))}
-            </div>
-          )}
-        </div>
+                {s.description && (
+                  <p className="text-sm text-[var(--muted-foreground)] mb-3">{s.description}</p>
+                )}
+                <div className="text-xs font-mono text-[var(--muted-foreground)] bg-[var(--muted)] px-2 py-1 rounded mb-3 truncate">
+                  /mcp/{s.id}
+                </div>
+                <div className="flex gap-4 text-xs text-[var(--muted-foreground)]">
+                  <span>{s._count?.connectors || 0} connectors</span>
+                  <span>{s._count?.apiKeys || 0} API keys</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
       </main>
       <Footer />
     </div>

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -74,7 +74,7 @@ export default function DashboardPage() {
     <div className="min-h-screen bg-[var(--background)] flex flex-col">
       <NavBar />
 
-      <main className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
         <div className="mb-8">
           <h2 className="text-2xl font-semibold">Welcome back{user?.name ? `, ${user.name}` : ''}</h2>
           <p className="text-[var(--muted-foreground)] mt-1 text-sm">Here&apos;s an overview of your MCP server.</p>

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -36,7 +36,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
         title="Settings"
       />
 
-      <div className="max-w-7xl mx-auto px-6 py-8 flex-1 w-full flex flex-col lg:flex-row gap-6 lg:gap-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full flex flex-col lg:flex-row gap-6 lg:gap-8">
         {/* Sidebar navigation */}
         <aside className="w-full lg:w-56 flex-shrink-0">
           <nav className="flex lg:flex-col gap-1.5 overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0">

--- a/packages/frontend/src/app/settings/page.tsx
+++ b/packages/frontend/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
-import { users, server, mcpKeys } from '@/lib/api';
+import { users, server } from '@/lib/api';
 
 const AUTH_MODE_LABELS: Record<string, string> = {
   none: 'None (not recommended)',
@@ -24,12 +24,6 @@ export default function SettingsPage() {
   const [oauthEndpoints, setOauthEndpoints] = useState<Record<string, string> | null>(null);
   const [serverUrl, setServerUrl] = useState('');
 
-  // MCP API Keys
-  const [keyList, setKeyList] = useState<any[]>([]);
-  const [newKeyName, setNewKeyName] = useState('');
-  const [generatedKey, setGeneratedKey] = useState('');
-  const [keyMsg, setKeyMsg] = useState('');
-
   // Load server info
   useEffect(() => {
     server.info().then((info) => {
@@ -38,12 +32,6 @@ export default function SettingsPage() {
       setServerUrl(info.serverUrl);
     }).catch(() => {});
   }, []);
-
-  // Load MCP API keys
-  useEffect(() => {
-    if (!token) return;
-    mcpKeys.list(token).then(setKeyList).catch(() => {});
-  }, [token]);
 
   const handleSaveProfile = async () => {
     if (!token) return;
@@ -75,41 +63,6 @@ export default function SettingsPage() {
       }
     } catch (err: any) {
       setPasswordMsg(`Error: ${err.message}`);
-    }
-  };
-
-  const handleGenerateKey = async () => {
-    if (!token || !newKeyName.trim()) return;
-    try {
-      const result = await mcpKeys.generate(newKeyName.trim(), token);
-      setGeneratedKey(result.key);
-      setNewKeyName('');
-      setKeyMsg('Key generated! Copy it now — it will not be shown again.');
-      mcpKeys.list(token).then(setKeyList).catch(() => {});
-    } catch (err: any) {
-      setKeyMsg(`Error: ${err.message}`);
-    }
-  };
-
-  const handleRevokeKey = async (id: string) => {
-    if (!token) return;
-    try {
-      await mcpKeys.revoke(id, token);
-      mcpKeys.list(token).then(setKeyList).catch(() => {});
-      setKeyMsg('Key revoked');
-    } catch (err: any) {
-      setKeyMsg(`Error: ${err.message}`);
-    }
-  };
-
-  const handleDeleteKey = async (id: string) => {
-    if (!token || !confirm('Delete this API key permanently?')) return;
-    try {
-      await mcpKeys.delete(id, token);
-      setKeyList((prev) => prev.filter((k) => k.id !== id));
-      setKeyMsg('Key deleted');
-    } catch (err: any) {
-      setKeyMsg(`Error: ${err.message}`);
     }
   };
 
@@ -251,116 +204,14 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      {/* MCP API Keys */}
+      {/* MCP API Keys note */}
       <div className="border border-[var(--border)] rounded-lg p-6">
-        <h3 className="text-lg font-medium mb-4">MCP API Keys</h3>
-        <p className="text-sm text-[var(--muted-foreground)] mb-4">
-          Generate personal API keys to authenticate MCP clients (Claude Desktop, ChatGPT, Cursor).
-          Each key is linked to your account and respects your assigned MCP role permissions.
+        <h3 className="text-lg font-medium mb-2">MCP API Keys</h3>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          API keys are now managed per MCP server. Go to{' '}
+          <a href="/mcp-server" className="text-[var(--brand)] hover:underline">MCP Servers</a>{' '}
+          to generate and manage keys for each server.
         </p>
-
-        {/* Generate new key */}
-        <div className="space-y-3 mb-4">
-          <div className="flex gap-2 items-end">
-            <div className="flex-1 max-w-sm">
-              <label className="block text-sm font-medium mb-1">Key Label</label>
-              <input
-                type="text"
-                value={newKeyName}
-                onChange={(e) => setNewKeyName(e.target.value)}
-                placeholder="e.g. Claude Desktop, Cursor"
-                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
-              />
-            </div>
-            <button
-              onClick={handleGenerateKey}
-              disabled={!newKeyName.trim()}
-              className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
-            >
-              Generate Key
-            </button>
-          </div>
-
-          {/* Show generated key */}
-          {generatedKey && (
-            <div className="border border-[var(--success-border)] bg-[var(--success-bg)] rounded-md p-3">
-              <p className="text-xs font-medium text-[var(--success-text)] mb-1">
-                Copy this key now! It will not be shown again.
-              </p>
-              <div className="flex items-center gap-2">
-                <code className="flex-1 text-xs font-mono bg-[var(--background)] px-3 py-2 rounded border border-[var(--border)] select-all break-all">
-                  {generatedKey}
-                </code>
-                <button
-                  onClick={() => { navigator.clipboard.writeText(generatedKey); setKeyMsg('Copied!'); }}
-                  className="border border-[var(--border)] px-3 py-1.5 rounded text-xs hover:bg-[var(--accent)]"
-                >
-                  Copy
-                </button>
-              </div>
-              <p className="text-xs text-[var(--muted-foreground)] mt-2">
-                Use this key as <code className="bg-[var(--muted)] px-1 rounded">X-API-Key</code> header in your MCP client configuration.
-              </p>
-            </div>
-          )}
-
-          {keyMsg && (
-            <p className={`text-sm ${keyMsg.startsWith('Error') ? 'text-[var(--destructive)]' : 'text-[var(--success)]'}`}>
-              {keyMsg}
-            </p>
-          )}
-        </div>
-
-        {/* Key list */}
-        {keyList.length > 0 && (
-          <div className="border border-[var(--border)] rounded-lg overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-[var(--muted)]">
-                <tr>
-                  <th className="text-left px-4 py-2 font-medium text-xs">Label</th>
-                  <th className="text-left px-4 py-2 font-medium text-xs">Key</th>
-                  <th className="text-left px-4 py-2 font-medium text-xs">Status</th>
-                  <th className="text-left px-4 py-2 font-medium text-xs">Last Used</th>
-                  <th className="text-right px-4 py-2 font-medium text-xs">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {keyList.map((k) => (
-                  <tr key={k.id} className="border-t border-[var(--border)]">
-                    <td className="px-4 py-2 text-sm">{k.name}</td>
-                    <td className="px-4 py-2 font-mono text-xs text-[var(--muted-foreground)]">{k.key}</td>
-                    <td className="px-4 py-2">
-                      <span className={`text-xs px-1.5 py-0.5 rounded ${k.isActive ? 'bg-[var(--success-bg)] text-[var(--success-text)]' : 'bg-[var(--muted)] text-[var(--muted-foreground)]'}`}>
-                        {k.isActive ? 'active' : 'revoked'}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2 text-xs text-[var(--muted-foreground)]">
-                      {k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : 'never'}
-                    </td>
-                    <td className="px-4 py-2 text-right">
-                      <div className="flex gap-1 justify-end">
-                        {k.isActive && (
-                          <button
-                            onClick={() => handleRevokeKey(k.id)}
-                            className="border border-[var(--border)] px-2 py-1 rounded text-xs hover:bg-[var(--accent)]"
-                          >
-                            Revoke
-                          </button>
-                        )}
-                        <button
-                          onClick={() => handleDeleteKey(k.id)}
-                          className="border border-[var(--destructive)] text-[var(--destructive)] px-2 py-1 rounded text-xs hover:bg-[var(--destructive-bg)]"
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/packages/frontend/src/components/footer.tsx
+++ b/packages/frontend/src/components/footer.tsx
@@ -53,7 +53,7 @@ export function Footer() {
 
   return (
     <footer className="border-t border-[var(--border)] bg-[var(--background)]">
-      <div className="max-w-7xl mx-auto px-6 py-4">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
           {/* Left: Legal links */}
           <div className="flex flex-wrap items-center gap-3 text-xs text-[var(--muted-foreground)]">

--- a/packages/frontend/src/components/nav-bar.tsx
+++ b/packages/frontend/src/components/nav-bar.tsx
@@ -29,7 +29,7 @@ function LogoIcon({ size = 28 }: { size?: number }) {
 
 const NAV_ITEMS = [
   { href: '/connectors', label: 'Connectors', icon: CableIcon },
-  { href: '/mcp-server', label: 'MCP Server', icon: ServerIcon },
+  { href: '/mcp-server', label: 'MCP Servers', icon: ServerIcon },
 
   { href: '/logs', label: 'Logs', icon: ListIcon },
   { href: '/settings', label: 'Settings', icon: GearIcon },
@@ -50,7 +50,7 @@ export function NavBar({ breadcrumbs, title, actions }: NavBarProps) {
 
   return (
     <header className="border-b border-[var(--border)] bg-[var(--background)]/95 backdrop-blur-sm sticky top-0 z-50">
-      <div className="flex items-center justify-between max-w-7xl mx-auto px-6 h-14">
+      <div className="flex items-center justify-between max-w-7xl mx-auto px-4 sm:px-6 h-14">
         <div className="flex items-center gap-6">
           <Link href="/" className="flex items-center gap-2.5 group">
             <span className="transition-transform group-hover:scale-105"><LogoIcon /></span>
@@ -153,7 +153,7 @@ export function NavBar({ breadcrumbs, title, actions }: NavBarProps) {
 
       {/* Breadcrumbs + Actions bar */}
       {(breadcrumbs || actions) && (
-        <div className="flex items-center justify-between max-w-7xl mx-auto px-6 py-2 text-sm border-t border-[var(--border)]">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 max-w-7xl mx-auto px-4 sm:px-6 py-2 text-sm border-t border-[var(--border)]">
           <div className="flex items-center gap-1.5 text-[var(--muted-foreground)]">
             {breadcrumbs?.map((crumb, i) => (
               <span key={crumb.href} className="flex items-center gap-1.5">

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -137,12 +137,14 @@ export const tools = {
 
 // Audit
 export const audit = {
-  invocations: (token: string, params?: { limit?: number; offset?: number; toolId?: string; status?: string }) => {
+  invocations: (token: string, params?: { limit?: number; offset?: number; toolId?: string; status?: string; search?: string; connectorId?: string }) => {
     const query = new URLSearchParams();
     if (params?.limit) query.set('limit', String(params.limit));
     if (params?.offset) query.set('offset', String(params.offset));
     if (params?.toolId) query.set('toolId', params.toolId);
     if (params?.status) query.set('status', params.status);
+    if (params?.search) query.set('search', params.search);
+    if (params?.connectorId) query.set('connectorId', params.connectorId);
     const qs = query.toString();
     return request<any[]>(`/api/audit/invocations${qs ? `?${qs}` : ''}`, { token });
   },
@@ -213,10 +215,30 @@ export const roles = {
 export const mcpKeys = {
   list: (token: string) =>
     request<any[]>('/api/mcp-keys', { token }),
-  generate: (name: string, token: string) =>
-    request<{ id: string; key: string; name: string }>('/api/mcp-keys', { method: 'POST', body: { name }, token }),
+  generate: (name: string, token: string, mcpServerId?: string) =>
+    request<{ id: string; key: string; name: string; mcpServerId?: string }>('/api/mcp-keys', {
+      method: 'POST',
+      body: { name, ...(mcpServerId ? { mcpServerId } : {}) },
+      token,
+    }),
   revoke: (id: string, token: string) =>
     request(`/api/mcp-keys/${id}/revoke`, { method: 'POST', token }),
   delete: (id: string, token: string) =>
     request(`/api/mcp-keys/${id}`, { method: 'DELETE', token }),
+};
+
+// MCP Servers
+export const mcpServers = {
+  list: (token: string) =>
+    request<any[]>('/api/mcp-servers', { token }),
+  get: (id: string, token: string) =>
+    request<any>(`/api/mcp-servers/${id}`, { token }),
+  create: (data: { name: string; slug?: string; description?: string }, token: string) =>
+    request<any>('/api/mcp-servers', { method: 'POST', body: data, token }),
+  update: (id: string, data: { name?: string; slug?: string; description?: string; isActive?: boolean }, token: string) =>
+    request<any>(`/api/mcp-servers/${id}`, { method: 'PUT', body: data, token }),
+  delete: (id: string, token: string) =>
+    request(`/api/mcp-servers/${id}`, { method: 'DELETE', token }),
+  assignConnectors: (id: string, connectorIds: string[], token: string) =>
+    request(`/api/mcp-servers/${id}/connectors`, { method: 'PUT', body: { connectorIds }, token }),
 };


### PR DESCRIPTION
## Summary
- Per-server MCP endpoints (/mcp/:serverId) with per-request tool scoping
- OAuth exception filter fixing missing WWW-Authenticate header on 401
- McpServers CRUD module with connector assignment
- UI updates for multi-server management and audit logs