### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BSL-1.1",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.1 in all package.json files (root, backend, frontend)
- After merge, push tag `v0.1.1` to trigger Docker Hub build with `0.1.1` and `0.1` tags