### PR TITLE
feat: audit logs with user identity, MCP server tracking, and UI improvements

### DIFF
--- a/packages/backend/prisma/migrations/20260304135618_add_mcp_server_to_invocations/migration.sql
+++ b/packages/backend/prisma/migrations/20260304135618_add_mcp_server_to_invocations/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "tool_invocations" ADD COLUMN "mcp_server_id" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "tool_invocations" ADD CONSTRAINT "tool_invocations_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_server_configs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "tool_invocations_mcp_server_id_created_at_idx" ON "tool_invocations"("mcp_server_id", "created_at");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -288,8 +288,9 @@ model McpServerConfig {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  connectors McpServerConnector[]
-  apiKeys    McpApiKey[]
+  connectors      McpServerConnector[]
+  apiKeys         McpApiKey[]
+  toolInvocations ToolInvocation[]
 
   @@unique([userId, slug])
   @@map("mcp_server_configs")
@@ -325,18 +326,22 @@ model ToolInvocation {
   userId String? @map("user_id")
   user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
 
+  mcpServerId String?          @map("mcp_server_id")
+  mcpServer   McpServerConfig? @relation(fields: [mcpServerId], references: [id], onDelete: SetNull)
+
   input      Json
   output     Json?
   status     InvocationStatus
   durationMs Int?              @map("duration_ms")
   error      String?           @db.Text
 
-  clientInfo String? @map("client_info") // e.g. "Claude Desktop", "Cursor"
+  clientInfo String? @map("client_info") // JSON: {authMethod, apiKeyName, userEmail, mcpServerName}
 
   createdAt DateTime @default(now()) @map("created_at")
 
   @@index([toolId, createdAt])
   @@index([userId, createdAt])
+  @@index([mcpServerId, createdAt])
   @@map("tool_invocations")
 }
 

