### PR TITLE
Fix ARM64 Docker build timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ COPY packages/backend/package.json ./packages/backend/
 COPY packages/frontend/package.json ./packages/frontend/
 
 # Install all workspace dependencies
-RUN npm ci
+# Extended timeout for ARM64 QEMU emulation in CI
+RUN npm ci --network-timeout 600000
 
 # ── Stage 2: Build Backend ──────────────────────────────────────────────────
 FROM node:22-alpine AS backend-builder


### PR DESCRIPTION
## Summary

- Increase `npm ci` network timeout to 600s in Dockerfile
- Fixes ARM64 QEMU emulation timeouts in GitHub Actions CI

The ARM64 build runs under QEMU emulation which is significantly slower than native. The default npm timeout (300s) is not enough.