### PR TITLE
feat: MCP connector OAuth2 + tool discovery + execution

### DIFF
--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
 import {
   IsString,
   IsEnum,
@@ -26,8 +27,11 @@ import { WsdlParser } from './parsers/wsdl.parser';
 import { GraphqlParser } from './parsers/graphql.parser';
 import { PostmanParser } from './parsers/postman.parser';
 import { CurlParser } from './parsers/curl.parser';
+import { McpClientEngine } from './engines/mcp-client.engine';
+import { McpOAuthService } from './mcp-oauth.service';
 import { PrismaService } from '../common/prisma.service';
 import { McpServerService } from '../mcp-server/mcp-server.service';
+import { decrypt } from '../common/crypto/encryption.util';
 
 class CreateConnectorDto {
   @IsString()
@@ -100,7 +104,7 @@ class UpdateConnectorDto {
 
 class ImportToolsDto {
   @IsString()
-  source: 'openapi' | 'wsdl' | 'graphql' | 'postman' | 'curl' | 'json';
+  source: 'openapi' | 'wsdl' | 'graphql' | 'postman' | 'curl' | 'json' | 'mcp';
 
   @IsOptional()
   @IsString()
@@ -125,9 +129,18 @@ export class ConnectorsController {
     private readonly graphqlParser: GraphqlParser,
     private readonly postmanParser: PostmanParser,
     private readonly curlParser: CurlParser,
+    private readonly mcpClientEngine: McpClientEngine,
+    private readonly mcpOAuthService: McpOAuthService,
     private readonly prisma: PrismaService,
     private readonly mcpServer: McpServerService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.encryptionKey =
+      this.configService.get<string>('ENCRYPTION_KEY') ||
+      'default-dev-key-change-in-prod!!';
+  }
+
+  private readonly encryptionKey: string;
 
   @Get()
   @ApiOperation({ summary: 'List all connectors for the current user' })
@@ -284,6 +297,132 @@ export class ConnectorsController {
   @ApiOperation({ summary: 'Test connector connection' })
   async test(@Req() req: any, @Param('id') id: string) {
     return this.connectorsService.testConnection(id, req.user.sub);
+  }
+
+  @Post(':id/oauth/authorize')
+  @ApiOperation({
+    summary: 'Initiate OAuth2 authorization for an MCP connector',
+    description:
+      'Discovers the remote MCP server OAuth endpoints, registers as a client, ' +
+      'and returns an authorization URL for the user to visit.',
+  })
+  async initiateOAuth(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id, req.user.sub);
+
+    if (connector.type !== 'MCP') {
+      return { error: 'OAuth authorization is only available for MCP connectors' };
+    }
+    if (connector.authType !== 'OAUTH2') {
+      return { error: 'Connector auth type must be OAUTH2' };
+    }
+
+    try {
+      // 1. Discover OAuth metadata from remote server
+      const metadata = await this.mcpOAuthService.discoverMetadata(connector.baseUrl);
+      this.logger.log(`OAuth metadata discovered from ${connector.baseUrl}: issuer=${metadata.issuer}`);
+
+      // 2. Register as OAuth client (dynamic registration)
+      const callbackUrl = `${this.configService.get('SERVER_URL') || 'http://localhost:4000'}/api/mcp-oauth/callback`;
+
+      let clientId: string;
+      let clientSecret: string | undefined;
+
+      if (metadata.registration_endpoint) {
+        const registration = await this.mcpOAuthService.registerClient(
+          metadata.registration_endpoint,
+          callbackUrl,
+        );
+        clientId = registration.clientId;
+        clientSecret = registration.clientSecret;
+      } else {
+        // Fallback: use clientId/clientSecret from existing authConfig
+        const authConfig = connector.authConfig
+          ? JSON.parse(decrypt(connector.authConfig, this.encryptionKey))
+          : {};
+        clientId = String(authConfig.clientId || '');
+        clientSecret = authConfig.clientSecret ? String(authConfig.clientSecret) : undefined;
+        if (!clientId) {
+          return {
+            error: 'Remote server does not support dynamic registration and no clientId is configured',
+          };
+        }
+      }
+
+      // 3. Generate PKCE challenge
+      const codeVerifier = this.mcpOAuthService.generateCodeVerifier();
+      const codeChallenge = this.mcpOAuthService.generateCodeChallenge(codeVerifier);
+      const state = this.mcpOAuthService.generateState();
+
+      // 4. Store pending flow
+      this.mcpOAuthService.storePendingFlow(state, {
+        codeVerifier,
+        connectorId: connector.id,
+        userId: req.user.sub,
+        redirectUri: callbackUrl,
+        clientId,
+        clientSecret,
+        tokenUrl: metadata.token_endpoint,
+        createdAt: Date.now(),
+      });
+
+      // 5. Build authorization URL
+      const authorizationUrl = this.mcpOAuthService.buildAuthorizationUrl({
+        authorizationEndpoint: metadata.authorization_endpoint,
+        clientId,
+        redirectUri: callbackUrl,
+        codeChallenge,
+        state,
+        scope: metadata.scopes_supported?.join(' '),
+      });
+
+      return { authorizationUrl };
+    } catch (error: any) {
+      this.logger.error(`OAuth initiation failed for connector ${id}: ${error.message}`);
+      return { error: `OAuth initiation failed: ${error.message}` };
+    }
+  }
+
+  @Post(':id/discover-tools')
+  @ApiOperation({
+    summary: 'Discover and import tools from a remote MCP server',
+    description:
+      'Connects to the remote MCP server using stored credentials, ' +
+      'lists all available tools, and imports them as MCP tools.',
+  })
+  async discoverMcpTools(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id, req.user.sub);
+
+    if (connector.type !== 'MCP') {
+      return { error: 'Tool discovery is only available for MCP connectors' };
+    }
+
+    try {
+      const authConfig = connector.authConfig
+        ? JSON.parse(decrypt(connector.authConfig, this.encryptionKey))
+        : undefined;
+
+      const remoteTools = await this.mcpClientEngine.listTools({
+        baseUrl: connector.baseUrl,
+        authType: connector.authType,
+        authConfig,
+        headers: connector.headers as Record<string, string>,
+      });
+
+      const parsedTools = remoteTools.map((rt) => ({
+        name: rt.name,
+        description: rt.description || `MCP tool: ${rt.name}`,
+        parameters: rt.inputSchema || { type: 'object', properties: {} },
+        endpointMapping: {
+          method: rt.name,
+          path: '/mcp',
+        },
+      }));
+
+      return this.createToolsFromParsed(connector.id, parsedTools);
+    } catch (error: any) {
+      this.logger.error(`Tool discovery failed for connector ${id}: ${error.message}`);
+      return { error: `Tool discovery failed: ${error.message}` };
+    }
   }
 
   @Post('import-all')
@@ -467,6 +606,33 @@ export class ConnectorsController {
             }
           } catch (e: any) {
             return { error: `Invalid JSON: ${e.message}` };
+          }
+          break;
+        }
+        case 'mcp': {
+          if (connector.type !== 'MCP') {
+            return { error: 'MCP import source is only available for MCP connectors' };
+          }
+          const authConfig = connector.authConfig
+            ? JSON.parse(decrypt(connector.authConfig, this.encryptionKey))
+            : undefined;
+          const remoteTools = await this.mcpClientEngine.listTools({
+            baseUrl: connector.baseUrl,
+            authType: connector.authType,
+            authConfig,
+            headers: connector.headers as Record<string, string>,
+            mcpPath: dto.url || '/mcp',
+          });
+          for (const rt of remoteTools) {
+            parsedTools.push({
+              name: rt.name,
+              description: rt.description || `MCP tool: ${rt.name}`,
+              parameters: rt.inputSchema || { type: 'object', properties: {} },
+              endpointMapping: {
+                method: rt.name,
+                path: dto.url || '/mcp',
+              },
+            });
           }
           break;
         }

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -14,6 +14,8 @@ import { WsdlParser } from './parsers/wsdl.parser';
 import { GraphqlParser } from './parsers/graphql.parser';
 import { PostmanParser } from './parsers/postman.parser';
 import { CurlParser } from './parsers/curl.parser';
+import { McpOAuthService } from './mcp-oauth.service';
+import { McpOAuthCallbackController } from './mcp-oauth-callback.controller';
 
 const ENGINES = [
   RestEngine,
@@ -28,8 +30,8 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
 
 @Module({
   imports: [McpServerModule],
-  controllers: [ConnectorsController, ToolsController],
-  providers: [ConnectorsService, ...ENGINES, ...PARSERS],
-  exports: [ConnectorsService, ...ENGINES],
+  controllers: [ConnectorsController, McpOAuthCallbackController, ToolsController],
+  providers: [ConnectorsService, McpOAuthService, ...ENGINES, ...PARSERS],
+  exports: [ConnectorsService, McpOAuthService, ...ENGINES],
 })
 export class ConnectorsModule {}

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -6,6 +6,7 @@ import { RestEngine } from './engines/rest.engine';
 import { SoapEngine } from './engines/soap.engine';
 import { GraphqlEngine } from './engines/graphql.engine';
 import { DatabaseEngine } from './engines/database.engine';
+import { McpClientEngine } from './engines/mcp-client.engine';
 import { encrypt, decrypt } from '../common/crypto/encryption.util';
 
 @Injectable()
@@ -20,6 +21,7 @@ export class ConnectorsService {
     private readonly soapEngine: SoapEngine,
     private readonly graphqlEngine: GraphqlEngine,
     private readonly databaseEngine: DatabaseEngine,
+    private readonly mcpClientEngine: McpClientEngine,
   ) {
     this.encryptionKey =
       this.configService.get<string>('ENCRYPTION_KEY') ||
@@ -168,6 +170,18 @@ export class ConnectorsService {
             authConfig,
           });
           break;
+        case 'MCP': {
+          const tools = await this.mcpClientEngine.listTools({
+            baseUrl: connector.baseUrl,
+            authType: connector.authType,
+            authConfig,
+            headers: connector.headers as Record<string, string>,
+          });
+          return {
+            ok: true,
+            message: `Connection successful — found ${tools.length} tools on remote MCP server`,
+          };
+        }
         default:
           return {
             ok: true,
@@ -220,6 +234,8 @@ export class ConnectorsService {
         return this.graphqlEngine.execute(config, endpointMapping, mergedParams);
       case 'DATABASE':
         return this.databaseEngine.execute(config, endpointMapping, mergedParams);
+      case 'MCP':
+        return this.mcpClientEngine.execute(config, endpointMapping, mergedParams);
       default:
         throw new NotFoundException(
           `Connector type '${connector.type}' not yet implemented`,

--- a/packages/backend/src/connectors/engines/mcp-client.engine.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.ts
@@ -1,10 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 @Injectable()
 export class McpClientEngine {
   private readonly logger = new Logger(McpClientEngine.name);
+
+  // In-memory cache for refreshed OAuth2 tokens (keyed by tokenUrl)
+  private tokenCache = new Map<
+    string,
+    { accessToken: string; expiresAt: number }
+  >();
 
   async execute(
     config: {
@@ -49,6 +56,92 @@ export class McpClientEngine {
       });
 
       return result;
+    } catch (error: any) {
+      // OAuth2 auto-refresh: retry once on auth error
+      if (
+        config.authType === 'OAUTH2' &&
+        config.authConfig?.refreshToken &&
+        config.authConfig?.tokenUrl &&
+        error?.message?.includes?.('401')
+      ) {
+        this.logger.debug('MCP OAuth2: token may be expired, attempting refresh...');
+        const newToken = await this.refreshOAuth2Token(config.authConfig);
+        if (newToken) {
+          const retryHeaders: Record<string, string> = { ...config.headers };
+          retryHeaders['Authorization'] = `Bearer ${newToken}`;
+
+          const retryTransport = new StreamableHTTPClientTransport(mcpUrl, {
+            requestInit: { headers: retryHeaders },
+          });
+          const retryClient = new Client({
+            name: 'anything-to-mcp-bridge',
+            version: '1.0.0',
+          });
+          try {
+            await retryClient.connect(retryTransport);
+            return await retryClient.callTool({
+              name: endpointMapping.method,
+              arguments: params,
+            });
+          } finally {
+            try { await retryClient.close(); } catch { /* ignore */ }
+          }
+        }
+      }
+      throw error;
+    } finally {
+      try {
+        await client.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+  }
+
+  /**
+   * Discover available tools on a remote MCP server.
+   */
+  async listTools(config: {
+    baseUrl: string;
+    authType: string;
+    authConfig?: Record<string, unknown>;
+    headers?: Record<string, string>;
+    mcpPath?: string;
+  }): Promise<
+    Array<{
+      name: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+    }>
+  > {
+    const mcpUrl = new URL(config.mcpPath || '/mcp', config.baseUrl);
+
+    this.logger.debug(`MCP listTools: ${mcpUrl.toString()}`);
+
+    const headers: Record<string, string> = { ...config.headers };
+    this.injectAuth(headers, config.authType, config.authConfig);
+
+    const transport = new StreamableHTTPClientTransport(mcpUrl, {
+      requestInit: { headers },
+    });
+
+    const client = new Client({
+      name: 'anything-to-mcp-bridge',
+      version: '1.0.0',
+    });
+
+    try {
+      await client.connect(transport);
+      const result = await client.listTools();
+
+      return (result.tools || []).map((tool) => ({
+        name: tool.name,
+        description: tool.description || '',
+        inputSchema: (tool.inputSchema as Record<string, unknown>) || {
+          type: 'object',
+          properties: {},
+        },
+      }));
     } finally {
       try {
         await client.close();
@@ -74,6 +167,70 @@ export class McpClientEngine {
           authConfig.apiKey,
         );
         break;
+      case 'OAUTH2': {
+        let accessToken = String(authConfig.accessToken || '');
+
+        // Check if we have a cached (refreshed) token
+        const tokenUrl = String(authConfig.tokenUrl || '');
+        if (tokenUrl) {
+          const cached = this.tokenCache.get(tokenUrl);
+          if (cached && cached.expiresAt > Date.now()) {
+            accessToken = cached.accessToken;
+          }
+        }
+
+        if (accessToken) {
+          headers['Authorization'] = `Bearer ${accessToken}`;
+        }
+        break;
+      }
+    }
+  }
+
+  private async refreshOAuth2Token(
+    authConfig: Record<string, unknown>,
+  ): Promise<string | null> {
+    const tokenUrl = String(authConfig.tokenUrl);
+    const refreshToken = String(authConfig.refreshToken);
+    const clientId = authConfig.clientId
+      ? String(authConfig.clientId)
+      : undefined;
+    const clientSecret = authConfig.clientSecret
+      ? String(authConfig.clientSecret)
+      : undefined;
+
+    try {
+      const body: Record<string, string> = {
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      };
+      if (clientId) body.client_id = clientId;
+      if (clientSecret) body.client_secret = clientSecret;
+
+      const response = await axios.post(
+        tokenUrl,
+        new URLSearchParams(body).toString(),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          timeout: 10000,
+        },
+      );
+
+      const { access_token, expires_in } = response.data;
+      if (!access_token) return null;
+
+      // Cache the new token (default 1 hour if no expires_in)
+      const expiresInMs = (expires_in || 3600) * 1000;
+      this.tokenCache.set(tokenUrl, {
+        accessToken: access_token,
+        expiresAt: Date.now() + expiresInMs - 60000, // refresh 1 min early
+      });
+
+      this.logger.debug('MCP OAuth2: token refreshed successfully');
+      return access_token;
+    } catch (err: any) {
+      this.logger.warn(`MCP OAuth2 token refresh failed: ${err.message}`);
+      return null;
     }
   }
 }

--- a/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
+++ b/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
@@ -1,0 +1,159 @@
+import { Controller, Get, Query, Res, Logger } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+import type { Response } from 'express';
+import { McpOAuthService } from './mcp-oauth.service';
+import { ConnectorsService } from './connectors.service';
+import { McpClientEngine } from './engines/mcp-client.engine';
+import { PrismaService } from '../common/prisma.service';
+import { McpServerService } from '../mcp-server/mcp-server.service';
+
+/**
+ * Separate controller for the OAuth2 callback — no JWT guard.
+ * The remote MCP server redirects the user's browser here after login.
+ */
+@ApiTags('MCP OAuth')
+@Controller('api/mcp-oauth')
+export class McpOAuthCallbackController {
+  private readonly logger = new Logger(McpOAuthCallbackController.name);
+
+  constructor(
+    private readonly mcpOAuthService: McpOAuthService,
+    private readonly connectorsService: ConnectorsService,
+    private readonly mcpClientEngine: McpClientEngine,
+    private readonly prisma: PrismaService,
+    private readonly mcpServer: McpServerService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Get('callback')
+  @ApiOperation({
+    summary: 'OAuth2 callback handler for MCP connector authorization',
+    description:
+      'Handles the redirect from a remote MCP server after user authorization. ' +
+      'Exchanges the auth code for tokens and auto-discovers MCP tools.',
+  })
+  async oauthCallback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Res() res: Response,
+  ) {
+    const frontendUrl =
+      this.configService.get<string>('FRONTEND_URL') || 'http://localhost:3000';
+
+    if (!code || !state) {
+      return res.redirect(
+        `${frontendUrl}/connectors?error=${encodeURIComponent('Missing code or state in OAuth callback')}`,
+      );
+    }
+
+    const flow = this.mcpOAuthService.getPendingFlow(state);
+    if (!flow) {
+      this.logger.warn(`OAuth callback with unknown state: ${state}`);
+      return res.redirect(
+        `${frontendUrl}/connectors?error=${encodeURIComponent('OAuth session expired or invalid state')}`,
+      );
+    }
+
+    try {
+      // 1. Exchange auth code for tokens
+      const tokens = await this.mcpOAuthService.exchangeCodeForTokens({
+        tokenUrl: flow.tokenUrl,
+        code,
+        redirectUri: flow.redirectUri,
+        clientId: flow.clientId,
+        clientSecret: flow.clientSecret,
+        codeVerifier: flow.codeVerifier,
+      });
+
+      this.logger.log(
+        `OAuth tokens obtained for connector ${flow.connectorId}`,
+      );
+
+      // 2. Store tokens (encrypted) in the connector's authConfig
+      await this.connectorsService.update(
+        flow.connectorId,
+        flow.userId,
+        {
+          authConfig: {
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            tokenUrl: flow.tokenUrl,
+            clientId: flow.clientId,
+            clientSecret: flow.clientSecret,
+            expiresIn: tokens.expiresIn,
+            authorizedAt: new Date().toISOString(),
+          },
+        },
+      );
+
+      // 3. Auto-discover tools from the remote MCP server
+      let toolsImported = 0;
+      try {
+        const connector = await this.connectorsService.findByIdInternal(
+          flow.connectorId,
+        );
+
+        const remoteTools = await this.mcpClientEngine.listTools({
+          baseUrl: connector.baseUrl,
+          authType: 'OAUTH2',
+          authConfig: {
+            accessToken: tokens.accessToken,
+          },
+          headers: connector.headers as Record<string, string>,
+        });
+
+        for (const rt of remoteTools) {
+          try {
+            await this.prisma.mcpTool.create({
+              data: {
+                connectorId: flow.connectorId,
+                name: rt.name,
+                description: rt.description || `MCP tool: ${rt.name}`,
+                parameters: rt.inputSchema as any,
+                endpointMapping: {
+                  method: rt.name,
+                  path: '/mcp',
+                } as any,
+              },
+            });
+            toolsImported++;
+          } catch (err: any) {
+            // Skip duplicates
+            if (err.code !== 'P2002') {
+              this.logger.warn(
+                `Failed to import tool ${rt.name}: ${err.message}`,
+              );
+            }
+          }
+        }
+
+        await this.mcpServer.reloadConnectorTools(flow.connectorId);
+
+        this.logger.log(
+          `Auto-discovered ${toolsImported} tools for connector ${flow.connectorId}`,
+        );
+      } catch (discoverErr: any) {
+        this.logger.warn(
+          `Tool discovery failed after OAuth (will proceed anyway): ${discoverErr.message}`,
+        );
+      }
+
+      // 4. Clean up
+      this.mcpOAuthService.deletePendingFlow(state);
+
+      // 5. Redirect to frontend
+      return res.redirect(
+        `${frontendUrl}/connectors/${flow.connectorId}?oauth=success&tools=${toolsImported}`,
+      );
+    } catch (error: any) {
+      this.logger.error(
+        `OAuth callback failed for connector ${flow.connectorId}: ${error.message}`,
+      );
+      this.mcpOAuthService.deletePendingFlow(state);
+      return res.redirect(
+        `${frontendUrl}/connectors/${flow.connectorId}?oauth=error&message=${encodeURIComponent(error.message)}`,
+      );
+    }
+  }
+}

--- a/packages/backend/src/connectors/mcp-oauth.service.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.ts
@@ -1,0 +1,234 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import axios from 'axios';
+
+interface OAuthMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  scopes_supported?: string[];
+  code_challenge_methods_supported?: string[];
+}
+
+interface PendingOAuthFlow {
+  codeVerifier: string;
+  connectorId: string;
+  userId: string;
+  redirectUri: string;
+  clientId: string;
+  clientSecret?: string;
+  tokenUrl: string;
+  createdAt: number;
+}
+
+@Injectable()
+export class McpOAuthService {
+  private readonly logger = new Logger(McpOAuthService.name);
+
+  // In-memory store for pending OAuth flows, keyed by state.
+  // Entries auto-expire after 10 minutes.
+  private pendingFlows = new Map<string, PendingOAuthFlow>();
+
+  /**
+   * Fetch OAuth Authorization Server Metadata (RFC 8414)
+   * from a remote MCP server's .well-known endpoint.
+   *
+   * If the metadata contains endpoint URLs with a different origin than the
+   * actual server (common misconfiguration), they are rebased automatically.
+   */
+  async discoverMetadata(baseUrl: string): Promise<OAuthMetadata> {
+    const actualOrigin = new URL(baseUrl).origin;
+
+    // Try the standard well-known path
+    const metadataUrl = new URL(
+      '/.well-known/oauth-authorization-server',
+      baseUrl,
+    ).toString();
+
+    this.logger.debug(`Discovering OAuth metadata from ${metadataUrl}`);
+
+    const response = await axios.get(metadataUrl, { timeout: 10000 });
+    const metadata: OAuthMetadata = response.data;
+
+    // Rebase endpoint URLs if the remote server reports a different origin
+    // (e.g. the server's OAUTH_SERVER_URL env var is misconfigured).
+    const rebase = (endpoint: string): string => {
+      try {
+        const parsed = new URL(endpoint);
+        if (parsed.origin !== actualOrigin) {
+          this.logger.warn(
+            `Rebasing OAuth endpoint from ${parsed.origin} → ${actualOrigin} (${parsed.pathname})`,
+          );
+          return `${actualOrigin}${parsed.pathname}${parsed.search}`;
+        }
+        return endpoint;
+      } catch {
+        return endpoint;
+      }
+    };
+
+    metadata.issuer = rebase(metadata.issuer);
+    metadata.authorization_endpoint = rebase(metadata.authorization_endpoint);
+    metadata.token_endpoint = rebase(metadata.token_endpoint);
+    if (metadata.registration_endpoint) {
+      metadata.registration_endpoint = rebase(metadata.registration_endpoint);
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Register as an OAuth client via RFC 7591 Dynamic Client Registration.
+   */
+  async registerClient(
+    registrationEndpoint: string,
+    callbackUrl: string,
+  ): Promise<{ clientId: string; clientSecret?: string }> {
+    this.logger.debug(
+      `Registering OAuth client at ${registrationEndpoint}`,
+    );
+
+    const response = await axios.post(
+      registrationEndpoint,
+      {
+        client_name: 'AnythingToMCP Bridge',
+        redirect_uris: [callbackUrl],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'client_secret_post',
+      },
+      { timeout: 10000 },
+    );
+
+    const clientId = response.data?.client_id;
+    if (!clientId) {
+      throw new Error(
+        'Dynamic client registration failed: server did not return a client_id',
+      );
+    }
+
+    return {
+      clientId,
+      clientSecret: response.data.client_secret,
+    };
+  }
+
+  /**
+   * Build the authorization URL with PKCE S256 challenge.
+   */
+  buildAuthorizationUrl(params: {
+    authorizationEndpoint: string;
+    clientId: string;
+    redirectUri: string;
+    codeChallenge: string;
+    state: string;
+    scope?: string;
+  }): string {
+    const url = new URL(params.authorizationEndpoint);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', params.clientId);
+    url.searchParams.set('redirect_uri', params.redirectUri);
+    url.searchParams.set('code_challenge', params.codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    url.searchParams.set('state', params.state);
+    if (params.scope) {
+      url.searchParams.set('scope', params.scope);
+    }
+    return url.toString();
+  }
+
+  /**
+   * Exchange an authorization code for tokens (with PKCE verifier).
+   */
+  async exchangeCodeForTokens(params: {
+    tokenUrl: string;
+    code: string;
+    redirectUri: string;
+    clientId: string;
+    clientSecret?: string;
+    codeVerifier: string;
+  }): Promise<{
+    accessToken: string;
+    refreshToken?: string;
+    expiresIn?: number;
+  }> {
+    const body: Record<string, string> = {
+      grant_type: 'authorization_code',
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: params.clientId,
+      code_verifier: params.codeVerifier,
+    };
+    if (params.clientSecret) {
+      body.client_secret = params.clientSecret;
+    }
+
+    this.logger.debug(`Exchanging auth code at ${params.tokenUrl}`);
+
+    const response = await axios.post(
+      params.tokenUrl,
+      new URLSearchParams(body).toString(),
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        timeout: 10000,
+      },
+    );
+
+    const data = response.data;
+    if (data.error) {
+      throw new Error(`Token exchange failed: ${data.error} — ${data.error_description || ''}`);
+    }
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresIn: data.expires_in,
+    };
+  }
+
+  // --- PKCE Helpers ---
+
+  generateCodeVerifier(): string {
+    return randomBytes(32).toString('base64url');
+  }
+
+  generateCodeChallenge(verifier: string): string {
+    return createHash('sha256').update(verifier).digest('base64url');
+  }
+
+  generateState(): string {
+    return randomBytes(16).toString('hex');
+  }
+
+  // --- Pending Flow Storage ---
+
+  storePendingFlow(state: string, data: PendingOAuthFlow): void {
+    // Clean up expired entries (>10 min)
+    const now = Date.now();
+    for (const [key, flow] of this.pendingFlows) {
+      if (now - flow.createdAt > 10 * 60 * 1000) {
+        this.pendingFlows.delete(key);
+      }
+    }
+
+    this.pendingFlows.set(state, data);
+  }
+
+  getPendingFlow(state: string): PendingOAuthFlow | undefined {
+    const flow = this.pendingFlows.get(state);
+    if (!flow) return undefined;
+
+    // Check expiry
+    if (Date.now() - flow.createdAt > 10 * 60 * 1000) {
+      this.pendingFlows.delete(state);
+      return undefined;
+    }
+
+    return flow;
+  }
+
+  deletePendingFlow(state: string): void {
+    this.pendingFlows.delete(state);
+  }
+}

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
 import { connectors, tools } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
@@ -15,17 +15,23 @@ const IMPORT_SOURCES = [
   { id: 'graphql', label: 'GraphQL Introspection', placeholder: 'Enter GraphQL endpoint URL...' },
   { id: 'wsdl', label: 'WSDL', placeholder: 'Enter WSDL URL...' },
   { id: 'json', label: 'JSON Definition', placeholder: '[\n  {\n    "name": "get_users",\n    "description": "Fetch users",\n    "parameters": { "type": "object", "properties": { "limit": { "type": "number" } } },\n    "endpointMapping": { "method": "GET", "path": "/users", "queryParams": { "limit": "$limit" } }\n  }\n]' },
+  { id: 'mcp', label: 'MCP Discovery', placeholder: 'Enter MCP endpoint path (default: /mcp)' },
 ];
 
 export default function ConnectorDetailPage() {
   const { token } = useAuth();
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const id = params.id as string;
 
   const [connector, setConnector] = useState<any>(null);
   const [toolList, setToolList] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // OAuth + MCP discovery
+  const [authorizing, setAuthorizing] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState('');
   const [editBaseUrl, setEditBaseUrl] = useState('');
@@ -85,6 +91,23 @@ export default function ConnectorDetailPage() {
   };
 
   useEffect(() => {
+    // Handle OAuth callback query params
+    const oauthStatus = searchParams.get('oauth');
+    if (oauthStatus === 'success') {
+      const toolsImported = searchParams.get('tools');
+      setMsg(
+        toolsImported && Number(toolsImported) > 0
+          ? `OAuth2 authorization successful! ${toolsImported} tools discovered and imported.`
+          : 'OAuth2 authorization successful! You can now discover tools.',
+      );
+      // Clean URL
+      window.history.replaceState({}, '', `/connectors/${id}`);
+    } else if (oauthStatus === 'error') {
+      const message = searchParams.get('message') || 'Authorization failed';
+      setMsg(`OAuth2 error: ${message}`);
+      window.history.replaceState({}, '', `/connectors/${id}`);
+    }
+
     fetchConnector();
   }, [token, id]);
 
@@ -290,6 +313,41 @@ export default function ConnectorDetailPage() {
     }
   };
 
+  const handleOAuthAuthorize = async () => {
+    if (!token) return;
+    setAuthorizing(true);
+    try {
+      const result = await connectors.oauthAuthorize(id, token);
+      if (result.authorizationUrl) {
+        window.location.href = result.authorizationUrl;
+      } else if (result.error) {
+        setMsg(result.error);
+      }
+    } catch (err: any) {
+      setMsg(`Authorization failed: ${err.message}`);
+    } finally {
+      setAuthorizing(false);
+    }
+  };
+
+  const handleDiscoverTools = async () => {
+    if (!token) return;
+    setDiscovering(true);
+    try {
+      const result = await connectors.discoverTools(id, token);
+      if (result.error) {
+        setMsg(result.error);
+      } else {
+        setMsg(result.message);
+        fetchConnector();
+      }
+    } catch (err: any) {
+      setMsg(`Discovery failed: ${err.message}`);
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
 
   if (loading) {
     return (
@@ -477,6 +535,32 @@ export default function ConnectorDetailPage() {
           )}
         </div>
 
+        {/* OAuth2 Authorization (MCP + OAUTH2 only) */}
+        {connector.type === 'MCP' && connector.authType === 'OAUTH2' && (
+          <div className="border border-[var(--border)] rounded-lg p-6">
+            <h3 className="text-lg font-medium mb-2">OAuth2 Authorization</h3>
+            <p className="text-sm text-[var(--muted-foreground)] mb-4">
+              Authorize this connector to access the remote MCP server. After authorization, tools will be automatically discovered.
+            </p>
+            <div className="flex gap-3 flex-wrap">
+              <button
+                onClick={handleOAuthAuthorize}
+                disabled={authorizing}
+                className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90 disabled:opacity-50"
+              >
+                {authorizing ? 'Redirecting...' : 'Authorize with Remote Server'}
+              </button>
+              <button
+                onClick={handleDiscoverTools}
+                disabled={discovering}
+                className="border border-[var(--border)] px-4 py-2 rounded-md text-sm font-medium hover:bg-[var(--accent)] disabled:opacity-50"
+              >
+                {discovering ? 'Discovering...' : 'Re-discover Tools'}
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Environment Variables */}
         <div className="border border-[var(--border)] rounded-lg p-6">
           <div className="flex items-center justify-between mb-4">
@@ -567,6 +651,15 @@ export default function ConnectorDetailPage() {
                   className="border border-[var(--border)] px-3 py-1.5 rounded text-sm hover:bg-[var(--accent)]"
                 >
                   Auto-Import from Spec
+                </button>
+              )}
+              {connector.type === 'MCP' && (
+                <button
+                  onClick={handleDiscoverTools}
+                  disabled={discovering}
+                  className="border border-purple-300 text-purple-700 dark:border-purple-500/30 dark:text-purple-400 px-3 py-1.5 rounded text-sm hover:bg-purple-50 dark:hover:bg-purple-500/10 disabled:opacity-50"
+                >
+                  {discovering ? 'Discovering...' : 'Discover from MCP Server'}
                 </button>
               )}
               <button

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -77,7 +77,12 @@ export default function NewConnectorPage() {
         } catch {}
       }
 
-      router.push('/connectors');
+      // For MCP+OAuth2 connectors, redirect to the detail page so the user can authorize
+      if (selectedType === 'MCP' && authType === 'OAUTH2') {
+        router.push(`/connectors/${created.id}`);
+      } else {
+        router.push('/connectors');
+      }
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -226,6 +231,12 @@ export default function NewConnectorPage() {
                   <option value="OAUTH2">OAuth 2.0</option>
                 </select>
               </div>
+
+              {selectedType === 'MCP' && authType === 'OAUTH2' && (
+                <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
+                  After creating the connector, you will be redirected to authorize with the remote MCP server via OAuth. Tools will be discovered automatically after authorization.
+                </div>
+              )}
 
               {authType === 'API_KEY' && (
                 <div className="grid grid-cols-2 gap-4">

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -111,6 +111,16 @@ export const connectors = {
     request<{ message: string; created: number; skipped: number; tools: number }>('/api/connectors/import-all', { method: 'POST', body: data, token }),
   healthCheck: (token: string) =>
     request<{ total: number; healthy: number; unhealthy: number; connectors: any[] }>('/api/connectors/health-check', { token }),
+  oauthAuthorize: (id: string, token: string) =>
+    request<{ authorizationUrl?: string; error?: string }>(
+      `/api/connectors/${id}/oauth/authorize`,
+      { method: 'POST', token },
+    ),
+  discoverTools: (id: string, token: string) =>
+    request<{ message: string; tools: any[]; skipped?: string[]; error?: string }>(
+      `/api/connectors/${id}/discover-tools`,
+      { method: 'POST', token },
+    ),
 };
 
 // Tools


### PR DESCRIPTION
## Summary
- Add OAuth 2.1 + PKCE authorization flow for MCP-type connectors
- Auto-discover tools from remote MCP servers via `listTools()`
- Execute MCP tools through the bridge via `callTool()`
- Rebase OAuth metadata URLs when remote server has misconfigured origin
- Frontend UI: OAuth authorize button, discover tools button, callback handling

## Test plan
- [x] Create MCP connector with OAUTH2 auth type
- [x] Click "Authorize" → redirected to remote server login
- [x] After login → redirected back with tokens + tools discovered
- [x] Test tool execution via "Run Test"
- [x] Test connection shows tool count