### PR TITLE
Switch license from MIT to BSL 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,76 @@
-MIT License
+Business Source License 1.1
 
-Copyright (c) 2026 Koch Freiburg
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Parameters
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Licensor:             helpcode.ai GmbH
+Licensed Work:        AnythingToMCP
+                      The Licensed Work is (c) 2026 helpcode.ai GmbH.
+Additional Use Grant: You may make use of the Licensed Work, provided that
+                      you may not use the Licensed Work for a Service.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+                      A "Service" is a commercial offering that allows
+                      third parties to access the functionality of the
+                      Licensed Work by creating server accounts on behalf
+                      of third parties, or as part of a hosted or managed
+                      service where the service provides the primary value.
+
+                      For purposes of clarity, the following uses are
+                      explicitly permitted under this Additional Use Grant:
+                      - Internal use within your organization
+                      - Personal, non-commercial use
+                      - Use for development, testing, and evaluation
+                      - Academic and educational use
+
+Change Date:          2030-03-04
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact: licensing@helpcode.ai
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above
+terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently
+in effect as described in this License, you must purchase a commercial license
+from the Licensor, its affiliated entities, or authorized resellers, or you must
+refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of
+the Licensed Work. If you receive the Licensed Work in original or modified form
+from a third party, the terms and conditions set forth in this License apply to
+your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnythingToMCP
 
-> Convert **any** API into an MCP server — self-hosted and open source.
+> Convert **any** API into an MCP server — self-hosted and source available.
 
 AnythingToMCP is a platform that lets you create dynamic [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers by connecting your existing APIs through a web interface or API calls. It acts as a **bridge** between any API (REST, SOAP, GraphQL, Database, Webhook, other MCP servers) and MCP-compatible AI clients like Claude Desktop, Claude Code, ChatGPT, Cursor, and more.
 
@@ -45,7 +45,7 @@ AnythingToMCP is a platform that lets you create dynamic [MCP (Model Context Pro
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/kochfreiburg/anything-to-mcp.git
+git clone https://github.com/HelpCode-ai/anything-to-mcp.git
 cd anything-to-mcp
 
 # 2. Configure environment
@@ -746,4 +746,12 @@ Copy `.env.example` to `.env` and configure:
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+This software is licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1).
+
+- **Free for**: internal use, personal use, development, testing, evaluation, and academic use.
+- **Not permitted**: offering the software as a commercial hosted service to third parties without a separate commercial license.
+- **Change Date**: 2030-03-04 — on this date the license automatically converts to Apache 2.0.
+
+For commercial licensing inquiries, contact [licensing@helpcode.ai](mailto:licensing@helpcode.ai).
+
+Copyright (c) 2026 helpcode.ai GmbH

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "anything-to-mcp",
   "version": "0.1.0",
-  "description": "Convert any API into an MCP server — self-hosted, open source, AI-assisted",
+  "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
-  "license": "MIT",
+  "license": "BSL-1.1",
   "workspaces": [
     "packages/backend",
     "packages/frontend"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "AnythingToMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
-  "license": "MIT",
+  "license": "BSL-1.1",
   "scripts": {
     "build": "prisma generate && nest build",
     "dev": "nest start --watch",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "AnythingToMCP — Next.js Admin UI",
   "private": true,
-  "license": "MIT",
+  "license": "BSL-1.1",
   "scripts": {
     "dev": "next dev --port 3000",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Replace MIT license with **Business Source License 1.1** (helpcode.ai GmbH as licensor)
- Free for internal, personal, dev/test, and academic use
- Prohibits offering the software as a hosted service to third parties
- Automatic conversion to Apache 2.0 on 2030-03-04
- Update all package.json files, README, and clone URL