### PR TITLE
Add 12 unit test files (115 → 245 tests)

### DIFF
--- a/packages/backend/src/auth/mcp-auth.guard.spec.ts
+++ b/packages/backend/src/auth/mcp-auth.guard.spec.ts
@@ -1,0 +1,148 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { McpAuthGuard } from './mcp-auth.guard';
+
+describe('McpAuthGuard', () => {
+  let guard: McpAuthGuard;
+  let mockConfig: any;
+  let mockAuth: any;
+  let mockApiKeys: any;
+
+  const mockContext = (headers: Record<string, string> = {}) => {
+    const request = { headers, user: undefined as any };
+    const response = { setHeader: jest.fn() };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+      _request: request,
+      _response: response,
+    } as any;
+  };
+
+  beforeEach(() => {
+    mockConfig = { get: jest.fn() };
+    mockAuth = { verifyToken: jest.fn() };
+    mockApiKeys = { resolveUserByKey: jest.fn() };
+    guard = new McpAuthGuard(mockConfig, mockAuth, mockApiKeys);
+  });
+
+  describe('per-user MCP API key (mcp_ prefix)', () => {
+    it('should authenticate valid mcp_ key and set request.user', async () => {
+      const user = { id: 'u1', email: 'a@b.com', role: 'USER', mcpRoleId: 'r1' };
+      mockApiKeys.resolveUserByKey.mockResolvedValue(user);
+
+      const ctx = mockContext({ 'x-api-key': 'mcp_abc123' });
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      const req = ctx.switchToHttp().getRequest();
+      expect(req.user).toEqual({
+        sub: 'u1',
+        email: 'a@b.com',
+        role: 'USER',
+        mcpRoleId: 'r1',
+      });
+    });
+
+    it('should fall through to 401 for invalid mcp_ key', async () => {
+      mockApiKeys.resolveUserByKey.mockResolvedValue(null);
+      mockConfig.get.mockReturnValue('some-key');
+
+      const ctx = mockContext({ 'x-api-key': 'mcp_invalid' });
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('dev mode', () => {
+    it('should allow when neither MCP_API_KEY nor MCP_BEARER_TOKEN configured', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+
+      const ctx = mockContext({});
+      const result = await guard.canActivate(ctx);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('static API key', () => {
+    it('should allow when x-api-key matches MCP_API_KEY', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'MCP_API_KEY') return 'static-key';
+        return undefined;
+      });
+
+      const ctx = mockContext({ 'x-api-key': 'static-key' });
+      const result = await guard.canActivate(ctx);
+      expect(result).toBe(true);
+    });
+
+    it('should reject when x-api-key does not match', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'MCP_API_KEY') return 'static-key';
+        return undefined;
+      });
+
+      const ctx = mockContext({ 'x-api-key': 'wrong-key' });
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('bearer token', () => {
+    it('should allow when bearer matches MCP_BEARER_TOKEN', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'MCP_BEARER_TOKEN') return 'static-bearer';
+        return undefined;
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer static-bearer' });
+      const result = await guard.canActivate(ctx);
+      expect(result).toBe(true);
+    });
+
+    it('should allow when bearer is a valid JWT and set request.user', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'MCP_API_KEY') return 'some-key';
+        return undefined;
+      });
+      const payload = { sub: 'u1', email: 'a@b.com', role: 'USER' };
+      mockAuth.verifyToken.mockReturnValue(payload);
+
+      const ctx = mockContext({ authorization: 'Bearer jwt-token-here' });
+      const result = await guard.canActivate(ctx);
+      expect(result).toBe(true);
+      expect(ctx.switchToHttp().getRequest().user).toBe(payload);
+    });
+
+    it('should reject invalid JWT when no static bearer configured', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'MCP_API_KEY') return 'some-key';
+        return undefined;
+      });
+      mockAuth.verifyToken.mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer bad-token' });
+      await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('rejection', () => {
+    it('should set WWW-Authenticate header on rejection', async () => {
+      mockConfig.get.mockReturnValue('some-key');
+
+      const ctx = mockContext({});
+      try {
+        await guard.canActivate(ctx);
+      } catch {
+        // expected
+      }
+
+      const response = ctx.switchToHttp().getResponse();
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'WWW-Authenticate',
+        'Bearer realm="AnythingMCP MCP Server"',
+      );
+    });
+  });
+});

--- a/packages/backend/src/auth/mcp-rate-limit.guard.spec.ts
+++ b/packages/backend/src/auth/mcp-rate-limit.guard.spec.ts
@@ -1,0 +1,101 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { McpRateLimitGuard } from './mcp-rate-limit.guard';
+
+describe('McpRateLimitGuard', () => {
+  let guard: McpRateLimitGuard;
+  let mockRedis: any;
+  let mockConfig: any;
+
+  const mockContext = (
+    headers: Record<string, string> = {},
+    ip = '127.0.0.1',
+  ) => {
+    const mockResponse = { header: jest.fn() };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ headers, ip }),
+        getResponse: () => mockResponse,
+      }),
+      _response: mockResponse,
+    } as any;
+  };
+
+  beforeEach(() => {
+    mockRedis = {
+      isConnected: true,
+      incr: jest.fn().mockResolvedValue(1),
+      expire: jest.fn().mockResolvedValue(true),
+      ttl: jest.fn().mockResolvedValue(55),
+    };
+    mockConfig = {
+      get: jest.fn().mockReturnValue('60'),
+    };
+    guard = new McpRateLimitGuard(mockRedis, mockConfig);
+  });
+
+  it('should allow request when Redis is not connected', async () => {
+    mockRedis.isConnected = false;
+    const result = await guard.canActivate(mockContext());
+    expect(result).toBe(true);
+    expect(mockRedis.incr).not.toHaveBeenCalled();
+  });
+
+  it('should allow request under rate limit', async () => {
+    mockRedis.incr.mockResolvedValue(5);
+    const result = await guard.canActivate(mockContext());
+    expect(result).toBe(true);
+  });
+
+  it('should set rate limit headers on response', async () => {
+    mockRedis.incr.mockResolvedValue(10);
+    const ctx = mockContext();
+    await guard.canActivate(ctx);
+    const response = ctx.switchToHttp().getResponse();
+    expect(response.header).toHaveBeenCalledWith('X-RateLimit-Limit', '60');
+    expect(response.header).toHaveBeenCalledWith('X-RateLimit-Remaining', '50');
+    expect(response.header).toHaveBeenCalledWith(
+      'X-RateLimit-Reset',
+      expect.any(String),
+    );
+  });
+
+  it('should throw HttpException 429 when limit exceeded', async () => {
+    mockRedis.incr.mockResolvedValue(61);
+    await expect(guard.canActivate(mockContext())).rejects.toThrow(HttpException);
+    try {
+      await guard.canActivate(mockContext());
+    } catch (e) {
+      expect((e as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+    }
+  });
+
+  it('should set TTL on first request (incr returns 1)', async () => {
+    mockRedis.incr.mockResolvedValue(1);
+    await guard.canActivate(mockContext());
+    expect(mockRedis.expire).toHaveBeenCalledWith(expect.any(String), 60);
+  });
+
+  it('should not set TTL on subsequent requests', async () => {
+    mockRedis.incr.mockResolvedValue(5);
+    await guard.canActivate(mockContext());
+    expect(mockRedis.expire).not.toHaveBeenCalled();
+  });
+
+  it('should use API key for client identification when present', async () => {
+    mockRedis.incr.mockResolvedValue(1);
+    await guard.canActivate(mockContext({ 'x-api-key': 'my-key' }));
+    expect(mockRedis.incr).toHaveBeenCalledWith('mcp:rate:key:my-key');
+  });
+
+  it('should fall back to IP for client identification', async () => {
+    mockRedis.incr.mockResolvedValue(1);
+    await guard.canActivate(mockContext({}, '10.0.0.1'));
+    expect(mockRedis.incr).toHaveBeenCalledWith('mcp:rate:ip:10.0.0.1');
+  });
+
+  it('should allow request on Redis error (graceful degradation)', async () => {
+    mockRedis.incr.mockRejectedValue(new Error('Redis connection lost'));
+    const result = await guard.canActivate(mockContext());
+    expect(result).toBe(true);
+  });
+});

