### PR TITLE
Add SDL schema fallback to GraphQL parser

### DIFF
--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -520,7 +520,9 @@ export class ConnectorsController {
       }
       case 'GRAPHQL': {
         const headers = connector.headers as Record<string, string> | undefined;
-        parsedTools = await this.graphqlParser.parse(connector.baseUrl, headers || undefined);
+        parsedTools = await this.graphqlParser.parse(
+          connector.baseUrl, headers || undefined, connector.specUrl || undefined,
+        );
         break;
       }
       default:
@@ -563,7 +565,9 @@ export class ConnectorsController {
         case 'graphql': {
           const headers = connector.headers as Record<string, string> | undefined;
           const endpoint = dto.url || connector.baseUrl;
-          parsedTools = await this.graphqlParser.parse(endpoint, headers || undefined);
+          parsedTools = await this.graphqlParser.parse(
+            endpoint, headers || undefined, dto.url || undefined,
+          );
           break;
         }
         case 'postman': {

--- a/packages/backend/src/connectors/parsers/graphql.parser.spec.ts
+++ b/packages/backend/src/connectors/parsers/graphql.parser.spec.ts
@@ -28,7 +28,7 @@ describe('GraphqlParser', () => {
     jest.clearAllMocks();
   });
 
-  describe('parse', () => {
+  describe('parse (introspection path)', () => {
     it('should make introspection query to the endpoint', async () => {
       mockedAxios.post.mockResolvedValue(makeIntrospectionResponse([]));
       await parser.parse('https://api.example.com/graphql');
@@ -232,15 +232,6 @@ describe('GraphqlParser', () => {
       expect(tools[0].endpointMapping.queryParams).toEqual({ id: '$id' });
     });
 
-    it('should throw on introspection errors', async () => {
-      mockedAxios.post.mockResolvedValue({
-        data: { errors: [{ message: 'Unauthorized' }] },
-      });
-      await expect(
-        parser.parse('https://api.example.com/graphql'),
-      ).rejects.toThrow('GraphQL introspection errors');
-    });
-
     it('should handle LIST type in type string', async () => {
       const types = [
         {
@@ -260,6 +251,130 @@ describe('GraphqlParser', () => {
       mockedAxios.post.mockResolvedValue(makeIntrospectionResponse(types));
       const tools = await parser.parse('https://api.example.com/graphql');
       expect(tools[0].endpointMapping.path).toContain('[ID]');
+    });
+  });
+
+  describe('parse (SDL fallback)', () => {
+    it('should fall back to SDL when introspection returns errors', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { errors: [{ message: 'Introspection disabled' }] },
+      });
+      mockedAxios.get.mockResolvedValue({
+        data: `type Query { users: [String] }`,
+      });
+
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('graphql_users');
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.example.com/graphql/schema',
+        expect.any(Object),
+      );
+    });
+
+    it('should fall back to SDL when introspection request fails', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+      mockedAxios.get.mockResolvedValue({
+        data: `type Query { ping: Boolean }`,
+      });
+
+      const tools = await parser.parse('https://api.example.com/graphql');
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('graphql_ping');
+    });
+
+    it('should use specUrl for SDL when provided', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { errors: [{ message: 'Disabled' }] },
+      });
+      mockedAxios.get.mockResolvedValue({
+        data: `type Query { hello: String }`,
+      });
+
+      await parser.parse(
+        'https://api.example.com/graphql',
+        undefined,
+        'https://api.example.com/custom-schema',
+      );
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.example.com/custom-schema',
+        expect.any(Object),
+      );
+    });
+
+    it('should throw when both introspection and SDL fail', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { errors: [{ message: 'Disabled' }] },
+      });
+      mockedAxios.get.mockRejectedValue(new Error('404 Not Found'));
+
+      await expect(
+        parser.parse('https://api.example.com/graphql'),
+      ).rejects.toThrow('introspection failed and SDL fallback');
+    });
+  });
+
+  describe('parseFromSdl', () => {
+    it('should extract query tools from SDL', () => {
+      const sdl = `
+        type Query {
+          "Get all users"
+          users(limit: Int): [User]
+          "Get user by ID"
+          user(id: ID!): User
+        }
+        type User { id: ID!, name: String }
+      `;
+      const tools = parser.parseFromSdl(sdl);
+      expect(tools).toHaveLength(2);
+      expect(tools[0].name).toBe('graphql_users');
+      expect(tools[0].description).toBe('Get all users');
+      expect(tools[1].name).toBe('graphql_user');
+      expect((tools[1].parameters as any).required).toEqual(['id']);
+    });
+
+    it('should extract mutation tools from SDL', () => {
+      const sdl = `
+        type Query { _empty: String }
+        type Mutation {
+          createUser(name: String!, email: String!): User
+        }
+        type User { id: ID! }
+      `;
+      const tools = parser.parseFromSdl(sdl);
+      const mutation = tools.find(t => t.name === 'graphql_createuser');
+      expect(mutation).toBeDefined();
+      expect(mutation!.endpointMapping.method).toBe('mutation');
+      expect((mutation!.parameters as any).required).toEqual(expect.arrayContaining(['name', 'email']));
+    });
+
+    it('should map SDL scalar types to JSON types', () => {
+      const sdl = `
+        type Query {
+          test(count: Int, price: Float, active: Boolean, label: String, uid: ID): String
+        }
+      `;
+      const tools = parser.parseFromSdl(sdl);
+      const props = (tools[0].parameters as any).properties;
+      expect(props.count.type).toBe('number');
+      expect(props.price.type).toBe('number');
+      expect(props.active.type).toBe('boolean');
+      expect(props.label.type).toBe('string');
+      expect(props.uid.type).toBe('string');
+    });
+
+    it('should throw on invalid SDL without query type', () => {
+      const sdl = `type User { id: ID!, name: String }`;
+      expect(() => parser.parseFromSdl(sdl)).toThrow();
+    });
+
+    it('should handle large SDL schemas', () => {
+      const fields = Array.from({ length: 50 }, (_, i) =>
+        `field${i}(arg: String): String`,
+      ).join('\n  ');
+      const sdl = `type Query { ${fields} }`;
+      const tools = parser.parseFromSdl(sdl);
+      expect(tools).toHaveLength(50);
     });
   });
 });

