### PR TITLE
Show invite link always and display email error

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -422,7 +422,7 @@ export class AuthController {
     }
 
     // Send email
-    const sent = await this.emailService.sendInvitationEmail(
+    const emailResult = await this.emailService.sendInvitationEmail(
       dto.email,
       inviteUrl,
       inviterName,
@@ -430,10 +430,12 @@ export class AuthController {
     );
 
     return {
-      message: sent
+      message: emailResult.sent
         ? `Invitation sent to ${dto.email}`
-        : `Invitation created for ${dto.email} (email could not be sent — SMTP not configured). Share this link manually.`,
-      inviteUrl: sent ? undefined : inviteUrl,
+        : `Invitation created for ${dto.email}, but the email could not be sent. Share the link manually.`,
+      inviteUrl,
+      emailSent: emailResult.sent,
+      ...(emailResult.error ? { emailError: emailResult.error } : {}),
     };
   }
 

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -89,7 +89,7 @@ export class EmailService {
     inviteUrl: string,
     invitedByName: string,
     roleName: string,
-  ): Promise<boolean> {
+  ): Promise<{ sent: boolean; error?: string }> {
     const transport = await this.createTransporter();
 
     if (transport) {
@@ -115,10 +115,10 @@ export class EmailService {
         });
 
         this.logger.log(`Invitation email sent to ${to}`);
-        return true;
-      } catch (err) {
+        return { sent: true };
+      } catch (err: any) {
         this.logger.error(`Failed to send invitation via SMTP to ${to}: ${err}`);
-        return false;
+        return { sent: false, error: err.message || 'SMTP delivery failed' };
       }
     }
 
@@ -127,7 +127,7 @@ export class EmailService {
     this.logger.log(
       `SMTP not configured, using external API fallback (licenseKey ${licenseKey ? 'present' : 'MISSING'})`,
     );
-    return this.sendViaExternalApi('/api/email/invite', {
+    return this.sendViaExternalApiWithError('/api/email/invite', {
       email: to,
       inviterName: invitedByName,
       instanceUrl: inviteUrl,
@@ -263,6 +263,29 @@ export class EmailService {
         `Failed to send email via external API ${endpoint} (${err.response?.status || 'N/A'}): ${detail}`,
       );
       return false;
+    }
+  }
+
+  private async sendViaExternalApiWithError(
+    endpoint: string,
+    body: Record<string, string>,
+  ): Promise<{ sent: boolean; error?: string }> {
+    try {
+      await axios.post(`${this.apiBase}${endpoint}`, body, {
+        timeout: 10000,
+      });
+      this.logger.log(
+        `Email sent via external API: ${endpoint} to ${body.email}`,
+      );
+      return { sent: true };
+    } catch (err: any) {
+      const detail = err.response?.data
+        ? JSON.stringify(err.response.data)
+        : err.message;
+      this.logger.error(
+        `Failed to send email via external API ${endpoint} (${err.response?.status || 'N/A'}): ${detail}`,
+      );
+      return { sent: false, error: detail };
     }
   }
 

--- a/packages/frontend/src/app/settings/users/page.tsx
+++ b/packages/frontend/src/app/settings/users/page.tsx
@@ -26,6 +26,7 @@ export default function SettingsUsersPage() {
   const [inviteMcpRoleId, setInviteMcpRoleId] = useState('');
   const [inviting, setInviting] = useState(false);
   const [inviteUrl, setInviteUrl] = useState('');
+  const [inviteEmailError, setInviteEmailError] = useState('');
 
   const loadData = async () => {
     if (!token) return;
@@ -88,6 +89,7 @@ export default function SettingsUsersPage() {
     if (!token || !inviteEmail.trim()) return;
     setInviting(true);
     setInviteUrl('');
+    setInviteEmailError('');
     try {
       const result = await auth.inviteUser(
         {
@@ -98,13 +100,9 @@ export default function SettingsUsersPage() {
         token,
       );
       setMsg(result.message);
-      if (result.inviteUrl) {
-        setInviteUrl(result.inviteUrl);
-      } else {
-        setInviteEmail('');
-        setInviteRole('EDITOR');
-        setInviteMcpRoleId('');
-        setShowInvite(false);
+      setInviteUrl(result.inviteUrl);
+      if (result.emailError) {
+        setInviteEmailError(result.emailError);
       }
       // Reload invitations to show the new one
       users.invitations(token).then(setInvitationList).catch(() => {});
@@ -197,13 +195,23 @@ export default function SettingsUsersPage() {
           </div>
 
           {inviteUrl && (
-            <div className="border border-[var(--success-border)] bg-[var(--success-bg)] rounded-md p-3">
-              <p className="text-xs font-medium text-[var(--success-text)] mb-1">
-                SMTP not configured. Share this invitation link manually:
-              </p>
-              <code className="text-xs font-mono bg-[var(--background)] px-3 py-2 rounded border border-[var(--border)] select-all break-all block">
-                {inviteUrl}
-              </code>
+            <div className="space-y-2">
+              {inviteEmailError && (
+                <div className="border border-[var(--destructive)] bg-[var(--destructive-bg)] rounded-md p-3">
+                  <p className="text-xs font-medium text-[var(--destructive)] mb-1">
+                    Failed to send email:
+                  </p>
+                  <p className="text-xs text-[var(--destructive)]">{inviteEmailError}</p>
+                </div>
+              )}
+              <div className="border border-[var(--border)] bg-[var(--muted)] rounded-md p-3">
+                <p className="text-xs font-medium text-[var(--foreground)] mb-1">
+                  Invitation link (share manually):
+                </p>
+                <code className="text-xs font-mono bg-[var(--background)] px-3 py-2 rounded border border-[var(--border)] select-all break-all block">
+                  {inviteUrl}
+                </code>
+              </div>
             </div>
           )}
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -56,7 +56,7 @@ export const auth = {
       body: { token, newPassword },
     }),
   inviteUser: (data: { email: string; role: string; mcpRoleId?: string }, token: string) =>
-    request<{ message: string; inviteUrl?: string }>('/api/auth/invite', {
+    request<{ message: string; inviteUrl: string; emailSent: boolean; emailError?: string }>('/api/auth/invite', {
       method: 'POST',
       body: data,
       token,


### PR DESCRIPTION
## Summary
- Always return and display the invitation link after creating an invite, even when the email is sent successfully
- Show the specific error message when the invitation email fails to send
- Updated `sendInvitationEmail` to return error details instead of just a boolean

## Test plan
- [ ] Send an invite with SMTP configured — link should appear alongside success message
- [ ] Send an invite with SMTP misconfigured — error message and link should both appear
- [ ] Send an invite without SMTP — external API fallback error should be displayed