### PR TITLE
Fix Docker build context path

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,10 +6,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
-defaults:
-  run:
-    working-directory: anythingmcp
-
 jobs:
   publish:
     name: Build & Push to Docker Hub
@@ -47,7 +43,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: anythingmcp
+          context: .
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
- Remove incorrect `working-directory: anythingmcp` default (Dockerfile is at repo root)
- Fix build context from `anythingmcp` to `.`

Fixes `path "anythingmcp" not found` error in the Docker publish workflow.