### PR TITLE
Add Docker Hub publish and switch Railway to pre-built image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: anythingmcp
+
+jobs:
+  publish:
+    name: Build & Push to Docker Hub
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: helpcodeai/anythingmcp
+          tags: |
+            # "latest" on every push to main
+            type=raw,value=latest,enable={{is_default_branch}}
+            # semver tags: v1.2.3 → 1.2.3, 1.2, 1
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # short SHA for traceability
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: anythingmcp
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trigger Railway redeploy
+        if: env.RAILWAY_WEBHOOK_URL != ''
+        env:
+          RAILWAY_WEBHOOK_URL: ${{ secrets.RAILWAY_WEBHOOK_URL }}
+        run: curl -fsSL -X POST "$RAILWAY_WEBHOOK_URL"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
 
   # NestJS Backend + Next.js Frontend (single container)
   app:
+    image: helpcodeai/anythingmcp:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/railway.json
+++ b/railway.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "builder": "DOCKERIMAGE",
+    "dockerImage": "helpcodeai/anythingmcp:latest"
   },
   "deploy": {
     "startCommand": "./start.sh",
@@ -18,11 +18,7 @@
       "description": "AnythingMCP — NestJS Backend + Next.js Frontend",
       "icon": "https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/packages/frontend/public/logo.svg",
       "source": {
-        "repo": "HelpCode-ai/anythingmcp"
-      },
-      "build": {
-        "builder": "DOCKERFILE",
-        "dockerfilePath": "Dockerfile"
+        "image": "helpcodeai/anythingmcp:latest"
       },
       "deploy": {
         "startCommand": "./start.sh",

--- a/railway.toml
+++ b/railway.toml
@@ -6,8 +6,8 @@
 # =============================================================================
 
 [build]
-builder = "DOCKERFILE"
-dockerfilePath = "Dockerfile"
+builder = "DOCKERIMAGE"
+dockerImage = "helpcodeai/anythingmcp:latest"
 
 [deploy]
 startCommand = "./start.sh"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build multi-arch Docker images (amd64 + arm64) and publish to `helpcodeai/anythingmcp` on Docker Hub
- Switch Railway from building via Dockerfile to pulling pre-built image from Docker Hub (`DOCKERIMAGE` builder)
- Add `image: helpcodeai/anythingmcp:latest` to docker-compose.yml so self-hosters can pull without building
- Supports semver tags (`v*` → `1.0.0`, `1.0`) and `latest` on push to main

## Deploy flow after merge
```
Push to main → GitHub Actions builds + pushes to Docker Hub → Railway (Wait for CI) pulls pre-built image → Deploy
```

## Setup required
GitHub secrets already configured:
- `DOCKERHUB_USERNAME` ✅
- `DOCKERHUB_TOKEN` ✅
- `RAILWAY_WEBHOOK_URL` (optional, for explicit redeploy trigger)

## Test plan
- [ ] Verify GitHub Actions workflow triggers on push to main
- [ ] Verify image appears on hub.docker.com/r/helpcodeai/anythingmcp
- [ ] Verify Railway picks up the DOCKERIMAGE config and pulls from Docker Hub