--- a/packages/backend/src/audit/audit.controller.ts
+++ b/packages/backend/src/audit/audit.controller.ts
@@ -18,6 +18,7 @@ export class AuditController {
   @ApiQuery({ name: 'status', required: false, enum: ['SUCCESS', 'ERROR', 'TIMEOUT'] })
   @ApiQuery({ name: 'search', required: false, type: String })
   @ApiQuery({ name: 'connectorId', required: false, type: String })
+  @ApiQuery({ name: 'mcpServerId', required: false, type: String })
   async listInvocations(
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
@@ -25,11 +26,12 @@ export class AuditController {
     @Query('status') status?: 'SUCCESS' | 'ERROR' | 'TIMEOUT',
     @Query('search') search?: string,
     @Query('connectorId') connectorId?: string,
+    @Query('mcpServerId') mcpServerId?: string,
   ) {
     return this.auditService.getRecentInvocations(
       limit ? parseInt(limit, 10) : 100,
       offset ? parseInt(offset, 10) : 0,
-      { toolId, status: status as any, search, connectorId },
+      { toolId, status: status as any, search, connectorId, mcpServerId },
     );
   }
 

--- a/packages/backend/src/audit/audit.service.ts
+++ b/packages/backend/src/audit/audit.service.ts
@@ -11,6 +11,7 @@ export class AuditService {
   async logInvocation(data: {
     toolId: string;
     userId?: string;
+    mcpServerId?: string;
     input: Record<string, unknown>;
     output?: Record<string, unknown>;
     status: 'SUCCESS' | 'ERROR' | 'TIMEOUT';
@@ -23,6 +24,7 @@ export class AuditService {
         data: {
           toolId: data.toolId,
           userId: data.userId,
+          mcpServerId: data.mcpServerId,
           input: data.input as any,
           output: data.output as any,
           status: data.status as InvocationStatus,
@@ -32,6 +34,29 @@ export class AuditService {
         },
       });
     } catch (error: any) {
+      // FK violation on userId — retry without userId (user info is still in clientInfo)
+      if (error.message?.includes('user_id_fkey') && data.userId) {
+        try {
+          await this.prisma.toolInvocation.create({
+            data: {
+              toolId: data.toolId,
+              mcpServerId: data.mcpServerId,
+              input: data.input as any,
+              output: data.output as any,
+              status: data.status as InvocationStatus,
+              durationMs: data.durationMs,
+              error: data.error,
+              clientInfo: data.clientInfo,
+            },
+          });
+          return;
+        } catch (retryError: any) {
+          this.logger.warn(
+            `Failed to persist invocation for tool ${data.toolId} (retry): ${retryError.message}`,
+          );
+          return;
+        }
+      }
       this.logger.warn(
         `Failed to persist invocation for tool ${data.toolId}: ${error.message}`,
       );
@@ -49,11 +74,13 @@ export class AuditService {
       status?: InvocationStatus;
       search?: string;
       connectorId?: string;
+      mcpServerId?: string;
     },
   ) {
     const where: any = {};
     if (filters?.toolId) where.toolId = filters.toolId;
     if (filters?.status) where.status = filters.status;
+    if (filters?.mcpServerId) where.mcpServerId = filters.mcpServerId;
     if (filters?.search) {
       where.tool = { name: { contains: filters.search, mode: 'insensitive' } };
     }
@@ -73,6 +100,12 @@ export class AuditService {
             connectorId: true,
             connector: { select: { name: true, type: true } },
           },
+        },
+        user: {
+          select: { id: true, email: true, name: true },
+        },
+        mcpServer: {
+          select: { id: true, name: true, slug: true },
         },
       },
     });

--- a/packages/backend/src/auth/local-oauth.strategy.ts
+++ b/packages/backend/src/auth/local-oauth.strategy.ts
@@ -38,6 +38,20 @@ export class LocalOAuthStrategy extends Strategy {
   }
 
   authenticate(req: Request): void {
+    // Workaround: @rekog/mcp-nest's authorize endpoint calls
+    // passport.authenticate() without { session: false }, so passport
+    // tries to serialize the user to a session that doesn't exist.
+    // Patch req.logIn to always disable sessions.
+    const origLogIn = req.logIn;
+    if (origLogIn) {
+      req.logIn = function (user: any, optionsOrDone?: any, done?: any) {
+        if (typeof optionsOrDone === 'function') {
+          return origLogIn.call(this, user, { session: false }, optionsOrDone);
+        }
+        return origLogIn.call(this, user, { ...optionsOrDone, session: false }, done);
+      } as any;
+    }
+
     // Check if the user has already authenticated via the login form
     // (login controller sets a signed cookie with user profile)
     const loginUserCookie = (req as any).cookies?.login_user;

--- a/packages/backend/src/auth/mcp-auth.middleware.ts
+++ b/packages/backend/src/auth/mcp-auth.middleware.ts
@@ -38,7 +38,11 @@ export class McpAuthMiddleware implements NestMiddleware {
     if (apiKey?.startsWith('mcp_')) {
       const user = await this.mcpApiKeysService.resolveUserByKey(apiKey);
       if (user) {
-        (req as any).user = { sub: user.id, email: user.email, role: user.role, mcpRoleId: user.mcpRoleId, mcpServerId: user.mcpServerId };
+        (req as any).user = {
+          sub: user.id, email: user.email, role: user.role,
+          mcpRoleId: user.mcpRoleId, mcpServerId: user.mcpServerId,
+          authMethod: 'mcp_api_key', apiKeyName: user.apiKeyName,
+        };
         return next();
       }
       // Invalid per-user key — fall through to 401
@@ -46,11 +50,13 @@ export class McpAuthMiddleware implements NestMiddleware {
 
     // If no auth is configured, allow all (dev mode)
     if (!configuredApiKey && !mcpBearerToken) {
+      (req as any).user = { authMethod: 'none' };
       return next();
     }
 
     // Check static API key
     if (apiKey && configuredApiKey && apiKey === configuredApiKey) {
+      (req as any).user = { authMethod: 'static_api_key' };
       return next();
     }
 
@@ -60,13 +66,14 @@ export class McpAuthMiddleware implements NestMiddleware {
 
       // Static MCP bearer token
       if (mcpBearerToken && token === mcpBearerToken) {
+        (req as any).user = { authMethod: 'static_bearer' };
         return next();
       }
 
       // JWT token
       try {
         const payload = this.authService.verifyToken(token);
-        (req as any).user = payload;
+        (req as any).user = { ...payload, authMethod: 'jwt' };
         return next();
       } catch {
         // Invalid JWT — fall through to 401

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -45,6 +45,8 @@ export class McpCombinedAuthGuard implements CanActivate {
           role: user.role,
           mcpRoleId: user.mcpRoleId,
           mcpServerId: user.mcpServerId,
+          authMethod: 'mcp_api_key',
+          apiKeyName: user.apiKeyName,
         };
         return true;
       }
@@ -53,6 +55,7 @@ export class McpCombinedAuthGuard implements CanActivate {
 
     // 2. Check static API key (legacy mode)
     if (apiKey && configuredApiKey && apiKey === configuredApiKey) {
+      req.user = { authMethod: 'static_api_key' };
       return true;
     }
 
@@ -62,13 +65,14 @@ export class McpCombinedAuthGuard implements CanActivate {
 
       // Static MCP bearer token
       if (mcpBearerToken && token === mcpBearerToken) {
+        req.user = { authMethod: 'static_bearer' };
         return true;
       }
 
       // JWT token (OAuth or legacy JWT)
       try {
         const payload = this.authService.verifyToken(token);
-        req.user = payload;
+        req.user = { ...payload, authMethod: 'jwt' };
         return true;
       } catch {
         // Invalid JWT — continue
@@ -77,11 +81,13 @@ export class McpCombinedAuthGuard implements CanActivate {
 
     // 4. If auth mode is 'none', allow all
     if (mode === 'none') {
+      req.user = { authMethod: 'none' };
       return true;
     }
 
     // 5. If no auth is configured at all (dev mode), allow
     if (!configuredApiKey && !mcpBearerToken && mode !== 'oauth2') {
+      req.user = { authMethod: 'none' };
       return true;
     }
 

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -39,6 +39,14 @@ export class DynamicMcpTools {
   async executeTool(
     toolName: string,
     params: Record<string, unknown>,
+    context?: {
+      userId?: string;
+      userEmail?: string;
+      authMethod?: string;
+      apiKeyName?: string;
+      mcpServerId?: string;
+      mcpServerName?: string;
+    },
   ): Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }> {
     const tool = this.toolRegistry.getTool(toolName);
     if (!tool) {
@@ -114,10 +122,18 @@ export class DynamicMcpTools {
 
       await this.auditService.logInvocation({
         toolId: tool.id,
+        userId: context?.userId,
+        mcpServerId: context?.mcpServerId,
         input: params,
         output: result as Record<string, unknown>,
         status: 'SUCCESS',
         durationMs,
+        clientInfo: context ? JSON.stringify({
+          authMethod: context.authMethod,
+          apiKeyName: context.apiKeyName,
+          userEmail: context.userEmail,
+          mcpServerName: context.mcpServerName,
+        }) : undefined,
       });
 
       const resultText = JSON.stringify(result, null, 2);
@@ -140,12 +156,20 @@ export class DynamicMcpTools {
 
       await this.auditService.logInvocation({
         toolId: tool.id,
+        userId: context?.userId,
+        mcpServerId: context?.mcpServerId,
         input: params,
         status: 'ERROR',
         durationMs,
         error: errorDetail.status
           ? `${errorDetail.status} ${errorDetail.statusText || ''}: ${errorDetail.error}`
           : String(errorDetail.error),
+        clientInfo: context ? JSON.stringify({
+          authMethod: context.authMethod,
+          apiKeyName: context.apiKeyName,
+          userEmail: context.userEmail,
+          mcpServerName: context.mcpServerName,
+        }) : undefined,
       });
 
       return {

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -125,6 +125,17 @@ export class McpEndpointController {
       { name: mcpServerConfig.name, version: mcpServerConfig.version || '1.0.0' },
     );
 
+    // Build invocation context for audit logging
+    // OAuth JWTs store email inside user_data, app JWTs have it top-level
+    const invocationContext = {
+      userId: user?.sub as string | undefined,
+      userEmail: (user?.email || user?.user_data?.email) as string | undefined,
+      authMethod: (user?.authMethod || 'none') as string,
+      apiKeyName: user?.apiKeyName as string | undefined,
+      mcpServerId: mcpServerConfig.id,
+      mcpServerName: mcpServerConfig.name,
+    };
+
     for (const tool of serverTools) {
       // Skip tools not allowed by role
       if (allowedToolIds !== null && !allowedToolIds.includes(tool.id)) {
@@ -135,7 +146,7 @@ export class McpEndpointController {
       const zodShape = this.jsonSchemaToZodShape(schema);
 
       mcpServer.tool(tool.name, tool.description, zodShape, async (args: any) => {
-        const result = await this.toolExecutor.executeTool(tool.name, args);
+        const result = await this.toolExecutor.executeTool(tool.name, args, invocationContext);
         return result;
       });
     }

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -195,7 +195,16 @@ export class McpServerService implements OnModuleInit {
           }
         }
 
-        return this.toolExecutor.executeTool(name, args);
+        // OAuth JWTs store email inside user_data, app JWTs have it top-level
+        const invocationContext = {
+          userId: user?.sub,
+          userEmail: user?.email || user?.user_data?.email,
+          authMethod: user?.authMethod || 'none',
+          apiKeyName: user?.apiKeyName,
+          mcpServerId: user?.mcpServerId,
+        };
+
+        return this.toolExecutor.executeTool(name, args, invocationContext);
       },
     });
   }

--- a/packages/backend/src/roles/mcp-api-keys.service.ts
+++ b/packages/backend/src/roles/mcp-api-keys.service.ts
@@ -78,6 +78,6 @@ export class McpApiKeysService {
       data: { lastUsedAt: new Date() },
     }).catch(() => {});
 
-    return { ...record.user, mcpServerId: record.mcpServerId };
+    return { ...record.user, mcpServerId: record.mcpServerId, apiKeyName: record.name };
   }
 }

--- a/packages/frontend/next-env.d.ts
+++ b/packages/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/frontend/src/app/logs/page.tsx
+++ b/packages/frontend/src/app/logs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { Fragment, useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/lib/auth-context';
 import { audit, connectors as connectorsApi } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
@@ -137,9 +137,8 @@ export default function LogsPage() {
                   </tr>
                 ) : (
                   logs.map((log) => (
-                    <>
+                    <Fragment key={log.id}>
                       <tr
-                        key={log.id}
                         onClick={() => setExpandedId(expandedId === log.id ? null : log.id)}
                         className="border-b border-[var(--border)] hover:bg-[var(--accent)] transition-colors cursor-pointer"
                       >
@@ -161,7 +160,7 @@ export default function LogsPage() {
                         <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.clientInfo || '-'}</td>
                       </tr>
                       {expandedId === log.id && (
-                        <tr key={`${log.id}-detail`}>
+                        <tr>
                           <td colSpan={6} className="px-4 py-4 bg-[var(--muted)]/50 border-b border-[var(--border)]">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-full">
                               <div>
@@ -189,7 +188,7 @@ export default function LogsPage() {
                           </td>
                         </tr>
                       )}
-                    </>
+                    </Fragment>
                   ))
                 )}
               </tbody>

--- a/packages/frontend/src/app/logs/page.tsx
+++ b/packages/frontend/src/app/logs/page.tsx
@@ -2,9 +2,49 @@
 
 import { Fragment, useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/lib/auth-context';
-import { audit, connectors as connectorsApi } from '@/lib/api';
+import { audit, connectors as connectorsApi, mcpServers } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
 import { Footer } from '@/components/footer';
+
+const PAGE_SIZE = 50;
+
+function parseClientInfo(raw: string | null | undefined) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { raw };
+  }
+}
+
+function authMethodLabel(method: string | undefined): string {
+  switch (method) {
+    case 'mcp_api_key': return 'API Key';
+    case 'jwt': return 'JWT';
+    case 'static_api_key': return 'Static Key';
+    case 'static_bearer': return 'Static Bearer';
+    case 'none': return 'No Auth';
+    default: return method || '-';
+  }
+}
+
+function UserCell({ log }: { log: any }) {
+  const ci = parseClientInfo(log.clientInfo);
+  const email = log.user?.email || ci?.userEmail;
+  const method = ci?.authMethod;
+  const keyName = ci?.apiKeyName;
+
+  if (!email && !method) return <span>-</span>;
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {email && <span className="truncate max-w-[150px]" title={email}>{email}</span>}
+      <span className="text-[10px] text-[var(--muted-foreground)]">
+        {keyName ? `${keyName}` : authMethodLabel(method)}
+      </span>
+    </div>
+  );
+}
 
 export default function LogsPage() {
   const { token } = useAuth();
@@ -13,8 +53,12 @@ export default function LogsPage() {
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [search, setSearch] = useState('');
   const [connectorFilter, setConnectorFilter] = useState<string>('');
+  const [mcpServerFilter, setMcpServerFilter] = useState<string>('');
   const [connectors, setConnectors] = useState<any[]>([]);
+  const [servers, setServers] = useState<any[]>([]);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
 
   // Debounced search
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -23,27 +67,42 @@ export default function LogsPage() {
     return () => clearTimeout(timer);
   }, [search]);
 
-  // Load connectors for filter dropdown
+  // Reset page when filters change
+  useEffect(() => {
+    setPage(0);
+  }, [statusFilter, debouncedSearch, connectorFilter, mcpServerFilter]);
+
+  // Load connectors and MCP servers for filter dropdowns
   useEffect(() => {
     if (!token) return;
     connectorsApi.list(token).then(setConnectors).catch(() => {});
+    mcpServers.list(token).then(setServers).catch(() => {});
   }, [token]);
 
-  // Load logs
-  useEffect(() => {
+  const fetchLogs = useCallback(() => {
     if (!token) return;
     setLoading(true);
     audit
       .invocations(token, {
-        limit: 200,
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
         ...(statusFilter ? { status: statusFilter } : {}),
         ...(debouncedSearch ? { search: debouncedSearch } : {}),
         ...(connectorFilter ? { connectorId: connectorFilter } : {}),
+        ...(mcpServerFilter ? { mcpServerId: mcpServerFilter } : {}),
       })
-      .then(setLogs)
+      .then((data) => {
+        setLogs(data);
+        setHasMore(data.length === PAGE_SIZE);
+      })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [token, statusFilter, debouncedSearch, connectorFilter]);
+  }, [token, page, statusFilter, debouncedSearch, connectorFilter, mcpServerFilter]);
+
+  // Load logs
+  useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs]);
 
   const formatTime = (ts: string) => {
     const d = new Date(ts);
@@ -58,6 +117,8 @@ export default function LogsPage() {
       return String(data);
     }
   };
+
+  const colSpan = 7;
 
   return (
     <div className="min-h-screen bg-[var(--background)] flex flex-col">
@@ -101,11 +162,35 @@ export default function LogsPage() {
               <option key={c.id} value={c.id}>{c.name}</option>
             ))}
           </select>
+          <select
+            value={mcpServerFilter}
+            onChange={(e) => setMcpServerFilter(e.target.value)}
+            className="border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+          >
+            <option value="">All MCP servers</option>
+            {servers.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+          <button
+            onClick={fetchLogs}
+            disabled={loading}
+            className="flex items-center gap-1.5 border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] hover:bg-[var(--accent)] transition-colors disabled:opacity-50"
+            title="Refresh"
+          >
+            <svg className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
         </div>
 
         <div className="border border-[var(--border)] rounded-lg">
-          <div className="p-4 border-b border-[var(--border)]">
-            <h3 className="font-medium">Tool Invocation Logs ({logs.length})</h3>
+          <div className="p-4 border-b border-[var(--border)] flex items-center justify-between">
+            <h3 className="font-medium">Tool Invocation Logs</h3>
+            <span className="text-sm text-[var(--muted-foreground)]">
+              Page {page + 1}{logs.length > 0 ? ` (${logs.length} results)` : ''}
+            </span>
           </div>
 
           {/* Desktop table */}
@@ -116,23 +201,24 @@ export default function LogsPage() {
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Time</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Tool</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Connector</th>
+                  <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">User</th>
+                  <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Server</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Status</th>
                   <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Duration</th>
-                  <th className="px-4 py-3 font-medium text-[var(--muted-foreground)]">Client</th>
                 </tr>
               </thead>
               <tbody>
                 {loading ? (
                   <tr>
-                    <td colSpan={6} className="px-4 py-8 text-center text-[var(--muted-foreground)]">
+                    <td colSpan={colSpan} className="px-4 py-8 text-center text-[var(--muted-foreground)]">
                       <div className="inline-block w-5 h-5 border-2 border-[var(--brand)] border-t-transparent rounded-full animate-spin mb-2"></div>
                       <p>Loading logs...</p>
                     </td>
                   </tr>
                 ) : logs.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-4 py-12 text-center text-[var(--muted-foreground)]">
-                      <p className="text-sm">No invocations found.</p>
+                    <td colSpan={colSpan} className="px-4 py-12 text-center text-[var(--muted-foreground)]">
+                      <p className="text-sm">{page > 0 ? 'No more results.' : 'No invocations found.'}</p>
                     </td>
                   </tr>
                 ) : (
@@ -147,6 +233,12 @@ export default function LogsPage() {
                         <td className="px-4 py-3 text-xs text-[var(--muted-foreground)]">
                           {log.tool?.connector?.name || '-'}
                         </td>
+                        <td className="px-4 py-3 text-xs">
+                          <UserCell log={log} />
+                        </td>
+                        <td className="px-4 py-3 text-xs text-[var(--muted-foreground)]">
+                          {log.mcpServer?.name || '-'}
+                        </td>
                         <td className="px-4 py-3">
                           <span className={`px-2 py-0.5 rounded text-xs font-medium ${
                             log.status === 'SUCCESS' ? 'bg-[var(--success-bg)] text-[var(--success-text)]' :
@@ -157,11 +249,10 @@ export default function LogsPage() {
                           </span>
                         </td>
                         <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.durationMs ? `${log.durationMs}ms` : '-'}</td>
-                        <td className="px-4 py-3 text-[var(--muted-foreground)] text-xs">{log.clientInfo || '-'}</td>
                       </tr>
                       {expandedId === log.id && (
                         <tr>
-                          <td colSpan={6} className="px-4 py-4 bg-[var(--muted)]/50 border-b border-[var(--border)]">
+                          <td colSpan={colSpan} className="px-4 py-4 bg-[var(--muted)]/50 border-b border-[var(--border)]">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-full">
                               <div>
                                 <h4 className="text-xs font-medium mb-2 text-[var(--muted-foreground)] uppercase tracking-wide">Input Parameters</h4>
@@ -178,13 +269,21 @@ export default function LogsPage() {
                                 </pre>
                               </div>
                             </div>
-                            {(log.clientInfo || log.userId) && (
-                              <div className="mt-3 flex gap-4 text-xs text-[var(--muted-foreground)]">
-                                {log.clientInfo && <span>Client: {log.clientInfo}</span>}
-                                {log.userId && <span>User: {log.userId}</span>}
-                                {log.tool?.connector && <span>Connector: {log.tool.connector.name} ({log.tool.connector.type})</span>}
-                              </div>
-                            )}
+                            <div className="mt-3 flex flex-wrap gap-4 text-xs text-[var(--muted-foreground)]">
+                              {log.user?.email && <span>User: {log.user.email}</span>}
+                              {(() => {
+                                const ci = parseClientInfo(log.clientInfo);
+                                if (!ci) return null;
+                                return (
+                                  <>
+                                    {ci.authMethod && <span>Auth: {authMethodLabel(ci.authMethod)}</span>}
+                                    {ci.apiKeyName && <span>Key: {ci.apiKeyName}</span>}
+                                  </>
+                                );
+                              })()}
+                              {log.mcpServer && <span>Server: {log.mcpServer.name}</span>}
+                              {log.tool?.connector && <span>Connector: {log.tool.connector.name} ({log.tool.connector.type})</span>}
+                            </div>
                           </td>
                         </tr>
                       )}
@@ -204,7 +303,7 @@ export default function LogsPage() {
               </div>
             ) : logs.length === 0 ? (
               <div className="px-4 py-12 text-center text-[var(--muted-foreground)]">
-                <p className="text-sm">No invocations found.</p>
+                <p className="text-sm">{page > 0 ? 'No more results.' : 'No invocations found.'}</p>
               </div>
             ) : (
               logs.map((log) => (
@@ -226,6 +325,8 @@ export default function LogsPage() {
                     <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]">
                       <span>{formatTime(log.createdAt)}</span>
                       {log.durationMs && <span>{log.durationMs}ms</span>}
+                      {log.user?.email && <span>{log.user.email}</span>}
+                      {log.mcpServer?.name && <span>{log.mcpServer.name}</span>}
                     </div>
                   </button>
                   {expandedId === log.id && (
@@ -245,7 +346,8 @@ export default function LogsPage() {
                         </pre>
                       </div>
                       <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)]">
-                        {log.clientInfo && <span>Client: {log.clientInfo}</span>}
+                        {log.user?.email && <span>User: {log.user.email}</span>}
+                        {log.mcpServer && <span>Server: {log.mcpServer.name}</span>}
                         {log.tool?.connector && <span>Connector: {log.tool.connector.name}</span>}
                       </div>
                     </div>
@@ -253,6 +355,31 @@ export default function LogsPage() {
                 </div>
               ))
             )}
+          </div>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between px-4 py-3 border-t border-[var(--border)]">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0 || loading}
+              className="flex items-center gap-1 px-3 py-1.5 text-sm border border-[var(--input)] rounded-md hover:bg-[var(--accent)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Previous
+            </button>
+            <span className="text-sm text-[var(--muted-foreground)]">Page {page + 1}</span>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!hasMore || loading}
+              className="flex items-center gap-1 px-3 py-1.5 text-sm border border-[var(--input)] rounded-md hover:bg-[var(--accent)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Next
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
           </div>
         </div>
       </main>

--- a/packages/frontend/src/components/nav-bar.tsx
+++ b/packages/frontend/src/components/nav-bar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
 
 /* Inline SVG logo component */
@@ -45,6 +45,19 @@ export function NavBar({ breadcrumbs, title, actions }: NavBarProps) {
   const { user, logout } = useAuth();
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
+        setUserMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const allNavItems = NAV_ITEMS;
 
@@ -80,18 +93,38 @@ export function NavBar({ breadcrumbs, title, actions }: NavBarProps) {
           </nav>
         </div>
         <div className="flex items-center gap-3 text-sm">
-          <div className="hidden sm:flex items-center gap-2 text-[var(--muted-foreground)]">
-            <div className="w-6 h-6 rounded-full bg-[var(--brand)] text-white flex items-center justify-center text-xs font-medium">
-              {(user?.name || user?.email || '?')[0].toUpperCase()}
-            </div>
-            <span className="max-w-[120px] truncate">{user?.email}</span>
+          {/* User dropdown (desktop) */}
+          <div className="hidden sm:block relative" ref={userMenuRef}>
+            <button
+              onClick={() => setUserMenuOpen((v) => !v)}
+              className="flex items-center gap-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] px-2 py-1.5 rounded-md hover:bg-[var(--accent)] transition-colors"
+            >
+              <div className="w-6 h-6 rounded-full bg-[var(--brand)] text-white flex items-center justify-center text-xs font-medium">
+                {(user?.name || user?.email || '?')[0].toUpperCase()}
+              </div>
+              <span className="max-w-[120px] truncate">{user?.email}</span>
+              <svg className={`w-3.5 h-3.5 transition-transform ${userMenuOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {userMenuOpen && (
+              <div className="absolute right-0 mt-1 w-48 bg-[var(--background)] border border-[var(--border)] rounded-lg shadow-lg py-1 z-50">
+                <div className="px-3 py-2 border-b border-[var(--border)]">
+                  <p className="text-xs font-medium truncate">{user?.name || user?.email}</p>
+                  {user?.name && <p className="text-xs text-[var(--muted-foreground)] truncate">{user?.email}</p>}
+                </div>
+                <button
+                  onClick={() => { setUserMenuOpen(false); logout(); }}
+                  className="w-full text-left px-3 py-2 text-sm text-[var(--destructive)] hover:bg-[var(--accent)] transition-colors flex items-center gap-2"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                  </svg>
+                  Logout
+                </button>
+              </div>
+            )}
           </div>
-          <button
-            onClick={logout}
-            className="hidden sm:block text-[var(--muted-foreground)] hover:text-[var(--destructive)] px-2 py-1 rounded text-xs"
-          >
-            Logout
-          </button>
           {/* Mobile hamburger */}
           <button
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -147,7 +147,7 @@ export const tools = {
 
 // Audit
 export const audit = {
-  invocations: (token: string, params?: { limit?: number; offset?: number; toolId?: string; status?: string; search?: string; connectorId?: string }) => {
+  invocations: (token: string, params?: { limit?: number; offset?: number; toolId?: string; status?: string; search?: string; connectorId?: string; mcpServerId?: string }) => {
     const query = new URLSearchParams();
     if (params?.limit) query.set('limit', String(params.limit));
     if (params?.offset) query.set('offset', String(params.offset));
@@ -155,6 +155,7 @@ export const audit = {
     if (params?.status) query.set('status', params.status);
     if (params?.search) query.set('search', params.search);
     if (params?.connectorId) query.set('connectorId', params.connectorId);
+    if (params?.mcpServerId) query.set('mcpServerId', params.mcpServerId);
     const qs = query.toString();
     return request<any[]>(`/api/audit/invocations${qs ? `?${qs}` : ''}`, { token });
   },


### PR DESCRIPTION
## Summary
- Track user identity (email, auth method, API key name) and MCP server per tool invocation
- Add pagination, refresh button, and MCP server filter to Logs page
- Move logout to username dropdown menu
- Fix OAuth /authorize 500 error (passport session workaround)
- Handle FK constraint on userId gracefully for OAuth JWT users