### PR TITLE
Add ALLOW_OPEN_REGISTRATION env var to control self-registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ NEXTAUTH_SECRET=change-me-in-production
 # ── CORS ─────────────────────────────────────────────────────────────────────
 CORS_ORIGIN=http://localhost:3000
 
+# ── Registration ──────────────────────────────────────────────────────────────
+# When false (default), only the first user can self-register via the UI.
+# All other users must be invited by an admin. Set to true to allow open registration.
+ALLOW_OPEN_REGISTRATION=false
+
 # ── MCP Server Auth (for external MCP clients like Claude Desktop) ───────────
 # Auth mode: none | legacy | oauth2 | both
 #   none    — No authentication (not recommended for production)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ No SDK. No code changes. Just point, configure, and connect.
 1. Click the button above to open the Railway template.
 2. Fill in the required environment variables (secrets are auto-generated for you).
 3. Click **Deploy** — Railway will build the container and provision a managed PostgreSQL database.
-4. Once the deploy is complete (2-3 minutes), open the generated URL and register your admin account.
+4. Once the deploy is complete (2-3 minutes), open the generated URL and register your admin account. By default, only the admin can self-register — invite other users from the admin panel. Set `ALLOW_OPEN_REGISTRATION=true` to allow anyone to register.
 
 > **Self-hosting instead?** Run `./setup.sh` for the interactive Docker setup. See [Quick Start](#quick-start) below.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       - MCP_AUTH_MODE=${MCP_AUTH_MODE:-legacy}
       - MCP_API_KEY=${MCP_API_KEY:-}
       - MCP_BEARER_TOKEN=${MCP_BEARER_TOKEN:-}
+      # Registration (false = invite-only after first admin, true = anyone can register)
+      - ALLOW_OPEN_REGISTRATION=${ALLOW_OPEN_REGISTRATION:-false}
       # Uncomment to enable Redis (optional — used for response caching and rate limiting)
       # - REDIS_URL=redis://redis:6379
 

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import {
   UnauthorizedException,
   ConflictException,
   BadRequestException,
+  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
@@ -214,9 +215,15 @@ export class AuthController {
       throw new ConflictException('Email already registered');
     }
 
-    // First user becomes ADMIN
+    // First user becomes ADMIN; subsequent self-registration requires ALLOW_OPEN_REGISTRATION=true
     const userCount = await this.usersService.count();
     const role = userCount === 0 ? 'ADMIN' : 'EDITOR';
+
+    if (userCount > 0 && this.configService.get<string>('ALLOW_OPEN_REGISTRATION') !== 'true') {
+      throw new ForbiddenException(
+        'Registration is disabled. Please contact an administrator for an invitation.',
+      );
+    }
 
     const passwordHash = await this.authService.hashPassword(dto.password);
     const user = await this.usersService.create({

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/terminus';
 import { PrismaService } from '../common/prisma.service';
 import { RedisService } from '../common/redis.service';
+import { UsersService } from '../users/users.service';
 
 @ApiTags('Health')
 @Controller('health')
@@ -18,16 +19,20 @@ export class HealthController {
     private readonly prisma: PrismaService,
     private readonly redis: RedisService,
     private readonly configService: ConfigService,
+    private readonly usersService: UsersService,
   ) {}
 
   @Get('server-info')
-  getServerInfo() {
+  async getServerInfo() {
     const authMode = this.configService.get<string>('MCP_AUTH_MODE') || 'none';
     const serverUrl = this.configService.get<string>('SERVER_URL') || '';
+    const userCount = await this.usersService.count();
+    const allowOpen = this.configService.get<string>('ALLOW_OPEN_REGISTRATION') === 'true';
     return {
       mcpAuthMode: authMode,
       serverUrl,
       mcpEndpoint: '/mcp',
+      registrationEnabled: userCount === 0 || allowOpen,
       oauthEndpoints: authMode === 'oauth2' || authMode === 'both'
         ? {
             wellKnown: '/.well-known/oauth-authorization-server',

--- a/packages/backend/src/health/health.module.ts
+++ b/packages/backend/src/health/health.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TerminusModule],
+  imports: [TerminusModule, UsersModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/packages/frontend/next-env.d.ts
+++ b/packages/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { auth, license } from '@/lib/api';
+import { auth, license, server } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { LogoIcon } from '@/components/nav-bar';
 
@@ -27,12 +27,19 @@ function LoginForm() {
   const [storedUser, setStoredUser] = useState<any>(null);
   const [resendMessage, setResendMessage] = useState('');
   const [resendCooldown, setResendCooldown] = useState(0);
+  const [registrationEnabled, setRegistrationEnabled] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
   const { login } = useAuth();
 
   const redirectTo = searchParams.get('redirect') || '/';
   const emailVerifiedParam = searchParams.get('emailVerified');
+
+  useEffect(() => {
+    server.info().then((info) => {
+      setRegistrationEnabled(info.registrationEnabled);
+    }).catch(() => {});
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -564,15 +571,17 @@ function LoginForm() {
           </p>
         )}
 
-        <p className="text-center text-sm text-[var(--muted-foreground)] mt-3">
-          {isRegister ? 'Already have an account?' : "Don't have an account?"}{' '}
-          <button
-            onClick={() => { setIsRegister(!isRegister); setError(''); }}
-            className="text-[var(--brand)] hover:underline font-medium"
-          >
-            {isRegister ? 'Sign In' : 'Register'}
-          </button>
-        </p>
+        {(registrationEnabled || isRegister) && (
+          <p className="text-center text-sm text-[var(--muted-foreground)] mt-3">
+            {isRegister ? 'Already have an account?' : "Don't have an account?"}{' '}
+            <button
+              onClick={() => { setIsRegister(!isRegister); setError(''); }}
+              className="text-[var(--brand)] hover:underline font-medium"
+            >
+              {isRegister ? 'Sign In' : 'Register'}
+            </button>
+          </p>
+        )}
       </div>
     </div>
   );

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -191,6 +191,7 @@ export const server = {
       mcpAuthMode: string;
       serverUrl: string;
       mcpEndpoint: string;
+      registrationEnabled: boolean;
       oauthEndpoints: { wellKnown: string; authorize: string; token: string; register: string } | null;
     }>('/health/server-info'),
 };

--- a/railway.json
+++ b/railway.json
@@ -137,6 +137,11 @@
           "description": "Sender display name in outgoing emails.",
           "default": "AnythingMCP",
           "required": false
+        },
+        "ALLOW_OPEN_REGISTRATION": {
+          "description": "Allow anyone to register an account. When false (default), only the first user can self-register; subsequent users must be invited by an admin.",
+          "default": "false",
+          "required": false
         }
       }
     },


### PR DESCRIPTION
## Summary
- By default, only the first user can self-register (becomes admin). After that, registration is disabled and new users must be invited by an admin.
- Setting `ALLOW_OPEN_REGISTRATION=true` re-enables open self-registration for anyone.
- The login page hides the Register toggle when registration is disabled.
- Added the env var to Railway template, docker-compose, and .env.example.

## Changes
- **Backend:** Guard `/api/auth/register` with `ForbiddenException` when disabled; expose `registrationEnabled` flag via `/health/server-info`
- **Frontend:** Fetch registration status on mount; conditionally show/hide Register toggle
- **Config:** Add `ALLOW_OPEN_REGISTRATION` to `railway.json`, `docker-compose.yml`, `.env.example`, `README.md`