### PR TITLE
Share connectors across all users

### DIFF
--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -9,6 +9,7 @@ import {
   Req,
   UseGuards,
   Logger,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -142,10 +143,16 @@ export class ConnectorsController {
 
   private readonly encryptionKey: string;
 
+  private assertOwnerOrAdmin(connector: any, req: any) {
+    if (connector.userId !== req.user.sub && req.user.role !== 'ADMIN') {
+      throw new ForbiddenException('Only the connector owner or an admin can modify this connector');
+    }
+  }
+
   @Get()
-  @ApiOperation({ summary: 'List all connectors for the current user' })
-  async list(@Req() req: any) {
-    return this.connectorsService.findAllByUser(req.user.sub);
+  @ApiOperation({ summary: 'List all connectors' })
+  async list() {
+    return this.connectorsService.findAll();
   }
 
   @Post()
@@ -185,15 +192,15 @@ export class ConnectorsController {
     description:
       'Runs a health check against all active connectors and returns their status.',
   })
-  async healthCheck(@Req() req: any) {
-    const allConnectors = await this.connectorsService.findAllByUser(req.user.sub);
+  async healthCheck() {
+    const allConnectors = await this.connectorsService.findAll();
     const active = allConnectors.filter((c) => c.isActive);
 
     const results = await Promise.allSettled(
       active.map(async (c) => {
         const start = Date.now();
         try {
-          const result = await this.connectorsService.testConnection(c.id, req.user.sub);
+          const result = await this.connectorsService.testConnection(c.id);
           return {
             id: c.id,
             name: c.name,
@@ -236,9 +243,8 @@ export class ConnectorsController {
       'Returns all connectors with their tools, environment variables, ' +
       'and configuration. Auth credentials are excluded for security.',
   })
-  async exportAll(@Req() req: any) {
+  async exportAll() {
     const allConnectors = await this.prisma.connector.findMany({
-      where: { userId: req.user.sub },
       include: { tools: true },
     });
 
@@ -271,8 +277,8 @@ export class ConnectorsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get connector details' })
-  async findOne(@Req() req: any, @Param('id') id: string) {
-    return this.connectorsService.findById(id, req.user.sub);
+  async findOne(@Param('id') id: string) {
+    return this.connectorsService.findById(id);
   }
 
   @Put(':id')
@@ -282,13 +288,17 @@ export class ConnectorsController {
     @Param('id') id: string,
     @Body() dto: UpdateConnectorDto,
   ) {
-    return this.connectorsService.update(id, req.user.sub, dto);
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
+    return this.connectorsService.update(id, dto);
   }
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete connector' })
   async remove(@Req() req: any, @Param('id') id: string) {
-    await this.connectorsService.remove(id, req.user.sub);
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
+    await this.connectorsService.remove(id);
     // Unregister tools from in-memory MCP registries after DB cascade delete
     await this.mcpServer.reloadConnectorTools(id);
     return { message: 'Connector deleted' };
@@ -296,8 +306,8 @@ export class ConnectorsController {
 
   @Post(':id/test')
   @ApiOperation({ summary: 'Test connector connection' })
-  async test(@Req() req: any, @Param('id') id: string) {
-    return this.connectorsService.testConnection(id, req.user.sub);
+  async test(@Param('id') id: string) {
+    return this.connectorsService.testConnection(id);
   }
 
   @Post(':id/oauth/authorize')
@@ -309,7 +319,8 @@ export class ConnectorsController {
       'Returns an authorization URL for the user to visit.',
   })
   async initiateOAuth(@Req() req: any, @Param('id') id: string) {
-    const connector = await this.connectorsService.findById(id, req.user.sub);
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
 
     if (connector.authType !== 'OAUTH2') {
       return { error: 'Connector auth type must be OAUTH2' };
@@ -405,7 +416,8 @@ export class ConnectorsController {
       'lists all available tools, and imports them as MCP tools.',
   })
   async discoverMcpTools(@Req() req: any, @Param('id') id: string) {
-    const connector = await this.connectorsService.findById(id, req.user.sub);
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
 
     if (connector.type !== 'MCP') {
       return { error: 'Tool discovery is only available for MCP connectors' };
@@ -513,7 +525,8 @@ export class ConnectorsController {
   @Post(':id/import-spec')
   @ApiOperation({ summary: 'Auto-generate MCP tools from API specification' })
   async importSpec(@Req() req: any, @Param('id') id: string) {
-    const connector = await this.connectorsService.findById(id, req.user.sub);
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
 
     let parsedTools: any[] = [];
 
@@ -556,7 +569,8 @@ export class ConnectorsController {
     @Param('id') id: string,
     @Body() dto: ImportToolsDto,
   ) {
-    const connector = await this.connectorsService.findById(id, req.user.sub);
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
 
     let parsedTools: any[] = [];
 
@@ -673,7 +687,9 @@ export class ConnectorsController {
     @Param('id') id: string,
     @Body() body: { envVars: Record<string, string> },
   ) {
-    const updated = await this.connectorsService.update(id, req.user.sub, {
+    const connector = await this.connectorsService.findById(id);
+    this.assertOwnerOrAdmin(connector, req);
+    const updated = await this.connectorsService.update(id, {
       envVars: body.envVars,
     });
     await this.mcpServer.reloadConnectorTools(id);

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -28,17 +28,16 @@ export class ConnectorsService {
       'default-dev-key-change-in-prod!!';
   }
 
-  async findAllByUser(userId: string): Promise<Connector[]> {
+  async findAll(): Promise<Connector[]> {
     return this.prisma.connector.findMany({
-      where: { userId },
       include: { tools: true },
       orderBy: { createdAt: 'desc' },
     });
   }
 
-  async findById(id: string, userId: string): Promise<Connector> {
-    const connector = await this.prisma.connector.findFirst({
-      where: { id, userId },
+  async findById(id: string): Promise<Connector> {
+    const connector = await this.prisma.connector.findUnique({
+      where: { id },
       include: { tools: true, resources: true, prompts: true },
     });
     if (!connector) {
@@ -94,7 +93,6 @@ export class ConnectorsService {
 
   async update(
     id: string,
-    userId: string,
     data: Partial<{
       name: string;
       baseUrl: string;
@@ -106,7 +104,7 @@ export class ConnectorsService {
       envVars: Record<string, string>;
     }>,
   ): Promise<Connector> {
-    await this.findById(id, userId);
+    await this.findById(id);
 
     const updateData: any = { ...data };
     if (data.authConfig) {
@@ -122,16 +120,15 @@ export class ConnectorsService {
     });
   }
 
-  async remove(id: string, userId: string): Promise<void> {
-    await this.findById(id, userId);
+  async remove(id: string): Promise<void> {
+    await this.findById(id);
     await this.prisma.connector.delete({ where: { id } });
   }
 
   async testConnection(
     id: string,
-    userId: string,
   ): Promise<{ ok: boolean; message: string }> {
-    const connector = await this.findById(id, userId);
+    const connector = await this.findById(id);
 
     try {
       const authConfig = connector.authConfig

--- a/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
+++ b/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
@@ -73,7 +73,6 @@ export class McpOAuthCallbackController {
       // 2. Store tokens (encrypted) in the connector's authConfig
       await this.connectorsService.update(
         flow.connectorId,
-        flow.userId,
         {
           authConfig: {
             accessToken: tokens.accessToken,


### PR DESCRIPTION
## Summary
- All authenticated users can now see all connectors (not just their own)
- Write operations (update, delete, import, OAuth) are restricted to the connector owner or ADMIN role
- Fixes editors not seeing admin-created connectors after accepting invite

## Test plan
- [ ] Login as admin, create connectors → visible
- [ ] Login as editor → sees admin's connectors in the list
- [ ] Editor tries to edit/delete admin's connector → gets 403
- [ ] Editor creates own connector → visible alongside admin's
- [ ] Admin can edit/delete any connector