--- a/packages/backend/src/auth/roles.guard.spec.ts
+++ b/packages/backend/src/auth/roles.guard.spec.ts
@@ -1,0 +1,54 @@
+import { ForbiddenException } from '@nestjs/common';
+import { RolesGuard, ROLES_KEY } from './roles.guard';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let mockReflector: any;
+
+  const mockContext = (user?: { role: string }) =>
+    ({
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+    }) as any;
+
+  beforeEach(() => {
+    mockReflector = { getAllAndOverride: jest.fn() };
+    guard = new RolesGuard(mockReflector);
+  });
+
+  it('should export ROLES_KEY as "roles"', () => {
+    expect(ROLES_KEY).toBe('roles');
+  });
+
+  it('should allow when no roles are required', () => {
+    mockReflector.getAllAndOverride.mockReturnValue(undefined);
+    expect(guard.canActivate(mockContext({ role: 'USER' }))).toBe(true);
+  });
+
+  it('should allow when required roles is empty array', () => {
+    mockReflector.getAllAndOverride.mockReturnValue([]);
+    expect(guard.canActivate(mockContext({ role: 'USER' }))).toBe(true);
+  });
+
+  it('should allow when user role matches a required role', () => {
+    mockReflector.getAllAndOverride.mockReturnValue(['ADMIN', 'EDITOR']);
+    expect(guard.canActivate(mockContext({ role: 'ADMIN' }))).toBe(true);
+  });
+
+  it('should throw ForbiddenException when user role does not match', () => {
+    mockReflector.getAllAndOverride.mockReturnValue(['ADMIN']);
+    expect(() => guard.canActivate(mockContext({ role: 'USER' }))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should throw ForbiddenException when request has no user', () => {
+    mockReflector.getAllAndOverride.mockReturnValue(['ADMIN']);
+    expect(() => guard.canActivate(mockContext(undefined))).toThrow(
+      ForbiddenException,
+    );
+  });
+});

--- a/packages/backend/src/connectors/engines/database.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/database.engine.spec.ts
@@ -1,0 +1,217 @@
+import { DatabaseEngine } from './database.engine';
+
+// Mock pg — use factory functions to avoid hoisting issues
+const mockQuery = jest.fn();
+const mockEnd = jest.fn();
+jest.mock('pg', () => ({
+  Pool: jest.fn().mockImplementation(() => ({
+    query: mockQuery,
+    end: mockEnd,
+  })),
+}));
+
+// Mock mssql — return lazy reference
+const mockMssqlQuery = jest.fn();
+jest.mock('mssql', () => ({
+  connect: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      request: () => ({ query: mockMssqlQuery }),
+      close: jest.fn(),
+    }),
+  ),
+}));
+
+// Mock mongodb
+const mockToArray = jest.fn();
+const mockLimit = jest.fn().mockReturnValue({ toArray: mockToArray });
+const mockSort = jest.fn().mockReturnValue({ limit: mockLimit });
+const mockFind = jest.fn().mockReturnValue({ sort: mockSort, limit: mockLimit });
+const mockCollection = jest.fn().mockReturnValue({ find: mockFind });
+const mockDb = jest.fn().mockReturnValue({ collection: mockCollection });
+const mockConnect = jest.fn();
+const mockClose = jest.fn();
+jest.mock('mongodb', () => ({
+  MongoClient: jest.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    db: mockDb,
+    close: mockClose,
+  })),
+}));
+
+describe('DatabaseEngine', () => {
+  let engine: DatabaseEngine;
+
+  beforeEach(() => {
+    engine = new DatabaseEngine();
+    jest.clearAllMocks();
+    // Re-set default mock chain
+    mockFind.mockReturnValue({ sort: mockSort, limit: mockLimit });
+    mockSort.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockReturnValue({ toArray: mockToArray });
+  });
+
+  describe('static response mode', () => {
+    it('should return static response without DB execution', async () => {
+      const result = await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'static', path: '', staticResponse: 'Example: SELECT * FROM users' },
+        {},
+      );
+      expect(result).toEqual({ text: 'Example: SELECT * FROM users' });
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SQL validation (validateQuery)', () => {
+    it('should allow SELECT queries', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users' },
+        {},
+      );
+      expect(mockQuery).toHaveBeenCalledWith('SELECT * FROM users');
+    });
+
+    it('should block INSERT queries', async () => {
+      await expect(
+        engine.execute(
+          { baseUrl: 'postgres://host/db', authType: 'NONE' },
+          { method: 'query', path: 'INSERT INTO users VALUES (1)' },
+          {},
+        ),
+      ).rejects.toThrow('Only SELECT queries are allowed');
+    });
+
+    it('should block UPDATE queries', async () => {
+      await expect(
+        engine.execute(
+          { baseUrl: 'postgres://host/db', authType: 'NONE' },
+          { method: 'query', path: 'UPDATE users SET name = \'x\'' },
+          {},
+        ),
+      ).rejects.toThrow('Only SELECT queries are allowed');
+    });
+
+    it('should block DELETE queries', async () => {
+      await expect(
+        engine.execute(
+          { baseUrl: 'postgres://host/db', authType: 'NONE' },
+          { method: 'query', path: 'DELETE FROM users' },
+          {},
+        ),
+      ).rejects.toThrow('Only SELECT queries are allowed');
+    });
+
+    it('should block DROP queries', async () => {
+      await expect(
+        engine.execute(
+          { baseUrl: 'postgres://host/db', authType: 'NONE' },
+          { method: 'query', path: 'DROP TABLE users' },
+          {},
+        ),
+      ).rejects.toThrow('Only SELECT queries are allowed');
+    });
+  });
+
+  describe('SQL parameter interpolation (escapeValue)', () => {
+    it('should escape string values with single quotes', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users WHERE name = $name' },
+        { name: 'John' },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        "SELECT * FROM users WHERE name = 'John'",
+      );
+    });
+
+    it('should escape single quotes by doubling them', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users WHERE name = $name' },
+        { name: "O'Brien" },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        "SELECT * FROM users WHERE name = 'O''Brien'",
+      );
+    });
+
+    it('should return NULL for null/undefined', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users WHERE name = $name' },
+        { name: null },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM users WHERE name = NULL',
+      );
+    });
+
+    it('should return numeric values unquoted', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users WHERE age = $age' },
+        { age: 25 },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM users WHERE age = 25',
+      );
+    });
+
+    it('should return TRUE/FALSE for booleans', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users WHERE active = $active' },
+        { active: true },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM users WHERE active = TRUE',
+      );
+    });
+  });
+
+  describe('row truncation', () => {
+    it('should truncate results exceeding MAX_ROWS (1000)', async () => {
+      const bigResult = Array.from({ length: 1500 }, (_, i) => ({ id: i }));
+      mockQuery.mockResolvedValue({ rows: bigResult });
+      const result = (await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM big_table' },
+        {},
+      )) as any;
+      expect(result.truncated).toBe(true);
+      expect(result.rows).toHaveLength(1000);
+      expect(result.totalRows).toBe(1500);
+    });
+
+    it('should not truncate results under MAX_ROWS', async () => {
+      mockQuery.mockResolvedValue({ rows: [{ id: 1 }, { id: 2 }] });
+      const result = (await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users' },
+        {},
+      )) as any;
+      expect(result.truncated).toBeUndefined();
+      expect(result.rows).toHaveLength(2);
+      expect(result.totalRows).toBe(2);
+    });
+  });
+
+  describe('raw param reference', () => {
+    it('should use raw param value as SQL when path is ${param}', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: '${query}' },
+        { query: 'SELECT 1' },
+      );
+      expect(mockQuery).toHaveBeenCalledWith('SELECT 1');
+    });
+  });
+});

