### PR TITLE
OAuth2 authorization flow for REST and GraphQL connectors

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -83,6 +83,8 @@ curl -s http://localhost:4000/api/auth/invite \
 | POST | `/api/connectors/:id/import-spec` | Auto-import tools from connector's spec URL |
 | POST | `/api/connectors/:id/import` | Import tools from any source |
 | PUT | `/api/connectors/:id/env-vars` | Set environment variables |
+| POST | `/api/connectors/:id/oauth/authorize` | Start OAuth2 authorization flow (returns redirect URL) |
+| GET | `/api/mcp-oauth/callback` | OAuth2 callback — exchanges code for tokens |
 
 ### Create Connector
 

--- a/docs/connectors/graphql.md
+++ b/docs/connectors/graphql.md
@@ -127,7 +127,11 @@ GraphQL connectors support all standard auth types:
 | **Bearer Token** | `"authType": "BEARER_TOKEN", "authConfig": {"token": "..."}` |
 | **API Key** | `"authType": "API_KEY", "authConfig": {"key": "X-API-Key", "value": "..."}` |
 | **Basic Auth** | `"authType": "BASIC_AUTH", "authConfig": {"username": "...", "password": "..."}` |
-| **OAuth2** | `"authType": "OAUTH2", "authConfig": {"tokenUrl": "...", "clientId": "...", "clientSecret": "..."}` |
+| **OAuth2** | `"authType": "OAUTH2", "authConfig": {"clientId": "...", "clientSecret": "...", "authorizationUrl": "...", "tokenUrl": "...", "scopes": "read write"}` |
+
+### OAuth2 Authorization Flow
+
+OAuth2 connectors use the **Authorization Code + PKCE** flow. After creating the connector, click **Authorize with Provider** on the detail page to start the flow. Set `http://localhost:4000/api/mcp-oauth/callback` as the redirect URI in your provider. On 401 responses, the engine automatically refreshes the token and retries.
 
 ---
 

--- a/docs/connectors/rest.md
+++ b/docs/connectors/rest.md
@@ -182,11 +182,19 @@ Optionally filter and transform API responses:
 | **API Key** | `"authType": "API_KEY", "authConfig": {"key": "X-API-Key", "value": "your-key"}` |
 | **Bearer Token** | `"authType": "BEARER_TOKEN", "authConfig": {"token": "your-token"}` |
 | **Basic Auth** | `"authType": "BASIC_AUTH", "authConfig": {"username": "user", "password": "pass"}` |
-| **OAuth2** | `"authType": "OAUTH2", "authConfig": {"tokenUrl": "...", "clientId": "...", "clientSecret": "...", "scope": "..."}` |
+| **OAuth2** | `"authType": "OAUTH2", "authConfig": {"clientId": "...", "clientSecret": "...", "authorizationUrl": "...", "tokenUrl": "...", "scopes": "read write"}` |
 
 All credentials are encrypted with AES-256-GCM at rest.
 
-OAuth2 supports automatic token refresh on 401 responses.
+### OAuth2 Authorization Flow
+
+OAuth2 connectors use the **Authorization Code + PKCE** flow:
+
+1. Create the connector with `authType: "OAUTH2"` and fill in `clientId`, `clientSecret`, `authorizationUrl`, `tokenUrl`, and optionally `scopes`.
+2. Register **`http://localhost:4000/api/mcp-oauth/callback`** as the redirect URI in your OAuth provider settings (use your `SERVER_URL` in production).
+3. From the connector detail page, click **Authorize with Provider** — you will be redirected to the provider's login/consent screen.
+4. After consent, the backend exchanges the authorization code for access and refresh tokens (stored encrypted).
+5. On 401 responses, the engine automatically refreshes the token using the stored refresh token and retries the request.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "anything-to-mcp",
+  "name": "anythingmcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "anything-to-mcp",
+      "name": "anythingmcp",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
         "packages/frontend"
@@ -170,11 +170,11 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@anything-to-mcp/backend": {
+    "node_modules/@anythingmcp/backend": {
       "resolved": "packages/backend",
       "link": true
     },
