### PR TITLE
Fix invite email links pointing to backend port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ JWT_SECRET=change-me-in-production-min-32-chars
 ENCRYPTION_KEY=change-me-in-production-exactly-32
 
 # ── Frontend ─────────────────────────────────────────────────────────────────
+FRONTEND_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:4000
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=change-me-in-production

--- a/packages/backend/prisma/migrations/20260305120000_add_license_model/migration.sql
+++ b/packages/backend/prisma/migrations/20260305120000_add_license_model/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "licenses" (
+    "id" TEXT NOT NULL,
+    "license_key" TEXT NOT NULL,
+    "plan" TEXT NOT NULL DEFAULT 'community',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "features" JSONB,
+    "expires_at" TIMESTAMP(3),
+    "activated_at" TIMESTAMP(3),
+    "instance_id" TEXT,
+    "last_verified_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "licenses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "licenses_license_key_key" ON "licenses"("license_key");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -68,6 +68,24 @@ model SiteSettings {
   @@map("site_settings")
 }
 
+// ── License Management ──────────────────────────────────────────────────────
+
+model License {
+  id             String    @id @default(cuid())
+  licenseKey     String    @unique @map("license_key")
+  plan           String    @default("community")
+  status         String    @default("active")
+  features       Json?
+  expiresAt      DateTime? @map("expires_at")
+  activatedAt    DateTime? @map("activated_at")
+  instanceId     String?   @map("instance_id")
+  lastVerifiedAt DateTime? @map("last_verified_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+
+  @@map("licenses")
+}
+
 // ── User Invitation Tokens ──────────────────────────────────────────────────
 
 model InvitationToken {

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { HealthModule } from './health/health.module';
 import { SettingsModule } from './settings/settings.module';
 import { RolesModule } from './roles/roles.module';
 import { McpServersModule } from './mcp-servers/mcp-servers.module';
+import { LicenseModule } from './license/license.module';
 import { PrismaModule } from './common/prisma.module';
 import { RedisModule } from './common/redis.module';
 import { McpAuthMiddleware } from './auth/mcp-auth.middleware';
@@ -70,6 +71,7 @@ if (useOAuth) {
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: [
+        join(__dirname, '..', '..', '..', '..', '.env'),
         join(__dirname, '..', '..', '..', '.env'),
         '.env',
       ],
@@ -110,6 +112,7 @@ if (useOAuth) {
     SettingsModule,
     RolesModule,
     McpServersModule,
+    LicenseModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -180,6 +180,7 @@ export class AuthController {
         name: user.name,
         role: user.role,
       },
+      isFirstUser: role === 'ADMIN',
     };
   }
 

--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -1,0 +1,106 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Post,
+  Body,
+  Req,
+  UseGuards,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { IsString, Matches } from 'class-validator';
+import { Roles, RolesGuard } from '../auth/roles.guard';
+import { LicenseService } from './license.service';
+import { UsersService } from '../users/users.service';
+
+class SetLicenseKeyDto {
+  @IsString()
+  @Matches(/^AMCP-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}$/, {
+    message: 'Invalid license key format. Expected: AMCP-XXXX-XXXX-XXXX-XXXX',
+  })
+  licenseKey: string;
+}
+
+@ApiTags('License')
+@Controller('api/license')
+export class LicenseController {
+  private readonly logger = new Logger(LicenseController.name);
+
+  constructor(
+    private readonly licenseService: LicenseService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  @Get('status')
+  @ApiOperation({ summary: 'Get current license status' })
+  async getStatus() {
+    const license = await this.licenseService.getCurrentLicense();
+    if (!license) {
+      return { plan: null, status: 'none', features: null, expiresAt: null, instanceId: null };
+    }
+    return {
+      plan: license.plan,
+      status: license.status,
+      features: license.features,
+      expiresAt: license.expiresAt,
+      lastVerifiedAt: license.lastVerifiedAt,
+      instanceId: license.instanceId,
+    };
+  }
+
+  @Get('instance-id')
+  @ApiOperation({ summary: 'Get the instance ID' })
+  async getInstanceId() {
+    const instanceId = await this.licenseService.getInstanceId();
+    return { instanceId };
+  }
+
+  @Put('key')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('ADMIN')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set and activate a license key (ADMIN)' })
+  async setLicenseKey(@Body() dto: SetLicenseKeyDto) {
+    try {
+      const license = await this.licenseService.setLicenseKey(dto.licenseKey);
+      return { message: 'License activated successfully', license };
+    } catch (err: any) {
+      throw new BadRequestException(err.message || 'Failed to activate license');
+    }
+  }
+
+  @Post('verify')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('ADMIN')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Force re-verify license against remote API (ADMIN)' })
+  async verifyLicense() {
+    const result = await this.licenseService.verifyLicense();
+    return result;
+  }
+
+  @Post('register-community')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('ADMIN')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Register a free community license (ADMIN)' })
+  async registerCommunity(@Req() req: any) {
+    const user = await this.usersService.findById(req.user.sub);
+    if (!user) {
+      throw new BadRequestException('User not found');
+    }
+
+    try {
+      const license = await this.licenseService.registerCommunityLicense(
+        user.email,
+        user.name || user.email,
+      );
+      return { message: 'Community license registered', license };
+    } catch (err: any) {
+      throw new BadRequestException(err.message || 'Failed to register community license');
+    }
+  }
+}

--- a/packages/backend/src/license/license.module.ts
+++ b/packages/backend/src/license/license.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { LicenseService } from './license.service';
+import { LicenseController } from './license.controller';
+import { SettingsModule } from '../settings/settings.module';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [SettingsModule, UsersModule],
+  controllers: [LicenseController],
+  providers: [LicenseService],
+  exports: [LicenseService],
+})
+export class LicenseModule {}

--- a/packages/backend/src/license/license.service.ts
+++ b/packages/backend/src/license/license.service.ts
@@ -1,0 +1,305 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import axios from 'axios';
+import * as crypto from 'crypto';
+import { PrismaService } from '../common/prisma.service';
+import { SiteSettingsService } from '../settings/site-settings.service';
+
+const LICENSE_API_URL =
+  process.env.NODE_ENV === 'production'
+    ? 'https://anythingmcp.com'
+    : 'http://localhost:3100';
+
+export interface LicenseInfo {
+  licenseKey: string;
+  plan: string;
+  status: string;
+  features: Record<string, any> | null;
+  expiresAt: Date | null;
+  lastVerifiedAt: Date | null;
+  instanceId: string | null;
+}
+
+export interface RemoteVerifyResponse {
+  valid: boolean;
+  plan?: string;
+  features?: Record<string, any>;
+  expiresAt?: string;
+  error?: string;
+}
+
+@Injectable()
+export class LicenseService implements OnModuleInit {
+  private readonly logger = new Logger(LicenseService.name);
+  private readonly apiBase = LICENSE_API_URL;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly siteSettings: SiteSettingsService,
+  ) {}
+
+  async onModuleInit() {
+    await this.ensureInstanceId();
+    await this.verifyOnStartup();
+  }
+
+  // ── Instance ID ────────────────────────────────────────────────────────────
+
+  async ensureInstanceId(): Promise<string> {
+    let instanceId = await this.siteSettings.get('instance_id');
+    if (!instanceId) {
+      instanceId = crypto.randomUUID();
+      await this.siteSettings.set('instance_id', instanceId);
+      this.logger.log(`Generated instance ID: ${instanceId}`);
+    }
+    return instanceId;
+  }
+
+  async getInstanceId(): Promise<string> {
+    return (await this.siteSettings.get('instance_id')) || (await this.ensureInstanceId());
+  }
+
+  // ── Community License Registration ─────────────────────────────────────────
+
+  async registerCommunityLicense(
+    email: string,
+    name: string,
+  ): Promise<LicenseInfo> {
+    const instanceId = await this.getInstanceId();
+
+    try {
+      const { data } = await axios.post(
+        `${this.apiBase}/api/license/register`,
+        { email, name, instanceId },
+        { timeout: 10000 },
+      );
+
+      const license = await this.prisma.license.create({
+        data: {
+          licenseKey: data.licenseKey,
+          plan: data.plan || 'community',
+          status: 'active',
+          expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
+          instanceId,
+        },
+      });
+
+      await this.siteSettings.set('license_key', data.licenseKey);
+
+      // Activate in background
+      this.activateLicense(data.licenseKey).catch((err) =>
+        this.logger.warn(`License activation failed: ${err.message}`),
+      );
+
+      return this.toLicenseInfo(license);
+    } catch (err: any) {
+      // If remote is unreachable, create a pending license locally
+      if (err.response?.status === 409) {
+        // Community license already exists for this email — try to use it
+        throw new Error('A community license already exists for this email');
+      }
+
+      this.logger.warn(
+        `Remote license registration failed: ${err.message}. Creating pending license.`,
+      );
+
+      const pendingKey = `AMCP-PEND-${crypto.randomBytes(6).toString('hex').toUpperCase().slice(0, 12).replace(/(.{4})/g, '$1-').slice(0, -1)}`;
+      const license = await this.prisma.license.create({
+        data: {
+          licenseKey: pendingKey,
+          plan: 'community',
+          status: 'pending',
+          instanceId,
+        },
+      });
+
+      await this.siteSettings.set('license_key', pendingKey);
+      return this.toLicenseInfo(license);
+    }
+  }
+
+  // ── License Activation ─────────────────────────────────────────────────────
+
+  async activateLicense(licenseKey: string): Promise<boolean> {
+    const instanceId = await this.getInstanceId();
+
+    try {
+      await axios.post(
+        `${this.apiBase}/api/license/activate`,
+        { licenseKey, instanceId },
+        { timeout: 10000 },
+      );
+
+      await this.prisma.license.update({
+        where: { licenseKey },
+        data: { activatedAt: new Date(), instanceId },
+      });
+
+      return true;
+    } catch (err: any) {
+      this.logger.warn(`License activation failed: ${err.message}`);
+      return false;
+    }
+  }
+
+  // ── License Verification ───────────────────────────────────────────────────
+
+  async verifyLicense(key?: string): Promise<RemoteVerifyResponse> {
+    const licenseKey =
+      key || (await this.siteSettings.get('license_key'));
+
+    if (!licenseKey) {
+      return { valid: false, error: 'No license key configured' };
+    }
+
+    try {
+      const { data } = await axios.get<RemoteVerifyResponse>(
+        `${this.apiBase}/api/license/verify`,
+        { params: { key: licenseKey }, timeout: 10000 },
+      );
+
+      // Update local record
+      const updateData: any = {
+        lastVerifiedAt: new Date(),
+      };
+
+      if (data.valid) {
+        updateData.plan = data.plan;
+        updateData.features = data.features || undefined;
+        updateData.expiresAt = data.expiresAt
+          ? new Date(data.expiresAt)
+          : null;
+        updateData.status = 'active';
+      } else {
+        updateData.status =
+          data.error?.includes('expired') ? 'expired' : 'invalid';
+      }
+
+      await this.prisma.license
+        .update({ where: { licenseKey }, data: updateData })
+        .catch(() => {
+          // License may not exist locally yet
+        });
+
+      return data;
+    } catch (err: any) {
+      this.logger.warn(`License verification failed: ${err.message}`);
+      return { valid: false, error: 'Verification service unreachable' };
+    }
+  }
+
+  async verifyOnStartup(): Promise<void> {
+    try {
+      const licenseKey = await this.siteSettings.get('license_key');
+      if (!licenseKey) return;
+
+      const license = await this.prisma.license.findUnique({
+        where: { licenseKey },
+      });
+
+      if (!license) return;
+
+      // Only verify if last check was >24h ago
+      const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      if (license.lastVerifiedAt && license.lastVerifiedAt > dayAgo) {
+        return;
+      }
+
+      await this.verifyLicense(licenseKey);
+      this.logger.log('Startup license verification completed');
+    } catch (err: any) {
+      this.logger.warn(
+        `Startup license verification failed: ${err.message}`,
+      );
+    }
+  }
+
+  // ── Admin: Set License Key ─────────────────────────────────────────────────
+
+  async setLicenseKey(licenseKey: string): Promise<LicenseInfo> {
+    // Verify remotely first
+    const verification = await this.verifyLicense(licenseKey);
+
+    if (!verification.valid) {
+      throw new Error(verification.error || 'Invalid license key');
+    }
+
+    const instanceId = await this.getInstanceId();
+
+    // Upsert local license
+    const license = await this.prisma.license.upsert({
+      where: { licenseKey },
+      update: {
+        plan: verification.plan || 'community',
+        status: 'active',
+        features: verification.features || undefined,
+        expiresAt: verification.expiresAt
+          ? new Date(verification.expiresAt)
+          : null,
+        lastVerifiedAt: new Date(),
+        instanceId,
+      },
+      create: {
+        licenseKey,
+        plan: verification.plan || 'community',
+        status: 'active',
+        features: verification.features || undefined,
+        expiresAt: verification.expiresAt
+          ? new Date(verification.expiresAt)
+          : null,
+        lastVerifiedAt: new Date(),
+        instanceId,
+      },
+    });
+
+    await this.siteSettings.set('license_key', licenseKey);
+
+    // Activate in background
+    this.activateLicense(licenseKey).catch((err) =>
+      this.logger.warn(`License activation failed: ${err.message}`),
+    );
+
+    return this.toLicenseInfo(license);
+  }
+
+  // ── Get Current License ────────────────────────────────────────────────────
+
+  async getCurrentLicense(): Promise<LicenseInfo | null> {
+    const licenseKey = await this.siteSettings.get('license_key');
+    if (!licenseKey) return null;
+
+    const license = await this.prisma.license.findUnique({
+      where: { licenseKey },
+    });
+
+    return license ? this.toLicenseInfo(license) : null;
+  }
+
+  // ── Commercial Use Flag ────────────────────────────────────────────────────
+
+  async setCommercialUse(isCommercial: boolean): Promise<void> {
+    await this.siteSettings.set(
+      'commercial_use',
+      isCommercial ? 'true' : 'false',
+    );
+  }
+
+  async isCommercialUse(): Promise<boolean | null> {
+    const value = await this.siteSettings.get('commercial_use');
+    if (value === null) return null;
+    return value === 'true';
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private toLicenseInfo(license: any): LicenseInfo {
+    return {
+      licenseKey: license.licenseKey,
+      plan: license.plan,
+      status: license.status,
+      features: license.features as Record<string, any> | null,
+      expiresAt: license.expiresAt,
+      lastVerifiedAt: license.lastVerifiedAt,
+      instanceId: license.instanceId,
+    };
+  }
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -2,6 +2,7 @@
 // (e.g. MCP_AUTH_MODE in app.module.ts) have access to all variables.
 import { config } from 'dotenv';
 import { join } from 'path';
+config({ path: join(__dirname, '..', '..', '..', '..', '.env') });
 config({ path: join(__dirname, '..', '..', '..', '.env') });
 config({ path: '.env' });
 

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -1,12 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
+import axios from 'axios';
 import { SiteSettingsService } from './site-settings.service';
+
+const LICENSE_API_URL =
+  process.env.NODE_ENV === 'production'
+    ? 'https://anythingmcp.com'
+    : 'http://localhost:3100';
 
 @Injectable()
 export class EmailService {
   private readonly logger = new Logger(EmailService.name);
+  private readonly apiBase = LICENSE_API_URL;
 
   constructor(private readonly siteSettings: SiteSettingsService) {}
+
+  // ── Password Reset (SMTP only — no external fallback for security) ────────
 
   async sendPasswordResetEmail(
     to: string,
@@ -59,6 +68,8 @@ export class EmailService {
     }
   }
 
+  // ── Invitation Email (SMTP with external API fallback) ────────────────────
+
   private async createTransporter() {
     const smtp = await this.siteSettings.getSmtpConfig();
     if (!smtp) return null;
@@ -80,39 +91,115 @@ export class EmailService {
     roleName: string,
   ): Promise<boolean> {
     const transport = await this.createTransporter();
-    if (!transport) {
-      this.logger.warn('Cannot send invitation email: SMTP not configured');
-      return false;
+
+    if (transport) {
+      try {
+        await transport.transporter.sendMail({
+          from: transport.from,
+          to,
+          subject: 'You\'ve been invited to AnythingMCP',
+          html: `
+            <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
+              <h2 style="color: #6366f1;">You're Invited!</h2>
+              <p><strong>${invitedByName}</strong> has invited you to join the AnythingMCP workspace as <strong>${roleName}</strong>.</p>
+              <p>Click the button below to create your account. This invitation expires in 48 hours.</p>
+              <a href="${inviteUrl}" style="display: inline-block; background: #6366f1; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600; margin: 16px 0;">
+                Accept Invitation
+              </a>
+              <p style="color: #737373; font-size: 14px;">If you weren't expecting this invite, you can safely ignore this email.</p>
+              <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+              <p style="color: #a3a3a3; font-size: 12px;">AnythingMCP</p>
+            </div>
+          `,
+          text: `You're Invited!\n\n${invitedByName} has invited you to join AnythingMCP as ${roleName}.\n\nAccept your invitation: ${inviteUrl}\n\nThis link expires in 48 hours.`,
+        });
+
+        this.logger.log(`Invitation email sent to ${to}`);
+        return true;
+      } catch (err) {
+        this.logger.error(`Failed to send invitation via SMTP to ${to}: ${err}`);
+        return false;
+      }
     }
 
-    try {
-      await transport.transporter.sendMail({
-        from: transport.from,
-        to,
-        subject: 'You\'ve been invited to AnythingMCP',
-        html: `
-          <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
-            <h2 style="color: #6366f1;">You're Invited!</h2>
-            <p><strong>${invitedByName}</strong> has invited you to join the AnythingMCP workspace as <strong>${roleName}</strong>.</p>
-            <p>Click the button below to create your account. This invitation expires in 48 hours.</p>
-            <a href="${inviteUrl}" style="display: inline-block; background: #6366f1; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600; margin: 16px 0;">
-              Accept Invitation
-            </a>
-            <p style="color: #737373; font-size: 14px;">If you weren't expecting this invite, you can safely ignore this email.</p>
-            <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
-            <p style="color: #a3a3a3; font-size: 12px;">AnythingMCP</p>
-          </div>
-        `,
-        text: `You're Invited!\n\n${invitedByName} has invited you to join AnythingMCP as ${roleName}.\n\nAccept your invitation: ${inviteUrl}\n\nThis link expires in 48 hours.`,
-      });
+    // Fallback: send via external API
+    return this.sendViaExternalApi('/api/email/invite', {
+      email: to,
+      inviterName: invitedByName,
+      instanceUrl: inviteUrl,
+    });
+  }
 
-      this.logger.log(`Invitation email sent to ${to}`);
+  // ── Welcome Email (SMTP with external API fallback) ───────────────────────
+
+  async sendWelcomeEmail(
+    to: string,
+    name: string,
+    licenseKey: string,
+  ): Promise<boolean> {
+    const transport = await this.createTransporter();
+
+    if (transport) {
+      try {
+        await transport.transporter.sendMail({
+          from: transport.from,
+          to,
+          subject: 'Welcome to AnythingMCP — Your License Key',
+          html: `
+            <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
+              <h2 style="color: #6366f1;">Welcome to AnythingMCP!</h2>
+              <p>Hi ${name},</p>
+              <p>Your license key is:</p>
+              <div style="background: #f5f5f5; padding: 16px; border-radius: 8px; text-align: center; font-family: monospace; font-size: 18px; letter-spacing: 2px; margin: 16px 0;">
+                ${licenseKey}
+              </div>
+              <p>Keep this key safe — you'll need it to activate your AnythingMCP instance.</p>
+              <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+              <p style="color: #a3a3a3; font-size: 12px;">AnythingMCP</p>
+            </div>
+          `,
+          text: `Welcome to AnythingMCP!\n\nHi ${name},\n\nYour license key is: ${licenseKey}\n\nKeep this key safe — you'll need it to activate your AnythingMCP instance.`,
+        });
+
+        this.logger.log(`Welcome email sent to ${to}`);
+        return true;
+      } catch (err) {
+        this.logger.error(`Failed to send welcome email via SMTP to ${to}: ${err}`);
+        return false;
+      }
+    }
+
+    // Fallback: send via external API
+    return this.sendViaExternalApi('/api/email/welcome', {
+      email: to,
+      name,
+      licenseKey,
+    });
+  }
+
+  // ── External API Fallback ─────────────────────────────────────────────────
+
+  private async sendViaExternalApi(
+    endpoint: string,
+    body: Record<string, string>,
+  ): Promise<boolean> {
+    try {
+      await axios.post(`${this.apiBase}${endpoint}`, body, {
+        timeout: 10000,
+      });
+      this.logger.log(
+        `Email sent via external API: ${endpoint} to ${body.email}`,
+      );
       return true;
-    } catch (err) {
-      this.logger.error(`Failed to send invitation to ${to}: ${err}`);
+    } catch (err: any) {
+      this.logger.error(
+        `Failed to send email via external API ${endpoint}: ${err.message}`,
+      );
       return false;
     }
   }
+
+  // ── SMTP Test ─────────────────────────────────────────────────────────────
 
   async testConnection(): Promise<{ ok: boolean; message: string }> {
     const smtp = await this.siteSettings.getSmtpConfig();

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -3,9 +3,11 @@
 import { Suspense, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { auth } from '@/lib/api';
+import { auth, license } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { LogoIcon } from '@/components/nav-bar';
+
+type SetupStep = 'auth' | 'license-choice' | 'license-key';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -14,9 +16,14 @@ function LoginForm() {
   const [loading, setLoading] = useState(false);
   const [isRegister, setIsRegister] = useState(false);
   const [name, setName] = useState('');
+  const [setupStep, setSetupStep] = useState<SetupStep>('auth');
+  const [licenseKey, setLicenseKey] = useState('');
+  const [authToken, setAuthToken] = useState('');
   const router = useRouter();
   const searchParams = useSearchParams();
   const { login } = useAuth();
+
+  const redirectTo = searchParams.get('redirect') || '/';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -24,21 +31,189 @@ function LoginForm() {
     setLoading(true);
 
     try {
+      let isFirstUser = false;
       let result;
       if (isRegister) {
-        result = await auth.register(email, password, name);
+        const regResult = await auth.register(email, password, name);
+        result = regResult;
+        isFirstUser = !!regResult.isFirstUser;
       } else {
         result = await auth.login(email, password);
       }
       login(result.accessToken, result.user);
-      const redirectTo = searchParams.get('redirect') || '/';
-      router.push(redirectTo);
+
+      // If this is the first user (admin), show license setup
+      if (isFirstUser) {
+        setAuthToken(result.accessToken);
+        setSetupStep('license-choice');
+      } else {
+        router.push(redirectTo);
+      }
     } catch (err: any) {
       setError(err.message || 'Authentication failed');
     } finally {
       setLoading(false);
     }
   };
+
+  const handlePersonalUse = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await license.registerCommunity(authToken);
+    } catch {
+      // Non-blocking — user can still proceed
+    }
+    router.push(redirectTo);
+  };
+
+  const handleCommercialChoice = () => {
+    setSetupStep('license-key');
+  };
+
+  const handleActivateLicense = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await license.setKey(licenseKey, authToken);
+      router.push(redirectTo);
+    } catch (err: any) {
+      setError(err.message || 'Failed to activate license');
+      setLoading(false);
+    }
+  };
+
+  const handleSkip = () => {
+    router.push(redirectTo);
+  };
+
+  // ── License Choice Step ─────────────────────────────────────────────────
+
+  if (setupStep === 'license-choice') {
+    return (
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="flex justify-center mb-4">
+            <LogoIcon size={56} />
+          </div>
+          <h1 className="text-2xl font-bold">Welcome to AnythingMCP</h1>
+          <p className="text-[var(--muted-foreground)] mt-1 text-sm">
+            One last step to get started
+          </p>
+        </div>
+
+        <div className="border border-[var(--border)] rounded-lg p-6 bg-[var(--card)]">
+          <h2 className="text-lg font-semibold mb-2 text-center">
+            How will you use AnythingMCP?
+          </h2>
+          <p className="text-sm text-[var(--muted-foreground)] mb-6 text-center">
+            Commercial use requires a license from anythingmcp.com
+          </p>
+
+          <div className="space-y-3">
+            <button
+              onClick={handlePersonalUse}
+              disabled={loading}
+              className="w-full border border-[var(--border)] rounded-lg p-4 text-left hover:border-[var(--brand)] hover:bg-[var(--brand-light)] transition-colors disabled:opacity-50"
+            >
+              <div className="font-medium text-sm">Personal / Non-commercial</div>
+              <div className="text-xs text-[var(--muted-foreground)] mt-1">
+                Free community license — unlimited connectors and users
+              </div>
+            </button>
+
+            <button
+              onClick={handleCommercialChoice}
+              disabled={loading}
+              className="w-full border border-[var(--border)] rounded-lg p-4 text-left hover:border-[var(--brand)] hover:bg-[var(--brand-light)] transition-colors disabled:opacity-50"
+            >
+              <div className="font-medium text-sm">Commercial</div>
+              <div className="text-xs text-[var(--muted-foreground)] mt-1">
+                For businesses — purchase a license to unlock all features
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── License Key Entry Step ──────────────────────────────────────────────
+
+  if (setupStep === 'license-key') {
+    return (
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="flex justify-center mb-4">
+            <LogoIcon size={56} />
+          </div>
+          <h1 className="text-2xl font-bold">Activate License</h1>
+          <p className="text-[var(--muted-foreground)] mt-1 text-sm">
+            Enter your license key to activate AnythingMCP
+          </p>
+        </div>
+
+        <div className="border border-[var(--border)] rounded-lg p-6 bg-[var(--card)]">
+          <p className="text-sm text-[var(--muted-foreground)] mb-4">
+            Purchase a license at{' '}
+            <a
+              href="https://anythingmcp.com/pricing"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--brand)] hover:underline font-medium"
+            >
+              anythingmcp.com
+            </a>
+            , then enter your key below.
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 rounded-md bg-[var(--destructive-bg)] text-[var(--destructive-text)] text-sm border border-[var(--destructive-border)]">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">License Key</label>
+              <input
+                type="text"
+                value={licenseKey}
+                onChange={(e) => setLicenseKey(e.target.value.toUpperCase())}
+                placeholder="AMCP-XXXX-XXXX-XXXX-XXXX"
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono tracking-wider"
+              />
+            </div>
+
+            <button
+              onClick={handleActivateLicense}
+              disabled={loading || !licenseKey}
+              className="w-full bg-[var(--brand)] text-white px-4 py-2.5 rounded-md text-sm font-medium hover:brightness-90 disabled:opacity-50"
+            >
+              {loading ? 'Activating...' : 'Activate License'}
+            </button>
+          </div>
+
+          <div className="flex justify-between mt-4 text-sm">
+            <button
+              onClick={() => setSetupStep('license-choice')}
+              className="text-[var(--muted-foreground)] hover:text-[var(--brand)] hover:underline"
+            >
+              Back
+            </button>
+            <button
+              onClick={handleSkip}
+              className="text-[var(--muted-foreground)] hover:text-[var(--brand)] hover:underline"
+            >
+              Skip for now
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Auth Form (Login / Register) ──────────────────────────────────────────
 
   return (
     <div className="w-full max-w-sm">

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -56,14 +56,9 @@ function LoginForm() {
     }
   };
 
-  const handlePersonalUse = async () => {
-    setError('');
-    setLoading(true);
-    try {
-      await license.registerCommunity(authToken);
-    } catch {
-      // Non-blocking — user can still proceed
-    }
+  const handlePersonalUse = () => {
+    // Fire-and-forget: register community license in background, navigate immediately
+    license.registerCommunity(authToken).catch(() => {});
     router.push(redirectTo);
   };
 

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -19,6 +19,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   { href: '/settings', label: 'General', description: 'Profile, password, AI & MCP keys', icon: GearIcon, exact: true },
   { href: '/settings/users', label: 'Users', description: 'Manage users and invitations', icon: UsersIcon, adminOnly: true },
   { href: '/settings/roles', label: 'Roles', description: 'MCP tool access control', icon: ShieldIcon, adminOnly: true },
+  { href: '/settings/license', label: 'License', description: 'Plan, license key, features', icon: KeyIcon, adminOnly: true },
   { href: '/settings/admin', label: 'Administration', description: 'SMTP, footer links', icon: WrenchIcon, adminOnly: true },
 ];
 
@@ -102,6 +103,16 @@ function ShieldIcon({ size = 16 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+    </svg>
+  );
+}
+
+function KeyIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+      <path d="m21 2-9.6 9.6" />
+      <circle cx="7.5" cy="15.5" r="5.5" />
     </svg>
   );
 }

--- a/packages/frontend/src/app/settings/license/page.tsx
+++ b/packages/frontend/src/app/settings/license/page.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/auth-context';
+import { license } from '@/lib/api';
+
+interface LicenseStatus {
+  plan: string | null;
+  status: string;
+  features: Record<string, any> | null;
+  expiresAt: string | null;
+  lastVerifiedAt: string | null;
+  instanceId: string | null;
+}
+
+export default function LicenseSettingsPage() {
+  const { token, user } = useAuth();
+  const [status, setStatus] = useState<LicenseStatus | null>(null);
+  const [licenseKey, setLicenseKey] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+
+  useEffect(() => {
+    loadStatus();
+  }, [token]);
+
+  const loadStatus = async () => {
+    try {
+      const data = await license.getStatus();
+      setStatus(data);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleActivate = async () => {
+    if (!token || !licenseKey) return;
+    setError('');
+    setMessage('');
+    setLoading(true);
+    try {
+      const result = await license.setKey(licenseKey, token);
+      setMessage(result.message);
+      setLicenseKey('');
+      await loadStatus();
+    } catch (err: any) {
+      setError(err.message || 'Failed to activate license');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerify = async () => {
+    if (!token) return;
+    setError('');
+    setMessage('');
+    setVerifying(true);
+    try {
+      const result = await license.verify(token);
+      if (result.valid) {
+        setMessage('License verified successfully');
+      } else {
+        setError(result.error || 'License is invalid');
+      }
+      await loadStatus();
+    } catch (err: any) {
+      setError(err.message || 'Verification failed');
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const handleRegisterCommunity = async () => {
+    if (!token) return;
+    setError('');
+    setMessage('');
+    setLoading(true);
+    try {
+      const result = await license.registerCommunity(token);
+      setMessage(result.message);
+      await loadStatus();
+    } catch (err: any) {
+      setError(err.message || 'Failed to register community license');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return '—';
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const planLabel = (plan: string | null) => {
+    if (!plan) return 'None';
+    return plan.charAt(0).toUpperCase() + plan.slice(1);
+  };
+
+  const statusColor = (s: string) => {
+    switch (s) {
+      case 'active': return 'text-emerald-600';
+      case 'expired': return 'text-amber-600';
+      case 'invalid': case 'revoked': return 'text-red-600';
+      case 'pending': return 'text-amber-500';
+      default: return 'text-[var(--muted-foreground)]';
+    }
+  };
+
+  if (user?.role !== 'ADMIN') {
+    return (
+      <div className="text-center py-12 text-[var(--muted-foreground)]">
+        Only administrators can manage the license.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-xl font-semibold">License & Plan</h1>
+        <p className="text-sm text-[var(--muted-foreground)] mt-1">
+          Manage your AnythingMCP license
+        </p>
+      </div>
+
+      {/* Feedback */}
+      {message && (
+        <div className="p-3 rounded-md bg-emerald-50 text-emerald-700 text-sm border border-emerald-200 dark:bg-emerald-950/30 dark:text-emerald-400 dark:border-emerald-800">
+          {message}
+        </div>
+      )}
+      {error && (
+        <div className="p-3 rounded-md bg-[var(--destructive-bg)] text-[var(--destructive-text)] text-sm border border-[var(--destructive-border)]">
+          {error}
+        </div>
+      )}
+
+      {/* Current Plan */}
+      <section className="border border-[var(--border)] rounded-lg p-5 bg-[var(--card)]">
+        <h2 className="text-sm font-semibold mb-4">Current Plan</h2>
+
+        {!status || !status.plan ? (
+          <div className="space-y-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              No license registered yet.
+            </p>
+            <button
+              onClick={handleRegisterCommunity}
+              disabled={loading}
+              className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90 disabled:opacity-50"
+            >
+              {loading ? 'Registering...' : 'Register Free Community License'}
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+            <div>
+              <div className="text-[var(--muted-foreground)] text-xs mb-0.5">Plan</div>
+              <div className="font-medium">{planLabel(status.plan)}</div>
+            </div>
+            <div>
+              <div className="text-[var(--muted-foreground)] text-xs mb-0.5">Status</div>
+              <div className={`font-medium capitalize ${statusColor(status.status)}`}>
+                {status.status}
+              </div>
+            </div>
+            <div>
+              <div className="text-[var(--muted-foreground)] text-xs mb-0.5">Expires</div>
+              <div>{formatDate(status.expiresAt)}</div>
+            </div>
+            <div>
+              <div className="text-[var(--muted-foreground)] text-xs mb-0.5">Last Verified</div>
+              <div>{formatDate(status.lastVerifiedAt)}</div>
+            </div>
+            <div className="sm:col-span-2">
+              <div className="text-[var(--muted-foreground)] text-xs mb-0.5">Instance ID</div>
+              <div className="font-mono text-xs break-all">{status.instanceId || '—'}</div>
+            </div>
+          </div>
+        )}
+
+        {status?.plan && (
+          <div className="mt-4 pt-4 border-t border-[var(--border)]">
+            <button
+              onClick={handleVerify}
+              disabled={verifying}
+              className="border border-[var(--border)] px-4 py-2 rounded-md text-sm font-medium hover:bg-[var(--accent)] disabled:opacity-50"
+            >
+              {verifying ? 'Verifying...' : 'Verify Now'}
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* Features */}
+      {status?.features && Object.keys(status.features).length > 0 && (
+        <section className="border border-[var(--border)] rounded-lg p-5 bg-[var(--card)]">
+          <h2 className="text-sm font-semibold mb-4">Features</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+            {Object.entries(status.features).map(([key, value]) => (
+              <div key={key} className="flex justify-between py-1">
+                <span className="text-[var(--muted-foreground)]">
+                  {key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase())}
+                </span>
+                <span className="font-medium">
+                  {value === true ? 'Yes' : value === false ? 'No' : value === null ? 'Unlimited' : String(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Change License Key */}
+      <section className="border border-[var(--border)] rounded-lg p-5 bg-[var(--card)]">
+        <h2 className="text-sm font-semibold mb-4">
+          {status?.plan ? 'Change License Key' : 'Activate License Key'}
+        </h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Purchase a license at{' '}
+          <a
+            href="https://anythingmcp.com/pricing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--brand)] hover:underline font-medium"
+          >
+            anythingmcp.com
+          </a>
+        </p>
+
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={licenseKey}
+            onChange={(e) => setLicenseKey(e.target.value.toUpperCase())}
+            placeholder="AMCP-XXXX-XXXX-XXXX-XXXX"
+            className="flex-1 border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono tracking-wider"
+          />
+          <button
+            onClick={handleActivate}
+            disabled={loading || !licenseKey}
+            className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90 disabled:opacity-50 whitespace-nowrap"
+          >
+            {loading ? 'Activating...' : 'Activate'}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -39,7 +39,7 @@ export const auth = {
       body: { email, password },
     }),
   register: (email: string, password: string, name: string) =>
-    request<{ accessToken: string; user: any }>('/api/auth/register', {
+    request<{ accessToken: string; user: any; isFirstUser?: boolean }>('/api/auth/register', {
       method: 'POST',
       body: { email, password, name },
     }),
@@ -236,6 +236,30 @@ export const mcpKeys = {
     request(`/api/mcp-keys/${id}/revoke`, { method: 'POST', token }),
   delete: (id: string, token: string) =>
     request(`/api/mcp-keys/${id}`, { method: 'DELETE', token }),
+};
+
+// License
+export const license = {
+  getStatus: () =>
+    request<{ plan: string | null; status: string; features: any; expiresAt: string | null; lastVerifiedAt: string | null; instanceId: string | null }>('/api/license/status'),
+  setKey: (licenseKey: string, token: string) =>
+    request<{ message: string; license: any }>('/api/license/key', {
+      method: 'PUT',
+      body: { licenseKey },
+      token,
+    }),
+  verify: (token: string) =>
+    request<{ valid: boolean; plan?: string; features?: any; expiresAt?: string; error?: string }>('/api/license/verify', {
+      method: 'POST',
+      token,
+    }),
+  registerCommunity: (token: string) =>
+    request<{ message: string; license: any }>('/api/license/register-community', {
+      method: 'POST',
+      token,
+    }),
+  getInstanceId: () =>
+    request<{ instanceId: string }>('/api/license/instance-id'),
 };
 
 // MCP Servers


### PR DESCRIPTION
## Summary
- Add `FRONTEND_URL` to `.env.example` so `getFrontendUrl()` returns the frontend URL instead of falling through to `SERVER_URL` (backend port)
- Fixes invite emails linking to `localhost:4000` instead of `localhost:3000`

## Test plan
- [x] Send invitation email → link now points to `localhost:3000/accept-invite?token=...`