### PR TITLE
Make Redis optional, cleanup README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ PORT=4000
 POSTGRES_PASSWORD=change-me-in-production
 DATABASE_URL=postgresql://atmcp:${POSTGRES_PASSWORD}@postgres:5432/anythingmcp
 
-# ── Redis ────────────────────────────────────────────────────────────────────
-REDIS_URL=redis://redis:6379
+# ── Redis (optional) ─────────────────────────────────────────────────────────
+# Redis enables response caching and rate limiting. The app works without it.
+# REDIS_URL=redis://redis:6379
 
 # ── Security ─────────────────────────────────────────────────────────────────
 # JWT secret for API authentication (min 32 characters)
@@ -46,5 +47,5 @@ MCP_AUTH_MODE=oauth2
 SERVER_URL=http://localhost:4000
 
 # ── MCP Rate Limiting ──────────────────────────────────────────────────────
-# Max requests per minute per client (by API key or IP). Requires Redis.
+# Max requests per minute per client (by API key or IP). Only enforced when Redis is available.
 MCP_RATE_LIMIT_PER_MINUTE=60

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
   <p align="center">
     <a href="https://github.com/HelpCode-ai/anythingmcp/stargazers"><img src="https://img.shields.io/github/stars/HelpCode-ai/anythingmcp?style=social" alt="GitHub Stars"></a>&nbsp;
     <a href="https://github.com/HelpCode-ai/anythingmcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSL--1.1-blue" alt="License"></a>&nbsp;
-    <a href="https://github.com/HelpCode-ai/anythingmcp/releases"><img src="https://img.shields.io/github/v/release/HelpCode-ai/anythingmcp?include_prereleases" alt="Release"></a>&nbsp;
-    <a href="https://discord.gg/anythingmcp"><img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+    <a href="https://github.com/HelpCode-ai/anythingmcp/releases"><img src="https://img.shields.io/github/v/release/HelpCode-ai/anythingmcp?include_prereleases" alt="Release"></a>
   </p>
 </p>
 
@@ -17,10 +16,6 @@
 **AnythingMCP** is a self-hosted, open-source MCP middleware that turns your existing APIs into [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers. Connect **any** API — REST, SOAP, GraphQL, databases, or other MCP servers — and expose them as tools to AI clients like **Claude**, **ChatGPT**, **Gemini**, **Copilot**, **Cursor**, and more.
 
 No SDK. No code changes. Just point, configure, and connect.
-
-<p align="center">
-  <img src="docs/assets/architecture-overview.png" alt="AnythingMCP Architecture" width="700"/>
-</p>
 
 > **Looking for an MCP gateway?** AnythingMCP acts as a universal MCP proxy and API-to-MCP bridge — the missing middleware between your APIs and AI agents.
 
@@ -129,7 +124,7 @@ Each connector type has dedicated documentation with setup instructions, example
                         └─────────────────────────────────┘
                           Single Docker container:
                           Next.js UI + NestJS Backend
-                          PostgreSQL  │  Redis
+                          PostgreSQL  │  Redis (optional)
 ```
 
 **How it works:**
@@ -149,22 +144,9 @@ Each connector type has dedicated documentation with setup instructions, example
 | Backend | NestJS 11, TypeScript |
 | MCP | @modelcontextprotocol/sdk, Streamable HTTP |
 | Database | PostgreSQL 17, Prisma 7 |
-| Cache | Redis 7 |
+| Cache | Redis 7 (optional) |
 | Auth | JWT, OAuth2, AES-256-GCM |
 | Deploy | Docker (single container for app) + Docker Compose |
-
----
-
-## Community
-
-We're building the universal MCP gateway and we need your help!
-
-- **Star this repo** to help others discover AnythingMCP
-- **Join the [Discord community](https://discord.gg/anythingmcp)** to share ideas, get help, and connect with other developers
-- **Open an issue** to report bugs or suggest features
-- **Submit a PR** to contribute code, docs, or connector types
-
-Every star, issue, and conversation helps us build a better MCP ecosystem for everyone.
 
 ---
 
@@ -175,7 +157,7 @@ See the [Deployment Guide](docs/deployment.md#local-development) for full local 
 ```bash
 # Quick local dev setup
 cp .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
 npm install
 ln -sf ../../.env packages/backend/.env
 ln -sf ../../.env packages/frontend/.env
@@ -194,6 +176,6 @@ Licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1).
 - **Not permitted**: offering as a commercial hosted service without a separate license
 - **Change Date**: 2030-03-04 — converts to Apache 2.0
 
-For commercial licensing: [licensing@helpcode.ai](mailto:licensing@helpcode.ai)
+For commercial licensing: [info@helpcode.ai](mailto:info@helpcode.ai)
 
 Copyright (c) 2026 helpcode.ai GmbH

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@
 # AnythingMCP — Development Overrides
 # =============================================================================
 # Usage:  docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
-# Only starts postgres + redis; run frontend/backend locally with hot reload.
+# Only starts postgres; run frontend/backend locally with hot reload.
 # =============================================================================
 
 services:
@@ -14,6 +14,7 @@ services:
     ports:
       - "${POSTGRES_PORT:-5433}:5432"
 