-    "node_modules/@anything-to-mcp/frontend": {
+    "node_modules/@anythingmcp/frontend": {
       "resolved": "packages/frontend",
       "link": true
     },
@@ -19531,9 +19531,9 @@
       }
     },
     "packages/backend": {
-      "name": "@anything-to-mcp/backend",
+      "name": "@anythingmcp/backend",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -19610,9 +19610,9 @@
       "license": "MIT"
     },
     "packages/frontend": {
-      "name": "@anything-to-mcp/frontend",
+      "name": "@anythingmcp/frontend",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -301,59 +301,73 @@ export class ConnectorsController {
 
   @Post(':id/oauth/authorize')
   @ApiOperation({
-    summary: 'Initiate OAuth2 authorization for an MCP connector',
+    summary: 'Initiate OAuth2 authorization for a connector',
     description:
-      'Discovers the remote MCP server OAuth endpoints, registers as a client, ' +
-      'and returns an authorization URL for the user to visit.',
+      'For MCP connectors: discovers OAuth endpoints via .well-known and optionally registers dynamically. ' +
+      'For REST/GraphQL connectors: uses authorizationUrl and tokenUrl from authConfig. ' +
+      'Returns an authorization URL for the user to visit.',
   })
   async initiateOAuth(@Req() req: any, @Param('id') id: string) {
     const connector = await this.connectorsService.findById(id, req.user.sub);
 
-    if (connector.type !== 'MCP') {
-      return { error: 'OAuth authorization is only available for MCP connectors' };
-    }
     if (connector.authType !== 'OAUTH2') {
       return { error: 'Connector auth type must be OAUTH2' };
     }
 
     try {
-      // 1. Discover OAuth metadata from remote server
-      const metadata = await this.mcpOAuthService.discoverMetadata(connector.baseUrl);
-      this.logger.log(`OAuth metadata discovered from ${connector.baseUrl}: issuer=${metadata.issuer}`);
-
-      // 2. Register as OAuth client (dynamic registration)
       const callbackUrl = `${this.configService.get('SERVER_URL') || 'http://localhost:4000'}/api/mcp-oauth/callback`;
+      const authConfig = connector.authConfig
+        ? JSON.parse(decrypt(connector.authConfig, this.encryptionKey))
+        : {};
 
       let clientId: string;
       let clientSecret: string | undefined;
+      let authorizationEndpoint: string;
+      let tokenEndpoint: string;
+      let scope: string | undefined;
 
-      if (metadata.registration_endpoint) {
-        const registration = await this.mcpOAuthService.registerClient(
-          metadata.registration_endpoint,
-          callbackUrl,
-        );
-        clientId = registration.clientId;
-        clientSecret = registration.clientSecret;
+      if (connector.type === 'MCP') {
+        // MCP: discover OAuth metadata from remote server
+        const metadata = await this.mcpOAuthService.discoverMetadata(connector.baseUrl);
+        this.logger.log(`OAuth metadata discovered from ${connector.baseUrl}: issuer=${metadata.issuer}`);
+
+        authorizationEndpoint = metadata.authorization_endpoint;
+        tokenEndpoint = metadata.token_endpoint;
+        scope = metadata.scopes_supported?.join(' ');
+
+        if (metadata.registration_endpoint) {
+          const registration = await this.mcpOAuthService.registerClient(
+            metadata.registration_endpoint,
+            callbackUrl,
+          );
+          clientId = registration.clientId;
+          clientSecret = registration.clientSecret;
+        } else {
+          clientId = String(authConfig.clientId || '');
+          clientSecret = authConfig.clientSecret ? String(authConfig.clientSecret) : undefined;
+        }
       } else {
-        // Fallback: use clientId/clientSecret from existing authConfig
-        const authConfig = connector.authConfig
-          ? JSON.parse(decrypt(connector.authConfig, this.encryptionKey))
-          : {};
+        // REST/GraphQL: use authConfig values directly
         clientId = String(authConfig.clientId || '');
         clientSecret = authConfig.clientSecret ? String(authConfig.clientSecret) : undefined;
-        if (!clientId) {
-          return {
-            error: 'Remote server does not support dynamic registration and no clientId is configured',
-          };
-        }
+        authorizationEndpoint = String(authConfig.authorizationUrl || '');
+        tokenEndpoint = String(authConfig.tokenUrl || '');
+        scope = authConfig.scopes ? String(authConfig.scopes) : undefined;
       }
 
-      // 3. Generate PKCE challenge
+      if (!clientId) {
+        return { error: 'No clientId configured for this connector' };
+      }
+      if (!authorizationEndpoint) {
+        return { error: 'No authorization URL configured for this connector' };
+      }
+
+      // Generate PKCE challenge
       const codeVerifier = this.mcpOAuthService.generateCodeVerifier();
       const codeChallenge = this.mcpOAuthService.generateCodeChallenge(codeVerifier);
       const state = this.mcpOAuthService.generateState();
 
-      // 4. Store pending flow
+      // Store pending flow
       this.mcpOAuthService.storePendingFlow(state, {
         codeVerifier,
         connectorId: connector.id,
@@ -361,18 +375,18 @@ export class ConnectorsController {
         redirectUri: callbackUrl,
         clientId,
         clientSecret,
-        tokenUrl: metadata.token_endpoint,
+        tokenUrl: tokenEndpoint,
         createdAt: Date.now(),
       });
 
-      // 5. Build authorization URL
+      // Build authorization URL
       const authorizationUrl = this.mcpOAuthService.buildAuthorizationUrl({
-        authorizationEndpoint: metadata.authorization_endpoint,
+        authorizationEndpoint,
         clientId,
         redirectUri: callbackUrl,
         codeChallenge,
         state,
-        scope: metadata.scopes_supported?.join(' '),
+        scope,
       });
 
       return { authorizationUrl };

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -8,6 +8,7 @@ import { SoapEngine } from './engines/soap.engine';
 import { GraphqlEngine } from './engines/graphql.engine';
 import { McpClientEngine } from './engines/mcp-client.engine';
 import { DatabaseEngine } from './engines/database.engine';
+import { OAuth2TokenService } from './engines/oauth2-token.service';
 import { OpenApiParser } from './parsers/openapi.parser';
 import { WsdlParser } from './parsers/wsdl.parser';
 import { GraphqlParser } from './parsers/graphql.parser';
@@ -29,7 +30,7 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
 @Module({
   imports: [McpServerModule],
   controllers: [ConnectorsController, McpOAuthCallbackController, ToolsController],
-  providers: [ConnectorsService, McpOAuthService, ...ENGINES, ...PARSERS],
-  exports: [ConnectorsService, McpOAuthService, ...ENGINES],
+  providers: [ConnectorsService, McpOAuthService, OAuth2TokenService, ...ENGINES, ...PARSERS],
+  exports: [ConnectorsService, McpOAuthService, OAuth2TokenService, ...ENGINES],
 })
 export class ConnectorsModule {}

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -215,6 +215,7 @@ export class ConnectorsService {
       authConfig,
       headers: connector.headers as Record<string, string>,
       specUrl: connector.specUrl ?? undefined,
+      connectorId: connector.id,
     };
 
     // Inject env vars as parameter defaults

--- a/packages/backend/src/connectors/engines/graphql.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.spec.ts
@@ -1,14 +1,20 @@
 import { GraphqlEngine } from './graphql.engine';
-import axios from 'axios';
+import { OAuth2TokenService } from './oauth2-token.service';
+import axios, { AxiosError } from 'axios';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('GraphqlEngine', () => {
   let engine: GraphqlEngine;
+  let mockOAuth2TokenService: jest.Mocked<OAuth2TokenService>;
 
   beforeEach(() => {
-    engine = new GraphqlEngine();
+    mockOAuth2TokenService = {
+      getAccessToken: jest.fn().mockReturnValue('oauth2-access-token'),
+      refreshToken: jest.fn().mockResolvedValue('new-access-token'),
+    } as any;
+    engine = new GraphqlEngine(mockOAuth2TokenService);
     jest.clearAllMocks();
   });
 
@@ -194,5 +200,86 @@ describe('GraphqlEngine', () => {
         headers: expect.objectContaining({ 'X-Custom': 'value' }),
       }),
     );
+  });
+
+  it('should inject OAUTH2 auth using OAuth2TokenService', async () => {
+    mockOAuth2TokenService.getAccessToken.mockReturnValue('my-oauth-token');
+    mockedAxios.post.mockResolvedValue({ data: { data: { me: {} } } });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'OAUTH2',
+        authConfig: { accessToken: 'my-oauth-token' },
+        connectorId: 'conn-1',
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(mockOAuth2TokenService.getAccessToken).toHaveBeenCalledWith(
+      { accessToken: 'my-oauth-token' },
+      'conn-1',
+    );
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer my-oauth-token' }),
+      }),
+    );
+  });
+
+  it('should inject BASIC_AUTH auth into headers', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { data: {} } });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'BASIC_AUTH',
+        authConfig: { username: 'user', password: 'pass' },
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    const expectedBasic = `Basic ${Buffer.from('user:pass').toString('base64')}`;
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: expectedBasic }),
+      }),
+    );
+  });
+
+  it('should refresh OAuth2 token and retry on 401', async () => {
+    mockOAuth2TokenService.getAccessToken.mockReturnValue('expired-token');
+    mockOAuth2TokenService.refreshToken.mockResolvedValue('fresh-token');
+
+    // AxiosError is auto-mocked, so create instance and set properties manually
+    const error401 = new AxiosError() as any;
+    error401.response = { status: 401, data: {}, headers: {}, statusText: 'Unauthorized', config: {} };
+    mockedAxios.post
+      .mockRejectedValueOnce(error401)
+      .mockResolvedValueOnce({ data: { data: { me: { id: '1' } } } });
+
+    const result = await engine.execute(
+      {
+        baseUrl: 'https://api.example.com/graphql',
+        authType: 'OAUTH2',
+        authConfig: { accessToken: 'expired-token', refreshToken: 'rt', tokenUrl: 'https://auth/token' },
+        connectorId: 'conn-1',
+      },
+      { method: 'query', path: '{ me { id } }' },
+      {},
+    );
+
+    expect(result).toEqual({ me: { id: '1' } });
+    expect(mockOAuth2TokenService.refreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: 'rt', tokenUrl: 'https://auth/token' }),
+      'conn-1',
+    );
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -1,13 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import { OAuth2TokenService } from './oauth2-token.service';
 
 /**
  * GraphqlEngine — executes GraphQL queries/mutations.
- * Supports query variables, custom headers, and auth injection.
+ * Supports query variables, custom headers, auth injection, and OAuth2 token refresh.
  */
 @Injectable()
 export class GraphqlEngine {
   private readonly logger = new Logger(GraphqlEngine.name);
+
+  constructor(private readonly oauth2TokenService: OAuth2TokenService) {}
 
   async execute(
     config: {
@@ -15,6 +18,7 @@ export class GraphqlEngine {
       authType: string;
       authConfig?: Record<string, unknown>;
       headers?: Record<string, string>;
+      connectorId?: string;
     },
     endpointMapping: {
       method: string; // "query" or "mutation"
@@ -56,6 +60,21 @@ export class GraphqlEngine {
           headers[String(config.authConfig.headerName || 'X-API-Key')] =
             String(config.authConfig.apiKey);
           break;
+        case 'OAUTH2': {
+          const accessToken = this.oauth2TokenService.getAccessToken(
+            config.authConfig,
+            config.connectorId,
+          );
+          headers['Authorization'] = `Bearer ${accessToken}`;
+          break;
+        }
+        case 'BASIC_AUTH': {
+          const username = String(config.authConfig.username || '');
+          const password = String(config.authConfig.password || '');
+          headers['Authorization'] =
+            `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+          break;
+        }
       }
     }
 
@@ -71,21 +90,58 @@ export class GraphqlEngine {
       }
     }
 
-    const response = await axios.post(
-      config.baseUrl,
-      {
-        query: endpointMapping.path, // The GraphQL query
-        variables,
-      },
-      { headers, timeout: 30000 },
-    );
+    const requestConfig = {
+      query: endpointMapping.path,
+      variables,
+    };
 
-    if (response.data.errors) {
-      throw new Error(
-        `GraphQL errors: ${JSON.stringify(response.data.errors)}`,
-      );
+    try {
+      const response = await axios.post(config.baseUrl, requestConfig, {
+        headers,
+        timeout: 30000,
+      });
+
+      if (response.data.errors) {
+        throw new Error(
+          `GraphQL errors: ${JSON.stringify(response.data.errors)}`,
+        );
+      }
+
+      return response.data.data;
+    } catch (error) {
+      // OAuth2 auto-refresh: retry once on 401
+      if (
+        error instanceof AxiosError &&
+        error.response?.status === 401 &&
+        config.authType === 'OAUTH2' &&
+        config.authConfig?.refreshToken &&
+        config.authConfig?.tokenUrl
+      ) {
+        this.logger.debug(
+          'OAuth2: access token expired, attempting refresh...',
+        );
+        const newToken = await this.oauth2TokenService.refreshToken(
+          config.authConfig,
+          config.connectorId,
+        );
+        if (newToken) {
+          headers['Authorization'] = `Bearer ${newToken}`;
+          const retryResponse = await axios.post(
+            config.baseUrl,
+            requestConfig,
+            { headers, timeout: 30000 },
+          );
+
+          if (retryResponse.data.errors) {
+            throw new Error(
+              `GraphQL errors: ${JSON.stringify(retryResponse.data.errors)}`,
+            );
+          }
+
+          return retryResponse.data.data;
+        }
+      }
+      throw error;
     }
-
-    return response.data.data;
   }
 }

--- a/packages/backend/src/connectors/engines/oauth2-token.service.spec.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.spec.ts
@@ -1,0 +1,247 @@
+import { OAuth2TokenService } from './oauth2-token.service';
+import { PrismaService } from '../../common/prisma.service';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { encrypt } from '../../common/crypto/encryption.util';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('OAuth2TokenService', () => {
+  let service: OAuth2TokenService;
+  let mockPrisma: any;
+  let mockConfigService: jest.Mocked<ConfigService>;
+
+  const encryptionKey = 'test-encryption-key-32-chars!!!!';
+
+  beforeEach(() => {
+    mockPrisma = {
+      connector: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+
+    mockConfigService = {
+      get: jest.fn().mockReturnValue(encryptionKey),
+    } as any;
+
+    service = new OAuth2TokenService(mockPrisma, mockConfigService);
+    jest.clearAllMocks();
+    // Re-mock configService.get since clearAllMocks resets it
+    mockConfigService.get.mockReturnValue(encryptionKey);
+  });
+
+  describe('getAccessToken', () => {
+    it('should return accessToken from authConfig when no cached token', () => {
+      const result = service.getAccessToken(
+        { accessToken: 'stored-token', tokenUrl: 'https://auth/token' },
+        'conn-1',
+      );
+      expect(result).toBe('stored-token');
+    });
+
+    it('should return empty string when no accessToken in authConfig', () => {
+      const result = service.getAccessToken({}, 'conn-1');
+      expect(result).toBe('');
+    });
+
+    it('should return cached token after a successful refresh', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'refreshed-token',
+          expires_in: 3600,
+        },
+      });
+
+      await service.refreshToken(
+        {
+          tokenUrl: 'https://auth/token',
+          refreshToken: 'rt-123',
+        },
+        'conn-1',
+      );
+
+      const result = service.getAccessToken(
+        { accessToken: 'old-token', tokenUrl: 'https://auth/token' },
+        'conn-1',
+      );
+      expect(result).toBe('refreshed-token');
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('should POST to tokenUrl with grant_type=refresh_token', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'new-at',
+          expires_in: 3600,
+        },
+      });
+
+      const result = await service.refreshToken({
+        tokenUrl: 'https://auth.example.com/token',
+        refreshToken: 'rt-abc',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      });
+
+      expect(result).toBe('new-at');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://auth.example.com/token',
+        expect.stringContaining('grant_type=refresh_token'),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          timeout: 10000,
+        }),
+      );
+
+      // Verify client_id and client_secret are included
+      const postedBody = mockedAxios.post.mock.calls[0][1] as string;
+      expect(postedBody).toContain('client_id=client-id');
+      expect(postedBody).toContain('client_secret=client-secret');
+    });
+
+    it('should return null when tokenUrl is missing', async () => {
+      const result = await service.refreshToken({
+        refreshToken: 'rt-abc',
+      });
+      expect(result).toBeNull();
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('should return null when refreshToken is missing', async () => {
+      const result = await service.refreshToken({
+        tokenUrl: 'https://auth/token',
+      });
+      expect(result).toBeNull();
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('should return null when token endpoint returns no access_token', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { error: 'invalid_grant' },
+      });
+
+      const result = await service.refreshToken({
+        tokenUrl: 'https://auth/token',
+        refreshToken: 'rt-expired',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('should return null on network error', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+
+      const result = await service.refreshToken({
+        tokenUrl: 'https://auth/token',
+        refreshToken: 'rt-abc',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('should cache the refreshed token', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'cached-token',
+          expires_in: 3600,
+        },
+      });
+
+      await service.refreshToken(
+        { tokenUrl: 'https://auth/token', refreshToken: 'rt' },
+        'conn-1',
+      );
+
+      // Should return cached token, not the one from authConfig
+      const token = service.getAccessToken(
+        { accessToken: 'old', tokenUrl: 'https://auth/token' },
+        'conn-1',
+      );
+      expect(token).toBe('cached-token');
+    });
+
+    it('should persist refreshed token to DB when connectorId is provided', async () => {
+      const authConfigObj = {
+        accessToken: 'old-at',
+        refreshToken: 'old-rt',
+        tokenUrl: 'https://auth/token',
+      };
+
+      mockPrisma.connector.findUnique.mockResolvedValue({
+        authConfig: encrypt(JSON.stringify(authConfigObj), encryptionKey),
+      } as any);
+      mockPrisma.connector.update.mockResolvedValue({} as any);
+
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'new-at',
+          expires_in: 3600,
+          refresh_token: 'new-rt',
+        },
+      });
+
+      await service.refreshToken(
+        { tokenUrl: 'https://auth/token', refreshToken: 'old-rt' },
+        'conn-42',
+      );
+
+      expect(mockPrisma.connector.findUnique).toHaveBeenCalledWith({
+        where: { id: 'conn-42' },
+        select: { authConfig: true },
+      });
+      expect(mockPrisma.connector.update).toHaveBeenCalledWith({
+        where: { id: 'conn-42' },
+        data: { authConfig: expect.any(String) },
+      });
+    });
+
+    it('should not persist to DB when connectorId is not provided', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'new-at',
+          expires_in: 3600,
+        },
+      });
+
+      await service.refreshToken({
+        tokenUrl: 'https://auth/token',
+        refreshToken: 'rt',
+      });
+
+      expect(mockPrisma.connector.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.connector.update).not.toHaveBeenCalled();
+    });
+
+    it('should use original refreshToken if provider does not return a new one', async () => {
+      const authConfigObj = {
+        accessToken: 'old-at',
+        refreshToken: 'original-rt',
+        tokenUrl: 'https://auth/token',
+      };
+
+      mockPrisma.connector.findUnique.mockResolvedValue({
+        authConfig: encrypt(JSON.stringify(authConfigObj), encryptionKey),
+      } as any);
+      mockPrisma.connector.update.mockResolvedValue({} as any);
+
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'new-at',
+          expires_in: 3600,
+          // No refresh_token returned — should keep original
+        },
+      });
+
+      await service.refreshToken(
+        { tokenUrl: 'https://auth/token', refreshToken: 'original-rt' },
+        'conn-1',
+      );
+
+      // DB update should have been called (we verify the refresh token was preserved
+      // by checking the mock was called — detailed verification of encrypted content
+      // would require decrypting, which the service handles internally)
+      expect(mockPrisma.connector.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/connectors/engines/oauth2-token.service.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { PrismaService } from '../../common/prisma.service';
+import { encrypt, decrypt } from '../../common/crypto/encryption.util';
+
+/**
+ * Shared OAuth2 token management: in-memory cache, refresh, and DB persistence.
+ * Used by RestEngine and GraphqlEngine to handle OAuth2 token lifecycle.
+ */
+@Injectable()
+export class OAuth2TokenService {
+  private readonly logger = new Logger(OAuth2TokenService.name);
+  private readonly encryptionKey: string;
+
+  // In-memory cache for refreshed tokens (keyed by connectorId or tokenUrl)
+  private tokenCache = new Map<
+    string,
+    { accessToken: string; expiresAt: number }
+  >();
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+  ) {
+    this.encryptionKey =
+      this.configService.get<string>('ENCRYPTION_KEY') ||
+      'default-dev-key-change-in-prod!!';
+  }
+
+  /**
+   * Returns the best available access token:
+   * 1. Cached (refreshed) token if still valid
+   * 2. Original token from authConfig
+   */
+  getAccessToken(
+    authConfig: Record<string, unknown>,
+    connectorId?: string,
+  ): string {
+    const cacheKey = connectorId || String(authConfig.tokenUrl || '');
+
+    if (cacheKey) {
+      const cached = this.tokenCache.get(cacheKey);
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.accessToken;
+      }
+    }
+
+    return String(authConfig.accessToken || '');
+  }
+
+  /**
+   * Refresh the OAuth2 access token using the refresh token.
+   * On success: caches in-memory and persists to DB.
+   * Returns the new access token, or null on failure.
+   */
+  async refreshToken(
+    authConfig: Record<string, unknown>,
+    connectorId?: string,
+  ): Promise<string | null> {
+    const tokenUrl = String(authConfig.tokenUrl || '');
+    const refreshToken = String(authConfig.refreshToken || '');
+
+    if (!tokenUrl || !refreshToken) {
+      this.logger.warn('OAuth2 refresh: missing tokenUrl or refreshToken');
+      return null;
+    }
+
+    const clientId = authConfig.clientId
+      ? String(authConfig.clientId)
+      : undefined;
+    const clientSecret = authConfig.clientSecret
+      ? String(authConfig.clientSecret)
+      : undefined;
+
+    try {
+      const body: Record<string, string> = {
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      };
+      if (clientId) body.client_id = clientId;
+      if (clientSecret) body.client_secret = clientSecret;
+
+      const response = await axios.post(
+        tokenUrl,
+        new URLSearchParams(body).toString(),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          timeout: 10000,
+        },
+      );
+
+      const { access_token, expires_in, refresh_token: newRefreshToken } =
+        response.data;
+      if (!access_token) return null;
+
+      // Cache the new token (default 1 hour, refresh 1 min early)
+      const expiresInMs = (expires_in || 3600) * 1000;
+      const cacheKey = connectorId || tokenUrl;
+      this.tokenCache.set(cacheKey, {
+        accessToken: access_token,
+        expiresAt: Date.now() + expiresInMs - 60000,
+      });
+
+      // Persist to DB if connectorId is available
+      if (connectorId) {
+        await this.persistRefreshedToken(
+          connectorId,
+          access_token,
+          newRefreshToken || refreshToken,
+        );
+      }
+
+      this.logger.debug('OAuth2: token refreshed successfully');
+      return access_token;
+    } catch (err: any) {
+      this.logger.warn(`OAuth2 token refresh failed: ${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Update the connector's encrypted authConfig with the new access token
+   * so it survives server restarts.
+   */
+  private async persistRefreshedToken(
+    connectorId: string,
+    newAccessToken: string,
+    newRefreshToken: string,
+  ): Promise<void> {
+    try {
+      const connector = await this.prisma.connector.findUnique({
+        where: { id: connectorId },
+        select: { authConfig: true },
+      });
+
+      if (!connector?.authConfig) return;
+
+      const authConfig = JSON.parse(
+        decrypt(connector.authConfig, this.encryptionKey),
+      );
+      authConfig.accessToken = newAccessToken;
+      authConfig.refreshToken = newRefreshToken;
+      authConfig.lastRefreshedAt = new Date().toISOString();
+
+      await this.prisma.connector.update({
+        where: { id: connectorId },
+        data: {
+          authConfig: encrypt(
+            JSON.stringify(authConfig),
+            this.encryptionKey,
+          ),
+        },
+      });
+
+      this.logger.debug(
+        `OAuth2: persisted refreshed token for connector ${connectorId}`,
+      );
+    } catch (err: any) {
+      this.logger.warn(
+        `OAuth2: failed to persist refreshed token: ${err.message}`,
+      );
+    }
+  }
+}

--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -1,4 +1,5 @@
 import { RestEngine } from './rest.engine';
+import { OAuth2TokenService } from './oauth2-token.service';
 import axios from 'axios';
 
 jest.mock('axios');
@@ -6,9 +7,14 @@ const mockedAxios = axios as jest.MockedFunction<typeof axios>;
 
 describe('RestEngine', () => {
   let engine: RestEngine;
+  let mockOAuth2TokenService: jest.Mocked<OAuth2TokenService>;
 
   beforeEach(() => {
-    engine = new RestEngine();
+    mockOAuth2TokenService = {
+      getAccessToken: jest.fn().mockReturnValue('oauth2-access-token'),
+      refreshToken: jest.fn().mockResolvedValue('new-access-token'),
+    } as any;
+    engine = new RestEngine(mockOAuth2TokenService);
     jest.clearAllMocks();
   });
 

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
 import FormData from 'form-data';
+import { OAuth2TokenService } from './oauth2-token.service';
 
 /**
  * RestEngine — executes HTTP calls to REST APIs.
@@ -12,8 +13,7 @@ import FormData from 'form-data';
 export class RestEngine {
   private readonly logger = new Logger(RestEngine.name);
 
-  // In-memory cache for refreshed tokens (keyed by tokenUrl)
-  private tokenCache = new Map<string, { accessToken: string; expiresAt: number }>();
+  constructor(private readonly oauth2TokenService: OAuth2TokenService) {}
 
   async execute(
     config: {
@@ -21,6 +21,7 @@ export class RestEngine {
       authType: string;
       authConfig?: Record<string, unknown>;
       headers?: Record<string, string>;
+      connectorId?: string;
     },
     endpointMapping: {
       method: string;
@@ -68,7 +69,7 @@ export class RestEngine {
     };
 
     // Inject authentication
-    await this.injectAuth(axiosConfig, config.authType, config.authConfig);
+    this.injectAuth(axiosConfig, config);
 
     // Query parameters
     if (endpointMapping.queryParams) {
@@ -146,7 +147,10 @@ export class RestEngine {
         config.authConfig?.tokenUrl
       ) {
         this.logger.debug('OAuth2: access token expired, attempting refresh...');
-        const newToken = await this.refreshOAuth2Token(config.authConfig);
+        const newToken = await this.oauth2TokenService.refreshToken(
+          config.authConfig,
+          config.connectorId,
+        );
         if (newToken) {
           axiosConfig.headers = {
             ...axiosConfig.headers,
@@ -160,91 +164,48 @@ export class RestEngine {
     }
   }
 
-  private async injectAuth(
-    config: AxiosRequestConfig,
-    authType: string,
-    authConfig?: Record<string, unknown>,
-  ): Promise<void> {
-    if (!authConfig) return;
+  private injectAuth(
+    axiosConfig: AxiosRequestConfig,
+    config: {
+      authType: string;
+      authConfig?: Record<string, unknown>;
+      connectorId?: string;
+    },
+  ): void {
+    if (!config.authConfig) return;
 
-    switch (authType) {
+    switch (config.authType) {
       case 'API_KEY':
-        config.headers = {
-          ...config.headers,
-          [String(authConfig.headerName || 'X-API-Key')]: String(
-            authConfig.apiKey,
+        axiosConfig.headers = {
+          ...axiosConfig.headers,
+          [String(config.authConfig.headerName || 'X-API-Key')]: String(
+            config.authConfig.apiKey,
           ),
         };
         break;
       case 'BEARER_TOKEN':
-        config.headers = {
-          ...config.headers,
-          Authorization: `Bearer ${authConfig.token}`,
+        axiosConfig.headers = {
+          ...axiosConfig.headers,
+          Authorization: `Bearer ${config.authConfig.token}`,
         };
         break;
       case 'BASIC_AUTH':
-        config.auth = {
-          username: String(authConfig.username),
-          password: String(authConfig.password),
+        axiosConfig.auth = {
+          username: String(config.authConfig.username),
+          password: String(config.authConfig.password),
         };
         break;
       case 'OAUTH2': {
-        let accessToken = String(authConfig.accessToken || '');
-
-        // Check if we have a cached (refreshed) token
-        const tokenUrl = String(authConfig.tokenUrl || '');
-        if (tokenUrl) {
-          const cached = this.tokenCache.get(tokenUrl);
-          if (cached && cached.expiresAt > Date.now()) {
-            accessToken = cached.accessToken;
-          }
-        }
-
-        config.headers = {
-          ...config.headers,
+        const accessToken = this.oauth2TokenService.getAccessToken(
+          config.authConfig,
+          config.connectorId,
+        );
+        axiosConfig.headers = {
+          ...axiosConfig.headers,
           Authorization: `Bearer ${accessToken}`,
         };
         break;
       }
-    }
-  }
-
-  private async refreshOAuth2Token(
-    authConfig: Record<string, unknown>,
-  ): Promise<string | null> {
-    const tokenUrl = String(authConfig.tokenUrl);
-    const refreshToken = String(authConfig.refreshToken);
-    const clientId = authConfig.clientId ? String(authConfig.clientId) : undefined;
-    const clientSecret = authConfig.clientSecret ? String(authConfig.clientSecret) : undefined;
-
-    try {
-      const body: Record<string, string> = {
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-      };
-      if (clientId) body.client_id = clientId;
-      if (clientSecret) body.client_secret = clientSecret;
-
-      const response = await axios.post(tokenUrl, new URLSearchParams(body).toString(), {
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        timeout: 10000,
-      });
-
-      const { access_token, expires_in } = response.data;
-      if (!access_token) return null;
-
-      // Cache the new token (default 1 hour if no expires_in)
-      const expiresInMs = (expires_in || 3600) * 1000;
-      this.tokenCache.set(tokenUrl, {
-        accessToken: access_token,
-        expiresAt: Date.now() + expiresInMs - 60000, // refresh 1 min early
-      });
-
-      this.logger.debug('OAuth2: token refreshed successfully');
-      return access_token;
-    } catch (err: any) {
-      this.logger.warn(`OAuth2 token refresh failed: ${err.message}`);
-      return null;
     }
   }
 

--- a/packages/backend/src/connectors/mcp-oauth.service.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.ts
@@ -170,7 +170,10 @@ export class McpOAuthService {
       params.tokenUrl,
       new URLSearchParams(body).toString(),
       {
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json',
+        },
         timeout: 10000,
       },
     );

--- a/packages/backend/src/mcp-server/mcp-server.module.ts
+++ b/packages/backend/src/mcp-server/mcp-server.module.ts
@@ -9,6 +9,7 @@ import { GraphqlEngine } from '../connectors/engines/graphql.engine';
 import { SoapEngine } from '../connectors/engines/soap.engine';
 import { McpClientEngine } from '../connectors/engines/mcp-client.engine';
 import { DatabaseEngine } from '../connectors/engines/database.engine';
+import { OAuth2TokenService } from '../connectors/engines/oauth2-token.service';
 import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 
 const ENGINES = [
@@ -22,7 +23,7 @@ const ENGINES = [
 @Module({
   imports: [McpServersModule],
   controllers: [McpEndpointController],
-  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, ...ENGINES],
+  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, OAuth2TokenService, ...ENGINES],
   exports: [McpServerService, ToolRegistry],
 })
 export class McpServerModule {}

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -487,6 +487,23 @@ export default function ConnectorDetailPage() {
                   </div>
                 </div>
               )}
+              {editAuthType === 'OAUTH2' && connector.type !== 'MCP' && (
+                <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Client ID</label>
+                      <input type="text" value={editAuthKey} onChange={(e) => setEditAuthKey(e.target.value)} placeholder="Leave empty to keep current" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Client Secret</label>
+                      <input type="password" value={editAuthValue} onChange={(e) => setEditAuthValue(e.target.value)} placeholder="Leave empty to keep current" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                    </div>
+                  </div>
+                  <p className="text-xs text-[var(--muted-foreground)]">
+                    Leave credential fields empty to keep the current values. Authorization URL, Token URL, and Scopes are preserved from initial setup.
+                  </p>
+                </div>
+              )}
               {editAuthType !== 'NONE' && editAuthType !== 'OAUTH2' && (
                 <p className="text-xs text-[var(--muted-foreground)]">
                   Leave credential fields empty to keep the current values.
@@ -535,12 +552,14 @@ export default function ConnectorDetailPage() {
           )}
         </div>
 
-        {/* OAuth2 Authorization (MCP + OAUTH2 only) */}
-        {connector.type === 'MCP' && connector.authType === 'OAUTH2' && (
+        {/* OAuth2 Authorization */}
+        {connector.authType === 'OAUTH2' && (
           <div className="border border-[var(--border)] rounded-lg p-6">
             <h3 className="text-lg font-medium mb-2">OAuth2 Authorization</h3>
             <p className="text-sm text-[var(--muted-foreground)] mb-4">
-              Authorize this connector to access the remote MCP server. After authorization, tools will be automatically discovered.
+              {connector.type === 'MCP'
+                ? 'Authorize this connector to access the remote MCP server. After authorization, tools will be automatically discovered.'
+                : 'Authorize this connector with the OAuth2 provider. After authorization, tokens will be stored securely for API calls.'}
             </p>
             <div className="flex gap-3 flex-wrap">
               <button
@@ -548,15 +567,17 @@ export default function ConnectorDetailPage() {
                 disabled={authorizing}
                 className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90 disabled:opacity-50"
               >
-                {authorizing ? 'Redirecting...' : 'Authorize with Remote Server'}
+                {authorizing ? 'Redirecting...' : connector.type === 'MCP' ? 'Authorize with Remote Server' : 'Authorize with Provider'}
               </button>
-              <button
-                onClick={handleDiscoverTools}
-                disabled={discovering}
-                className="border border-[var(--border)] px-4 py-2 rounded-md text-sm font-medium hover:bg-[var(--accent)] disabled:opacity-50"
-              >
-                {discovering ? 'Discovering...' : 'Re-discover Tools'}
-              </button>
+              {connector.type === 'MCP' && (
+                <button
+                  onClick={handleDiscoverTools}
+                  disabled={discovering}
+                  className="border border-[var(--border)] px-4 py-2 rounded-md text-sm font-medium hover:bg-[var(--accent)] disabled:opacity-50"
+                >
+                  {discovering ? 'Discovering...' : 'Re-discover Tools'}
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -277,7 +277,10 @@ export default function NewConnectorPage() {
                     <input type="text" value={oauthScopes} onChange={(e) => setOauthScopes(e.target.value)} placeholder="read write (space-separated, optional)" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
                   </div>
                   <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
-                    After creating the connector, you will be redirected to authorize via OAuth2. Tokens will be stored securely.
+                    <p>After creating the connector, you will be redirected to authorize via OAuth2. Tokens will be stored securely.</p>
+                    <p className="mt-1.5 text-xs text-blue-600 dark:text-blue-400">
+                      Set the <strong>Redirect / Callback URI</strong> in your OAuth provider to: <code className="bg-blue-100 dark:bg-blue-900/50 px-1 py-0.5 rounded font-mono">{typeof window !== 'undefined' ? window.location.origin.replace(':3000', ':4000') : 'http://localhost:4000'}/api/mcp-oauth/callback</code>
+                    </p>
                   </div>
                 </div>
               )}

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -33,6 +33,11 @@ export default function NewConnectorPage() {
   const [authType, setAuthType] = useState('NONE');
   const [authKey, setAuthKey] = useState('');
   const [authValue, setAuthValue] = useState('');
+  const [oauthClientId, setOauthClientId] = useState('');
+  const [oauthClientSecret, setOauthClientSecret] = useState('');
+  const [oauthAuthUrl, setOauthAuthUrl] = useState('');
+  const [oauthTokenUrl, setOauthTokenUrl] = useState('');
+  const [oauthScopes, setOauthScopes] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
@@ -45,6 +50,17 @@ export default function NewConnectorPage() {
         return { token: authValue };
       case 'BASIC_AUTH':
         return { username: authKey, password: authValue };
+      case 'OAUTH2':
+        if (selectedType !== 'MCP') {
+          return {
+            clientId: oauthClientId,
+            clientSecret: oauthClientSecret || undefined,
+            authorizationUrl: oauthAuthUrl,
+            tokenUrl: oauthTokenUrl,
+            scopes: oauthScopes || undefined,
+          };
+        }
+        return undefined;
       default:
         return undefined;
     }
@@ -75,8 +91,8 @@ export default function NewConnectorPage() {
         } catch {}
       }
 
-      // For MCP+OAuth2 connectors, redirect to the detail page so the user can authorize
-      if (selectedType === 'MCP' && authType === 'OAUTH2') {
+      // For OAuth2 connectors, redirect to the detail page so the user can authorize
+      if (authType === 'OAUTH2') {
         router.push(`/connectors/${created.id}`);
       } else {
         router.push('/connectors');
@@ -233,6 +249,36 @@ export default function NewConnectorPage() {
               {selectedType === 'MCP' && authType === 'OAUTH2' && (
                 <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
                   After creating the connector, you will be redirected to authorize with the remote MCP server via OAuth. Tools will be discovered automatically after authorization.
+                </div>
+              )}
+
+              {authType === 'OAUTH2' && selectedType !== 'MCP' && (
+                <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Client ID</label>
+                      <input type="text" value={oauthClientId} onChange={(e) => setOauthClientId(e.target.value)} placeholder="your-client-id" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Client Secret</label>
+                      <input type="password" value={oauthClientSecret} onChange={(e) => setOauthClientSecret(e.target.value)} placeholder="optional" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Authorization URL</label>
+                    <input type="text" value={oauthAuthUrl} onChange={(e) => setOauthAuthUrl(e.target.value)} placeholder="https://provider.com/oauth/authorize" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Token URL</label>
+                    <input type="text" value={oauthTokenUrl} onChange={(e) => setOauthTokenUrl(e.target.value)} placeholder="https://provider.com/oauth/token" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Scopes</label>
+                    <input type="text" value={oauthScopes} onChange={(e) => setOauthScopes(e.target.value)} placeholder="read write (space-separated, optional)" className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]" />
+                  </div>
+                  <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
+                    After creating the connector, you will be redirected to authorize via OAuth2. Tokens will be stored securely.
+                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
- Add shared `OAuth2TokenService` for token caching, refresh, and DB persistence
- Add OAuth2 + BasicAuth support to `GraphqlEngine` with automatic 401 refresh+retry
- Refactor `RestEngine` to use shared `OAuth2TokenService`
- Add OAuth2 form fields (clientId, clientSecret, authorizationUrl, tokenUrl, scopes) for non-MCP connectors in frontend
- Extend OAuth2 authorize endpoint to work with REST and GraphQL connectors (not just MCP)
- Add callback URI hint in the new connector form
- Update docs for OAuth2 authorization flow and API reference
- Add unit tests for all new functionality

## Test plan
- [x] All 268 unit tests pass
- [x] End-to-end test: GitHub OAuth2 REST connector created, authorized, and tool executed successfully