--- a/packages/backend/src/connectors/engines/graphql.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.spec.ts
@@ -1,0 +1,198 @@
+import { GraphqlEngine } from './graphql.engine';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('GraphqlEngine', () => {
+  let engine: GraphqlEngine;
+
+  beforeEach(() => {
+    engine = new GraphqlEngine();
+    jest.clearAllMocks();
+  });
+
+  it('should execute a basic query via axios.post', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { data: { users: [{ id: '1' }] } },
+    });
+
+    const result = await engine.execute(
+      { baseUrl: 'https://api.example.com/graphql', authType: 'NONE' },
+      { method: 'query', path: '{ users { id } }' },
+      {},
+    );
+
+    expect(result).toEqual({ users: [{ id: '1' }] });
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://api.example.com/graphql',
+      { query: '{ users { id } }', variables: {} },
+      expect.objectContaining({ timeout: 30000 }),
+    );
+  });
+
+  it('should set Content-Type: application/json header', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com/graphql', authType: 'NONE' },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+      }),
+    );
+  });
+
+  it('should map variables from params using queryParams mapping', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: { user: { id: '1' } } } });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com/graphql', authType: 'NONE' },
+      {
+        method: 'query',
+        path: 'query getUser($id: ID!) { user(id: $id) { id } }',
+        queryParams: { id: '$userId' },
+      },
+      { userId: '42' },
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ variables: { id: '42' } }),
+      expect.any(Object),
+    );
+  });
+
+  it('should inject BEARER_TOKEN auth into headers', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'BEARER_TOKEN',
+        authConfig: { token: 'my-token' },
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer my-token' }),
+      }),
+    );
+  });
+
+  it('should inject API_KEY auth with custom header name', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'API_KEY',
+        authConfig: { headerName: 'X-Custom-Key', apiKey: 'sk-test' },
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Custom-Key': 'sk-test' }),
+      }),
+    );
+  });
+
+  it('should inject API_KEY with default X-API-Key when no headerName', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'API_KEY',
+        authConfig: { apiKey: 'sk-test' },
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'sk-test' }),
+      }),
+    );
+  });
+
+  it('should resolve dynamic $param headers from endpoint mapping', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com/graphql', authType: 'NONE' },
+      {
+        method: 'query',
+        path: '{ me { id } }',
+        headers: { 'X-Tenant': '$tenantId', 'X-Static': 'fixed-value' },
+      },
+      { tenantId: 'tenant-42' },
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Tenant': 'tenant-42',
+          'X-Static': 'fixed-value',
+        }),
+      }),
+    );
+  });
+
+  it('should throw on GraphQL errors in response', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { errors: [{ message: 'Field not found' }] },
+    });
+
+    await expect(
+      engine.execute(
+        { baseUrl: 'https://api.example.com/graphql', authType: 'NONE' },
+        { method: 'query', path: '{ bad }' },
+        {},
+      ),
+    ).rejects.toThrow('GraphQL errors');
+  });
+
+  it('should merge connector-level headers', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'NONE',
+        headers: { 'X-Custom': 'value' },
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Custom': 'value' }),
+      }),
+    );
+  });
+});