--- a/packages/backend/src/connectors/parsers/graphql.parser.ts
+++ b/packages/backend/src/connectors/parsers/graphql.parser.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ParsedTool } from './openapi.parser';
+import { buildSchema, introspectionFromSchema } from 'graphql';
 import axios from 'axios';
 
 const INTROSPECTION_QUERY = `
@@ -42,23 +43,69 @@ export class GraphqlParser {
   async parse(
     endpoint: string,
     headers?: Record<string, string>,
+    specUrl?: string,
   ): Promise<ParsedTool[]> {
-    this.logger.debug(`Introspecting GraphQL schema from: ${endpoint}`);
+    // 1. Try standard introspection query
+    try {
+      this.logger.debug(`Introspecting GraphQL schema from: ${endpoint}`);
+      const response = await axios.post(
+        endpoint,
+        { query: INTROSPECTION_QUERY },
+        {
+          headers: { 'Content-Type': 'application/json', ...headers },
+          timeout: 15000,
+        },
+      );
 
-    const response = await axios.post(
-      endpoint,
-      { query: INTROSPECTION_QUERY },
-      {
-        headers: { 'Content-Type': 'application/json', ...headers },
-        timeout: 15000,
-      },
-    );
+      if (!response.data.errors) {
+        return this.extractToolsFromSchema(response.data.data.__schema);
+      }
 
-    if (response.data.errors) {
-      throw new Error(`GraphQL introspection errors: ${JSON.stringify(response.data.errors)}`);
+      this.logger.debug(
+        `Introspection returned errors: ${JSON.stringify(response.data.errors)}`,
+      );
+    } catch (err: any) {
+      this.logger.debug(`Introspection request failed: ${err.message}`);
     }
 
-    const schema = response.data.data.__schema;
+    // 2. Fallback: fetch SDL schema from specUrl or {endpoint}/schema
+    const sdlUrl = specUrl || `${endpoint}/schema`;
+    this.logger.debug(`Falling back to SDL schema from: ${sdlUrl}`);
+
+    try {
+      const sdlResponse = await axios.get(sdlUrl, {
+        headers,
+        timeout: 30000,
+        responseType: 'text',
+      });
+      return this.parseFromSdl(sdlResponse.data);
+    } catch (err: any) {
+      throw new Error(
+        `GraphQL introspection failed and SDL fallback from ${sdlUrl} also failed: ${err.message}`,
+      );
+    }
+  }
+
+  /**
+   * Parse tools from a GraphQL SDL (Schema Definition Language) string.
+   * Converts SDL → GraphQLSchema → introspection result → tools.
+   */
+  parseFromSdl(sdl: string): ParsedTool[] {
+    this.logger.debug('Parsing GraphQL SDL schema');
+
+    const schema = buildSchema(sdl);
+    const introspection = introspectionFromSchema(schema);
+    const tools = this.extractToolsFromSchema(introspection.__schema as any);
+
+    this.logger.log(`Extracted ${tools.length} tools from SDL schema`);
+    return tools;
+  }
+
+  /**
+   * Extract tools from an introspection schema result.
+   * Shared between introspection query path and SDL path.
+   */
+  private extractToolsFromSchema(schema: any): ParsedTool[] {
     const tools: ParsedTool[] = [];
 
     const queryTypeName = schema.queryType?.name || 'Query';


### PR DESCRIPTION
## Summary
- When introspection is blocked (common in production APIs like Sorare), the GraphQL parser now falls back to fetching the SDL schema from `specUrl` or `{endpoint}/schema`
- SDL is converted to introspection format via `buildSchema()` + `introspectionFromSchema()` from the `graphql` package (already a dependency)
- Connector controller now passes `specUrl` to the parser in both `importSpec()` and `importTools()`
- 8 new tests covering SDL parsing and fallback paths (253 total tests passing)

## Test plan
- [x] Unit tests: all 253 tests pass (`npx jest`)
- [x] Integration test: Sorare GraphQL connector with 275 tools imported via SDL fallback
- [x] Connection test with Bearer Token auth + JWT-AUD header
- [x] Tool execution test (`currentBlockHeight` query returns live data)
- [x] Frontend Chrome automation: full flow verified