-  redis:
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
+  # Uncomment if Redis is enabled in docker-compose.yml
+  # redis:
+  #   ports:
+  #     - "${REDIS_PORT:-6379}:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - PORT=4000
       - NEXT_PUBLIC_API_URL=http://localhost:4000
       - DATABASE_URL=postgresql://atmcp:${POSTGRES_PASSWORD:-atmcp}@postgres:5432/anythingmcp
-      - REDIS_URL=redis://redis:6379
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production-min-32-chars}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-change-me-in-production-exactly-32}
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3000}
@@ -35,11 +34,11 @@ services:
       - MCP_AUTH_MODE=${MCP_AUTH_MODE:-legacy}
       - MCP_API_KEY=${MCP_API_KEY:-}
       - MCP_BEARER_TOKEN=${MCP_BEARER_TOKEN:-}
+      # Uncomment to enable Redis (optional — used for response caching and rate limiting)
+      # - REDIS_URL=redis://redis:6379
 
     depends_on:
       postgres:
-        condition: service_healthy
-      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/health"]
@@ -66,19 +65,19 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # Redis Cache
-  redis:
-    image: redis:7-alpine
-    container_name: atmcp-redis
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-    restart: unless-stopped
+  # Redis Cache (optional — uncomment to enable response caching and rate limiting)
+  # redis:
+  #   image: redis:7-alpine
+  #   container_name: atmcp-redis
+  #   volumes:
+  #     - redis_data:/data
+  #   healthcheck:
+  #     test: ["CMD", "redis-cli", "ping"]
+  #     interval: 5s
+  #     timeout: 3s
+  #     retries: 5
+  #   restart: unless-stopped
 
 volumes:
   postgres_data:
-  redis_data:
+  # redis_data:  # Uncomment if Redis is enabled

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,7 +25,7 @@ The first user to register becomes **Admin**.
 |-----------|-------------|------|
 | `atmcp-app` | Next.js 16 + NestJS 11 (single image) | 3000, 4000 |
 | `atmcp-postgres` | PostgreSQL 17 | 5432 |
-| `atmcp-redis` | Redis 7 | 6379 |
+| `atmcp-redis` | Redis 7 (optional) | 6379 |
 
 > **Note:** Frontend and backend run in a single container since both are Node.js. A lightweight startup script (`start.sh`) manages both processes.
 
@@ -43,13 +43,13 @@ The first user to register becomes **Admin**.
 
 ## Local Development
 
-Run PostgreSQL and Redis in Docker, frontend and backend locally with hot reload.
+Run PostgreSQL in Docker, frontend and backend locally with hot reload.
 
 ### Prerequisites
 
 - **Node.js** 22+
 - **npm** 9+
-- **Docker** and **Docker Compose** (for PostgreSQL and Redis)
+- **Docker** and **Docker Compose** (for PostgreSQL)
 
 ### Setup
 
@@ -65,7 +65,7 @@ NODE_ENV=development
 PORT=4000
 POSTGRES_PASSWORD=your-local-password
 DATABASE_URL=postgresql://atmcp:your-local-password@localhost:5433/anythingmcp
-REDIS_URL=redis://localhost:6379
+# REDIS_URL=redis://localhost:6379  # Optional — enables caching and rate limiting
 JWT_SECRET=local-dev-secret-at-least-32-chars!!
 ENCRYPTION_KEY=local-dev-key-exactly-32-chars!!
 NEXT_PUBLIC_API_URL=http://localhost:4000
@@ -75,8 +75,8 @@ CORS_ORIGIN=http://localhost:3000
 ```
 
 ```bash
-# Start PostgreSQL and Redis (dev overlay disables the app container)
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres redis
+# Start PostgreSQL (dev overlay disables the app container)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
 
 # Install dependencies
 npm install
@@ -137,8 +137,9 @@ The container runs `prisma migrate deploy` on startup, then launches both backen
 ### Without Docker
 
 ```bash
-# Ensure PostgreSQL 17+ and Redis 7+ are running externally
-# Configure .env with correct DATABASE_URL and REDIS_URL
+# Ensure PostgreSQL 17+ is running externally
+# Configure .env with correct DATABASE_URL
+# Optionally run Redis 7+ and set REDIS_URL for caching and rate limiting
 
 # Build
 cd packages/backend && npm ci && npx prisma generate && npm run build
@@ -244,7 +245,7 @@ curl -s http://localhost:4000/api/mcp-api-keys \
 | `JWT_SECRET` | Yes | JWT signing secret (min 32 chars) |
 | `ENCRYPTION_KEY` | Yes | AES-256-GCM key (exactly 32 chars) |
 | `PORT` | No | Backend port (default: 4000) |
-| `REDIS_URL` | No | Redis URL (graceful fallback if unavailable) |
+| `REDIS_URL` | No | Redis URL (optional — enables response caching and rate limiting) |
 | `CORS_ORIGIN` | No | Allowed origin (default: `http://localhost:3000`) |
 | `NEXT_PUBLIC_API_URL` | No | Backend URL for frontend (default: `http://localhost:4000`) |
 | `NEXTAUTH_URL` | No | NextAuth callback URL (default: `http://localhost:3000`) |


### PR DESCRIPTION
## Summary
- Make Redis explicitly optional in docker-compose (commented out, easy to re-enable)
- Remove Discord badge and Community section
- Remove architecture PNG (text diagram remains)
- Fix license email to info@helpcode.ai
- Update deployment docs to reflect Redis is optional