--- a/packages/backend/src/connectors/engines/soap.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/soap.engine.spec.ts
@@ -1,0 +1,248 @@
+import { SoapEngine } from './soap.engine';
+import axios from 'axios';
+
+jest.mock('axios');
+jest.mock('soap');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('SoapEngine', () => {
+  let engine: SoapEngine;
+
+  const baseConfig = {
+    baseUrl: 'http://example.com/service',
+    authType: 'NONE',
+  };
+
+  const baseMapping = {
+    method: 'GetUser',
+    path: 'BasicHttpBinding_IService',
+    soapAction: 'http://tempuri.org/IService/GetUser',
+    endpoint: 'http://example.com/service',
+    targetNamespace: 'http://tempuri.org/',
+    paramOrder: ['userId'],
+  };
+
+  beforeEach(() => {
+    engine = new SoapEngine();
+    jest.clearAllMocks();
+  });
+
+  describe('SOAP envelope generation', () => {
+    it('should generate valid SOAP 1.1 XML envelope', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><GetUserResponse><result>ok</result></GetUserResponse></Body></Envelope>',
+      });
+
+      await engine.execute(baseConfig, baseMapping, { userId: '42' });
+
+      const envelope = mockedAxios.post.mock.calls[0][1] as string;
+      expect(envelope).toContain('<?xml version="1.0" encoding="utf-8"?>');
+      expect(envelope).toContain('soapenv:Envelope');
+      expect(envelope).toContain('xmlns:tns="http://tempuri.org/"');
+      expect(envelope).toContain('<tns:GetUser>');
+      expect(envelope).toContain('<tns:userId>42</tns:userId>');
+    });
+
+    it('should order parameters by paramOrder', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(
+        baseConfig,
+        { ...baseMapping, paramOrder: ['lastName', 'firstName'] },
+        { firstName: 'John', lastName: 'Doe' },
+      );
+
+      const envelope = mockedAxios.post.mock.calls[0][1] as string;
+      const lastNameIdx = envelope.indexOf('lastName');
+      const firstNameIdx = envelope.indexOf('firstName');
+      expect(lastNameIdx).toBeLessThan(firstNameIdx);
+    });
+
+    it('should escape XML special characters in parameter values', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(
+        baseConfig,
+        { ...baseMapping, paramOrder: ['name'] },
+        { name: '<script>alert("xss")&more</script>' },
+      );
+
+      const envelope = mockedAxios.post.mock.calls[0][1] as string;
+      expect(envelope).toContain('&lt;script&gt;');
+      expect(envelope).toContain('&amp;more');
+      expect(envelope).toContain('&quot;xss&quot;');
+      expect(envelope).not.toContain('<script>');
+    });
+  });
+
+  describe('SOAP response parsing', () => {
+    it('should extract body content from SOAP response XML', async () => {
+      const xml = `
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+          <soapenv:Body>
+            <GetUserResponse>
+              <Name>John</Name>
+            </GetUserResponse>
+          </soapenv:Body>
+        </soapenv:Envelope>
+      `;
+      mockedAxios.post.mockResolvedValue({ status: 200, data: xml });
+
+      const result = (await engine.execute(baseConfig, baseMapping, { userId: '1' })) as any;
+      expect(result.Name).toBe('John');
+    });
+
+    it('should throw on SOAP fault', async () => {
+      const xml = `
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+          <soapenv:Body>
+            <soapenv:Fault>
+              <faultstring>Server error</faultstring>
+            </soapenv:Fault>
+          </soapenv:Body>
+        </soapenv:Envelope>
+      `;
+      mockedAxios.post.mockResolvedValue({ status: 200, data: xml });
+
+      await expect(
+        engine.execute(baseConfig, baseMapping, { userId: '1' }),
+      ).rejects.toThrow('SOAP Fault');
+    });
+
+    it('should return non-string data as-is', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: { raw: 'object' },
+      });
+
+      const result = await engine.execute(baseConfig, baseMapping, { userId: '1' });
+      expect(result).toEqual({ raw: 'object' });
+    });
+  });
+
+  describe('auth injection', () => {
+    it('should inject Basic auth header', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(
+        {
+          ...baseConfig,
+          authType: 'BASIC_AUTH',
+          authConfig: { username: 'user', password: 'pass' },
+        },
+        baseMapping,
+        { userId: '1' },
+      );
+
+      const headers = mockedAxios.post.mock.calls[0][2]?.headers as Record<string, string>;
+      expect(headers.Authorization).toMatch(/^Basic /);
+      const decoded = Buffer.from(
+        headers.Authorization.replace('Basic ', ''),
+        'base64',
+      ).toString();
+      expect(decoded).toBe('user:pass');
+    });
+
+    it('should inject Bearer token header', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(
+        {
+          ...baseConfig,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'my-token' },
+        },
+        baseMapping,
+        { userId: '1' },
+      );
+
+      const headers = mockedAxios.post.mock.calls[0][2]?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer my-token');
+    });
+
+    it('should inject API key header', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(
+        {
+          ...baseConfig,
+          authType: 'API_KEY',
+          authConfig: { headerName: 'X-Key', apiKey: 'sk-123' },
+        },
+        baseMapping,
+        { userId: '1' },
+      );
+
+      const headers = mockedAxios.post.mock.calls[0][2]?.headers as Record<string, string>;
+      expect(headers['X-Key']).toBe('sk-123');
+    });
+  });
+
+  describe('endpoint host override', () => {
+    it('should replace WSDL endpoint host with connector baseUrl host', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(
+        { baseUrl: 'http://internal.local:8080/service', authType: 'NONE' },
+        {
+          ...baseMapping,
+          endpoint: 'http://external.public:9090/service',
+        },
+        { userId: '1' },
+      );
+
+      const calledUrl = mockedAxios.post.mock.calls[0][0];
+      expect(calledUrl).toContain('internal.local:8080');
+      expect(calledUrl).not.toContain('external.public');
+    });
+  });
+
+  describe('HTTP error handling', () => {
+    it('should throw enriched error for HTTP 500 status', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 500,
+        statusText: 'Internal Server Error',
+        data: 'Server error body',
+      });
+
+      await expect(
+        engine.execute(baseConfig, baseMapping, { userId: '1' }),
+      ).rejects.toThrow('SOAP call failed with HTTP 500');
+    });
+  });
+
+  describe('SOAPAction and Content-Type headers', () => {
+    it('should set correct headers for SOAP call', async () => {
+      mockedAxios.post.mockResolvedValue({
+        status: 200,
+        data: '<Envelope><Body><Resp/></Body></Envelope>',
+      });
+
+      await engine.execute(baseConfig, baseMapping, { userId: '1' });
+
+      const headers = mockedAxios.post.mock.calls[0][2]?.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('text/xml; charset=utf-8');
+      expect(headers.SOAPAction).toBe('http://tempuri.org/IService/GetUser');
+    });
+  });
+});

