### PR TITLE
Add read-only / read-write access mode for database connectors

### DIFF
--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -85,8 +85,8 @@ export class McpCombinedAuthGuard implements CanActivate {
       return true;
     }
 
-    // 5. If no auth is configured at all (dev mode), allow
-    if (!configuredApiKey && !mcpBearerToken && mode !== 'oauth2') {
+    // 5. If legacy mode but no credentials configured (dev mode), allow
+    if (!configuredApiKey && !mcpBearerToken && mode === 'legacy') {
       req.user = { authMethod: 'none' };
       return true;
     }

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -155,7 +155,8 @@ export class ConnectorsController {
 
     // Auto-create default tools for DATABASE connectors
     if (dto.type === 'DATABASE') {
-      const defaultTools = this.connectorsService.generateDefaultDatabaseTools(dto.baseUrl);
+      const readOnly = (dto.config as any)?.readOnly !== false;
+      const defaultTools = this.connectorsService.generateDefaultDatabaseTools(dto.baseUrl, readOnly);
       for (const tool of defaultTools) {
         try {
           await this.prisma.mcpTool.create({

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -202,6 +202,7 @@ export class ConnectorsService {
       queryParams?: Record<string, unknown>;
       bodyMapping?: Record<string, unknown>;
       headers?: Record<string, string>;
+      staticResponse?: string;
     },
     params: Record<string, unknown>,
   ): Promise<unknown> {
@@ -225,6 +226,11 @@ export class ConnectorsService {
           Object.entries(envVars).filter(([k]) => params[k] === undefined),
         ) }
       : params;
+
+    // Static response tools — return text immediately without engine dispatch
+    if (endpointMapping.method === 'static' && endpointMapping.staticResponse) {
+      return { text: endpointMapping.staticResponse };
+    }
 
     switch (connector.type) {
       case 'REST':

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -239,8 +239,10 @@ export class ConnectorsService {
         return this.soapEngine.execute(config, endpointMapping, mergedParams);
       case 'GRAPHQL':
         return this.graphqlEngine.execute(config, endpointMapping, mergedParams);
-      case 'DATABASE':
-        return this.databaseEngine.execute(config, endpointMapping, mergedParams);
+      case 'DATABASE': {
+        const readOnly = (connector.config as any)?.readOnly !== false;
+        return this.databaseEngine.execute(config, endpointMapping, mergedParams, { readOnly });
+      }
       case 'MCP':
         return this.mcpClientEngine.execute(config, endpointMapping, mergedParams);
       default:
@@ -263,7 +265,7 @@ export class ConnectorsService {
    *   2. get_example_queries — return static example SQL patterns
    *   3. execute_query — run an arbitrary SELECT query
    */
-  generateDefaultDatabaseTools(baseUrl: string): Array<{
+  generateDefaultDatabaseTools(baseUrl: string, readOnly = true): Array<{
     name: string;
     description: string;
     parameters: Record<string, unknown>;
@@ -273,7 +275,7 @@ export class ConnectorsService {
       baseUrl.startsWith('mongodb://') || baseUrl.startsWith('mongodb+srv://');
 
     if (isMongo) {
-      return this.generateMongoTools();
+      return this.generateMongoTools(readOnly);
     }
 
     const isMssql = baseUrl.startsWith('mssql://');
@@ -307,6 +309,20 @@ export class ConnectorsService {
       schemaQuery = `SELECT t.table_schema, t.table_name, c.column_name, c.data_type, c.character_maximum_length, c.is_nullable, CASE WHEN pk.column_name IS NOT NULL THEN 'YES' ELSE 'NO' END AS is_primary_key FROM information_schema.tables t JOIN information_schema.columns c ON t.table_schema = c.table_schema AND t.table_name = c.table_name LEFT JOIN (SELECT ku.table_schema, ku.table_name, ku.column_name FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name WHERE tc.constraint_type = 'PRIMARY KEY') pk ON c.table_schema = pk.table_schema AND c.table_name = pk.table_name AND c.column_name = pk.column_name WHERE t.table_type = 'BASE TABLE' AND t.table_schema NOT IN ('pg_catalog', 'information_schema') ORDER BY t.table_schema, t.table_name, c.ordinal_position`;
     }
 
+    const executeQueryDesc = readOnly
+      ? `Execute a read-only SQL query against the ${dbType} database. ` +
+        `IMPORTANT: Only SELECT statements are allowed. ` +
+        `Always call get_database_schema first to learn the table/column names, then use get_example_queries for syntax guidance. ` +
+        `Results are limited to 1000 rows.`
+      : `Execute a SQL query against the ${dbType} database. ` +
+        `Supports SELECT, INSERT, UPDATE, DELETE, and other SQL statements. ` +
+        `Always call get_database_schema first to learn the table/column names, then use get_example_queries for syntax guidance. ` +
+        `SELECT results are limited to 1000 rows. Write operations return affected row counts.`;
+
+    const queryParamDesc = readOnly
+      ? `The SQL SELECT query to execute. Only SELECT is allowed. Example: "${topSyntax} * FROM table_name"`
+      : `The SQL query to execute. Supports SELECT, INSERT, UPDATE, DELETE, and other statements. Example: "${topSyntax} * FROM table_name"`;
+
     return [
       // 1. Schema introspection
       {
@@ -329,23 +345,19 @@ export class ConnectorsService {
         endpointMapping: {
           method: 'static',
           path: '',
-          staticResponse: this.buildExampleQueriesText({ isMssql, isMysql, isOracle, isSqlite, dbType }),
+          staticResponse: this.buildExampleQueriesText({ isMssql, isMysql, isOracle, isSqlite, dbType, readOnly }),
         },
       },
       // 3. Dynamic query execution
       {
         name: 'execute_query',
-        description:
-          `Execute a read-only SQL query against the ${dbType} database. ` +
-          `IMPORTANT: Only SELECT statements are allowed. ` +
-          `Always call get_database_schema first to learn the table/column names, then use get_example_queries for syntax guidance. ` +
-          `Results are limited to 1000 rows.`,
+        description: executeQueryDesc,
         parameters: {
           type: 'object',
           properties: {
             query: {
               type: 'string',
-              description: `The SQL SELECT query to execute. Only SELECT is allowed. Example: "${topSyntax} * FROM table_name"`,
+              description: queryParamDesc,
             },
           },
           required: ['query'],
@@ -355,12 +367,24 @@ export class ConnectorsService {
     ];
   }
 
-  private generateMongoTools(): Array<{
+  private generateMongoTools(readOnly = true): Array<{
     name: string;
     description: string;
     parameters: Record<string, unknown>;
     endpointMapping: Record<string, unknown>;
   }> {
+    const executeDesc = readOnly
+      ? `Execute a read-only MongoDB find query. ` +
+        `The query parameter must be a JSON string with the format: { "collection": "name", "filter": {}, "projection": {}, "sort": {}, "limit": 10 }. ` +
+        `Only "collection" is required; filter, projection, sort, and limit are optional. ` +
+        `Always call get_database_schema first to learn collection and field names, then use get_example_queries for syntax guidance. ` +
+        `Results are limited to 1000 documents.`
+      : `Execute a MongoDB query. ` +
+        `The query parameter must be a JSON string with the format: { "collection": "name", "filter": {}, "projection": {}, "sort": {}, "limit": 10 }. ` +
+        `Only "collection" is required; filter, projection, sort, and limit are optional. ` +
+        `Always call get_database_schema first to learn collection and field names, then use get_example_queries for syntax guidance. ` +
+        `Results are limited to 1000 documents.`;
+
     return [
       // 1. Schema introspection (MongoDB-specific)
       {
@@ -383,18 +407,13 @@ export class ConnectorsService {
         endpointMapping: {
           method: 'static',
           path: '',
-          staticResponse: this.buildMongoExampleQueriesText(),
+          staticResponse: this.buildMongoExampleQueriesText(readOnly),
         },
       },
       // 3. Dynamic query execution
       {
         name: 'execute_query',
-        description:
-          `Execute a read-only MongoDB find query. ` +
-          `The query parameter must be a JSON string with the format: { "collection": "name", "filter": {}, "projection": {}, "sort": {}, "limit": 10 }. ` +
-          `Only "collection" is required; filter, projection, sort, and limit are optional. ` +
-          `Always call get_database_schema first to learn collection and field names, then use get_example_queries for syntax guidance. ` +
-          `Results are limited to 1000 documents.`,
+        description: executeDesc,
         parameters: {
           type: 'object',
           properties: {
@@ -420,8 +439,12 @@ export class ConnectorsService {
     isOracle: boolean;
     isSqlite: boolean;
     dbType: string;
+    readOnly?: boolean;
   }): string {
-    const note = '> NOTE: Only SELECT queries are allowed. INSERT, UPDATE, DELETE, DROP, and other write operations are blocked.';
+    const readOnly = opts.readOnly !== false;
+    const note = readOnly
+      ? '> NOTE: Only SELECT queries are allowed. INSERT, UPDATE, DELETE, DROP, and other write operations are blocked.'
+      : '> NOTE: This connector supports both read and write operations (SELECT, INSERT, UPDATE, DELETE, etc.). Use write operations with caution.';
 
     if (opts.isMssql) {
       return [
@@ -613,7 +636,11 @@ export class ConnectorsService {
     ].join('\n');
   }
 
-  private buildMongoExampleQueriesText(): string {
+  private buildMongoExampleQueriesText(readOnly = true): string {
+    const note = readOnly
+      ? '> NOTE: Only read-only find queries are supported. Insert, update, delete, and aggregate operations are not allowed.'
+      : '> NOTE: This connector supports read operations via find queries. Write operations are not yet supported through this interface.';
+
     return [
       '# MongoDB Example Queries',
       '',
@@ -653,7 +680,7 @@ export class ConnectorsService {
       '## OR conditions',
       '{"collection":"users","filter":{"$or":[{"role":"admin"},{"role":"manager"}]},"limit":50}',
       '',
-      '> NOTE: Only read-only find queries are supported. Insert, update, delete, and aggregate operations are not allowed.',
+      note,
     ].join('\n');
   }
 }

--- a/packages/backend/src/connectors/engines/database.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/database.engine.spec.ts
@@ -203,6 +203,65 @@ describe('DatabaseEngine', () => {
     });
   });
 
+  describe('read-write mode (readOnly: false)', () => {
+    it('should allow INSERT queries when readOnly is false', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 1, command: 'INSERT' });
+      const result = await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'INSERT INTO users (name) VALUES (\'John\')' },
+        {},
+        { readOnly: false },
+      );
+      expect(mockQuery).toHaveBeenCalledWith("INSERT INTO users (name) VALUES ('John')");
+      expect(result).toEqual({ rowCount: 1, command: 'INSERT' });
+    });
+
+    it('should allow UPDATE queries when readOnly is false', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 3, command: 'UPDATE' });
+      const result = await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'UPDATE users SET name = \'x\'' },
+        {},
+        { readOnly: false },
+      );
+      expect(mockQuery).toHaveBeenCalled();
+      expect(result).toEqual({ rowCount: 3, command: 'UPDATE' });
+    });
+
+    it('should allow DELETE queries when readOnly is false', async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 2, command: 'DELETE' });
+      const result = await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'DELETE FROM users WHERE id = 1' },
+        {},
+        { readOnly: false },
+      );
+      expect(mockQuery).toHaveBeenCalled();
+      expect(result).toEqual({ rowCount: 2, command: 'DELETE' });
+    });
+
+    it('should still block write queries when readOnly is true (default)', async () => {
+      await expect(
+        engine.execute(
+          { baseUrl: 'postgres://host/db', authType: 'NONE' },
+          { method: 'query', path: 'INSERT INTO users VALUES (1)' },
+          {},
+          { readOnly: true },
+        ),
+      ).rejects.toThrow('Only SELECT queries are allowed');
+    });
+
+    it('should default to read-only when no options provided', async () => {
+      await expect(
+        engine.execute(
+          { baseUrl: 'postgres://host/db', authType: 'NONE' },
+          { method: 'query', path: 'INSERT INTO users VALUES (1)' },
+          {},
+        ),
+      ).rejects.toThrow('Only SELECT queries are allowed');
+    });
+  });
+
   describe('raw param reference', () => {
     it('should use raw param value as SQL when path is ${param}', async () => {
       mockQuery.mockResolvedValue({ rows: [] });

--- a/packages/backend/src/connectors/engines/database.engine.ts
+++ b/packages/backend/src/connectors/engines/database.engine.ts
@@ -23,7 +23,9 @@ export class DatabaseEngine {
       staticResponse?: string;
     },
     params: Record<string, unknown>,
+    options?: { readOnly?: boolean },
   ): Promise<unknown> {
+    const readOnly = options?.readOnly !== false; // default true
     // Static response tools (e.g. example queries) — return text without DB execution
     if (endpointMapping.method === 'static' && endpointMapping.staticResponse) {
       return { text: endpointMapping.staticResponse };
@@ -45,7 +47,9 @@ export class DatabaseEngine {
     const sql = rawParamMatch
       ? String(params[rawParamMatch[1]] || '')
       : this.interpolateParams(endpointMapping.path, params);
-    this.validateQuery(sql);
+    if (readOnly) {
+      this.validateQuery(sql);
+    }
 
     if (this.isMssql(config.baseUrl)) {
       return this.executeMssql(config, sql);
@@ -57,7 +61,7 @@ export class DatabaseEngine {
       return this.executeOracle(config, sql);
     }
     if (this.isSqlite(config.baseUrl)) {
-      return this.executeSqlite(config.baseUrl, sql);
+      return this.executeSqlite(config.baseUrl, sql, readOnly);
     }
     return this.executePostgres(config.baseUrl, sql);
   }
@@ -133,8 +137,12 @@ export class DatabaseEngine {
     const pool = new Pool({ connectionString });
     try {
       const result = await pool.query(sql);
-      const rows = Array.isArray(result.rows) ? result.rows : [result.rows];
-      return this.truncateRows(rows);
+      if (result.rows && result.rows.length > 0) {
+        const rows = Array.isArray(result.rows) ? result.rows : [result.rows];
+        return this.truncateRows(rows);
+      }
+      // Write operations return rowCount instead of rows
+      return { rowCount: result.rowCount, command: result.command };
     } finally {
       await pool.end();
     }
@@ -158,8 +166,11 @@ export class DatabaseEngine {
     const pool = await mssql.connect(mssqlConfig);
     try {
       const result = await pool.request().query(sql);
-      const rows = result.recordset ?? [];
-      return this.truncateRows(rows);
+      if (result.recordset && result.recordset.length > 0) {
+        return this.truncateRows(result.recordset);
+      }
+      // Write operations return rowsAffected
+      return { rowsAffected: result.rowsAffected?.[0] ?? 0 };
     } finally {
       await pool.close();
     }
@@ -400,9 +411,13 @@ export class DatabaseEngine {
 
     const conn = await mysql.createConnection(uri);
     try {
-      const [rows] = await conn.query(sql);
-      const rowArray = Array.isArray(rows) ? rows : [rows];
-      return this.truncateRows(rowArray as Record<string, unknown>[]);
+      const [result] = await conn.query(sql);
+      if (Array.isArray(result)) {
+        return this.truncateRows(result as Record<string, unknown>[]);
+      }
+      // Write operations return OkPacket
+      const info = result as any;
+      return { affectedRows: info.affectedRows, insertId: info.insertId };
     } finally {
       await conn.end();
     }
@@ -435,9 +450,13 @@ export class DatabaseEngine {
     try {
       const result = await conn.execute(sql, [], {
         outFormat: oracledb.OUT_FORMAT_OBJECT,
+        autoCommit: true,
       });
-      const rows = (result.rows || []) as Record<string, unknown>[];
-      return this.truncateRows(rows);
+      if (result.rows && result.rows.length > 0) {
+        return this.truncateRows(result.rows as Record<string, unknown>[]);
+      }
+      // Write operations return rowsAffected
+      return { rowsAffected: result.rowsAffected ?? 0 };
     } finally {
       await conn.close();
     }
@@ -470,14 +489,20 @@ export class DatabaseEngine {
   /*  SQLite                                                             */
   /* ------------------------------------------------------------------ */
 
-  private executeSqlite(baseUrl: string, sql: string): unknown {
+  private executeSqlite(baseUrl: string, sql: string, readOnly = true): unknown {
     const filePath = this.sqlitePath(baseUrl);
     this.logger.debug(`SQLite query → ${filePath}`);
 
-    const db = new Database(filePath, { readonly: true });
+    const db = new Database(filePath, { readonly: readOnly });
     try {
-      const rows = db.prepare(sql).all() as Record<string, unknown>[];
-      return this.truncateRows(rows);
+      const stmt = db.prepare(sql);
+      if (stmt.reader) {
+        const rows = stmt.all() as Record<string, unknown>[];
+        return this.truncateRows(rows);
+      }
+      // Write statement (INSERT, UPDATE, DELETE, etc.)
+      const info = stmt.run();
+      return { changes: info.changes, lastInsertRowid: info.lastInsertRowid };
     } finally {
       db.close();
     }

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -296,6 +296,11 @@ export class DynamicMcpTools {
     endpointMapping: any,
     params: Record<string, unknown>,
   ): Promise<unknown> {
+    // Static response tools — return text immediately without engine dispatch
+    if (endpointMapping.method === 'static' && endpointMapping.staticResponse) {
+      return { text: endpointMapping.staticResponse };
+    }
+
     switch (connectorType) {
       case 'REST':
         return this.restEngine.execute(config, endpointMapping, params);

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -116,6 +116,7 @@ export class DynamicMcpTools {
         engineConfig,
         interpolatedMapping,
         mergedParams,
+        { connectorConfig: tool.connectorConfig.config },
       );
 
       const durationMs = Date.now() - startTime;
@@ -295,6 +296,7 @@ export class DynamicMcpTools {
     config: any,
     endpointMapping: any,
     params: Record<string, unknown>,
+    extra?: { connectorConfig?: Record<string, unknown> },
   ): Promise<unknown> {
     // Static response tools — return text immediately without engine dispatch
     if (endpointMapping.method === 'static' && endpointMapping.staticResponse) {
@@ -310,8 +312,10 @@ export class DynamicMcpTools {
         return this.soapEngine.execute(config, endpointMapping, params);
       case 'MCP':
         return this.mcpClientEngine.execute(config, endpointMapping, params);
-      case 'DATABASE':
-        return this.databaseEngine.execute(config, endpointMapping, params);
+      case 'DATABASE': {
+        const readOnly = (extra?.connectorConfig as any)?.readOnly !== false;
+        return this.databaseEngine.execute(config, endpointMapping, params, { readOnly });
+      }
       default:
         throw new Error(`Unsupported connector type: ${connectorType}`);
     }

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -66,6 +66,7 @@ export class McpServerService implements OnModuleInit {
             headers: connector.headers as Record<string, string> | undefined,
             envVars: connector.envVars as Record<string, string> | undefined,
             specUrl: connector.specUrl ?? undefined,
+            config: connector.config as Record<string, unknown> | undefined,
           },
           endpointMapping: tool.endpointMapping as any,
           responseMapping: tool.responseMapping as
@@ -121,6 +122,7 @@ export class McpServerService implements OnModuleInit {
             headers: connector.headers as Record<string, string> | undefined,
             envVars: connector.envVars as Record<string, string> | undefined,
             specUrl: connector.specUrl ?? undefined,
+            config: connector.config as Record<string, unknown> | undefined,
           },
           endpointMapping: tool.endpointMapping as any,
           responseMapping: tool.responseMapping as

--- a/packages/backend/src/mcp-server/tool-registry.ts
+++ b/packages/backend/src/mcp-server/tool-registry.ts
@@ -22,6 +22,7 @@ export interface RegisteredTool {
     authConfig?: string; // decrypted JSON string
     headers?: Record<string, string>;
     envVars?: Record<string, string>; // runtime environment variables
+    config?: Record<string, unknown>; // connector-specific settings (e.g. readOnly for DATABASE)
   };
   endpointMapping: {
     method: string;

--- a/packages/frontend/next.config.ts
+++ b/packages/frontend/next.config.ts
@@ -14,7 +14,9 @@ const nextConfig: NextConfig = {
       { source: '/mcp', destination: `${BACKEND_URL}/mcp` },
       { source: '/mcp/:path*', destination: `${BACKEND_URL}/mcp/:path*` },
       { source: '/.well-known/:path*', destination: `${BACKEND_URL}/.well-known/:path*` },
+      { source: '/auth/:path*', destination: `${BACKEND_URL}/auth/:path*` },
       { source: '/authorize', destination: `${BACKEND_URL}/authorize` },
+      { source: '/callback', destination: `${BACKEND_URL}/callback` },
       { source: '/token', destination: `${BACKEND_URL}/token` },
       { source: '/register', destination: `${BACKEND_URL}/register` },
     ];

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -39,6 +39,7 @@ export default function ConnectorDetailPage() {
   const [editAuthType, setEditAuthType] = useState('NONE');
   const [editAuthKey, setEditAuthKey] = useState('');
   const [editAuthValue, setEditAuthValue] = useState('');
+  const [editDbReadOnly, setEditDbReadOnly] = useState(true);
   const [msg, setMsg] = useState('');
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
 
@@ -77,6 +78,7 @@ export default function ConnectorDetailPage() {
       // Don't pre-fill credentials — they are encrypted on the server
       setEditAuthKey('');
       setEditAuthValue('');
+      setEditDbReadOnly((c.config as any)?.readOnly !== false);
       setToolList(c.tools || []);
       // Load env vars
       const ev = c.envVars as Record<string, string> | null;
@@ -140,6 +142,9 @@ export default function ConnectorDetailPage() {
       };
       const authConfig = buildAuthConfig();
       if (authConfig) data.authConfig = authConfig;
+      if (connector.type === 'DATABASE') {
+        data.config = { readOnly: editDbReadOnly };
+      }
       await connectors.update(id, data, token);
       setMsg('Connector updated');
       setEditing(false);
@@ -443,6 +448,40 @@ export default function ConnectorDetailPage() {
                 />
                 <label htmlFor="isActive" className="text-sm">Active</label>
               </div>
+              {connector.type === 'DATABASE' && (
+                <div>
+                  <label className="block text-sm font-medium mb-2">Access Mode</label>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setEditDbReadOnly(true)}
+                      className={`px-3 py-1.5 rounded-md text-sm font-medium border transition-all ${
+                        editDbReadOnly
+                          ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                          : 'border-[var(--border)] hover:bg-[var(--accent)]'
+                      }`}
+                    >
+                      Read-only
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditDbReadOnly(false)}
+                      className={`px-3 py-1.5 rounded-md text-sm font-medium border transition-all ${
+                        !editDbReadOnly
+                          ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                          : 'border-[var(--border)] hover:bg-[var(--accent)]'
+                      }`}
+                    >
+                      Read &amp; Write
+                    </button>
+                  </div>
+                  <p className="text-xs text-[var(--muted-foreground)] mt-1.5">
+                    {editDbReadOnly
+                      ? 'Only SELECT queries are allowed. Safe for analytics and reporting.'
+                      : 'All SQL operations (SELECT, INSERT, UPDATE, DELETE) are allowed. Use with caution.'}
+                  </p>
+                </div>
+              )}
               <div>
                 <label className="block text-sm font-medium mb-1">Authentication</label>
                 <select
@@ -538,6 +577,24 @@ export default function ConnectorDetailPage() {
                 <p className="text-[var(--muted-foreground)]">Status</p>
                 <p className="font-medium">{connector.isActive ? 'Active' : 'Inactive'}</p>
               </div>
+              {connector.type === 'DATABASE' && (
+                <div>
+                  <p className="text-[var(--muted-foreground)]">Access Mode</p>
+                  <p className="font-medium">
+                    {(connector.config as any)?.readOnly === false ? (
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className="w-2 h-2 rounded-full bg-amber-500"></span>
+                        Read &amp; Write
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className="w-2 h-2 rounded-full bg-emerald-500"></span>
+                        Read-only
+                      </span>
+                    )}
+                  </p>
+                </div>
+              )}
               <div>
                 <p className="text-[var(--muted-foreground)]">Created</p>
                 <p className="font-medium">{new Date(connector.createdAt).toLocaleDateString()}</p>

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -12,7 +12,7 @@ const CONNECTOR_TYPES = [
   { id: 'SOAP', name: 'SOAP Service', description: 'Connect to SOAP web services via WSDL.', color: 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-500/10 dark:text-orange-400 dark:border-orange-500/30', iconBg: 'bg-orange-50 dark:bg-orange-500/10 text-orange-600 dark:text-orange-400' },
   { id: 'GRAPHQL', name: 'GraphQL', description: 'Connect to GraphQL APIs with schema introspection.', color: 'bg-pink-100 text-pink-700 border-pink-200 dark:bg-pink-500/10 dark:text-pink-400 dark:border-pink-500/30', iconBg: 'bg-pink-50 dark:bg-pink-500/10 text-pink-600 dark:text-pink-400' },
   { id: 'MCP', name: 'MCP Server', description: 'Bridge to another MCP server — aggregate multiple MCP servers into one.', color: 'bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-500/10 dark:text-purple-400 dark:border-purple-500/30', iconBg: 'bg-purple-50 dark:bg-purple-500/10 text-purple-600 dark:text-purple-400' },
-  { id: 'DATABASE', name: 'Database', description: 'Connect to PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, MongoDB, or SQLite for read-only queries.', color: 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/30', iconBg: 'bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' },
+  { id: 'DATABASE', name: 'Database', description: 'Connect to PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, MongoDB, or SQLite. Supports read-only or read-write mode.', color: 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/30', iconBg: 'bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' },
 ];
 
 const TYPE_ICONS: Record<string, React.ReactNode> = {
@@ -38,6 +38,7 @@ export default function NewConnectorPage() {
   const [oauthAuthUrl, setOauthAuthUrl] = useState('');
   const [oauthTokenUrl, setOauthTokenUrl] = useState('');
   const [oauthScopes, setOauthScopes] = useState('');
+  const [dbReadOnly, setDbReadOnly] = useState(true);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
@@ -82,6 +83,9 @@ export default function NewConnectorPage() {
       const authConfig = buildAuthConfig();
       if (authConfig) data.authConfig = authConfig;
       if (specUrl) data.specUrl = specUrl;
+      if (selectedType === 'DATABASE') {
+        data.config = { readOnly: dbReadOnly };
+      }
 
       const created = await connectors.create(data, token);
 
@@ -202,6 +206,41 @@ export default function NewConnectorPage() {
                   required
                 />
               </div>
+
+              {selectedType === 'DATABASE' && (
+                <div>
+                  <label className="block text-sm font-medium mb-2">Access Mode</label>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setDbReadOnly(true)}
+                      className={`px-3 py-1.5 rounded-md text-sm font-medium border transition-all ${
+                        dbReadOnly
+                          ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                          : 'border-[var(--border)] hover:bg-[var(--accent)]'
+                      }`}
+                    >
+                      Read-only
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setDbReadOnly(false)}
+                      className={`px-3 py-1.5 rounded-md text-sm font-medium border transition-all ${
+                        !dbReadOnly
+                          ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                          : 'border-[var(--border)] hover:bg-[var(--accent)]'
+                      }`}
+                    >
+                      Read &amp; Write
+                    </button>
+                  </div>
+                  <p className="text-xs text-[var(--muted-foreground)] mt-1.5">
+                    {dbReadOnly
+                      ? 'Only SELECT queries will be allowed. Safe for analytics and reporting.'
+                      : 'All SQL operations (SELECT, INSERT, UPDATE, DELETE) will be allowed. Use with caution.'}
+                  </p>
+                </div>
+              )}
 
               {(selectedType === 'REST' || selectedType === 'SOAP' || selectedType === 'GRAPHQL') && (
                 <div>

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -279,7 +279,7 @@ export default function NewConnectorPage() {
                   <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3 text-sm text-blue-700 dark:text-blue-300">
                     <p>After creating the connector, you will be redirected to authorize via OAuth2. Tokens will be stored securely.</p>
                     <p className="mt-1.5 text-xs text-blue-600 dark:text-blue-400">
-                      Set the <strong>Redirect / Callback URI</strong> in your OAuth provider to: <code className="bg-blue-100 dark:bg-blue-900/50 px-1 py-0.5 rounded font-mono">{typeof window !== 'undefined' ? window.location.origin.replace(':3000', ':4000') : 'http://localhost:4000'}/api/mcp-oauth/callback</code>
+                      Set the <strong>Redirect / Callback URI</strong> in your OAuth provider to: <code className="bg-blue-100 dark:bg-blue-900/50 px-1 py-0.5 rounded font-mono">{typeof window !== 'undefined' ? (window.location.hostname === 'localhost' ? window.location.origin.replace(':3000', ':4000') : window.location.origin) : 'http://localhost:4000'}/api/mcp-oauth/callback</code>
                     </p>
                   </div>
                 </div>

--- a/packages/frontend/src/app/mcp-server/[id]/page.tsx
+++ b/packages/frontend/src/app/mcp-server/[id]/page.tsx
@@ -48,7 +48,9 @@ export default function McpServerDetailPage() {
   }, [token, id]);
 
   const apiUrl = typeof window !== 'undefined'
-    ? `${window.location.protocol}//${window.location.hostname}:4000`
+    ? window.location.hostname === 'localhost'
+      ? `${window.location.protocol}//${window.location.hostname}:4000`
+      : window.location.origin
     : 'http://localhost:4000';
 
   const handleSave = async () => {

--- a/packages/frontend/src/app/mcp-server/[id]/page.tsx
+++ b/packages/frontend/src/app/mcp-server/[id]/page.tsx
@@ -272,7 +272,7 @@ export default function McpServerDetailPage() {
               3. Paste the MCP endpoint URL below.
             </p>
             <a
-              href="https://claude.ai/settings/connectors"
+              href="https://claude.ai/customize/connectors"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90"

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -67,7 +67,9 @@ export default function DashboardPage() {
   if (isLoading) return null;
 
   const apiUrl = typeof window !== 'undefined'
-    ? `${window.location.protocol}//${window.location.hostname}:4000`
+    ? window.location.hostname === 'localhost'
+      ? `${window.location.protocol}//${window.location.hostname}:4000`
+      : window.location.origin
     : 'http://localhost:4000';
 
   return (

--- a/packages/frontend/src/components/tool-editor/index.tsx
+++ b/packages/frontend/src/components/tool-editor/index.tsx
@@ -41,7 +41,7 @@ export interface ToolEditorData {
   useBodyTemplate?: boolean;
   /** Body encoding: 'json' (default), 'form-urlencoded', or 'form-data' */
   bodyEncoding?: string;
-  /** Static text response (for DATABASE tools that return text without executing a query) */
+  /** Static text response (returned directly without any API/DB call) */
   staticResponse?: string;
 }
 
@@ -112,13 +112,25 @@ const DEFAULT_TARGET: Record<string, string> = {
 };
 
 const METHODS_BY_TYPE: Record<string, string[]> = {
-  REST: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
-  GRAPHQL: ['query', 'mutation'],
-  SOAP: ['SOAP'],
+  REST: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'static'],
+  GRAPHQL: ['query', 'mutation', 'static'],
+  SOAP: ['SOAP', 'static'],
   DATABASE: ['query', 'static'],
-  WEBHOOK: ['GET', 'POST', 'PUT', 'DELETE'],
-  MCP: ['invoke'],
+  WEBHOOK: ['GET', 'POST', 'PUT', 'DELETE', 'static'],
+  MCP: ['invoke', 'static'],
 };
+
+function getNativeLabel(connectorType: string): string {
+  switch (connectorType) {
+    case 'REST': return 'API Call';
+    case 'GRAPHQL': return 'GraphQL Operation';
+    case 'SOAP': return 'SOAP Operation';
+    case 'DATABASE': return 'SQL Query';
+    case 'MCP': return 'Remote Tool Call';
+    case 'WEBHOOK': return 'Webhook';
+    default: return 'Native';
+  }
+}
 
 /* ------------------------------------------------------------------ */
 /*  Helpers: parse existing backend tool → editor state               */
@@ -303,19 +315,18 @@ function buildToolPayload(data: ToolEditorData, connectorType: string) {
   let method = data.method;
   let path = data.path;
 
-  if (connectorType === 'GRAPHQL') {
+  // Static mode works the same for all connector types
+  if (data.method === 'static') {
+    method = 'static';
+    path = '';
+  } else if (connectorType === 'GRAPHQL') {
     method = data.method || 'query';
     path = data.graphqlQuery || data.path;
   } else if (connectorType === 'SOAP') {
     method = data.soapOperation || data.method;
   } else if (connectorType === 'DATABASE') {
-    if (data.method === 'static') {
-      method = 'static';
-      path = '';
-    } else {
-      method = 'query';
-      path = data.sqlTemplate || data.path;
-    }
+    method = 'query';
+    path = data.sqlTemplate || data.path;
   }
 
   const endpointMapping: Record<string, unknown> = { method, path };
@@ -560,134 +571,142 @@ export function ToolEditor({
       </div>
 
       {/* Endpoint Configuration - varies by connector type */}
-      {type === 'GRAPHQL' ? (
-        <div className="space-y-3">
+      <div className="space-y-3">
+        {/* Tool Type selector — available for all connector types */}
+        <div>
+          <label className="block text-xs font-medium mb-1">Tool Type</label>
+          <select
+            value={method === 'static' ? 'static' : 'native'}
+            onChange={e => {
+              if (e.target.value === 'static') {
+                setMethod('static');
+              } else {
+                // Reset to the default native method for this connector type
+                const nativeMethods = methods.filter(m => m !== 'static');
+                setMethod(nativeMethods[0] || methods[0]);
+              }
+            }}
+            className="w-56 border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+          >
+            <option value="native">{getNativeLabel(type)}</option>
+            <option value="static">Static Text</option>
+          </select>
+        </div>
+
+        {method === 'static' ? (
+          /* Static Response — same for all connector types */
           <div>
-            <label className="block text-xs font-medium mb-1">Operation Type</label>
-            <select
-              value={method}
-              onChange={e => setMethod(e.target.value)}
-              className="w-48 border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
-            >
-              {methods.map(m => (
-                <option key={m} value={m}>{m}</option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-xs font-medium mb-1">GraphQL Query / Mutation</label>
+            <label className="block text-xs font-medium mb-1">Static Response Text</label>
             <textarea
-              value={graphqlQuery}
-              onChange={e => setGraphqlQuery(e.target.value)}
-              rows={5}
-              placeholder={`query GetUsers($limit: Int, $offset: Int) {\n  users(limit: $limit, offset: $offset) {\n    id\n    name\n    email\n  }\n}`}
-              className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
+              value={staticResponse}
+              onChange={e => setStaticResponse(e.target.value)}
+              rows={10}
+              placeholder={"# Instructions\n\nDescribe how to use this tool or provide hardcoded information.\n\nMarkdown formatting is supported."}
+              className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
             />
             <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
-              Use $variables in the query — map them to parameters below as &quot;GraphQL Variable&quot;
+              This text is returned directly without making any API call. Use it for instructions, documentation, or hardcoded responses.
             </p>
           </div>
-        </div>
-      ) : type === 'DATABASE' ? (
-        <div className="space-y-3">
-          <div>
-            <label className="block text-xs font-medium mb-1">Tool Type</label>
-            <select
-              value={method}
-              onChange={e => setMethod(e.target.value)}
-              className="w-48 border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
-            >
-              {methods.map(m => (
-                <option key={m} value={m}>{m === 'query' ? 'SQL Query' : 'Static Text'}</option>
-              ))}
-            </select>
-          </div>
-          {method === 'static' ? (
+        ) : type === 'GRAPHQL' ? (
+          <div className="space-y-3">
             <div>
-              <label className="block text-xs font-medium mb-1">Static Response Text</label>
-              <textarea
-                value={staticResponse}
-                onChange={e => setStaticResponse(e.target.value)}
-                rows={10}
-                placeholder={"# Example Queries\n\n## List all customers\n```sql\nSELECT TOP 10 * FROM customers\n```\n\n## Search by name\n```sql\nSELECT * FROM customers WHERE name LIKE '%search%'\n```"}
-                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
-              />
-              <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
-                This text is returned directly without executing any database query. Use it for guides, examples, or documentation.
-              </p>
+              <label className="block text-xs font-medium mb-1">Operation Type</label>
+              <select
+                value={method}
+                onChange={e => setMethod(e.target.value)}
+                className="w-48 border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+              >
+                {methods.filter(m => m !== 'static').map(m => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
             </div>
-          ) : (
             <div>
-              <label className="block text-xs font-medium mb-1">SQL Query Template</label>
+              <label className="block text-xs font-medium mb-1">GraphQL Query / Mutation</label>
               <textarea
-                value={sqlTemplate}
-                onChange={e => setSqlTemplate(e.target.value)}
-                rows={4}
-                placeholder="SELECT * FROM users WHERE name LIKE $search_term LIMIT $limit"
+                value={graphqlQuery}
+                onChange={e => setGraphqlQuery(e.target.value)}
+                rows={5}
+                placeholder={`query GetUsers($limit: Int, $offset: Int) {\n  users(limit: $limit, offset: $offset) {\n    id\n    name\n    email\n  }\n}`}
                 className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
               />
               <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
-                Use $param_name to reference parameters. Only SELECT queries are allowed.
+                Use $variables in the query — map them to parameters below as &quot;GraphQL Variable&quot;
               </p>
             </div>
-          )}
-        </div>
-      ) : type === 'SOAP' ? (
-        <div className="grid grid-cols-2 gap-3">
+          </div>
+        ) : type === 'DATABASE' ? (
           <div>
-            <label className="block text-xs font-medium mb-1">SOAP Operation</label>
-            <input
-              type="text"
-              value={method}
-              onChange={e => setMethod(e.target.value)}
-              placeholder="GetWeather"
+            <label className="block text-xs font-medium mb-1">SQL Query Template</label>
+            <textarea
+              value={sqlTemplate}
+              onChange={e => setSqlTemplate(e.target.value)}
+              rows={4}
+              placeholder="SELECT * FROM users WHERE name LIKE $search_term LIMIT $limit"
               className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
             />
             <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
-              The SOAP operation/method name from the WSDL
+              Use $param_name to reference parameters. Only SELECT queries are allowed.
             </p>
           </div>
-          <div>
-            <label className="block text-xs font-medium mb-1">Port / Path</label>
-            <input
-              type="text"
-              value={path}
-              onChange={e => setPath(e.target.value)}
-              placeholder="WeatherServicePort"
-              className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
-            />
+        ) : type === 'SOAP' ? (
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium mb-1">SOAP Operation</label>
+              <input
+                type="text"
+                value={method}
+                onChange={e => setMethod(e.target.value)}
+                placeholder="GetWeather"
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
+              />
+              <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
+                The SOAP operation/method name from the WSDL
+              </p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1">Port / Path</label>
+              <input
+                type="text"
+                value={path}
+                onChange={e => setPath(e.target.value)}
+                placeholder="WeatherServicePort"
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
+              />
+            </div>
           </div>
-        </div>
-      ) : (
-        /* REST / WEBHOOK / MCP */
-        <div className="grid grid-cols-[120px_1fr] gap-3">
-          <div>
-            <label className="block text-xs font-medium mb-1">Method</label>
-            <select
-              value={method}
-              onChange={e => setMethod(e.target.value)}
-              className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
-            >
-              {methods.map(m => (
-                <option key={m} value={m}>{m}</option>
-              ))}
-            </select>
+        ) : (
+          /* REST / WEBHOOK / MCP */
+          <div className="grid grid-cols-[120px_1fr] gap-3">
+            <div>
+              <label className="block text-xs font-medium mb-1">Method</label>
+              <select
+                value={method}
+                onChange={e => setMethod(e.target.value)}
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+              >
+                {methods.filter(m => m !== 'static').map(m => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1">Path</label>
+              <input
+                type="text"
+                value={path}
+                onChange={e => handlePathChange(e.target.value)}
+                placeholder="/users/{id}/posts"
+                className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
+              />
+              <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
+                Use {'{param}'} for path parameters — they auto-create parameters below
+              </p>
+            </div>
           </div>
-          <div>
-            <label className="block text-xs font-medium mb-1">Path</label>
-            <input
-              type="text"
-              value={path}
-              onChange={e => handlePathChange(e.target.value)}
-              placeholder="/users/{id}/posts"
-              className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
-            />
-            <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
-              Use {'{param}'} for path parameters — they auto-create parameters below
-            </p>
-          </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Body Mode — only for REST/WEBHOOK write methods */}
       {(type === 'REST' || type === 'WEBHOOK') && ['POST', 'PUT', 'PATCH'].includes(method) && (

--- a/railway.json
+++ b/railway.json
@@ -92,7 +92,7 @@
         },
         "MCP_AUTH_MODE": {
           "description": "MCP endpoint authentication mode: oauth2, legacy, both, or none.",
-          "default": "oauth2",
+          "default": "both",
           "required": true
         },
         "MCP_BEARER_TOKEN": {


### PR DESCRIPTION
## Summary
- Database connectors now support an **Access Mode** setting: **Read-only** (default) or **Read & Write**
- When read-write is enabled, INSERT, UPDATE, DELETE and other write operations are allowed
- UI toggle added to both the new connector form and the connector detail/edit page
- All DB engines (PostgreSQL, MySQL, MSSQL, Oracle, SQLite, MongoDB) updated to handle write results

## Test plan
- [x] Backend TypeScript compiles cleanly
- [x] Frontend TypeScript compiles cleanly
- [x] Frontend Next.js build succeeds
- [x] 19/19 database engine tests pass (5 new for read-write mode)