### PR TITLE
Change MCP_AUTH_MODE default to both for Claude Code

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -92,7 +92,7 @@
         },
         "MCP_AUTH_MODE": {
           "description": "MCP endpoint authentication mode: oauth2, legacy, both, or none.",
-          "default": "oauth2",
+          "default": "both",
           "required": true
         },
         "MCP_BEARER_TOKEN": {


### PR DESCRIPTION
Changes MCP_AUTH_MODE default from 'oauth2' to 'both' in railway.json template so Claude Code and other MCP clients that prefer legacy auth with redirect login can connect correctly.