--- a/packages/backend/src/connectors/parsers/graphql.parser.spec.ts
+++ b/packages/backend/src/connectors/parsers/graphql.parser.spec.ts
@@ -1,0 +1,265 @@
+import { GraphqlParser } from './graphql.parser';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const makeIntrospectionResponse = (types: any[]) => ({
+  data: {
+    data: {
+      __schema: {
+        queryType: { name: 'Query' },
+        mutationType: { name: 'Mutation' },
+        types,
+      },
+    },
+  },
+});
+
+const scalarType = (name: string) => ({ kind: 'SCALAR', name, ofType: null });
+const nonNullType = (inner: any) => ({ kind: 'NON_NULL', name: null, ofType: inner });
+const listType = (inner: any) => ({ kind: 'LIST', name: null, ofType: inner });
+
+describe('GraphqlParser', () => {
+  let parser: GraphqlParser;
+
+  beforeEach(() => {
+    parser = new GraphqlParser();
+    jest.clearAllMocks();
+  });
+
+  describe('parse', () => {
+    it('should make introspection query to the endpoint', async () => {
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse([]));
+      await parser.parse('https://api.example.com/graphql');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://api.example.com/graphql',
+        expect.objectContaining({ query: expect.stringContaining('IntrospectionQuery') }),
+        expect.objectContaining({ timeout: 15000 }),
+      );
+    });
+
+    it('should pass custom headers to the introspection request', async () => {
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse([]));
+      await parser.parse('https://api.example.com/graphql', { Authorization: 'Bearer tok' });
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
+        }),
+      );
+    });
+
+    it('should extract query fields as tools', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            { name: 'users', description: 'Get users', args: [] },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('graphql_users');
+      expect(tools[0].endpointMapping.method).toBe('query');
+      expect(tools[0].endpointMapping.path).toBe('query { users }');
+    });
+
+    it('should extract mutation fields as tools', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Mutation',
+          fields: [
+            { name: 'createUser', description: 'Create a user', args: [] },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('graphql_createuser');
+      expect(tools[0].endpointMapping.method).toBe('mutation');
+    });
+
+    it('should skip internal __-prefixed type fields', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            { name: '__type', description: 'Internal', args: [] },
+            { name: 'users', description: 'Get users', args: [] },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('graphql_users');
+    });
+
+    it('should skip non-OBJECT types', async () => {
+      const types = [
+        { kind: 'SCALAR', name: 'String', fields: null },
+        { kind: 'OBJECT', name: 'Query', fields: [{ name: 'ok', description: '', args: [] }] },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools).toHaveLength(1);
+    });
+
+    it('should map field args to tool parameters', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            {
+              name: 'user',
+              description: 'Get user by id',
+              args: [
+                { name: 'id', description: 'User ID', type: scalarType('ID') },
+                { name: 'limit', description: null, type: scalarType('Int') },
+              ],
+            },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      const params = tools[0].parameters as any;
+      expect(params.properties.id).toEqual({ type: 'string', description: 'User ID' });
+      expect(params.properties.limit).toEqual({ type: 'number' });
+    });
+
+    it('should mark NON_NULL args as required', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            {
+              name: 'user',
+              description: '',
+              args: [
+                { name: 'id', description: '', type: nonNullType(scalarType('ID')) },
+                { name: 'name', description: '', type: scalarType('String') },
+              ],
+            },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      const params = tools[0].parameters as any;
+      expect(params.required).toEqual(['id']);
+    });
+
+    it('should map GraphQL types to JSON types correctly', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            {
+              name: 'test',
+              description: '',
+              args: [
+                { name: 'count', description: '', type: scalarType('Int') },
+                { name: 'price', description: '', type: scalarType('Float') },
+                { name: 'active', description: '', type: scalarType('Boolean') },
+                { name: 'label', description: '', type: scalarType('String') },
+                { name: 'uid', description: '', type: scalarType('ID') },
+              ],
+            },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      const props = (tools[0].parameters as any).properties;
+      expect(props.count.type).toBe('number');
+      expect(props.price.type).toBe('number');
+      expect(props.active.type).toBe('boolean');
+      expect(props.label.type).toBe('string');
+      expect(props.uid.type).toBe('string');
+    });
+
+    it('should build query string with args', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            {
+              name: 'user',
+              description: '',
+              args: [
+                { name: 'id', description: '', type: nonNullType(scalarType('ID')) },
+              ],
+            },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools[0].endpointMapping.path).toBe('query user($id: ID!) { user(id: $id) }');
+    });
+
+    it('should set variable mapping in queryParams', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            {
+              name: 'user',
+              description: '',
+              args: [
+                { name: 'id', description: '', type: scalarType('ID') },
+              ],
+            },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools[0].endpointMapping.queryParams).toEqual({ id: '$id' });
+    });
+
+    it('should throw on introspection errors', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { errors: [{ message: 'Unauthorized' }] },
+      });
+      await expect(
+        parser.parse('https://api.example.com/graphql'),
+      ).rejects.toThrow('GraphQL introspection errors');
+    });
+
+    it('should handle LIST type in type string', async () => {
+      const types = [
+        {
+          kind: 'OBJECT',
+          name: 'Query',
+          fields: [
+            {
+              name: 'items',
+              description: '',
+              args: [
+                { name: 'ids', description: '', type: listType(scalarType('ID')) },
+              ],
+            },
+          ],
+        },
+      ];
+      mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools[0].endpointMapping.path).toContain('[ID]');
+    });
+  });
+});

