### PR TITLE
Show license setup screen on login when no license configured

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -26,6 +26,7 @@ import { UsersService } from '../users/users.service';
 import { McpServersService } from '../mcp-servers/mcp-servers.service';
 import { PrismaService } from '../common/prisma.service';
 import { EmailService } from '../settings/email.service';
+import { SiteSettingsService } from '../settings/site-settings.service';
 import { Roles, RolesGuard } from './roles.guard';
 
 class LoginDto {
@@ -115,6 +116,7 @@ export class AuthController {
     private readonly prisma: PrismaService,
     private readonly emailService: EmailService,
     private readonly configService: ConfigService,
+    private readonly siteSettings: SiteSettingsService,
   ) {}
 
   private getFrontendUrl(): string {
@@ -182,6 +184,15 @@ export class AuthController {
       await this.createAndSendVerificationCode(user.id, user.email);
     }
 
+    // Check if ADMIN needs to complete license setup
+    let needsLicenseSetup = false;
+    if (user.role === 'ADMIN') {
+      const licenseKey = await this.siteSettings.get('license_key');
+      if (!licenseKey) {
+        needsLicenseSetup = true;
+      }
+    }
+
     return {
       accessToken: token,
       user: {
@@ -191,6 +202,7 @@ export class AuthController {
         role: user.role,
         emailVerified: user.emailVerified,
       },
+      ...(needsLicenseSetup && { needsLicenseSetup: true }),
     };
   }
 

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -40,7 +40,7 @@ function LoginForm() {
     setLoading(true);
 
     try {
-      let isFirstUser = false;
+      let needsLicenseSetup = false;
       let result;
       if (isRegister) {
         // Validate password strength
@@ -63,9 +63,11 @@ function LoginForm() {
         }
         const regResult = await auth.register(email, password, name, acceptTerms);
         result = regResult;
-        isFirstUser = !!regResult.isFirstUser;
+        needsLicenseSetup = !!regResult.isFirstUser;
       } else {
-        result = await auth.login(email, password);
+        const loginResult = await auth.login(email, password);
+        result = loginResult;
+        needsLicenseSetup = !!loginResult.needsLicenseSetup;
       }
 
       // Check if email needs verification
@@ -73,12 +75,12 @@ function LoginForm() {
         setAuthToken(result.accessToken);
         setStoredUser(result.user);
         setUserEmail(result.user.email);
-        setIsFirstUserFlag(isFirstUser);
+        setIsFirstUserFlag(needsLicenseSetup);
         setResendCooldown(60);
         setSetupStep('verify-email');
       } else {
         login(result.accessToken, result.user);
-        if (isFirstUser) {
+        if (needsLicenseSetup) {
           setAuthToken(result.accessToken);
           setSetupStep('license-choice');
         } else {

--- a/packages/frontend/src/app/settings/page.tsx
+++ b/packages/frontend/src/app/settings/page.tsx
@@ -12,7 +12,7 @@ const AUTH_MODE_LABELS: Record<string, string> = {
 };
 
 export default function SettingsPage() {
-  const { token, user } = useAuth();
+  const { token, user, updateUser } = useAuth();
   const [profileName, setProfileName] = useState(user?.name || '');
   const [profileMsg, setProfileMsg] = useState('');
   // Change password
@@ -37,6 +37,7 @@ export default function SettingsPage() {
     if (!token) return;
     try {
       await users.updateProfile({ name: profileName }, token);
+      updateUser({ name: profileName });
       setProfileMsg('Profile updated');
       setTimeout(() => setProfileMsg(''), 3000);
     } catch (err: any) {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -36,7 +36,7 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
 // Auth
 export const auth = {
   login: (email: string, password: string) =>
-    request<{ accessToken: string; user: any }>('/api/auth/login', {
+    request<{ accessToken: string; user: any; needsLicenseSetup?: boolean }>('/api/auth/login', {
       method: 'POST',
       body: { email, password },
     }),

--- a/packages/frontend/src/lib/auth-context.tsx
+++ b/packages/frontend/src/lib/auth-context.tsx
@@ -15,6 +15,7 @@ interface AuthContextType {
   user: User | null;
   login: (token: string, user: User) => void;
   logout: () => void;
+  updateUser: (updates: Partial<User>) => void;
   isLoading: boolean;
 }
 
@@ -23,6 +24,7 @@ const AuthContext = createContext<AuthContextType>({
   user: null,
   login: () => {},
   logout: () => {},
+  updateUser: () => {},
   isLoading: true,
 });
 
@@ -59,6 +61,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     document.cookie = `amcp_token=${newToken}; path=/; max-age=${7 * 24 * 60 * 60}; SameSite=Lax`;
   };
 
+  const updateUser = (updates: Partial<User>) => {
+    setUser((prev) => {
+      if (!prev) return prev;
+      const updated = { ...prev, ...updates };
+      localStorage.setItem('amcp_user', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
   const logout = () => {
     setToken(null);
     setUser(null);
@@ -70,7 +81,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, user, login, logout, isLoading }}>
+    <AuthContext.Provider value={{ token, user, login, logout, updateUser, isLoading }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- The license-choice step (commercial vs personal) was only shown during registration via the `isFirstUser` flag
- If the admin closed the browser before completing license setup and later logged in, the step was skipped
- Now the login endpoint returns `needsLicenseSetup` for ADMIN users when no license key is configured, so the frontend shows the license-choice screen on login too