### PR TITLE
Fix Docker build: add dummy DATABASE_URL for Prisma generate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY package.json package-lock.json ./
 COPY packages/backend/ ./packages/backend/
 
 WORKDIR /app/packages/backend
+# Dummy URL so prisma.config.ts can resolve DATABASE_URL at generate time
+# (no actual connection is made during generate)
+ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
 RUN npx prisma generate
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- Add dummy DATABASE_URL env var in Docker backend-builder stage so `prisma generate` can resolve the config without a real DB connection

## Root cause
Prisma 7's `prisma.config.ts` calls `env('DATABASE_URL')` which fails during Docker build since DB vars are only available at runtime on Railway.