--- a/packages/backend/src/mcp-server/tool-registry.spec.ts
+++ b/packages/backend/src/mcp-server/tool-registry.spec.ts
@@ -1,0 +1,94 @@
+import { ToolRegistry, RegisteredTool } from './tool-registry';
+
+const makeTool = (overrides: Partial<RegisteredTool> = {}): RegisteredTool => ({
+  id: 'tool-1',
+  connectorId: 'conn-1',
+  name: 'test_tool',
+  description: 'A test tool',
+  parameters: {},
+  connectorType: 'REST',
+  connectorConfig: { baseUrl: 'http://example.com', authType: 'NONE' },
+  endpointMapping: { method: 'GET', path: '/' },
+  ...overrides,
+});
+
+describe('ToolRegistry', () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+  });
+
+  describe('registerTool', () => {
+    it('should register a tool and retrieve it by name', () => {
+      const tool = makeTool();
+      registry.registerTool(tool);
+      expect(registry.getTool('test_tool')).toBe(tool);
+    });
+
+    it('should overwrite a tool with the same name', () => {
+      const tool1 = makeTool({ id: 'tool-1' });
+      const tool2 = makeTool({ id: 'tool-2' });
+      registry.registerTool(tool1);
+      registry.registerTool(tool2);
+      expect(registry.getTool('test_tool')).toBe(tool2);
+      expect(registry.getToolCount()).toBe(1);
+    });
+  });
+
+  describe('getTool', () => {
+    it('should return undefined for unregistered tool name', () => {
+      expect(registry.getTool('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('unregisterConnectorTools', () => {
+    it('should remove all tools for a given connectorId', () => {
+      registry.registerTool(makeTool({ name: 'a', connectorId: 'conn-1' }));
+      registry.registerTool(makeTool({ name: 'b', connectorId: 'conn-1' }));
+      registry.registerTool(makeTool({ name: 'c', connectorId: 'conn-2' }));
+
+      registry.unregisterConnectorTools('conn-1');
+
+      expect(registry.getTool('a')).toBeUndefined();
+      expect(registry.getTool('b')).toBeUndefined();
+      expect(registry.getToolCount()).toBe(1);
+    });
+
+    it('should not remove tools from other connectors', () => {
+      registry.registerTool(makeTool({ name: 'x', connectorId: 'conn-2' }));
+      registry.unregisterConnectorTools('conn-1');
+      expect(registry.getTool('x')).toBeDefined();
+    });
+
+    it('should handle unregister when no tools match', () => {
+      registry.registerTool(makeTool({ name: 'a', connectorId: 'conn-1' }));
+      registry.unregisterConnectorTools('conn-999');
+      expect(registry.getToolCount()).toBe(1);
+    });
+  });
+
+  describe('getAllTools', () => {
+    it('should return all registered tools as an array', () => {
+      registry.registerTool(makeTool({ name: 'a' }));
+      registry.registerTool(makeTool({ name: 'b' }));
+      const tools = registry.getAllTools();
+      expect(tools).toHaveLength(2);
+      expect(tools.map((t) => t.name).sort()).toEqual(['a', 'b']);
+    });
+
+    it('should return empty array when no tools registered', () => {
+      expect(registry.getAllTools()).toEqual([]);
+    });
+  });
+
+  describe('getToolCount', () => {
+    it('should return the current number of registered tools', () => {
+      expect(registry.getToolCount()).toBe(0);
+      registry.registerTool(makeTool({ name: 'a' }));
+      expect(registry.getToolCount()).toBe(1);
+      registry.registerTool(makeTool({ name: 'b' }));
+      expect(registry.getToolCount()).toBe(2);
+    });
+  });
+});

--- a/packages/backend/src/mcp-server/tool-registry.ts
+++ b/packages/backend/src/mcp-server/tool-registry.ts
@@ -9,7 +9,7 @@ import { Injectable, Logger } from '@nestjs/common';
  * This is the bridge between MCP protocol and the Connector Engine.
  */
 
-interface RegisteredTool {
+export interface RegisteredTool {
   id: string;
   connectorId: string;
   name: string;

--- a/packages/backend/src/roles/mcp-api-keys.service.spec.ts
+++ b/packages/backend/src/roles/mcp-api-keys.service.spec.ts
@@ -1,0 +1,149 @@
+import { McpApiKeysService } from './mcp-api-keys.service';
+
+describe('McpApiKeysService', () => {
+  let service: McpApiKeysService;
+  let mockPrisma: any;
+
+  beforeEach(() => {
+    mockPrisma = {
+      mcpApiKey: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+        deleteMany: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+    service = new McpApiKeysService(mockPrisma);
+  });
+
+  describe('generate', () => {
+    it('should create key with mcp_ prefix and 64 hex chars', async () => {
+      mockPrisma.mcpApiKey.create.mockImplementation((args: any) => {
+        return Promise.resolve({
+          id: 'key-1',
+          key: args.data.key,
+          name: args.data.name,
+          isActive: true,
+          mcpServerId: args.data.mcpServerId,
+          createdAt: new Date(),
+        });
+      });
+
+      const result = await service.generate('user-1', 'My Key');
+      expect(result.key).toMatch(/^mcp_[0-9a-f]{64}$/);
+      expect(result.name).toBe('My Key');
+    });
+
+    it('should pass mcpServerId as null when not provided', async () => {
+      mockPrisma.mcpApiKey.create.mockImplementation((args: any) =>
+        Promise.resolve({ id: 'key-1', key: args.data.key, mcpServerId: args.data.mcpServerId }),
+      );
+
+      const result = await service.generate('user-1', 'Key');
+      expect(result.mcpServerId).toBeNull();
+    });
+
+    it('should pass mcpServerId when provided', async () => {
+      mockPrisma.mcpApiKey.create.mockImplementation((args: any) =>
+        Promise.resolve({ id: 'key-1', key: args.data.key, mcpServerId: args.data.mcpServerId }),
+      );
+
+      const result = await service.generate('user-1', 'Key', 'server-1');
+      expect(result.mcpServerId).toBe('server-1');
+    });
+  });
+
+  describe('listByUser', () => {
+    it('should return keys for user ordered by createdAt desc', async () => {
+      const keys = [{ id: 'k1', name: 'Key 1' }];
+      mockPrisma.mcpApiKey.findMany.mockResolvedValue(keys);
+      const result = await service.listByUser('user-1');
+      expect(result).toBe(keys);
+      expect(mockPrisma.mcpApiKey.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 'user-1' },
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+    });
+  });
+
+  describe('revoke', () => {
+    it('should set isActive to false for matching id and userId', async () => {
+      mockPrisma.mcpApiKey.updateMany.mockResolvedValue({ count: 1 });
+      await service.revoke('key-1', 'user-1');
+      expect(mockPrisma.mcpApiKey.updateMany).toHaveBeenCalledWith({
+        where: { id: 'key-1', userId: 'user-1' },
+        data: { isActive: false },
+      });
+    });
+  });
+
+  describe('deleteKey', () => {
+    it('should delete key matching id and userId', async () => {
+      mockPrisma.mcpApiKey.deleteMany.mockResolvedValue({ count: 1 });
+      await service.deleteKey('key-1', 'user-1');
+      expect(mockPrisma.mcpApiKey.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'key-1', userId: 'user-1' },
+      });
+    });
+  });
+
+  describe('resolveUserByKey', () => {
+    it('should return user data with mcpServerId when key is active', async () => {
+      const record = {
+        id: 'key-1',
+        isActive: true,
+        mcpServerId: 'srv-1',
+        name: 'My Key',
+        user: { id: 'u1', email: 'a@b.com', role: 'USER', mcpRoleId: 'r1' },
+      };
+      mockPrisma.mcpApiKey.findUnique.mockResolvedValue(record);
+      mockPrisma.mcpApiKey.update.mockResolvedValue({});
+
+      const result = await service.resolveUserByKey('mcp_abc');
+      expect(result).toEqual({
+        id: 'u1',
+        email: 'a@b.com',
+        role: 'USER',
+        mcpRoleId: 'r1',
+        mcpServerId: 'srv-1',
+        apiKeyName: 'My Key',
+      });
+    });
+
+    it('should return null when key is inactive', async () => {
+      mockPrisma.mcpApiKey.findUnique.mockResolvedValue({
+        id: 'key-1',
+        isActive: false,
+        user: { id: 'u1' },
+      });
+      const result = await service.resolveUserByKey('mcp_abc');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when key not found', async () => {
+      mockPrisma.mcpApiKey.findUnique.mockResolvedValue(null);
+      const result = await service.resolveUserByKey('mcp_invalid');
+      expect(result).toBeNull();
+    });
+
+    it('should not throw if lastUsedAt update fails', async () => {
+      const record = {
+        id: 'key-1',
+        isActive: true,
+        mcpServerId: null,
+        name: 'Key',
+        user: { id: 'u1', email: 'a@b.com', role: 'USER', mcpRoleId: null },
+      };
+      mockPrisma.mcpApiKey.findUnique.mockResolvedValue(record);
+      mockPrisma.mcpApiKey.update.mockRejectedValue(new Error('DB error'));
+
+      const result = await service.resolveUserByKey('mcp_abc');
+      expect(result).toBeDefined();
+      expect(result!.id).toBe('u1');
+    });
+  });
+});

--- a/packages/backend/src/roles/roles.service.spec.ts
+++ b/packages/backend/src/roles/roles.service.spec.ts
@@ -1,0 +1,229 @@
+import { RolesService } from './roles.service';
+
+describe('RolesService', () => {
+  let service: RolesService;
+  let mockPrisma: any;
+
+  beforeEach(() => {
+    mockPrisma = {
+      role: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+        upsert: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+        update: jest.fn(),
+      },
+      toolRoleAccess: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+        deleteMany: jest.fn(),
+        upsert: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    };
+    service = new RolesService(mockPrisma);
+  });
+
+  describe('findAll', () => {
+    it('should return roles with user/tool counts, ordered by isSystem then name', async () => {
+      const roles = [{ id: 'r1', name: 'Full Access', _count: { users: 2, toolAccess: 5 } }];
+      mockPrisma.role.findMany.mockResolvedValue(roles);
+      const result = await service.findAll();
+      expect(result).toBe(roles);
+      expect(mockPrisma.role.findMany).toHaveBeenCalledWith({
+        include: { _count: { select: { users: true, toolAccess: true } } },
+        orderBy: [{ isSystem: 'desc' }, { name: 'asc' }],
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('should return role with tool access and user count', async () => {
+      const role = { id: 'r1', name: 'Editor', toolAccess: [], _count: { users: 1 } };
+      mockPrisma.role.findUnique.mockResolvedValue(role);
+      const result = await service.findById('r1');
+      expect(result).toBe(role);
+      expect(mockPrisma.role.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'r1' } }),
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('should create role with name and description', async () => {
+      const created = { id: 'r2', name: 'Viewer', description: 'Read only' };
+      mockPrisma.role.create.mockResolvedValue(created);
+      const result = await service.create({ name: 'Viewer', description: 'Read only' });
+      expect(result).toBe(created);
+      expect(mockPrisma.role.create).toHaveBeenCalledWith({
+        data: { name: 'Viewer', description: 'Read only' },
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should update role fields', async () => {
+      const updated = { id: 'r1', name: 'New Name' };
+      mockPrisma.role.update.mockResolvedValue(updated);
+      const result = await service.update('r1', { name: 'New Name' });
+      expect(result).toBe(updated);
+      expect(mockPrisma.role.update).toHaveBeenCalledWith({
+        where: { id: 'r1' },
+        data: { name: 'New Name' },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('should unassign users then delete role', async () => {
+      mockPrisma.user.updateMany.mockResolvedValue({ count: 2 });
+      mockPrisma.role.delete.mockResolvedValue({});
+      await service.delete('r1');
+      expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+        where: { mcpRoleId: 'r1' },
+        data: { mcpRoleId: null },
+      });
+      expect(mockPrisma.role.delete).toHaveBeenCalledWith({ where: { id: 'r1' } });
+    });
+  });
+
+  describe('getToolAccess', () => {
+    it('should return tool access for a role', async () => {
+      const access = [{ roleId: 'r1', toolId: 't1', tool: { id: 't1', name: 'tool1' } }];
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue(access);
+      const result = await service.getToolAccess('r1');
+      expect(result).toBe(access);
+    });
+  });
+
+  describe('setToolAccess', () => {
+    it('should call $transaction with delete + create operations', async () => {
+      mockPrisma.toolRoleAccess.deleteMany.mockReturnValue('delete-op');
+      mockPrisma.toolRoleAccess.create
+        .mockReturnValueOnce('create-op-1')
+        .mockReturnValueOnce('create-op-2');
+      mockPrisma.$transaction.mockResolvedValue([]);
+
+      await service.setToolAccess('r1', ['t1', 't2']);
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith([
+        'delete-op',
+        'create-op-1',
+        'create-op-2',
+      ]);
+    });
+  });
+
+  describe('addToolAccess', () => {
+    it('should upsert tool access with compound key', async () => {
+      const access = { roleId: 'r1', toolId: 't1' };
+      mockPrisma.toolRoleAccess.upsert.mockResolvedValue(access);
+      const result = await service.addToolAccess('r1', 't1');
+      expect(result).toBe(access);
+      expect(mockPrisma.toolRoleAccess.upsert).toHaveBeenCalledWith({
+        where: { roleId_toolId: { roleId: 'r1', toolId: 't1' } },
+        create: { roleId: 'r1', toolId: 't1' },
+        update: {},
+      });
+    });
+  });
+
+  describe('removeToolAccess', () => {
+    it('should delete matching tool access', async () => {
+      mockPrisma.toolRoleAccess.deleteMany.mockResolvedValue({ count: 1 });
+      await service.removeToolAccess('r1', 't1');
+      expect(mockPrisma.toolRoleAccess.deleteMany).toHaveBeenCalledWith({
+        where: { roleId: 'r1', toolId: 't1' },
+      });
+    });
+  });
+
+  describe('getAllowedToolIds', () => {
+    it('should return null for ADMIN users (unrestricted)', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ role: 'ADMIN', mcpRoleId: null });
+      const result = await service.getAllowedToolIds('user-1');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when user has no mcpRoleId (backward compat)', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ role: 'USER', mcpRoleId: null });
+      const result = await service.getAllowedToolIds('user-1');
+      expect(result).toBeNull();
+    });
+
+    it('should return tool IDs for user with role', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ role: 'USER', mcpRoleId: 'r1' });
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue([
+        { toolId: 't1' },
+        { toolId: 't2' },
+      ]);
+      const result = await service.getAllowedToolIds('user-1');
+      expect(result).toEqual(['t1', 't2']);
+    });
+
+    it('should fall back to email lookup when id lookup fails', async () => {
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ role: 'ADMIN', mcpRoleId: null });
+      const result = await service.getAllowedToolIds('user@example.com');
+      expect(result).toBeNull();
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.user.findUnique).toHaveBeenLastCalledWith({
+        where: { email: 'user@example.com' },
+        select: { role: true, mcpRoleId: true },
+      });
+    });
+
+    it('should return empty array when user not found', async () => {
+      mockPrisma.user.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      const result = await service.getAllowedToolIds('ghost');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('assignRoleToUser', () => {
+    it('should update user mcpRoleId', async () => {
+      const updated = { id: 'user-1', mcpRoleId: 'r1' };
+      mockPrisma.user.update.mockResolvedValue(updated);
+      const result = await service.assignRoleToUser('user-1', 'r1');
+      expect(result).toBe(updated);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { mcpRoleId: 'r1' },
+      });
+    });
+
+    it('should allow setting roleId to null', async () => {
+      mockPrisma.user.update.mockResolvedValue({ id: 'user-1', mcpRoleId: null });
+      await service.assignRoleToUser('user-1', null);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { mcpRoleId: null },
+      });
+    });
+  });
+
+  describe('ensureSystemRoles', () => {
+    it('should upsert Full Access system role', async () => {
+      mockPrisma.role.upsert.mockResolvedValue({});
+      await service.ensureSystemRoles();
+      expect(mockPrisma.role.upsert).toHaveBeenCalledWith({
+        where: { name: 'Full Access' },
+        create: {
+          name: 'Full Access',
+          description: 'Unrestricted access to all MCP tools',
+          isSystem: true,
+        },
+        update: {},
+      });
+    });
+  });
+});

--- a/packages/backend/src/settings/site-settings.service.spec.ts
+++ b/packages/backend/src/settings/site-settings.service.spec.ts
@@ -1,0 +1,158 @@
+import { SiteSettingsService } from './site-settings.service';
+
+describe('SiteSettingsService', () => {
+  let service: SiteSettingsService;
+  let mockPrisma: any;
+
+  beforeEach(() => {
+    mockPrisma = {
+      siteSettings: {
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+        findMany: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+    };
+    service = new SiteSettingsService(mockPrisma);
+  });
+
+  describe('get', () => {
+    it('should return value for existing key', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue({
+        key: 'theme',
+        value: 'dark',
+      });
+      const result = await service.get('theme');
+      expect(result).toBe('dark');
+      expect(mockPrisma.siteSettings.findUnique).toHaveBeenCalledWith({
+        where: { key: 'theme' },
+      });
+    });
+
+    it('should return null when key not found', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue(null);
+      const result = await service.get('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('should upsert with key and value', async () => {
+      mockPrisma.siteSettings.upsert.mockResolvedValue({});
+      await service.set('theme', 'light');
+      expect(mockPrisma.siteSettings.upsert).toHaveBeenCalledWith({
+        where: { key: 'theme' },
+        update: { value: 'light' },
+        create: { key: 'theme', value: 'light' },
+      });
+    });
+  });
+
+  describe('getJson', () => {
+    it('should parse and return valid JSON', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue({
+        key: 'config',
+        value: '{"host":"smtp.example.com","port":587}',
+      });
+      const result = await service.getJson('config');
+      expect(result).toEqual({ host: 'smtp.example.com', port: 587 });
+    });
+
+    it('should return null for invalid JSON string', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue({
+        key: 'bad',
+        value: 'not-json{',
+      });
+      const result = await service.getJson('bad');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when key does not exist', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue(null);
+      const result = await service.getJson('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setJson', () => {
+    it('should stringify value and call set', async () => {
+      mockPrisma.siteSettings.upsert.mockResolvedValue({});
+      await service.setJson('config', { host: 'smtp.example.com' });
+      expect(mockPrisma.siteSettings.upsert).toHaveBeenCalledWith({
+        where: { key: 'config' },
+        update: { value: '{"host":"smtp.example.com"}' },
+        create: { key: 'config', value: '{"host":"smtp.example.com"}' },
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all settings as key-value record', async () => {
+      mockPrisma.siteSettings.findMany.mockResolvedValue([
+        { key: 'theme', value: 'dark' },
+        { key: 'lang', value: 'en' },
+      ]);
+      const result = await service.getAll();
+      expect(result).toEqual({ theme: 'dark', lang: 'en' });
+    });
+
+    it('should return empty record when no settings exist', async () => {
+      mockPrisma.siteSettings.findMany.mockResolvedValue([]);
+      const result = await service.getAll();
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('delete', () => {
+    it('should call deleteMany with key', async () => {
+      mockPrisma.siteSettings.deleteMany.mockResolvedValue({ count: 1 });
+      await service.delete('theme');
+      expect(mockPrisma.siteSettings.deleteMany).toHaveBeenCalledWith({
+        where: { key: 'theme' },
+      });
+    });
+  });
+
+  describe('getSmtpConfig', () => {
+    it('should return parsed SMTP config', async () => {
+      const smtp = {
+        host: 'smtp.example.com',
+        port: 587,
+        user: 'u',
+        pass: 'p',
+        from: 'noreply@example.com',
+        secure: true,
+      };
+      mockPrisma.siteSettings.findUnique.mockResolvedValue({
+        key: 'smtp_config',
+        value: JSON.stringify(smtp),
+      });
+      const result = await service.getSmtpConfig();
+      expect(result).toEqual(smtp);
+    });
+
+    it('should return null when not configured', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue(null);
+      const result = await service.getSmtpConfig();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getFooterLinks', () => {
+    it('should return parsed footer links', async () => {
+      const links = [{ label: 'Docs', url: 'https://docs.example.com' }];
+      mockPrisma.siteSettings.findUnique.mockResolvedValue({
+        key: 'footer_links',
+        value: JSON.stringify(links),
+      });
+      const result = await service.getFooterLinks();
+      expect(result).toEqual(links);
+    });
+
+    it('should return empty array when not configured', async () => {
+      mockPrisma.siteSettings.findUnique.mockResolvedValue(null);
+      const result = await service.getFooterLinks();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/backend/src/users/users.service.spec.ts
+++ b/packages/backend/src/users/users.service.spec.ts
@@ -1,0 +1,123 @@
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let mockPrisma: any;
+
+  const mockUser = {
+    id: 'user-1',
+    email: 'test@example.com',
+    name: 'Test User',
+    passwordHash: 'hashed',
+    role: 'USER',
+    mcpRoleId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    mockPrisma = {
+      user: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        count: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    service = new UsersService(mockPrisma);
+  });
+
+  describe('findByEmail', () => {
+    it('should call findUnique with email', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      const result = await service.findByEmail('test@example.com');
+      expect(result).toBe(mockUser);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { email: 'test@example.com' },
+      });
+    });
+
+    it('should return null when not found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const result = await service.findByEmail('nobody@example.com');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findById', () => {
+    it('should call findUnique with id', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+      const result = await service.findById('user-1');
+      expect(result).toBe(mockUser);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('should call create with provided data', async () => {
+      const data = {
+        email: 'new@example.com',
+        passwordHash: 'hash',
+        name: 'New User',
+      };
+      mockPrisma.user.create.mockResolvedValue({ ...mockUser, ...data });
+      const result = await service.create(data);
+      expect(mockPrisma.user.create).toHaveBeenCalledWith({ data });
+      expect(result.email).toBe('new@example.com');
+    });
+  });
+
+  describe('count', () => {
+    it('should return user count', async () => {
+      mockPrisma.user.count.mockResolvedValue(5);
+      const result = await service.count();
+      expect(result).toBe(5);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should call findMany with correct select fields', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([]);
+      await service.findAll();
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+          mcpRoleId: true,
+          mcpRole: { select: { id: true, name: true } },
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should call update with userId and data', async () => {
+      const data = { name: 'Updated' };
+      mockPrisma.user.update.mockResolvedValue({ ...mockUser, ...data });
+      const result = await service.update('user-1', data);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data,
+      });
+      expect(result.name).toBe('Updated');
+    });
+  });
+
+  describe('delete', () => {
+    it('should call delete with userId', async () => {
+      mockPrisma.user.delete.mockResolvedValue(mockUser);
+      await service.delete('user-1');
+      expect(mockPrisma.user.delete).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 new unit test files covering services, guards, engines, and parsers
- Export `RegisteredTool` interface from `tool-registry.ts` for test imports
- Total test count: 115 → 245 across 20 test suites, all passing

### New test files:
**Services:** `users.service`, `roles.service`, `mcp-api-keys.service`, `site-settings.service`
**Guards:** `roles.guard`, `mcp-auth.guard`, `mcp-rate-limit.guard`
**Engines:** `graphql.engine`, `database.engine`, `soap.engine`
**Parsers:** `graphql.parser`
**Core:** `tool-registry`

## Test plan
- [x] All 245 tests pass (`npm run test --workspace=packages/backend`)
- [x] No changes to production logic (only 1-line export change in tool-registry.ts)