### PR TITLE
Add license-gated email and email-based community license flow

### DIFF
--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -86,7 +86,7 @@ export class LicenseController {
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles('ADMIN')
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Register a free community license (ADMIN)' })
+  @ApiOperation({ summary: 'Request a free community license (sent via email)' })
   async registerCommunity(@Req() req: any) {
     const user = await this.usersService.findById(req.user.sub);
     if (!user) {
@@ -94,11 +94,11 @@ export class LicenseController {
     }
 
     try {
-      const license = await this.licenseService.registerCommunityLicense(
+      const result = await this.licenseService.requestCommunityLicense(
         user.email,
         user.name || user.email,
       );
-      return { message: 'Community license registered', license };
+      return { message: result.message, email: user.email };
     } catch (err: any) {
       throw new BadRequestException(err.message || 'Failed to register community license');
     }

--- a/packages/backend/src/license/license.service.ts
+++ b/packages/backend/src/license/license.service.ts
@@ -58,62 +58,34 @@ export class LicenseService implements OnModuleInit {
     return (await this.siteSettings.get('instance_id')) || (await this.ensureInstanceId());
   }
 
-  // ── Community License Registration ─────────────────────────────────────────
+  // ── Community License Request (sends key via email) ───────────────────────
 
-  async registerCommunityLicense(
+  async requestCommunityLicense(
     email: string,
     name: string,
-  ): Promise<LicenseInfo> {
+  ): Promise<{ success: boolean; message: string }> {
     const instanceId = await this.getInstanceId();
 
     try {
-      const { data } = await axios.post(
+      await axios.post(
         `${this.apiBase}/api/license/register`,
         { email, name, instanceId },
         { timeout: 10000 },
       );
 
-      const license = await this.prisma.license.create({
-        data: {
-          licenseKey: data.licenseKey,
-          plan: data.plan || 'community',
-          status: 'active',
-          expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
-          instanceId,
-        },
-      });
-
-      await this.siteSettings.set('license_key', data.licenseKey);
-
-      // Activate in background
-      this.activateLicense(data.licenseKey).catch((err) =>
-        this.logger.warn(`License activation failed: ${err.message}`),
-      );
-
-      return this.toLicenseInfo(license);
+      return {
+        success: true,
+        message: `License key sent to ${email}`,
+      };
     } catch (err: any) {
-      // If remote is unreachable, create a pending license locally
       if (err.response?.status === 409) {
-        // Community license already exists for this email — try to use it
-        throw new Error('A community license already exists for this email');
+        throw new Error('A community license already exists for this email. Check your inbox.');
       }
-
-      this.logger.warn(
-        `Remote license registration failed: ${err.message}. Creating pending license.`,
-      );
-
-      const pendingKey = `AMCP-PEND-${crypto.randomBytes(6).toString('hex').toUpperCase().slice(0, 12).replace(/(.{4})/g, '$1-').slice(0, -1)}`;
-      const license = await this.prisma.license.create({
-        data: {
-          licenseKey: pendingKey,
-          plan: 'community',
-          status: 'pending',
-          instanceId,
-        },
-      });
-
-      await this.siteSettings.set('license_key', pendingKey);
-      return this.toLicenseInfo(license);
+      if (err.response?.status === 429) {
+        throw new Error('Too many requests. Please try again later.');
+      }
+      this.logger.warn(`Remote license registration failed: ${err.message}`);
+      throw new Error('Failed to register license. Please try again later.');
     }
   }
 

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -122,11 +122,13 @@ export class EmailService {
       }
     }
 
-    // Fallback: send via external API
+    // Fallback: send via external API (requires active license)
+    const licenseKey = await this.siteSettings.get('license_key');
     return this.sendViaExternalApi('/api/email/invite', {
       email: to,
       inviterName: invitedByName,
       instanceUrl: inviteUrl,
+      ...(licenseKey ? { licenseKey } : {}),
     });
   }
 

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import { auth, license } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { LogoIcon } from '@/components/nav-bar';
 
-type SetupStep = 'auth' | 'license-choice' | 'license-key';
+type SetupStep = 'auth' | 'license-choice' | 'license-email-sent' | 'license-key';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -19,6 +19,7 @@ function LoginForm() {
   const [setupStep, setSetupStep] = useState<SetupStep>('auth');
   const [licenseKey, setLicenseKey] = useState('');
   const [authToken, setAuthToken] = useState('');
+  const [userEmail, setUserEmail] = useState('');
   const router = useRouter();
   const searchParams = useSearchParams();
   const { login } = useAuth();
@@ -56,10 +57,18 @@ function LoginForm() {
     }
   };
 
-  const handlePersonalUse = () => {
-    // Fire-and-forget: register community license in background, navigate immediately
-    license.registerCommunity(authToken).catch(() => {});
-    router.push(redirectTo);
+  const handlePersonalUse = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const result = await license.registerCommunity(authToken);
+      setUserEmail(result.email);
+      setSetupStep('license-email-sent');
+    } catch (err: any) {
+      setError(err.message || 'Failed to request license');
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleCommercialChoice = () => {
@@ -126,6 +135,69 @@ function LoginForm() {
               <div className="text-xs text-[var(--muted-foreground)] mt-1">
                 For businesses — purchase a license to unlock all features
               </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── License Email Sent Step ────────────────────────────────────────────
+
+  if (setupStep === 'license-email-sent') {
+    return (
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="flex justify-center mb-4">
+            <LogoIcon size={56} />
+          </div>
+          <h1 className="text-2xl font-bold">Check Your Email</h1>
+          <p className="text-[var(--muted-foreground)] mt-1 text-sm">
+            We sent your license key to <strong>{userEmail}</strong>
+          </p>
+        </div>
+
+        <div className="border border-[var(--border)] rounded-lg p-6 bg-[var(--card)]">
+          <p className="text-sm text-[var(--muted-foreground)] mb-4">
+            Enter the license key from the email to activate your instance.
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 rounded-md bg-[var(--destructive-bg)] text-[var(--destructive-text)] text-sm border border-[var(--destructive-border)]">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">License Key</label>
+              <input
+                type="text"
+                value={licenseKey}
+                onChange={(e) => setLicenseKey(e.target.value.toUpperCase())}
+                placeholder="AMCP-XXXX-XXXX-XXXX-XXXX"
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono tracking-wider"
+              />
+            </div>
+
+            <button
+              onClick={handleActivateLicense}
+              disabled={loading || !licenseKey}
+              className="w-full bg-[var(--brand)] text-white px-4 py-2.5 rounded-md text-sm font-medium hover:brightness-90 disabled:opacity-50"
+            >
+              {loading ? 'Activating...' : 'Activate License'}
+            </button>
+          </div>
+
+          <div className="flex justify-between mt-4 text-sm">
+            <p className="text-[var(--muted-foreground)]">
+              Didn&apos;t receive it? Check your spam folder.
+            </p>
+            <button
+              onClick={handleSkip}
+              className="text-[var(--muted-foreground)] hover:text-[var(--brand)] hover:underline whitespace-nowrap ml-2"
+            >
+              Skip
             </button>
           </div>
         </div>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -254,7 +254,7 @@ export const license = {
       token,
     }),
   registerCommunity: (token: string) =>
-    request<{ message: string; license: any }>('/api/license/register-community', {
+    request<{ message: string; email: string }>('/api/license/register-community', {
       method: 'POST',
       token,
     }),


### PR DESCRIPTION
## Summary
- Email invite via external API now requires an active license key (403 if missing)
- Community license flow changed: instead of auto-creating, sends license key via email — user must enter it to activate
- Frontend shows "Check Your Email" step with license key input after clicking Personal
- Melbourne-v1: rate limiting on register (5/hour/IP), invite (20/hour/license), welcome (3/hour/email) endpoints

## Test plan
- [x] Register first user → Personal → "Check Your Email" step shows with correct email
- [x] License key created in Melbourne MongoDB and email sent via Mailgun
- [x] Enter license key → activates → redirects to dashboard
- [x] Invite without license → 403 "licenseKey is required"
- [x] Invite with valid license → email sent successfully
- [x] Rate limiting works on register endpoint