### PR TITLE
docs: revamp README and split into modular documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,757 +1,198 @@
-# AnythingMCP
-
-> Convert **any** API into an MCP server — self-hosted and source available.
-
-AnythingMCP is a platform that lets you create dynamic [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers by connecting your existing APIs through a web interface or API calls. It acts as a **bridge** between any API (REST, SOAP, GraphQL, Database, Webhook, other MCP servers) and MCP-compatible AI clients like Claude Desktop, Claude Code, ChatGPT, Cursor, and more.
-
----
-
-## Features
-
-- **Universal Connectors**: REST (OpenAPI), SOAP (WSDL), GraphQL, MCP-to-MCP bridge, Database (PostgreSQL & MSSQL, read-only), Webhooks
-- **6 Import Formats**: OpenAPI/Swagger, Postman Collections, cURL commands, WSDL, GraphQL introspection, custom JSON definitions
-- **Dynamic MCP Server**: Tools registered at runtime — no restart required
-- **Visual Tool Editor**: Define parameters and visually configure where each maps in the API request (path, query, body, header)
-- **Database Auto-Tools**: DATABASE connectors auto-generate schema introspection, example queries (editable static text), and dynamic query execution tools
-- **Environment Variables**: Per-connector `{{VAR_NAME}}` interpolation at runtime, with automatic parameter injection for tool inputs matching env var names
-- **Bulk API**: Create connectors and tools programmatically via REST API (for Claude Code, CI/CD, scripts)
-- **Full Auth Support**: JWT + OAuth2/Bearer/API key for MCP clients, AES-256-GCM encrypted credentials
-- **Per-User MCP API Keys**: Generate individual API keys for MCP client authentication with usage tracking
-- **Custom Roles & Tool Access Control**: Create custom roles with tool-level whitelisting for fine-grained MCP access
-- **User Invitations**: Invite users via email with role and MCP role assignment
-- **Password Reset**: Secure password reset flow via email with time-limited tokens
-- **Audit Logging**: Every tool invocation is logged with input, output, duration, and status
-- **Dark/Light Theme**: System-aware theme toggle with persistent preference
-- **Site Settings**: Admin-configurable SMTP, footer links, and site-wide settings
-- **Docker Ready**: `docker compose up` and you're running
+<p align="center">
+  <h1 align="center">AnythingMCP</h1>
+  <p align="center">
+    <strong>Convert any API into an MCP server in minutes.</strong><br/>
+    REST API to MCP &bull; SOAP to MCP &bull; GraphQL to MCP &bull; Database to MCP &bull; MCP Gateway & Middleware
+  </p>
+  <p align="center">
+    <a href="https://github.com/HelpCode-ai/anythingmcp/stargazers"><img src="https://img.shields.io/github/stars/HelpCode-ai/anythingmcp?style=social" alt="GitHub Stars"></a>&nbsp;
+    <a href="https://github.com/HelpCode-ai/anythingmcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSL--1.1-blue" alt="License"></a>&nbsp;
+    <a href="https://github.com/HelpCode-ai/anythingmcp/releases"><img src="https://img.shields.io/github/v/release/HelpCode-ai/anythingmcp?include_prereleases" alt="Release"></a>&nbsp;
+    <a href="https://discord.gg/anythingmcp"><img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  </p>
+</p>
 
 ---
 
-## Table of Contents
+**AnythingMCP** is a self-hosted, open-source MCP middleware that turns your existing APIs into [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers. Connect **any** API — REST, SOAP, GraphQL, databases, or other MCP servers — and expose them as tools to AI clients like **Claude**, **ChatGPT**, **Gemini**, **Copilot**, **Cursor**, and more.
 
-- [Quick Start (Docker)](#quick-start-docker)
-- [Local Development Setup](#local-development-setup)
-- [Production Deployment](#production-deployment)
-- [Connecting AI Clients](#connecting-ai-clients)
-- [API Reference](#api-reference)
-- [Tool Definition Format](#tool-definition-format)
-- [Import Formats](#import-formats)
-- [Architecture](#architecture)
-- [Environment Variables](#environment-variables)
+No SDK. No code changes. Just point, configure, and connect.
+
+<p align="center">
+  <img src="docs/assets/architecture-overview.png" alt="AnythingMCP Architecture" width="700"/>
+</p>
+
+> **Looking for an MCP gateway?** AnythingMCP acts as a universal MCP proxy and API-to-MCP bridge — the missing middleware between your APIs and AI agents.
 
 ---
 
-## Quick Start (Docker)
+## Why AnythingMCP?
+
+| Problem | Solution |
+|---------|----------|
+| You have REST APIs but AI clients speak MCP | **REST API to MCP** conversion with OpenAPI/Swagger import |
+| You have legacy SOAP/WSDL services | **SOAP to MCP** bridge with automatic WSDL parsing |
+| You need to query databases from AI agents | **Database to MCP** with auto-generated query tools |
+| You want one MCP gateway for all your APIs | **MCP middleware** that aggregates multiple connectors |
+| You need auth, audit logs, and role-based access | Built-in **enterprise governance** layer |
+
+---
+
+## Key Features
+
+- **6 Connector Types** — [REST](docs/connectors/rest.md), [SOAP](docs/connectors/soap.md), [GraphQL](docs/connectors/graphql.md), [Database](docs/connectors/database.md) (PostgreSQL, MSSQL, MongoDB), [MCP-to-MCP Bridge](docs/connectors/mcp-bridge.md), Webhook
+- **6 Import Formats** — OpenAPI/Swagger, Postman Collections, cURL commands, WSDL, GraphQL introspection, custom JSON
+- **Dynamic MCP Server** — Tools registered at runtime, no restart needed
+- **Visual Tool Editor** — Map parameters to path, query, body, headers visually
+- **Database Auto-Tools** — Schema introspection + dynamic query execution out of the box
+- **Environment Variables** — Per-connector `{{VAR}}` interpolation, hidden from AI
+- **Full Auth** — OAuth2 (PKCE + Client Credentials), Bearer Token, API Key, Basic Auth, WS-Security, Certificates
+- **Audit Logging** — Every tool invocation logged with input, output, duration, status
+- **Roles & Access Control** — Tool-level whitelisting per custom role
+- **Per-User MCP API Keys** — Individual keys with usage tracking
+- **Docker Ready** — `docker compose up` and you're running
+
+---
+
+## Quick Start
 
 ```bash
-# 1. Clone the repo
 git clone https://github.com/HelpCode-ai/anythingmcp.git
 cd anythingmcp
-
-# 2. Configure environment
-cp .env.example .env
-# Edit .env — at minimum change JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD
-
-# 3. Start all services
+cp .env.example .env       # Edit: JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD
 docker compose up -d
-
-# 4. Open the UI
-open http://localhost:3000
+open http://localhost:3000  # First user becomes Admin
 ```
-
-The first user to register becomes **Admin**.
 
 | Service | URL |
 |---------|-----|
-| Web UI | http://localhost:3000 |
-| Backend API | http://localhost:4000 |
-| MCP Endpoint | http://localhost:4000/mcp |
-| Swagger Docs | http://localhost:4000/api/docs |
-| Health Check | http://localhost:4000/health |
+| Web UI | `http://localhost:3000` |
+| Backend API | `http://localhost:4000` |
+| MCP Endpoint | `http://localhost:4000/mcp` |
+| Swagger Docs | `http://localhost:4000/api/docs` |
 
-### Docker Services
-
-| Container | Image | Port |
-|-----------|-------|------|
-| `atmcp-frontend` | Next.js 16 (standalone) | 3000 |
-| `atmcp-backend` | NestJS 11 | 4000 |
-| `atmcp-postgres` | PostgreSQL 17 | 5432 |
-| `atmcp-redis` | Redis 7 | 6379 |
+> **Next step:** Create a connector, import your API spec, and connect your AI client. See the [Connector Guides](#connector-guides) below.
 
 ---
 
-## Local Development Setup
+## Connect Your AI Client
 
-Run PostgreSQL and Redis in Docker, and the frontend/backend locally with hot reload.
+AnythingMCP works with any MCP-compatible client. Follow the guide for your AI tool:
 
-### Prerequisites
-
-- **Node.js** 22+
-- **npm** 9+
-- **Docker** and **Docker Compose** (for PostgreSQL and Redis)
-
-### Step-by-Step
-
-```bash
-cd anythingmcp
-
-# 1. Create your .env file
-cp .env.example .env
-```
-
-Edit `.env` for local development — note the `localhost:5433` port for PostgreSQL (the dev Docker override maps host port 5433 to container port 5432):
-
-```env
-NODE_ENV=development
-PORT=4000
-POSTGRES_PASSWORD=your-local-password
-DATABASE_URL=postgresql://atmcp:your-local-password@localhost:5433/anythingmcp
-REDIS_URL=redis://localhost:6379
-JWT_SECRET=local-dev-secret-at-least-32-chars!!
-ENCRYPTION_KEY=local-dev-key-exactly-32-chars!!
-NEXT_PUBLIC_API_URL=http://localhost:4000
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=local-dev-nextauth-secret-32-chars!!
-CORS_ORIGIN=http://localhost:3000
-```
-
-```bash
-# 2. Start PostgreSQL and Redis via Docker
-#    Uses docker-compose.dev.yml overlay which:
-#    - Disables frontend/backend containers (you run them locally)
-#    - Exposes PostgreSQL on host port 5433 (to avoid conflicts with any local PostgreSQL)
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis
-
-# 3. Install dependencies
-npm install
-
-# 4. Symlink .env into package directories
-#    Prisma 7 and Next.js need the .env file in their own directories.
-ln -sf ../../.env packages/backend/.env
-ln -sf ../../.env packages/frontend/.env
-
-# 5. Export environment variables into your shell
-#    Prisma 7 CLI and the backend's PrismaService read DATABASE_URL at module
-#    level (before NestJS ConfigModule loads .env), so the variables must be
-#    present in the shell environment.
-export $(grep -v '^#' .env | grep -v '^$' | xargs)
-
-# 6. Run database migrations and generate Prisma client
-cd packages/backend
-npx prisma migrate dev
-npx prisma generate
-cd ../..
-
-# 7. Start both backend and frontend (concurrent)
-npm run dev
-```
-
-Or start them separately in two terminals:
-
-```bash
-# Terminal 1 — Backend (NestJS with hot reload)
-npm run dev:backend
-
-# Terminal 2 — Frontend (Next.js with Turbopack)
-npm run dev:frontend
-```
-
-The first user to register becomes **Admin**.
-
-| Service | URL |
-|---------|-----|
-| Frontend (Next.js) | http://localhost:3000 |
-| Backend API (NestJS) | http://localhost:4000 |
-| Swagger Docs | http://localhost:4000/api/docs |
-| MCP Endpoint | http://localhost:4000/mcp |
-| Health Check | http://localhost:4000/health |
-
-> **Tip:** If ports 3000 or 4000 are already in use, check for stale Node processes with `lsof -i:3000 -i:4000` and kill them before starting.
-
-### Useful Commands
-
-```bash
-# Run all tests
-npm test
-
-# Run backend tests only
-cd packages/backend && npm test
-
-# Open Prisma Studio (DB browser)
-cd packages/backend && npx prisma studio
-
-# Create a new migration after schema changes
-cd packages/backend && npx prisma migrate dev --name describe_change
-
-# Reset the database (drops all data and re-applies migrations)
-cd packages/backend && npx prisma migrate reset
-
-# Build for production
-npm run build
-
-# Stop Docker services
-docker compose -f docker-compose.yml -f docker-compose.dev.yml down
-
-# Stop Docker services and remove volumes (fresh database)
-docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
-```
+| Client | Guide | Transport |
+|--------|-------|-----------|
+| **Claude Desktop** | [Setup Guide](docs/integrations/claude.md) | Streamable HTTP |
+| **Claude Code** | [Setup Guide](docs/integrations/claude.md#claude-code) | Streamable HTTP |
+| **ChatGPT** | [Setup Guide](docs/integrations/chatgpt.md) | Streamable HTTP |
+| **Google Gemini** | [Setup Guide](docs/integrations/gemini.md) | HTTP / SSE |
+| **GitHub Copilot** | [Setup Guide](docs/integrations/copilot.md) | Streamable HTTP |
+| **Cursor** | [Setup Guide](docs/integrations/claude.md#cursor) | Streamable HTTP |
+| **Any MCP Client** | [Setup Guide](docs/integrations/claude.md#any-mcp-client) | Streamable HTTP |
 
 ---
 
-## Production Deployment
+## Connector Guides
 
-### With Docker (Recommended)
+Each connector type has dedicated documentation with setup instructions, examples, and best practices:
 
-```bash
-# 1. Configure production secrets
-cp .env.example .env
-# Set strong values for: JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD, NEXTAUTH_SECRET
-# Set MCP_BEARER_TOKEN or MCP_API_KEY to protect the MCP endpoint
-
-# 2. Build and start
-docker compose up -d --build
-
-# 3. Check health
-curl http://localhost:4000/health
-```
-
-The backend automatically runs `prisma migrate deploy` on startup to apply migrations.
-
-### Without Docker
-
-```bash
-# 1. Ensure PostgreSQL 17+ and Redis 7+ are running externally
-# 2. Configure .env with the correct DATABASE_URL and REDIS_URL
-# 3. Build
-cd packages/backend && npm ci && npx prisma generate && npm run build
-cd packages/frontend && npm ci && npm run build
-
-# 4. Run database migrations
-cd packages/backend && npx prisma migrate deploy
-
-# 5. Start backend
-cd packages/backend && node dist/main.js
-
-# 6. Start frontend
-cd packages/frontend && npm start
-```
-
-### Reverse Proxy (nginx example)
-
-```nginx
-server {
-    listen 443 ssl;
-    server_name mcp.yourdomain.com;
-
-    # Frontend
-    location / {
-        proxy_pass http://localhost:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-    }
-
-    # Backend API
-    location /api/ {
-        proxy_pass http://localhost:4000;
-    }
-
-    # MCP endpoint
-    location /mcp {
-        proxy_pass http://localhost:4000;
-        proxy_http_version 1.1;
-        proxy_set_header Connection '';
-        proxy_buffering off;
-    }
-
-    # Health check
-    location /health {
-        proxy_pass http://localhost:4000;
-    }
-}
-```
+| Connector | Use Case | Docs |
+|-----------|----------|------|
+| **REST** | HTTP APIs, OpenAPI/Swagger, Postman | [REST Connector Guide](docs/connectors/rest.md) |
+| **SOAP** | WSDL web services, WCF, legacy enterprise APIs | [SOAP Connector Guide](docs/connectors/soap.md) |
+| **GraphQL** | GraphQL endpoints with introspection | [GraphQL Connector Guide](docs/connectors/graphql.md) |
+| **Database** | PostgreSQL, MSSQL, MongoDB queries from AI | [Database Connector Guide](docs/connectors/database.md) |
+| **MCP Bridge** | Aggregate multiple MCP servers into one | [MCP Bridge Guide](docs/connectors/mcp-bridge.md) |
 
 ---
 
-## Connecting AI Clients
-
-### Claude Desktop
-
-Add this to your Claude Desktop configuration (`claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "anythingmcp": {
-      "type": "url",
-      "url": "http://localhost:4000/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
-      }
-    }
-  }
-}
-```
-
-### Claude Code
-
-```bash
-# Add AnythingMCP as an MCP server
-claude mcp add anythingmcp \
-  --transport http \
-  --url http://localhost:4000/mcp \
-  --header "Authorization: Bearer YOUR_MCP_BEARER_TOKEN"
-```
-
-### Any MCP Client
-
-The MCP endpoint supports **Streamable HTTP** transport at `POST /mcp`.
-
-Authentication is controlled by `MCP_AUTH_MODE` in your `.env`:
-
-| Mode | Description |
-|------|-------------|
-| `oauth2` | OAuth 2.0 Authorization Code (PKCE) + Client Credentials (default) |
-| `legacy` | Static Bearer Token or API Key |
-| `both` | Accepts either OAuth2 or legacy tokens |
-| `none` | No authentication (not recommended for production) |
-
-Legacy auth tokens (when `MCP_AUTH_MODE=legacy` or `both`):
-- `MCP_BEARER_TOKEN` — Bearer token authentication
-- `MCP_API_KEY` — API key via `X-API-Key` header
-
----
-
-## API Reference
-
-All API endpoints require JWT authentication (except auth and health). Get a token via `POST /api/auth/login`.
-
-### Auth
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/auth/register` | Register (first user becomes Admin) |
-| POST | `/api/auth/login` | Login, returns JWT token |
-| POST | `/api/auth/invite` | Invite a user via email (Admin only) |
-| GET | `/api/auth/invite/verify` | Verify an invitation token |
-| POST | `/api/auth/accept-invite` | Accept invitation and create account |
-| POST | `/api/auth/forgot-password` | Request a password reset email |
-| POST | `/api/auth/reset-password` | Reset password with token |
-
-### Connectors
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/connectors` | List all connectors |
-| POST | `/api/connectors` | Create connector |
-| GET | `/api/connectors/:id` | Get connector (with tools) |
-| PUT | `/api/connectors/:id` | Update connector |
-| DELETE | `/api/connectors/:id` | Delete connector (cascades tools) |
-| POST | `/api/connectors/:id/test` | Test API connection |
-| POST | `/api/connectors/:id/import-spec` | Auto-import tools from connector's spec URL |
-| POST | `/api/connectors/:id/import` | Import tools from any source |
-| PUT | `/api/connectors/:id/env-vars` | Set environment variables |
-
-### Tools
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/connectors/:id/tools` | List tools for connector |
-| POST | `/api/connectors/:id/tools` | Create a single tool |
-| POST | `/api/connectors/:id/tools/bulk` | Bulk create tools |
-| PUT | `/api/connectors/:id/tools/:toolId` | Update a tool |
-| DELETE | `/api/connectors/:id/tools/:toolId` | Delete a tool |
-
-### Audit
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/audit/invocations` | List invocations (with filters) |
-| GET | `/api/audit/stats` | Get invocation stats (24h, 7d, total) |
-
-### Roles & Access Control
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/roles` | List all roles |
-| POST | `/api/roles` | Create a custom role |
-| PUT | `/api/roles/:id` | Update a role |
-| DELETE | `/api/roles/:id` | Delete a role |
-| GET | `/api/roles/:id/tools` | List tool access for a role |
-| PUT | `/api/roles/:id/tools` | Set tool access whitelist for a role |
-
-### MCP API Keys
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/mcp-api-keys` | List your MCP API keys |
-| POST | `/api/mcp-api-keys` | Generate a new MCP API key |
-| DELETE | `/api/mcp-api-keys/:id` | Revoke an MCP API key |
-
-### Site Settings (Admin)
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/settings/smtp` | Get SMTP configuration |
-| PUT | `/api/settings/smtp` | Update SMTP configuration |
-| POST | `/api/settings/smtp/test` | Test SMTP connection |
-| GET | `/api/settings/footer-links` | Get footer link configuration |
-| PUT | `/api/settings/footer-links` | Update footer links |
-
-### Examples
-
-#### Create a connector + tools via API (e.g., from Claude Code or a script)
-
-```bash
-# 1. Login
-TOKEN=$(curl -s http://localhost:4000/api/auth/login \
-  -H 'Content-Type: application/json' \
-  -d '{"email":"admin@example.com","password":"your-password"}' \
-  | jq -r '.accessToken')
-
-# 2. Create a REST connector
-CONNECTOR_ID=$(curl -s http://localhost:4000/api/connectors \
-  -H "Authorization: Bearer $TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "name": "JSONPlaceholder",
-    "type": "REST",
-    "baseUrl": "https://jsonplaceholder.typicode.com",
-    "authType": "NONE"
-  }' | jq -r '.id')
-
-# 3. Bulk create tools
-curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/tools/bulk \
-  -H "Authorization: Bearer $TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "tools": [
-      {
-        "name": "get_posts",
-        "description": "Fetch all posts or filter by userId",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "userId": { "type": "integer", "description": "Filter by user ID" }
-          }
-        },
-        "endpointMapping": {
-          "method": "GET",
-          "path": "/posts",
-          "queryParams": { "userId": "$userId" }
-        }
-      },
-      {
-        "name": "get_post",
-        "description": "Get a single post by ID",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "id": { "type": "integer", "description": "Post ID" }
-          },
-          "required": ["id"]
-        },
-        "endpointMapping": {
-          "method": "GET",
-          "path": "/posts/{id}"
-        }
-      },
-      {
-        "name": "create_post",
-        "description": "Create a new post",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "title": { "type": "string", "description": "Post title" },
-            "body": { "type": "string", "description": "Post body" },
-            "userId": { "type": "integer", "description": "Author user ID" }
-          },
-          "required": ["title", "body", "userId"]
-        },
-        "endpointMapping": {
-          "method": "POST",
-          "path": "/posts",
-          "bodyMapping": {
-            "title": "$title",
-            "body": "$body",
-            "userId": "$userId"
-          }
-        }
-      }
-    ]
-  }'
-
-# 4. Import from a Postman collection via API
-curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/import \
-  -H "Authorization: Bearer $TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "source": "postman",
-    "url": "https://www.getpostman.com/collections/your-collection-id"
-  }'
-```
-
----
-
-## Tool Definition Format
-
-Every MCP tool in AnythingMCP is defined by three JSON objects:
-
-### 1. `parameters` — JSON Schema for tool inputs
-
-What the AI model can pass as input when calling the tool:
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "user_id": { "type": "integer", "description": "The user's ID" },
-    "include_details": { "type": "boolean", "description": "Include extra details" }
-  },
-  "required": ["user_id"]
-}
-```
-
-### 2. `endpointMapping` — How parameters map to the API request
-
-This is the **bridge configuration** that tells AnythingMCP how to transform MCP tool call parameters into actual API requests.
-
-```json
-{
-  "method": "GET",
-  "path": "/users/{user_id}",
-  "queryParams": {
-    "details": "$include_details"
-  },
-  "bodyMapping": {
-    "name": "$name",
-    "email": "$email"
-  },
-  "headers": {
-    "X-Custom-Header": "$api_token"
-  }
-}
-```
-
-#### Mapping Rules
-
-| Pattern | Where | Example |
-|---------|-------|---------|
-| `{param}` in path | **Path parameter** — replaced in the URL | `/users/{id}` → `/users/123` |
-| `"$param"` in queryParams | **Query parameter** — added to URL query string | `?search=value` |
-| `"$param"` in bodyMapping | **Request body field** — included in JSON body | `{"name": "John"}` |
-| `"$param"` in headers | **HTTP header** — sent as request header | `X-Token: abc123` |
-
-The `$` prefix means "take the value from the tool input parameter with this name".
-
-#### By Connector Type
-
-| Connector | method | path | queryParams | bodyMapping | headers |
-|-----------|--------|------|-------------|-------------|---------|
-| **REST** | HTTP method (GET, POST, etc.) | URL path | Query string params | JSON body fields | HTTP headers |
-| **GraphQL** | `query` or `mutation` | The GraphQL query string | GraphQL variables | — | HTTP headers |
-| **SOAP** | SOAP operation name | Port/path | — | SOAP parameters | HTTP headers |
-| **Database** | `query` or `static` | SQL template (`$param` interpolated) or static text | — | — | — |
-| **Webhook** | HTTP method | URL path | Query params | JSON body | HTTP headers |
-| **MCP** | Tool name on remote server | — | — | Passed through | — |
-
-### 3. `responseMapping` (Optional)
-
-Transform the API response before returning to the AI:
-
-```json
-{
-  "type": "json",
-  "fields": ["id", "name", "email"]
-}
-```
-
----
-
-## Import Formats
-
-AnythingMCP supports importing tool definitions from 6 sources:
-
-### 1. OpenAPI / Swagger
-
-Paste the spec JSON/YAML or provide a URL. Tools are auto-generated from each path+method with operationId, parameters, and request body.
-
-### 2. Postman Collection (v2.1)
-
-Paste the collection JSON or provide a URL (including Postman API export links). Supports nested folders, all auth types, body modes (raw JSON, form-data, urlencoded).
-
-### 3. cURL Commands
-
-Paste one or more cURL commands. Supports `-X` method, `-H` headers, `-d` body (JSON parsed), `-u` basic auth, multiline with `\` continuation.
-
-```bash
-curl -X POST https://api.example.com/users \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer {{token}}' \
-  -d '{"name": "John", "email": "john@example.com"}'
-```
-
-Variables using `{{name}}` pattern are auto-detected and added as tool parameters.
-
-### 4. GraphQL Introspection
-
-Provide the GraphQL endpoint URL. AnythingMCP runs an introspection query and generates tools for each query and mutation field.
-
-### 5. WSDL
-
-Provide the WSDL URL. Tools are generated for each SOAP operation.
-
-### 6. Custom JSON Definition
-
-The most flexible format. Paste a JSON array of tool definitions directly:
-
-```json
-[
-  {
-    "name": "search_products",
-    "description": "Search products by keyword and category",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "query": { "type": "string", "description": "Search keyword" },
-        "category": { "type": "string", "description": "Product category" },
-        "limit": { "type": "integer", "description": "Max results (default 10)" }
-      },
-      "required": ["query"]
-    },
-    "endpointMapping": {
-      "method": "GET",
-      "path": "/api/products/search",
-      "queryParams": {
-        "q": "$query",
-        "cat": "$category",
-        "limit": "$limit"
-      }
-    }
-  },
-  {
-    "name": "create_order",
-    "description": "Place a new order",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "product_id": { "type": "string" },
-        "quantity": { "type": "integer" },
-        "customer_token": { "type": "string", "description": "Customer auth token" }
-      },
-      "required": ["product_id", "quantity", "customer_token"]
-    },
-    "endpointMapping": {
-      "method": "POST",
-      "path": "/api/orders",
-      "bodyMapping": {
-        "productId": "$product_id",
-        "qty": "$quantity"
-      },
-      "headers": {
-        "X-Customer-Token": "$customer_token"
-      }
-    }
-  }
-]
-```
-
-You can also wrap the array in a `{ "tools": [...] }` object.
+## Documentation
+
+| Topic | Description |
+|-------|-------------|
+| [API Reference](docs/api-reference.md) | Full REST API for connectors, tools, auth, audit |
+| [Tool Definition Format](docs/tool-definition.md) | Parameters, endpoint mapping, response mapping |
+| [Deployment Guide](docs/deployment.md) | Docker, production setup, reverse proxy, env vars |
+| [Authentication](docs/deployment.md#authentication) | OAuth2, JWT, API keys, MCP auth modes |
 
 ---
 
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────┐
-│                    AnythingMCP                      │
-│                                                      │
-│  Next.js UI (3000) ◄────► NestJS Backend (4000)      │
-│  - Dashboard              │                          │
-│  - Connector CRUD         ├── Connector Engines      │
-│  - Visual Tool Editor     │   REST / SOAP / GraphQL  │
-│  - Import (6 formats)     │   MCP / Database / Hook  │
-│  - Env Variables          │                          │
-│  - Audit Logs             ├── Import Parsers         │
-│  - User Management        │   OpenAPI / Postman      │
-│  - Role & Access Control  │   cURL / WSDL / GraphQL  │
-│  - Site Settings          │   JSON definitions       │
-│  - Dark/Light Theme       │                          │
-│                           ├── Dynamic MCP Server     │
-│                           │   /mcp (Streamable HTTP) │
-│                           │                          │
-│                           ├── Roles & MCP API Keys   │
-│                           │   Tool-level access ctrl │
-│                           │                          │
-│                           └── Email Service (SMTP)   │
-│                               Invitations / Resets   │
-│                                                      │
-│  PostgreSQL 17          Redis 7                      │
-└──────────────────────────────────────────────────────┘
-         │
-         ▼ MCP Protocol (Streamable HTTP)
-  Claude Desktop / Claude Code / ChatGPT / Cursor
+                        ┌─────────────────────────────────┐
+  Claude Desktop ──────►│                                 │
+  ChatGPT ─────────────►│         AnythingMCP             │──── REST APIs
+  Gemini CLI ──────────►│      (MCP Middleware)            │──── SOAP Services
+  GitHub Copilot ──────►│                                 │──── GraphQL Endpoints
+  Cursor ──────────────►│   MCP Protocol (HTTP)           │──── PostgreSQL / MSSQL / MongoDB
+  Any MCP Client ──────►│                                 │──── Other MCP Servers
+                        └─────────────────────────────────┘
+                          Next.js UI │ NestJS Backend
+                          PostgreSQL │ Redis
 ```
 
-### How the MCP Bridge Works
+**How it works:**
 
-1. You create a **Connector** (e.g., a REST API with base URL + auth)
-2. You define **Tools** — each tool maps MCP input parameters to API request fields
-3. On startup (or after changes), tools are loaded into the **ToolRegistry** (in-memory)
-4. When an MCP client calls a tool, the system:
-   - Looks up the tool in the registry
-   - Interpolates environment variables (`{{VAR}}` patterns)
-   - Maps `$param` references to actual input values
-   - Sends the API request via the correct engine (REST/GraphQL/SOAP/etc.)
-   - Returns the response to the MCP client
+1. **Create a Connector** — Point to your API (REST base URL, WSDL endpoint, GraphQL URL, database connection string)
+2. **Import or Define Tools** — Auto-import from OpenAPI/Postman/WSDL/GraphQL or define manually
+3. **Connect AI Clients** — Point your MCP client to `http://your-server:4000/mcp`
+4. **AI calls tools** — AnythingMCP translates MCP tool calls into actual API requests and returns results
 
-### Tech Stack
+---
+
+## Tech Stack
 
 | Layer | Technology |
 |-------|------------|
 | Frontend | Next.js 16, React 19, Tailwind CSS v4 |
-| Backend | NestJS 11, TypeScript, @rekog/mcp-nest |
-| MCP SDK | @modelcontextprotocol/sdk (Streamable HTTP) |
-| Database | PostgreSQL 17 + Prisma 7 |
-| Cache | Redis 7 (ioredis) |
-| Validation | Zod v4, class-validator |
-| Auth | JWT (passport-jwt), AES-256-GCM encryption |
+| Backend | NestJS 11, TypeScript |
+| MCP | @modelcontextprotocol/sdk, Streamable HTTP |
+| Database | PostgreSQL 17, Prisma 7 |
+| Cache | Redis 7 |
+| Auth | JWT, OAuth2, AES-256-GCM |
 | Deploy | Docker + Docker Compose |
 
 ---
 
-## Environment Variables
+## Community
 
-Copy `.env.example` to `.env` and configure:
+We're building the universal MCP gateway and we need your help!
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `JWT_SECRET` | Yes | JWT signing secret (min 32 chars) |
-| `ENCRYPTION_KEY` | Yes | AES-256-GCM key (exactly 32 chars) |
-| `PORT` | No | Backend port (default: 4000) |
-| `REDIS_URL` | No | Redis URL (graceful fallback if unavailable) |
-| `CORS_ORIGIN` | No | Allowed origin (default: http://localhost:3000) |
-| `NEXT_PUBLIC_API_URL` | No | Backend URL for frontend (default: http://localhost:4000) |
-| `NEXTAUTH_URL` | No | NextAuth callback URL (default: http://localhost:3000) |
-| `NEXTAUTH_SECRET` | No | NextAuth secret for frontend |
-| `FRONTEND_URL` | No | Frontend URL for email links (default: http://localhost:3000) |
-| `MCP_AUTH_MODE` | No | MCP auth mode: `none`, `legacy`, `oauth2`, `both` (default: `oauth2`) |
-| `MCP_BEARER_TOKEN` | No | Bearer token for MCP endpoint auth (legacy mode) |
-| `MCP_API_KEY` | No | API key for MCP endpoint auth (legacy mode) |
-| `SERVER_URL` | No | Server URL for OAuth2 redirects and metadata (default: http://localhost:4000) |
-| `MCP_RATE_LIMIT_PER_MINUTE` | No | Rate limit per client (default: 60) |
+- **Star this repo** to help others discover AnythingMCP
+- **Join the [Discord community](https://discord.gg/anythingmcp)** to share ideas, get help, and connect with other developers
+- **Open an issue** to report bugs or suggest features
+- **Submit a PR** to contribute code, docs, or connector types
+
+Every star, issue, and conversation helps us build a better MCP ecosystem for everyone.
+
+---
+
+## Development
+
+See the [Deployment Guide](docs/deployment.md#local-development) for full local development setup.
+
+```bash
+# Quick local dev setup
+cp .env.example .env
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis
+npm install
+ln -sf ../../.env packages/backend/.env
+ln -sf ../../.env packages/frontend/.env
+export $(grep -v '^#' .env | grep -v '^$' | xargs)
+cd packages/backend && npx prisma migrate dev && npx prisma generate && cd ../..
+npm run dev
+```
 
 ---
 
 ## License
 
-This software is licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1).
+Licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1).
 
-- **Free for**: internal use, personal use, development, testing, evaluation, and academic use.
-- **Not permitted**: offering the software as a commercial hosted service to third parties without a separate commercial license.
-- **Change Date**: 2030-03-04 — on this date the license automatically converts to Apache 2.0.
+- **Free for**: internal use, personal use, development, testing, evaluation, academic use
+- **Not permitted**: offering as a commercial hosted service without a separate license
+- **Change Date**: 2030-03-04 — converts to Apache 2.0
 
-For commercial licensing inquiries, contact [licensing@helpcode.ai](mailto:licensing@helpcode.ai).
+For commercial licensing: [licensing@helpcode.ai](mailto:licensing@helpcode.ai)
 
 Copyright (c) 2026 helpcode.ai GmbH

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,323 @@
+# API Reference
+
+> Full REST API reference for AnythingMCP. All endpoints require JWT authentication unless noted.
+
+[Back to README](../README.md)
+
+---
+
+## Authentication
+
+Get a JWT token via login, then include it in all requests:
+
+```bash
+TOKEN=$(curl -s http://localhost:4000/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"your-password"}' \
+  | jq -r '.accessToken')
+
+# Use in subsequent requests
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4000/api/connectors
+```
+
+Interactive Swagger docs are available at `http://localhost:4000/api/docs`.
+
+---
+
+## Auth Endpoints
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/api/auth/register` | None | Register (first user becomes Admin) |
+| POST | `/api/auth/login` | None | Login, returns JWT token |
+| POST | `/api/auth/invite` | Admin | Invite a user via email |
+| GET | `/api/auth/invite/verify` | None | Verify an invitation token |
+| POST | `/api/auth/accept-invite` | None | Accept invitation and create account |
+| POST | `/api/auth/forgot-password` | None | Request a password reset email |
+| POST | `/api/auth/reset-password` | None | Reset password with token |
+
+### Register
+
+```bash
+curl -s http://localhost:4000/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"your-password","name":"Admin User"}'
+```
+
+### Login
+
+```bash
+curl -s http://localhost:4000/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"your-password"}'
+```
+
+Response:
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
+### Invite User (Admin)
+
+```bash
+curl -s http://localhost:4000/api/auth/invite \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"user@example.com","role":"EDITOR","mcpRoleId":"optional-role-id"}'
+```
+
+---
+
+## Connector Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/connectors` | List all connectors |
+| POST | `/api/connectors` | Create a connector |
+| GET | `/api/connectors/:id` | Get connector with tools |
+| PUT | `/api/connectors/:id` | Update connector |
+| DELETE | `/api/connectors/:id` | Delete connector (cascades tools) |
+| POST | `/api/connectors/:id/test` | Test API connection |
+| POST | `/api/connectors/:id/import-spec` | Auto-import tools from connector's spec URL |
+| POST | `/api/connectors/:id/import` | Import tools from any source |
+| PUT | `/api/connectors/:id/env-vars` | Set environment variables |
+
+### Create Connector
+
+```bash
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "My API",
+    "type": "REST",
+    "baseUrl": "https://api.example.com",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {"token": "api-token"},
+    "specUrl": "https://api.example.com/openapi.json"
+  }'
+```
+
+**Connector types:** `REST`, `SOAP`, `GRAPHQL`, `DATABASE`, `MCP`
+
+**Auth types:** `NONE`, `API_KEY`, `BEARER_TOKEN`, `BASIC_AUTH`, `OAUTH2`, `WS_SECURITY`, `CERTIFICATE`, `CONNECTION_STRING`
+
+### Import Tools
+
+```bash
+# From OpenAPI/Swagger spec URL
+curl -s http://localhost:4000/api/connectors/$ID/import-spec \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"specUrl": "https://api.example.com/openapi.json"}'
+
+# From Postman collection
+curl -s http://localhost:4000/api/connectors/$ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "postman", "url": "https://postman.com/collections/abc123"}'
+
+# From cURL commands
+curl -s http://localhost:4000/api/connectors/$ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "curl", "content": "curl -X GET https://api.example.com/users"}'
+
+# From GraphQL introspection
+curl -s http://localhost:4000/api/connectors/$ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "graphql", "url": "https://api.example.com/graphql"}'
+
+# From WSDL
+curl -s http://localhost:4000/api/connectors/$ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "wsdl", "url": "https://service.example.com/api?wsdl"}'
+
+# From custom JSON
+curl -s http://localhost:4000/api/connectors/$ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "json", "content": "[{\"name\":\"tool\",\"description\":\"desc\",...}]"}'
+```
+
+### Set Environment Variables
+
+```bash
+curl -s -X PUT http://localhost:4000/api/connectors/$ID/env-vars \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"envVars": {"API_SECRET": "value", "TENANT_ID": "abc"}}'
+```
+
+---
+
+## Tool Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/connectors/:id/tools` | List tools for connector |
+| POST | `/api/connectors/:id/tools` | Create a single tool |
+| POST | `/api/connectors/:id/tools/bulk` | Bulk create tools |
+| PUT | `/api/connectors/:id/tools/:toolId` | Update a tool |
+| DELETE | `/api/connectors/:id/tools/:toolId` | Delete a tool |
+
+### Create Tool
+
+```bash
+curl -s http://localhost:4000/api/connectors/$ID/tools \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "get_user",
+    "description": "Get user by ID",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "integer", "description": "User ID"}
+      },
+      "required": ["id"]
+    },
+    "endpointMapping": {
+      "method": "GET",
+      "path": "/users/{id}"
+    }
+  }'
+```
+
+### Bulk Create Tools
+
+```bash
+curl -s http://localhost:4000/api/connectors/$ID/tools/bulk \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"tools": [...]}'
+```
+
+See [Tool Definition Format](tool-definition.md) for the full schema.
+
+---
+
+## MCP Server Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/mcp-servers` | List MCP server configurations |
+| POST | `/api/mcp-servers` | Create MCP server config |
+| PUT | `/api/mcp-servers/:id` | Update MCP server config |
+| DELETE | `/api/mcp-servers/:id` | Delete MCP server config |
+
+---
+
+## Audit Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/audit/invocations` | List invocations (with filters) |
+| GET | `/api/audit/stats` | Get invocation stats (24h, 7d, total) |
+
+### Query Invocations
+
+```bash
+# Filter by tool name
+curl -s "http://localhost:4000/api/audit/invocations?toolName=get_user" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Filter by date range
+curl -s "http://localhost:4000/api/audit/invocations?from=2026-01-01&to=2026-01-31" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Get Stats
+
+```bash
+curl -s http://localhost:4000/api/audit/stats \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response:
+```json
+{
+  "last24h": 142,
+  "last7d": 1053,
+  "total": 8721
+}
+```
+
+---
+
+## Roles & Access Control
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/roles` | List all roles |
+| POST | `/api/roles` | Create a custom role |
+| PUT | `/api/roles/:id` | Update a role |
+| DELETE | `/api/roles/:id` | Delete a role |
+| GET | `/api/roles/:id/tools` | List tool access for a role |
+| PUT | `/api/roles/:id/tools` | Set tool access whitelist |
+
+### Create Role with Tool Whitelist
+
+```bash
+# 1. Create role
+ROLE_ID=$(curl -s http://localhost:4000/api/roles \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "Sales Team", "description": "Access to CRM tools only"}' \
+  | jq -r '.id')
+
+# 2. Set tool whitelist
+curl -s -X PUT http://localhost:4000/api/roles/$ROLE_ID/tools \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"toolIds": ["tool-id-1", "tool-id-2", "tool-id-3"]}'
+```
+
+---
+
+## MCP API Keys
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/mcp-api-keys` | List your MCP API keys |
+| POST | `/api/mcp-api-keys` | Generate a new MCP API key |
+| DELETE | `/api/mcp-api-keys/:id` | Revoke an MCP API key |
+
+### Generate API Key
+
+```bash
+curl -s http://localhost:4000/api/mcp-api-keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "My Claude Desktop Key", "mcpServerId": "optional-server-id"}'
+```
+
+---
+
+## Site Settings (Admin)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/settings/smtp` | Get SMTP configuration |
+| PUT | `/api/settings/smtp` | Update SMTP configuration |
+| POST | `/api/settings/smtp/test` | Test SMTP connection |
+| GET | `/api/settings/footer-links` | Get footer link configuration |
+| PUT | `/api/settings/footer-links` | Update footer links |
+
+---
+
+## Health Check
+
+```bash
+curl http://localhost:4000/health
+```
+
+No authentication required.
+
+---
+
+[Back to README](../README.md) | [Tool Definition Format](tool-definition.md) | [Deployment Guide](deployment.md)

--- a/docs/connectors/database.md
+++ b/docs/connectors/database.md
@@ -1,0 +1,209 @@
+# Database Connector — Database to MCP
+
+> Let AI agents query PostgreSQL, MSSQL, and MongoDB through MCP. Auto-generated schema tools + dynamic query execution.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+The Database connector lets AI clients query databases directly through MCP. It auto-generates tools for schema introspection, example queries, and dynamic query execution. Supports **PostgreSQL**, **Microsoft SQL Server**, and **MongoDB**.
+
+**Keywords:** Database to MCP, PostgreSQL to MCP, SQL to MCP, MongoDB to MCP, MSSQL to MCP, database MCP bridge, query database with AI, natural language SQL MCP
+
+---
+
+## Supported Databases
+
+| Database | Connection String Format |
+|----------|------------------------|
+| **PostgreSQL** | `postgresql://user:pass@host:5432/dbname` |
+| **Microsoft SQL Server** | `mssql://user:pass@host:1433/dbname` or `Server=host;Database=dbname;User Id=user;Password=pass;` |
+| **MongoDB** | `mongodb://user:pass@host:27017/dbname` or `mongodb+srv://...` |
+
+---
+
+## Creating a Database Connector
+
+### Via Web UI
+
+1. Go to **Connectors** > **New Connector**
+2. Select **Database** as the type
+3. Enter the **Connection String**
+4. Set auth type to **Connection String**
+5. Click **Create**
+
+### Via API
+
+```bash
+# PostgreSQL
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Production DB",
+    "type": "DATABASE",
+    "baseUrl": "postgresql://readonly:password@db.example.com:5432/myapp",
+    "authType": "CONNECTION_STRING"
+  }'
+
+# MongoDB
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Analytics MongoDB",
+    "type": "DATABASE",
+    "baseUrl": "mongodb+srv://reader:password@cluster.mongodb.net/analytics",
+    "authType": "CONNECTION_STRING"
+  }'
+```
+
+---
+
+## Auto-Generated Tools
+
+When you create a Database connector, AnythingMCP automatically generates three tools:
+
+### 1. Schema Introspection Tool
+
+Lists all tables/collections with their columns/fields and data types.
+
+```
+Tool: {connector_name}_schema
+Description: Get the database schema (tables, columns, types)
+```
+
+### 2. Example Queries Tool
+
+Returns pre-built example queries that demonstrate how to query this database. These are editable static text — you can customize them in the tool editor.
+
+```
+Tool: {connector_name}_examples
+Description: Show example queries for this database
+```
+
+### 3. Dynamic Query Tool
+
+Executes arbitrary SQL queries (PostgreSQL/MSSQL) or MongoDB operations.
+
+```
+Tool: {connector_name}_query
+Description: Execute a query against the database
+Parameters:
+  - query (string): The SQL query or MongoDB operation to execute
+```
+
+---
+
+## SQL Databases (PostgreSQL & MSSQL)
+
+### Endpoint Mapping
+
+SQL tools use parameterized queries with `$param` interpolation:
+
+```json
+{
+  "method": "query",
+  "path": "SELECT * FROM users WHERE status = $status AND created_at > $since LIMIT $limit"
+}
+```
+
+Parameters are safely interpolated into the query.
+
+### Static vs Dynamic Queries
+
+| Method | Description |
+|--------|-------------|
+| `query` | Dynamic — the AI provides the full SQL query |
+| `static` | Static — the SQL is pre-defined, AI only provides parameter values |
+
+Static query example:
+
+```json
+{
+  "name": "get_active_users",
+  "description": "Get active users created after a date",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "since": { "type": "string", "description": "Date (YYYY-MM-DD)" },
+      "limit": { "type": "integer", "description": "Max results" }
+    },
+    "required": ["since"]
+  },
+  "endpointMapping": {
+    "method": "static",
+    "path": "SELECT id, name, email, created_at FROM users WHERE status = 'active' AND created_at > $since ORDER BY created_at DESC LIMIT $limit"
+  }
+}
+```
+
+---
+
+## MongoDB
+
+### Native MongoDB Tools
+
+MongoDB connectors generate tools that support native MongoDB operations:
+
+- **Aggregation pipelines** — Complex data transformations and analytics
+- **CRUD operations** — Find, insert, update, delete
+- **Collection queries** — Filter, sort, project, limit
+
+### Endpoint Mapping for MongoDB
+
+```json
+{
+  "method": "query",
+  "path": "db.collection('users').find({ status: 'active' }).sort({ createdAt: -1 }).limit(10)"
+}
+```
+
+### Example: MongoDB Aggregation
+
+```json
+{
+  "name": "sales_by_category",
+  "description": "Get total sales grouped by product category",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "year": { "type": "integer", "description": "Year to filter" }
+    },
+    "required": ["year"]
+  },
+  "endpointMapping": {
+    "method": "query",
+    "path": "db.collection('orders').aggregate([{$match: {year: $year}}, {$group: {_id: '$category', total: {$sum: '$amount'}}}, {$sort: {total: -1}}])"
+  }
+}
+```
+
+---
+
+## Security Best Practices
+
+> **Important:** Database connectors execute queries directly against your database.
+
+1. **Use read-only credentials** — Create a dedicated database user with SELECT-only permissions
+2. **Limit accessible tables** — Use database-level grants to restrict which tables are visible
+3. **Use static queries when possible** — Pre-define queries to prevent unexpected operations
+4. **Enable audit logging** — Every query executed through MCP is logged in the audit trail
+5. **Use role-based access** — Create MCP roles that whitelist only specific database tools
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Connection timeout | Ensure the database is reachable from the AnythingMCP backend container. Check firewall rules |
+| SSL required | Add `?sslmode=require` to PostgreSQL connection strings |
+| MongoDB auth fails | Ensure `authSource=admin` is in the connection string if using admin database for auth |
+| Schema introspection empty | Check that the database user has read permissions on `information_schema` (SQL) or the target database (MongoDB) |
+
+---
+
+[Back to README](../../README.md) | [Tool Definition Format](../tool-definition.md) | [API Reference](../api-reference.md)

--- a/docs/connectors/graphql.md
+++ b/docs/connectors/graphql.md
@@ -1,0 +1,187 @@
+# GraphQL Connector — GraphQL to MCP
+
+> Turn GraphQL APIs into MCP tools. Auto-generate tools from introspection queries.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+The GraphQL connector exposes GraphQL queries and mutations as individual MCP tools. It supports automatic tool generation via introspection and manual query definition.
+
+**Keywords:** GraphQL to MCP, GraphQL MCP bridge, GraphQL API to MCP server, GraphQL introspection MCP
+
+---
+
+## Creating a GraphQL Connector
+
+### Via Web UI
+
+1. Go to **Connectors** > **New Connector**
+2. Select **GraphQL** as the type
+3. Enter the **GraphQL Endpoint URL** (e.g., `https://api.example.com/graphql`)
+4. Configure authentication if needed
+5. Click **Create**
+
+### Via API
+
+```bash
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "My GraphQL API",
+    "type": "GRAPHQL",
+    "baseUrl": "https://api.example.com/graphql",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "your-graphql-token"
+    }
+  }'
+```
+
+---
+
+## Importing Tools via Introspection
+
+Provide the GraphQL endpoint and AnythingMCP will run an introspection query to auto-generate tools for each:
+- **Query field** → Read-only tool
+- **Mutation field** → Write tool
+
+```bash
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "source": "graphql",
+    "url": "https://api.example.com/graphql"
+  }'
+```
+
+Each generated tool includes:
+- Typed parameters from the GraphQL schema
+- The full query/mutation string
+- Variable mapping
+
+---
+
+## Tool Configuration
+
+### Endpoint Mapping for GraphQL
+
+GraphQL tools use a specific mapping format:
+
+```json
+{
+  "method": "query",
+  "path": "query GetUser($id: ID!) { user(id: $id) { id name email } }",
+  "queryParams": {
+    "id": "$user_id"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `method` | `query` or `mutation` |
+| `path` | The GraphQL query/mutation string |
+| `queryParams` | Maps tool parameters to GraphQL variables |
+| `headers` | Optional HTTP headers for the request |
+
+### Manual Tool Definition
+
+```json
+{
+  "name": "search_products",
+  "description": "Search products by name and category",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "query": { "type": "string", "description": "Search term" },
+      "category": { "type": "string", "description": "Category filter" },
+      "limit": { "type": "integer", "description": "Max results" }
+    },
+    "required": ["query"]
+  },
+  "endpointMapping": {
+    "method": "query",
+    "path": "query SearchProducts($query: String!, $category: String, $limit: Int) { searchProducts(query: $query, category: $category, limit: $limit) { id name price category } }",
+    "queryParams": {
+      "query": "$query",
+      "category": "$category",
+      "limit": "$limit"
+    }
+  }
+}
+```
+
+---
+
+## Authentication
+
+GraphQL connectors support all standard auth types:
+
+| Auth Type | Config |
+|-----------|--------|
+| **Bearer Token** | `"authType": "BEARER_TOKEN", "authConfig": {"token": "..."}` |
+| **API Key** | `"authType": "API_KEY", "authConfig": {"key": "X-API-Key", "value": "..."}` |
+| **Basic Auth** | `"authType": "BASIC_AUTH", "authConfig": {"username": "...", "password": "..."}` |
+| **OAuth2** | `"authType": "OAUTH2", "authConfig": {"tokenUrl": "...", "clientId": "...", "clientSecret": "..."}` |
+
+---
+
+## Example: GitHub GraphQL API
+
+```bash
+# 1. Create connector
+CONNECTOR_ID=$(curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "GitHub GraphQL",
+    "type": "GRAPHQL",
+    "baseUrl": "https://api.github.com/graphql",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {"token": "ghp_your_github_token"}
+  }' | jq -r '.id')
+
+# 2. Create a tool manually
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/tools \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "get_repo_info",
+    "description": "Get GitHub repository information",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "owner": { "type": "string", "description": "Repository owner" },
+        "name": { "type": "string", "description": "Repository name" }
+      },
+      "required": ["owner", "name"]
+    },
+    "endpointMapping": {
+      "method": "query",
+      "path": "query GetRepo($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { name description stargazerCount forkCount primaryLanguage { name } } }",
+      "queryParams": {
+        "owner": "$owner",
+        "name": "$name"
+      }
+    }
+  }'
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Introspection fails | Ensure the endpoint allows introspection queries and auth is configured |
+| Variables not mapped | Verify `queryParams` keys match GraphQL variable names (case-sensitive) |
+| Mutation not working | Set `"method": "mutation"` in the endpoint mapping |
+
+---
+
+[Back to README](../../README.md) | [Tool Definition Format](../tool-definition.md) | [API Reference](../api-reference.md)

--- a/docs/connectors/mcp-bridge.md
+++ b/docs/connectors/mcp-bridge.md
@@ -1,0 +1,133 @@
+# MCP Bridge Connector — MCP-to-MCP Gateway
+
+> Aggregate multiple MCP servers into one. Create a unified MCP gateway that proxies tools from other MCP servers.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+The MCP Bridge connector lets you connect to **other MCP servers** and re-expose their tools through AnythingMCP. This creates a unified gateway where AI clients connect to a single MCP endpoint and access tools from multiple backend MCP servers.
+
+**Keywords:** MCP gateway, MCP proxy, MCP aggregator, MCP middleware, MCP-to-MCP bridge, MCP server federation, MCP hub
+
+---
+
+## Use Cases
+
+- **MCP Aggregation** — Combine tools from multiple MCP servers into one endpoint
+- **MCP Proxy** — Add authentication, rate limiting, and audit logging in front of existing MCP servers
+- **MCP Gateway** — Single entry point for AI clients to access all your MCP tools
+- **Tool Curation** — Select which tools from remote MCP servers to expose
+
+---
+
+## Creating an MCP Bridge Connector
+
+### Via Web UI
+
+1. Go to **Connectors** > **New Connector**
+2. Select **MCP** as the type
+3. Enter the **Remote MCP Server URL** (e.g., `http://other-mcp-server:3000/mcp`)
+4. Configure authentication for the remote server
+5. Click **Create**
+
+### Via API
+
+```bash
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Remote MCP Server",
+    "type": "MCP",
+    "baseUrl": "http://other-mcp-server:3000/mcp",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "remote-server-token"
+    }
+  }'
+```
+
+---
+
+## How It Works
+
+1. AnythingMCP connects to the remote MCP server
+2. It discovers available tools on the remote server
+3. Tools are registered in the local ToolRegistry
+4. When an AI client calls a bridged tool, AnythingMCP:
+   - Forwards the tool call to the remote MCP server
+   - Passes parameters through
+   - Returns the response
+
+### Endpoint Mapping
+
+MCP bridge tools use a simple mapping:
+
+```json
+{
+  "method": "remote_tool_name",
+  "bodyMapping": {
+    "param1": "$param1",
+    "param2": "$param2"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `method` | The tool name on the remote MCP server |
+| `bodyMapping` | Maps local parameters to remote tool parameters |
+
+---
+
+## Authentication
+
+The MCP Bridge supports automatic token refresh for OAuth2-protected remote servers.
+
+| Auth Type | Use Case |
+|-----------|----------|
+| **Bearer Token** | Static token for the remote MCP server |
+| **OAuth2** | Auto-refreshing tokens with client credentials |
+| **API Key** | API key header authentication |
+| **None** | For unprotected local MCP servers |
+
+---
+
+## Architecture Example
+
+```
+  Claude Desktop ─┐
+  ChatGPT ────────┤
+  Cursor ─────────┤
+                  ▼
+           AnythingMCP (Gateway)
+           ┌───────────────────┐
+           │ MCP Bridge #1 ────│──► File System MCP Server
+           │ MCP Bridge #2 ────│──► Slack MCP Server
+           │ MCP Bridge #3 ────│──► Custom MCP Server
+           │ REST Connector ───│──► Your REST API
+           │ DB Connector ─────│──► PostgreSQL
+           └───────────────────┘
+```
+
+All AI clients connect to **one** AnythingMCP endpoint and get access to tools from all connected servers.
+
+---
+
+## Benefits Over Direct Connection
+
+| Feature | Direct MCP | Via AnythingMCP |
+|---------|-----------|-----------------|
+| Auth & rate limiting | Per-server config | Centralized |
+| Audit logging | None | Every invocation logged |
+| Role-based access | None | Tool-level whitelisting |
+| API key management | None | Per-user keys |
+| Response caching | None | Redis caching |
+| Tool curation | All or nothing | Select which tools to expose |
+
+---
+
+[Back to README](../../README.md) | [Tool Definition Format](../tool-definition.md) | [API Reference](../api-reference.md)

--- a/docs/connectors/rest.md
+++ b/docs/connectors/rest.md
@@ -1,0 +1,291 @@
+# REST Connector — REST API to MCP
+
+> Convert any REST API into MCP tools. Import from OpenAPI, Postman, cURL, or define tools manually.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+The REST connector lets you expose HTTP-based APIs as MCP tools. It supports all HTTP methods, authentication types, and can auto-import tool definitions from multiple formats.
+
+**Keywords:** REST API to MCP, OpenAPI to MCP, Swagger to MCP, Postman to MCP, cURL to MCP, HTTP API MCP bridge
+
+---
+
+## Creating a REST Connector
+
+### Via Web UI
+
+1. Go to **Connectors** > **New Connector**
+2. Select **REST** as the type
+3. Enter the **Base URL** (e.g., `https://api.example.com`)
+4. Configure authentication (see [Auth Types](#authentication))
+5. Click **Create**
+
+### Via API
+
+```bash
+TOKEN=$(curl -s http://localhost:4000/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"your-password"}' \
+  | jq -r '.accessToken')
+
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "My REST API",
+    "type": "REST",
+    "baseUrl": "https://api.example.com",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "your-api-token"
+    }
+  }'
+```
+
+---
+
+## Importing Tools
+
+### From OpenAPI / Swagger
+
+Paste the spec URL or JSON/YAML content. Tools are auto-generated for each `path + method` with:
+- Tool name from `operationId`
+- Parameters from path params, query params, and request body
+- Endpoint mapping auto-configured
+
+```bash
+# Import from URL
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/import-spec \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"specUrl": "https://petstore.swagger.io/v2/swagger.json"}'
+```
+
+### From Postman Collection
+
+Supports Postman Collection v2.1 format, including:
+- Nested folders (flattened with folder prefixes)
+- All auth types (Bearer, Basic, API Key, OAuth2)
+- Body modes: raw JSON, form-data, urlencoded
+- Variable interpolation (`{{var}}` → tool parameters)
+
+```bash
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "source": "postman",
+    "url": "https://www.getpostman.com/collections/your-collection-id"
+  }'
+```
+
+### From cURL Commands
+
+Paste one or more cURL commands. Supports:
+- `-X` method, `-H` headers, `-d` body
+- `-u` basic auth
+- Multiline with `\` continuation
+- `{{var}}` patterns auto-detected as tool parameters
+
+```bash
+curl -X POST https://api.example.com/users \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer {{token}}' \
+  -d '{"name": "{{name}}", "email": "{{email}}"}'
+```
+
+This generates a tool with `token`, `name`, and `email` as parameters.
+
+### Custom JSON Definition
+
+Define tools directly as JSON:
+
+```json
+{
+  "tools": [
+    {
+      "name": "get_user",
+      "description": "Get user by ID",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "User ID" }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/users/{id}"
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Tool Configuration
+
+### Endpoint Mapping
+
+The `endpointMapping` defines how MCP tool parameters map to the HTTP request:
+
+```json
+{
+  "method": "POST",
+  "path": "/users/{user_id}/orders",
+  "queryParams": {
+    "page": "$page",
+    "limit": "$limit"
+  },
+  "bodyMapping": {
+    "productId": "$product_id",
+    "quantity": "$qty"
+  },
+  "headers": {
+    "X-Request-ID": "$request_id"
+  }
+}
+```
+
+| Pattern | Location | Description |
+|---------|----------|-------------|
+| `{param}` in path | URL path | Replaced in the URL: `/users/{id}` → `/users/123` |
+| `"$param"` in queryParams | Query string | Added as `?param=value` |
+| `"$param"` in bodyMapping | JSON body | Included in request body |
+| `"$param"` in headers | HTTP headers | Sent as request header |
+
+### Response Mapping
+
+Optionally filter and transform API responses:
+
+```json
+{
+  "responseMapping": {
+    "type": "json",
+    "fields": ["id", "name", "email", "status"]
+  }
+}
+```
+
+---
+
+## Authentication
+
+| Auth Type | Config |
+|-----------|--------|
+| **None** | `"authType": "NONE"` |
+| **API Key** | `"authType": "API_KEY", "authConfig": {"key": "X-API-Key", "value": "your-key"}` |
+| **Bearer Token** | `"authType": "BEARER_TOKEN", "authConfig": {"token": "your-token"}` |
+| **Basic Auth** | `"authType": "BASIC_AUTH", "authConfig": {"username": "user", "password": "pass"}` |
+| **OAuth2** | `"authType": "OAUTH2", "authConfig": {"tokenUrl": "...", "clientId": "...", "clientSecret": "...", "scope": "..."}` |
+
+All credentials are encrypted with AES-256-GCM at rest.
+
+OAuth2 supports automatic token refresh on 401 responses.
+
+---
+
+## Environment Variables
+
+Define per-connector environment variables for secrets that should be injected at runtime but hidden from the AI:
+
+```bash
+curl -s -X PUT http://localhost:4000/api/connectors/$CONNECTOR_ID/env-vars \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "envVars": {
+      "API_SECRET": "my-secret-value",
+      "TENANT_ID": "abc-123"
+    }
+  }'
+```
+
+Use `{{VAR_NAME}}` in endpoint mappings. Parameters matching env var names are automatically stripped from the tool schema.
+
+---
+
+## Example: Full REST API Setup
+
+```bash
+# 1. Create connector
+CONNECTOR_ID=$(curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "JSONPlaceholder",
+    "type": "REST",
+    "baseUrl": "https://jsonplaceholder.typicode.com",
+    "authType": "NONE"
+  }' | jq -r '.id')
+
+# 2. Bulk create tools
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/tools/bulk \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tools": [
+      {
+        "name": "list_posts",
+        "description": "List all posts, optionally filter by user",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "userId": { "type": "integer", "description": "Filter by user ID" }
+          }
+        },
+        "endpointMapping": {
+          "method": "GET",
+          "path": "/posts",
+          "queryParams": { "userId": "$userId" }
+        }
+      },
+      {
+        "name": "get_post",
+        "description": "Get a single post by ID",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "integer", "description": "Post ID" }
+          },
+          "required": ["id"]
+        },
+        "endpointMapping": {
+          "method": "GET",
+          "path": "/posts/{id}"
+        }
+      },
+      {
+        "name": "create_post",
+        "description": "Create a new blog post",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": { "type": "string", "description": "Post title" },
+            "body": { "type": "string", "description": "Post content" },
+            "userId": { "type": "integer", "description": "Author user ID" }
+          },
+          "required": ["title", "body", "userId"]
+        },
+        "endpointMapping": {
+          "method": "POST",
+          "path": "/posts",
+          "bodyMapping": {
+            "title": "$title",
+            "body": "$body",
+            "userId": "$userId"
+          }
+        }
+      }
+    ]
+  }'
+```
+
+---
+
+[Back to README](../../README.md) | [Tool Definition Format](../tool-definition.md) | [API Reference](../api-reference.md)

--- a/docs/connectors/soap.md
+++ b/docs/connectors/soap.md
@@ -1,0 +1,161 @@
+# SOAP Connector — SOAP API to MCP
+
+> Bridge legacy SOAP/WSDL web services to MCP. Let AI agents call enterprise SOAP APIs without writing integration code.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+The SOAP connector lets you expose SOAP web services as MCP tools. It parses WSDL definitions, auto-generates tools for each operation, and handles SOAP envelope construction, WS-Security, and parameter ordering.
+
+**Keywords:** SOAP to MCP, WSDL to MCP, SOAP MCP bridge, enterprise API to MCP, WCF to MCP, legacy API integration MCP
+
+---
+
+## Creating a SOAP Connector
+
+### Via Web UI
+
+1. Go to **Connectors** > **New Connector**
+2. Select **SOAP** as the type
+3. Enter the **WSDL URL** (e.g., `https://service.example.com/api?wsdl`)
+4. Configure authentication if needed
+5. Click **Create**
+
+### Via API
+
+```bash
+curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Enterprise CRM",
+    "type": "SOAP",
+    "baseUrl": "https://crm.example.com/service",
+    "specUrl": "https://crm.example.com/service?wsdl",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "api-user",
+      "password": "api-pass"
+    }
+  }'
+```
+
+---
+
+## Importing Tools from WSDL
+
+Provide the WSDL URL and AnythingMCP will:
+1. Fetch and parse the WSDL definition
+2. Extract all SOAP operations
+3. Generate an MCP tool for each operation with proper parameters
+
+```bash
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "source": "wsdl",
+    "url": "https://crm.example.com/service?wsdl"
+  }'
+```
+
+### Endpoint Mapping for SOAP
+
+SOAP tools use a specific endpoint mapping format:
+
+```json
+{
+  "method": "GetCustomerDetails",
+  "path": "CustomerServiceSoap12/BasicHttpBinding_ICustomerService",
+  "bodyMapping": {
+    "customerId": "$customer_id",
+    "includeOrders": "$include_orders"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `method` | SOAP operation name |
+| `path` | SOAP port/binding path |
+| `bodyMapping` | Maps tool params to SOAP envelope parameters |
+
+---
+
+## WCF Service Support
+
+AnythingMCP handles WCF-specific requirements:
+
+- **Parameter ordering** — WSDL-defined parameter order is preserved (WCF services are order-sensitive)
+- **Endpoint override** — The connector's `baseUrl` overrides the WSDL endpoint host, useful for internal networks where the WSDL advertises external IPs
+- **Multiple bindings** — Each port/binding generates separate tools
+
+---
+
+## Authentication
+
+| Auth Type | Description |
+|-----------|-------------|
+| **None** | No authentication |
+| **Basic Auth** | HTTP Basic (username/password in header) |
+| **WS-Security** | SOAP-level security headers |
+| **Certificate** | Client certificate authentication |
+| **Bearer Token** | Token in HTTP header |
+
+```json
+{
+  "authType": "WS_SECURITY",
+  "authConfig": {
+    "username": "ws-user",
+    "password": "ws-pass"
+  }
+}
+```
+
+---
+
+## Example: SOAP Service Integration
+
+Suppose you have a legacy CRM with a WSDL at `https://crm.internal.com/CustomerService?wsdl` that exposes operations like `GetCustomer`, `SearchCustomers`, `UpdateCustomer`.
+
+```bash
+# 1. Create the SOAP connector
+CONNECTOR_ID=$(curl -s http://localhost:4000/api/connectors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "CRM Customer Service",
+    "type": "SOAP",
+    "baseUrl": "https://crm.internal.com",
+    "specUrl": "https://crm.internal.com/CustomerService?wsdl",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "api-user",
+      "password": "api-pass"
+    }
+  }' | jq -r '.id')
+
+# 2. Auto-import all SOAP operations as tools
+curl -s http://localhost:4000/api/connectors/$CONNECTOR_ID/import-spec \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+After import, your AI client can call tools like `GetCustomer`, `SearchCustomers`, etc., and AnythingMCP builds the SOAP envelope and makes the call.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| WSDL fetch fails | Ensure the WSDL URL is reachable from the AnythingMCP backend container |
+| Parameter order errors | AnythingMCP respects WSDL parameter ordering; verify the WSDL definition matches service expectations |
+| WCF endpoint mismatch | Set `baseUrl` to the actual service URL; AnythingMCP overrides WSDL endpoint with this value |
+| Authentication failures | For WS-Security, ensure credentials are correct and the security policy matches |
+
+---
+
+[Back to README](../../README.md) | [Tool Definition Format](../tool-definition.md) | [API Reference](../api-reference.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,260 @@
+# Deployment Guide
+
+> Docker setup, production deployment, local development, reverse proxy, and environment configuration.
+
+[Back to README](../README.md)
+
+---
+
+## Quick Start (Docker)
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp
+cp .env.example .env
+# Edit .env — set JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD
+docker compose up -d
+open http://localhost:3000
+```
+
+The first user to register becomes **Admin**.
+
+### Docker Services
+
+| Container | Image | Port |
+|-----------|-------|------|
+| `atmcp-frontend` | Next.js 16 (standalone) | 3000 |
+| `atmcp-backend` | NestJS 11 | 4000 |
+| `atmcp-postgres` | PostgreSQL 17 | 5432 |
+| `atmcp-redis` | Redis 7 | 6379 |
+
+### Service URLs
+
+| Service | URL |
+|---------|-----|
+| Web UI | `http://localhost:3000` |
+| Backend API | `http://localhost:4000` |
+| MCP Endpoint | `http://localhost:4000/mcp` |
+| Swagger Docs | `http://localhost:4000/api/docs` |
+| Health Check | `http://localhost:4000/health` |
+
+---
+
+## Local Development
+
+Run PostgreSQL and Redis in Docker, frontend and backend locally with hot reload.
+
+### Prerequisites
+
+- **Node.js** 22+
+- **npm** 9+
+- **Docker** and **Docker Compose** (for PostgreSQL and Redis)
+
+### Setup
+
+```bash
+cd anythingmcp
+cp .env.example .env
+```
+
+Edit `.env` for local development (note: PostgreSQL on port 5433):
+
+```env
+NODE_ENV=development
+PORT=4000
+POSTGRES_PASSWORD=your-local-password
+DATABASE_URL=postgresql://atmcp:your-local-password@localhost:5433/anythingmcp
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=local-dev-secret-at-least-32-chars!!
+ENCRYPTION_KEY=local-dev-key-exactly-32-chars!!
+NEXT_PUBLIC_API_URL=http://localhost:4000
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=local-dev-nextauth-secret-32-chars!!
+CORS_ORIGIN=http://localhost:3000
+```
+
+```bash
+# Start PostgreSQL and Redis (dev overlay disables frontend/backend containers)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis
+
+# Install dependencies
+npm install
+
+# Symlink .env into package directories (Prisma & Next.js need it)
+ln -sf ../../.env packages/backend/.env
+ln -sf ../../.env packages/frontend/.env
+
+# Export env vars (Prisma CLI reads DATABASE_URL from shell)
+export $(grep -v '^#' .env | grep -v '^$' | xargs)
+
+# Run migrations and generate Prisma client
+cd packages/backend
+npx prisma migrate dev
+npx prisma generate
+cd ../..
+
+# Start both backend and frontend
+npm run dev
+```
+
+Or run separately:
+
+```bash
+npm run dev:backend   # Terminal 1 — NestJS with hot reload
+npm run dev:frontend  # Terminal 2 — Next.js with Turbopack
+```
+
+### Useful Commands
+
+```bash
+npm test                                             # Run all tests
+cd packages/backend && npm test                      # Backend tests only
+cd packages/backend && npx prisma studio             # DB browser
+cd packages/backend && npx prisma migrate dev --name describe_change  # New migration
+cd packages/backend && npx prisma migrate reset      # Reset DB
+npm run build                                        # Production build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down    # Stop
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v # Stop + wipe DB
+```
+
+---
+
+## Production Deployment
+
+### With Docker (Recommended)
+
+```bash
+cp .env.example .env
+# Set strong values for: JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD, NEXTAUTH_SECRET
+# Set MCP_BEARER_TOKEN or MCP_API_KEY for MCP endpoint auth
+docker compose up -d --build
+curl http://localhost:4000/health
+```
+
+The backend runs `prisma migrate deploy` on startup.
+
+### Without Docker
+
+```bash
+# Ensure PostgreSQL 17+ and Redis 7+ are running externally
+# Configure .env with correct DATABASE_URL and REDIS_URL
+
+# Build
+cd packages/backend && npm ci && npx prisma generate && npm run build
+cd packages/frontend && npm ci && npm run build
+
+# Migrate
+cd packages/backend && npx prisma migrate deploy
+
+# Start
+cd packages/backend && node dist/main.js
+cd packages/frontend && npm start
+```
+
+---
+
+## Reverse Proxy (nginx)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name mcp.yourdomain.com;
+
+    # Frontend
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+    }
+
+    # Backend API
+    location /api/ {
+        proxy_pass http://localhost:4000;
+    }
+
+    # MCP endpoint
+    location /mcp {
+        proxy_pass http://localhost:4000;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+    }
+
+    # Health check
+    location /health {
+        proxy_pass http://localhost:4000;
+    }
+}
+```
+
+---
+
+## Authentication
+
+### MCP Auth Modes
+
+Configure `MCP_AUTH_MODE` in `.env`:
+
+| Mode | Description |
+|------|-------------|
+| `oauth2` | OAuth 2.0 Authorization Code (PKCE) + Client Credentials **(default)** |
+| `legacy` | Static Bearer Token (`MCP_BEARER_TOKEN`) or API Key (`MCP_API_KEY`) |
+| `both` | Accepts either OAuth2 or legacy tokens |
+| `none` | No authentication (development only) |
+
+### Legacy Auth
+
+Set in `.env`:
+```env
+MCP_AUTH_MODE=legacy
+MCP_BEARER_TOKEN=your-secure-bearer-token
+MCP_API_KEY=your-secure-api-key
+```
+
+### OAuth2
+
+The OAuth2 discovery endpoint is at:
+```
+GET http://your-server:4000/.well-known/oauth-authorization-server
+```
+
+Supports:
+- **Authorization Code + PKCE** — For interactive clients
+- **Client Credentials** — For server-to-server integrations
+
+### Per-User API Keys
+
+Generate in the UI or via API:
+```bash
+curl -s http://localhost:4000/api/mcp-api-keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "My Key"}'
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `JWT_SECRET` | Yes | JWT signing secret (min 32 chars) |
+| `ENCRYPTION_KEY` | Yes | AES-256-GCM key (exactly 32 chars) |
+| `PORT` | No | Backend port (default: 4000) |
+| `REDIS_URL` | No | Redis URL (graceful fallback if unavailable) |
+| `CORS_ORIGIN` | No | Allowed origin (default: `http://localhost:3000`) |
+| `NEXT_PUBLIC_API_URL` | No | Backend URL for frontend (default: `http://localhost:4000`) |
+| `NEXTAUTH_URL` | No | NextAuth callback URL (default: `http://localhost:3000`) |
+| `NEXTAUTH_SECRET` | No | NextAuth secret for frontend |
+| `FRONTEND_URL` | No | Frontend URL for email links (default: `http://localhost:3000`) |
+| `MCP_AUTH_MODE` | No | MCP auth: `none`, `legacy`, `oauth2`, `both` (default: `oauth2`) |
+| `MCP_BEARER_TOKEN` | No | Bearer token for legacy MCP auth |
+| `MCP_API_KEY` | No | API key for legacy MCP auth |
+| `SERVER_URL` | No | Server URL for OAuth2 metadata (default: `http://localhost:4000`) |
+| `MCP_RATE_LIMIT_PER_MINUTE` | No | Rate limit per client (default: 60) |
+
+---
+
+[Back to README](../README.md) | [API Reference](api-reference.md) | [Integration Guides](../README.md#connect-your-ai-client)

--- a/docs/integrations/chatgpt.md
+++ b/docs/integrations/chatgpt.md
@@ -1,0 +1,108 @@
+# Connect AnythingMCP to ChatGPT
+
+> Setup guide for using AnythingMCP tools with ChatGPT.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+ChatGPT supports MCP server connections, allowing you to use your AnythingMCP tools directly in ChatGPT conversations. This works with ChatGPT Plus, Team, and Enterprise plans.
+
+---
+
+## Prerequisites
+
+- **ChatGPT Plus**, **Team**, or **Enterprise** plan
+- AnythingMCP deployed and accessible via a **public HTTPS URL** (ChatGPT connects from the cloud)
+- MCP tools configured in your AnythingMCP instance
+
+> **Important:** ChatGPT connects to MCP servers from the internet. Your AnythingMCP instance must be accessible via a public URL with HTTPS. A `localhost` URL will not work.
+
+---
+
+## Step 1: Deploy AnythingMCP Publicly
+
+If you haven't already, deploy AnythingMCP with a public HTTPS URL. See the [Deployment Guide](../deployment.md) for instructions on setting up a reverse proxy with TLS.
+
+Your MCP endpoint will be:
+```
+https://mcp.yourdomain.com/mcp
+```
+
+---
+
+## Step 2: Configure MCP Auth
+
+Set the appropriate auth mode in your `.env`:
+
+```env
+MCP_AUTH_MODE=legacy    # or 'both' for OAuth2 + legacy
+MCP_BEARER_TOKEN=your-secure-token
+```
+
+---
+
+## Step 3: Add MCP Server in ChatGPT
+
+1. Open **ChatGPT** in your browser
+2. Click on your **profile icon** > **Settings**
+3. Navigate to the **MCP Servers** or **Connected Tools** section
+4. Click **Add MCP Server**
+5. Enter:
+   - **Server URL**: `https://mcp.yourdomain.com/mcp`
+   - **Authentication**: Bearer Token
+   - **Token**: Your `MCP_BEARER_TOKEN` value
+6. Click **Connect**
+
+ChatGPT will discover and list all available tools from your AnythingMCP instance.
+
+---
+
+## Step 4: Use Tools in Conversations
+
+Once connected, you can ask ChatGPT to use your MCP tools naturally:
+
+- *"Use the CRM to look up customer John Smith"*
+- *"Query the database for orders from last week"*
+- *"Search our product catalog for wireless headphones"*
+
+ChatGPT will call the appropriate MCP tool and show you the results.
+
+---
+
+## Authentication Options
+
+| Method | Configuration |
+|--------|--------------|
+| **Bearer Token** | Set `MCP_BEARER_TOKEN` in `.env`, provide token in ChatGPT settings |
+| **API Key** | Generate an MCP API Key in AnythingMCP UI, provide in ChatGPT settings |
+| **OAuth2** | Configure OAuth2 in AnythingMCP, use ChatGPT's OAuth integration |
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Cannot connect to server" | Ensure your AnythingMCP URL is publicly accessible via HTTPS |
+| "Authentication failed" | Verify your token matches `MCP_BEARER_TOKEN` in `.env` |
+| "No tools found" | Check that connectors and tools are configured in AnythingMCP |
+| Timeout errors | Check that your reverse proxy doesn't have aggressive timeout settings; MCP uses long-lived connections |
+
+---
+
+## Security Considerations
+
+When exposing AnythingMCP to the internet for ChatGPT:
+
+1. **Always use HTTPS** — Never expose MCP over plain HTTP
+2. **Use strong tokens** — Generate long, random Bearer Tokens
+3. **Enable rate limiting** — Set `MCP_RATE_LIMIT_PER_MINUTE` in `.env`
+4. **Use roles** — Create a restricted MCP role for ChatGPT with only the tools it needs
+5. **Monitor audit logs** — Review tool invocations in the AnythingMCP audit log
+
+---
+
+[Back to README](../../README.md)

--- a/docs/integrations/claude.md
+++ b/docs/integrations/claude.md
@@ -1,0 +1,220 @@
+# Connect AnythingMCP to Claude
+
+> Setup guide for Claude Desktop, Claude Code, and Cursor.
+
+[Back to README](../../README.md)
+
+---
+
+## Claude Desktop
+
+Claude Desktop supports MCP servers natively via the Streamable HTTP transport.
+
+### Step 1: Get Your MCP Credentials
+
+1. Log into the AnythingMCP UI at `http://localhost:3000`
+2. Go to **MCP Server** to find your endpoint URL and auth config
+3. Generate an **MCP API Key** or note your Bearer Token
+
+### Step 2: Edit Claude Desktop Config
+
+Open your Claude Desktop configuration file:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add AnythingMCP as an MCP server:
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "type": "url",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### Step 3: Restart Claude Desktop
+
+Restart Claude Desktop. You should see your MCP tools available in the tools menu.
+
+### Using API Keys
+
+If you generated a per-user MCP API Key, use the `X-API-Key` header instead:
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "type": "url",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "X-API-Key": "your-mcp-api-key"
+      }
+    }
+  }
+}
+```
+
+### Multiple MCP Server Configs
+
+If you created multiple MCP server configurations in AnythingMCP (each with different connector assignments), use the server-specific endpoint:
+
+```json
+{
+  "mcpServers": {
+    "crm-tools": {
+      "type": "url",
+      "url": "http://localhost:4000/mcp?server=crm-server",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    },
+    "analytics-tools": {
+      "type": "url",
+      "url": "http://localhost:4000/mcp?server=analytics-server",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Claude Code
+
+Claude Code (CLI) supports adding MCP servers via the command line.
+
+### Add AnythingMCP
+
+```bash
+claude mcp add anythingmcp \
+  --transport http \
+  --url http://localhost:4000/mcp \
+  --header "Authorization: Bearer YOUR_MCP_BEARER_TOKEN"
+```
+
+### With API Key
+
+```bash
+claude mcp add anythingmcp \
+  --transport http \
+  --url http://localhost:4000/mcp \
+  --header "X-API-Key: your-mcp-api-key"
+```
+
+### Verify Connection
+
+```bash
+claude mcp list
+```
+
+You should see `anythingmcp` listed with its tools.
+
+---
+
+## Cursor
+
+Cursor supports MCP servers via its settings.
+
+### Step 1: Open Cursor Settings
+
+Go to **Settings** > **MCP Servers** (or `Cmd+,` / `Ctrl+,` and search for "MCP").
+
+### Step 2: Add Server
+
+Add a new MCP server with:
+- **Name**: `anythingmcp`
+- **Transport**: HTTP
+- **URL**: `http://localhost:4000/mcp`
+- **Headers**: `Authorization: Bearer YOUR_MCP_BEARER_TOKEN`
+
+### Via mcp.json
+
+Alternatively, add to your project's `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Any MCP Client
+
+AnythingMCP exposes a standard **Streamable HTTP** MCP endpoint at:
+
+```
+POST http://your-server:4000/mcp
+```
+
+### Authentication Modes
+
+Configure `MCP_AUTH_MODE` in your `.env`:
+
+| Mode | Description |
+|------|-------------|
+| `oauth2` | OAuth 2.0 Authorization Code (PKCE) + Client Credentials **(default)** |
+| `legacy` | Static Bearer Token or API Key |
+| `both` | Accepts either OAuth2 or legacy tokens |
+| `none` | No authentication (development only) |
+
+### Legacy Auth Headers
+
+When using `legacy` or `both` mode:
+
+```http
+POST /mcp HTTP/1.1
+Authorization: Bearer YOUR_MCP_BEARER_TOKEN
+Content-Type: application/json
+```
+
+Or with API Key:
+
+```http
+POST /mcp HTTP/1.1
+X-API-Key: your-mcp-api-key
+Content-Type: application/json
+```
+
+### OAuth2 Flow
+
+When using `oauth2` or `both` mode, clients can authenticate via:
+
+1. **Authorization Code + PKCE** — For interactive clients
+2. **Client Credentials** — For server-to-server integrations
+
+The OAuth2 discovery endpoint is at:
+```
+GET http://your-server:4000/.well-known/oauth-authorization-server
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "No tools available" | Verify connectors are created and have tools defined in AnythingMCP UI |
+| 401 Unauthorized | Check your token/API key is correct and `MCP_AUTH_MODE` matches your auth method |
+| Connection refused | Ensure the AnythingMCP backend is running on port 4000 |
+| Tools not updating | AnythingMCP hot-reloads tools; try reconnecting your MCP client |
+
+---
+
+[Back to README](../../README.md)

--- a/docs/integrations/copilot.md
+++ b/docs/integrations/copilot.md
@@ -1,0 +1,147 @@
+# Connect AnythingMCP to GitHub Copilot
+
+> Setup guide for using AnythingMCP tools with GitHub Copilot in VS Code and JetBrains IDEs.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+GitHub Copilot supports MCP server connections in **VS Code** and **JetBrains IDEs** (agent mode). You can connect your AnythingMCP tools to Copilot Chat for use in your coding workflow.
+
+---
+
+## VS Code Setup
+
+### Step 1: Enable MCP Support
+
+Ensure you have:
+- **GitHub Copilot** extension installed and active
+- **VS Code** 1.99+ (or latest Insiders)
+- Copilot Chat agent mode enabled
+
+### Step 2: Configure MCP Server
+
+Add AnythingMCP to your VS Code MCP settings. Create or edit `.vscode/mcp.json` in your project:
+
+```json
+{
+  "servers": {
+    "anythingmcp": {
+      "type": "http",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Or configure it globally via VS Code settings (`settings.json`):
+
+```json
+{
+  "github.copilot.chat.mcp.servers": {
+    "anythingmcp": {
+      "type": "http",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### Step 3: Use in Copilot Chat
+
+Open Copilot Chat in **Agent mode** (select "Agent" from the mode picker) and ask it to use your tools:
+
+- *"Use anythingmcp to search for customers"*
+- *"Query the database for recent orders"*
+- *"Call the CRM API to get contact details"*
+
+Copilot will discover available tools and invoke them as needed.
+
+---
+
+## JetBrains IDEs Setup
+
+GitHub Copilot in JetBrains IDEs (IntelliJ, WebStorm, PyCharm, etc.) also supports MCP servers.
+
+### Configure MCP Server
+
+Add to your project's `.github/copilot-mcp.json`:
+
+```json
+{
+  "servers": {
+    "anythingmcp": {
+      "type": "http",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Using API Keys
+
+If you use per-user MCP API Keys:
+
+```json
+{
+  "servers": {
+    "anythingmcp": {
+      "type": "http",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "X-API-Key": "your-mcp-api-key"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Team Setup
+
+For team-wide configurations, commit the `.vscode/mcp.json` file to your repository. Use environment variables for tokens:
+
+```json
+{
+  "servers": {
+    "anythingmcp": {
+      "type": "http",
+      "url": "https://mcp.yourcompany.com/mcp",
+      "headers": {
+        "X-API-Key": "${MCP_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Each team member sets their own `MCP_API_KEY` environment variable with their personal API key from AnythingMCP.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| MCP tools not showing | Ensure you're in **Agent mode** in Copilot Chat, not "Edit" or "Ask" mode |
+| "Server not available" | Verify AnythingMCP is running and the URL is correct |
+| Auth errors | Check token/API key; ensure `MCP_AUTH_MODE` includes `legacy` or `both` |
+| VS Code version | MCP support requires VS Code 1.99+ |
+
+---
+
+[Back to README](../../README.md)

--- a/docs/integrations/gemini.md
+++ b/docs/integrations/gemini.md
@@ -1,0 +1,181 @@
+# Connect AnythingMCP to Google Gemini
+
+> Setup guide for using AnythingMCP tools with Gemini CLI and Gemini API.
+
+[Back to README](../../README.md)
+
+---
+
+## Overview
+
+Google Gemini supports MCP server connections through **Gemini CLI** and the **Gemini API**. You can connect your AnythingMCP tools to Gemini for use in terminal-based workflows, automation, and AI-powered development.
+
+---
+
+## Gemini CLI
+
+The Gemini CLI supports MCP servers via its `settings.json` configuration.
+
+### Step 1: Install Gemini CLI
+
+```bash
+npm install -g @anthropic-ai/gemini-cli
+# or
+npx @anthropic-ai/gemini-cli
+```
+
+### Step 2: Add AnythingMCP Server
+
+#### Option A: Via Command Line
+
+```bash
+gemini mcp add anythingmcp http://localhost:4000/mcp \
+  -t http \
+  -H "Authorization: Bearer YOUR_MCP_BEARER_TOKEN"
+```
+
+#### Option B: Via settings.json
+
+Edit your Gemini CLI settings file:
+
+- **macOS/Linux**: `~/.gemini/settings.json`
+- **Windows**: `%USERPROFILE%\.gemini\settings.json`
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "httpUrl": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      },
+      "timeout": 30000
+    }
+  }
+}
+```
+
+### Step 3: Verify Connection
+
+```bash
+gemini mcp list
+```
+
+You should see `anythingmcp` listed with available tools.
+
+### Using API Keys
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "httpUrl": "http://localhost:4000/mcp",
+      "headers": {
+        "X-API-Key": "your-mcp-api-key"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Remote Server (Public URL)
+
+For connecting Gemini CLI to a publicly deployed AnythingMCP:
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "httpUrl": "https://mcp.yourdomain.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_BEARER_TOKEN"
+      },
+      "timeout": 30000
+    }
+  }
+}
+```
+
+---
+
+## Project-Scoped Configuration
+
+For project-specific MCP settings, create a `.gemini/settings.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "project-api": {
+      "httpUrl": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer PROJECT_SPECIFIC_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Use the `-s project` flag when adding via CLI:
+
+```bash
+gemini mcp add project-api http://localhost:4000/mcp \
+  -t http \
+  -s project \
+  -H "Authorization: Bearer PROJECT_SPECIFIC_TOKEN"
+```
+
+---
+
+## Tool Filtering
+
+Gemini CLI supports filtering which tools to expose:
+
+```json
+{
+  "mcpServers": {
+    "anythingmcp": {
+      "httpUrl": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      },
+      "includeTools": ["get_customers", "search_products"],
+      "excludeTools": ["delete_customer"]
+    }
+  }
+}
+```
+
+---
+
+## Managing Servers
+
+```bash
+# List all MCP servers
+gemini mcp list
+
+# Remove a server
+gemini mcp remove anythingmcp
+
+# Temporarily disable a server
+gemini mcp disable anythingmcp
+
+# Re-enable a server
+gemini mcp enable anythingmcp
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Server not found" | Run `gemini mcp list` to verify the server is configured |
+| Connection timeout | Increase the `timeout` value in settings.json |
+| Auth errors | Verify the token and ensure `MCP_AUTH_MODE` is set to `legacy` or `both` |
+| Tools not appearing | Check that connectors have tools defined in AnythingMCP UI |
+
+---
+
+[Back to README](../../README.md)

--- a/docs/tool-definition.md
+++ b/docs/tool-definition.md
@@ -1,0 +1,191 @@
+# Tool Definition Format
+
+> How to define MCP tools in AnythingMCP: parameters, endpoint mapping, and response mapping.
+
+[Back to README](../README.md)
+
+---
+
+## Overview
+
+Every MCP tool in AnythingMCP is defined by three JSON objects:
+
+1. **`parameters`** — What the AI can pass as input (JSON Schema)
+2. **`endpointMapping`** — How parameters map to the API request
+3. **`responseMapping`** — (Optional) How to transform the API response
+
+---
+
+## 1. Parameters (JSON Schema)
+
+Standard JSON Schema that defines tool inputs visible to the AI:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "user_id": { "type": "integer", "description": "The user's ID" },
+    "include_details": { "type": "boolean", "description": "Include extra details" },
+    "query": { "type": "string", "description": "Search query" }
+  },
+  "required": ["user_id"]
+}
+```
+
+Supported types: `string`, `integer`, `number`, `boolean`, `array`, `object`
+
+> **Tip:** Parameters matching environment variable names are automatically stripped from the tool schema, so the AI never sees them.
+
+---
+
+## 2. Endpoint Mapping
+
+The bridge configuration that transforms MCP tool calls into API requests.
+
+### REST Example
+
+```json
+{
+  "method": "POST",
+  "path": "/users/{user_id}/orders",
+  "queryParams": {
+    "page": "$page",
+    "limit": "$limit"
+  },
+  "bodyMapping": {
+    "productId": "$product_id",
+    "quantity": "$qty"
+  },
+  "headers": {
+    "X-Request-ID": "$request_id"
+  }
+}
+```
+
+### Mapping Patterns
+
+| Pattern | Location | Description |
+|---------|----------|-------------|
+| `{param}` in path | URL path | Replaced in URL: `/users/{id}` becomes `/users/123` |
+| `"$param"` in queryParams | Query string | Added as `?param=value` |
+| `"$param"` in bodyMapping | JSON body | Included in request body |
+| `"$param"` in headers | HTTP headers | Sent as request header |
+
+The `$` prefix means "take the value from the tool input parameter with this name."
+
+### By Connector Type
+
+| Connector | method | path | queryParams | bodyMapping | headers |
+|-----------|--------|------|-------------|-------------|---------|
+| **REST** | HTTP method (`GET`, `POST`, etc.) | URL path with `{param}` | Query string params | JSON body fields | HTTP headers |
+| **GraphQL** | `query` or `mutation` | The GraphQL query string | GraphQL variables | — | HTTP headers |
+| **SOAP** | SOAP operation name | Port/binding path | — | SOAP parameters | HTTP headers |
+| **Database** | `query` or `static` | SQL/MongoDB query with `$param` | — | — | — |
+| **MCP** | Remote tool name | — | — | Passed through | — |
+
+### GraphQL Example
+
+```json
+{
+  "method": "query",
+  "path": "query GetUser($id: ID!) { user(id: $id) { id name email } }",
+  "queryParams": {
+    "id": "$user_id"
+  }
+}
+```
+
+### SOAP Example
+
+```json
+{
+  "method": "GetCustomerDetails",
+  "path": "CustomerServiceSoap12/BasicHttpBinding",
+  "bodyMapping": {
+    "customerId": "$customer_id",
+    "includeHistory": "$include_history"
+  }
+}
+```
+
+### Database Example (SQL)
+
+```json
+{
+  "method": "static",
+  "path": "SELECT * FROM orders WHERE customer_id = $customer_id AND status = $status ORDER BY created_at DESC LIMIT $limit"
+}
+```
+
+### Database Example (MongoDB)
+
+```json
+{
+  "method": "query",
+  "path": "db.collection('orders').find({customerId: $customer_id, status: $status}).sort({createdAt: -1}).limit($limit)"
+}
+```
+
+### MCP Bridge Example
+
+```json
+{
+  "method": "remote_tool_name",
+  "bodyMapping": {
+    "param1": "$param1",
+    "param2": "$param2"
+  }
+}
+```
+
+---
+
+## 3. Response Mapping (Optional)
+
+Transform the API response before returning to the AI:
+
+```json
+{
+  "type": "json",
+  "fields": ["id", "name", "email", "status"]
+}
+```
+
+This filters the response to only include the specified fields, reducing token usage and focusing the AI on relevant data.
+
+---
+
+## Full Tool Example
+
+```json
+{
+  "name": "search_products",
+  "description": "Search products by keyword and category",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "query": { "type": "string", "description": "Search keyword" },
+      "category": { "type": "string", "description": "Product category" },
+      "limit": { "type": "integer", "description": "Max results (default 10)" }
+    },
+    "required": ["query"]
+  },
+  "endpointMapping": {
+    "method": "GET",
+    "path": "/api/products/search",
+    "queryParams": {
+      "q": "$query",
+      "cat": "$category",
+      "limit": "$limit"
+    }
+  },
+  "responseMapping": {
+    "type": "json",
+    "fields": ["id", "name", "price", "category"]
+  }
+}
+```
+
+---
+
+[Back to README](../README.md) | [API Reference](api-reference.md) | [REST Connector](connectors/rest.md)


### PR DESCRIPTION
## Summary
- Rewrote README with SEO-optimized content, badges, and concise structure
- Split docs into 12 sub-files: connector guides (REST, SOAP, GraphQL, Database, MCP Bridge), integration guides (Claude, ChatGPT, Gemini, Copilot), API reference, tool definition format, deployment guide
- Added keywords for discoverability: REST API to MCP, SOAP to MCP, MCP middleware, MCP gateway
- Added community call-to-action (star, Discord, contribute)