### PR TITLE
Proactive OAuth2 token refresh & auto-logout

### DIFF
--- a/packages/backend/src/connectors/engines/graphql.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.spec.ts
@@ -11,7 +11,7 @@ describe('GraphqlEngine', () => {
 
   beforeEach(() => {
     mockOAuth2TokenService = {
-      getAccessToken: jest.fn().mockReturnValue('oauth2-access-token'),
+      getAccessToken: jest.fn().mockResolvedValue('oauth2-access-token'),
       refreshToken: jest.fn().mockResolvedValue('new-access-token'),
     } as any;
     engine = new GraphqlEngine(mockOAuth2TokenService);
@@ -203,7 +203,7 @@ describe('GraphqlEngine', () => {
   });
 
   it('should inject OAUTH2 auth using OAuth2TokenService', async () => {
-    mockOAuth2TokenService.getAccessToken.mockReturnValue('my-oauth-token');
+    mockOAuth2TokenService.getAccessToken.mockResolvedValue('my-oauth-token');
     mockedAxios.post.mockResolvedValue({ data: { data: { me: {} } } });
 
     await engine.execute(
@@ -254,7 +254,7 @@ describe('GraphqlEngine', () => {
   });
 
   it('should refresh OAuth2 token and retry on 401', async () => {
-    mockOAuth2TokenService.getAccessToken.mockReturnValue('expired-token');
+    mockOAuth2TokenService.getAccessToken.mockResolvedValue('expired-token');
     mockOAuth2TokenService.refreshToken.mockResolvedValue('fresh-token');
 
     // AxiosError is auto-mocked, so create instance and set properties manually

--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -61,7 +61,7 @@ export class GraphqlEngine {
             String(config.authConfig.apiKey);
           break;
         case 'OAUTH2': {
-          const accessToken = this.oauth2TokenService.getAccessToken(
+          const accessToken = await this.oauth2TokenService.getAccessToken(
             config.authConfig,
             config.connectorId,
           );

--- a/packages/backend/src/connectors/engines/mcp-client.engine.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.ts
@@ -1,17 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
-import axios from 'axios';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { OAuth2TokenService } from './oauth2-token.service';
 
 @Injectable()
 export class McpClientEngine {
   private readonly logger = new Logger(McpClientEngine.name);
 
-  // In-memory cache for refreshed OAuth2 tokens (keyed by tokenUrl)
-  private tokenCache = new Map<
-    string,
-    { accessToken: string; expiresAt: number }
-  >();
+  constructor(private readonly oauth2TokenService: OAuth2TokenService) {}
 
   async execute(
     config: {
@@ -19,6 +15,7 @@ export class McpClientEngine {
       authType: string;
       authConfig?: Record<string, unknown>;
       headers?: Record<string, string>;
+      connectorId?: string;
     },
     endpointMapping: {
       method: string; // MCP tool name on remote server
@@ -36,7 +33,7 @@ export class McpClientEngine {
     );
 
     const headers: Record<string, string> = { ...config.headers };
-    this.injectAuth(headers, config.authType, config.authConfig);
+    await this.injectAuth(headers, config.authType, config.authConfig, config.connectorId);
 
     const transport = new StreamableHTTPClientTransport(mcpUrl, {
       requestInit: { headers },
@@ -57,15 +54,18 @@ export class McpClientEngine {
 
       return result;
     } catch (error: any) {
-      // OAuth2 auto-refresh: retry once on auth error
+      // OAuth2 safety-net: retry once on auth error
       if (
         config.authType === 'OAUTH2' &&
         config.authConfig?.refreshToken &&
         config.authConfig?.tokenUrl &&
         error?.message?.includes?.('401')
       ) {
-        this.logger.debug('MCP OAuth2: token may be expired, attempting refresh...');
-        const newToken = await this.refreshOAuth2Token(config.authConfig);
+        this.logger.debug('MCP OAuth2: 401 despite proactive refresh, retrying...');
+        const newToken = await this.oauth2TokenService.refreshToken(
+          config.authConfig,
+          config.connectorId,
+        );
         if (newToken) {
           const retryHeaders: Record<string, string> = { ...config.headers };
           retryHeaders['Authorization'] = `Bearer ${newToken}`;
@@ -107,6 +107,7 @@ export class McpClientEngine {
     authConfig?: Record<string, unknown>;
     headers?: Record<string, string>;
     mcpPath?: string;
+    connectorId?: string;
   }): Promise<
     Array<{
       name: string;
@@ -119,7 +120,7 @@ export class McpClientEngine {
     this.logger.debug(`MCP listTools: ${mcpUrl.toString()}`);
 
     const headers: Record<string, string> = { ...config.headers };
-    this.injectAuth(headers, config.authType, config.authConfig);
+    await this.injectAuth(headers, config.authType, config.authConfig, config.connectorId);
 
     const transport = new StreamableHTTPClientTransport(mcpUrl, {
       requestInit: { headers },
@@ -151,11 +152,12 @@ export class McpClientEngine {
     }
   }
 
-  private injectAuth(
+  private async injectAuth(
     headers: Record<string, string>,
     authType: string,
     authConfig?: Record<string, unknown>,
-  ): void {
+    connectorId?: string,
+  ): Promise<void> {
     if (!authConfig) return;
 
     switch (authType) {
@@ -168,69 +170,15 @@ export class McpClientEngine {
         );
         break;
       case 'OAUTH2': {
-        let accessToken = String(authConfig.accessToken || '');
-
-        // Check if we have a cached (refreshed) token
-        const tokenUrl = String(authConfig.tokenUrl || '');
-        if (tokenUrl) {
-          const cached = this.tokenCache.get(tokenUrl);
-          if (cached && cached.expiresAt > Date.now()) {
-            accessToken = cached.accessToken;
-          }
-        }
-
+        const accessToken = await this.oauth2TokenService.getAccessToken(
+          authConfig,
+          connectorId,
+        );
         if (accessToken) {
           headers['Authorization'] = `Bearer ${accessToken}`;
         }
         break;
       }
-    }
-  }
-
-  private async refreshOAuth2Token(
-    authConfig: Record<string, unknown>,
-  ): Promise<string | null> {
-    const tokenUrl = String(authConfig.tokenUrl);
-    const refreshToken = String(authConfig.refreshToken);
-    const clientId = authConfig.clientId
-      ? String(authConfig.clientId)
-      : undefined;
-    const clientSecret = authConfig.clientSecret
-      ? String(authConfig.clientSecret)
-      : undefined;
-
-    try {
-      const body: Record<string, string> = {
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-      };
-      if (clientId) body.client_id = clientId;
-      if (clientSecret) body.client_secret = clientSecret;
-
-      const response = await axios.post(
-        tokenUrl,
-        new URLSearchParams(body).toString(),
-        {
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          timeout: 10000,
-        },
-      );
-
-      const { access_token, expires_in } = response.data;
-      if (!access_token) return null;
-
-      // Cache the new token (default 1 hour if no expires_in)
-      const expiresInMs = (expires_in || 3600) * 1000;
-      this.tokenCache.set(tokenUrl, {
-        accessToken: access_token,
-        expiresAt: Date.now() + expiresInMs - 60000, // refresh 1 min early
-      });
-
-      this.logger.debug('MCP OAuth2: token refreshed successfully');
-      return access_token;
-    } catch (err: any) {
-      this.logger.warn(`MCP OAuth2 token refresh failed: ${err.message}`);
-      return null;
     }
   }
 }

--- a/packages/backend/src/connectors/engines/oauth2-token.service.spec.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.spec.ts
@@ -33,20 +33,21 @@ describe('OAuth2TokenService', () => {
   });
 
   describe('getAccessToken', () => {
-    it('should return accessToken from authConfig when no cached token', () => {
-      const result = service.getAccessToken(
-        { accessToken: 'stored-token', tokenUrl: 'https://auth/token' },
+    it('should return accessToken from authConfig when no cached token and no expiry info', async () => {
+      // No expiresAt, no refreshToken → returns stored token (no refresh attempt)
+      const result = await service.getAccessToken(
+        { accessToken: 'stored-token' },
         'conn-1',
       );
       expect(result).toBe('stored-token');
     });
 
-    it('should return empty string when no accessToken in authConfig', () => {
-      const result = service.getAccessToken({}, 'conn-1');
+    it('should return empty string when no accessToken in authConfig', async () => {
+      const result = await service.getAccessToken({}, 'conn-1');
       expect(result).toBe('');
     });
 
-    it('should return cached token after a successful refresh', async () => {
+    it('should return cached token when well within validity', async () => {
       mockedAxios.post.mockResolvedValue({
         data: {
           access_token: 'refreshed-token',
@@ -62,11 +63,121 @@ describe('OAuth2TokenService', () => {
         'conn-1',
       );
 
-      const result = service.getAccessToken(
+      const result = await service.getAccessToken(
         { accessToken: 'old-token', tokenUrl: 'https://auth/token' },
         'conn-1',
       );
       expect(result).toBe('refreshed-token');
+    });
+
+    it('should proactively refresh when token is near expiry', async () => {
+      // First, populate the cache with a token that expires in 2 minutes (within 5-min buffer)
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'first-token',
+          expires_in: 120, // 2 minutes — within 5-min buffer
+        },
+      });
+
+      await service.refreshToken(
+        { tokenUrl: 'https://auth/token', refreshToken: 'rt-123' },
+        'conn-1',
+      );
+
+      // Now mock the second refresh
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'proactively-refreshed',
+          expires_in: 3600,
+        },
+      });
+
+      const result = await service.getAccessToken(
+        {
+          accessToken: 'old-token',
+          tokenUrl: 'https://auth/token',
+          refreshToken: 'rt-123',
+        },
+        'conn-1',
+      );
+
+      expect(result).toBe('proactively-refreshed');
+      // Two POST calls total: initial + proactive
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('should proactively refresh when authConfig.expiresAt is near expiry', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          access_token: 'proactive-token',
+          expires_in: 3600,
+        },
+      });
+
+      const result = await service.getAccessToken(
+        {
+          accessToken: 'old-token',
+          tokenUrl: 'https://auth/token',
+          refreshToken: 'rt-123',
+          expiresAt: Date.now() + 60000, // 1 minute — within 5-min buffer
+        },
+        'conn-1',
+      );
+
+      expect(result).toBe('proactive-token');
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to stored token when proactive refresh fails', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+
+      const result = await service.getAccessToken(
+        {
+          accessToken: 'stored-token',
+          tokenUrl: 'https://auth/token',
+          refreshToken: 'rt-123',
+          expiresAt: Date.now() + 60000, // near expiry
+        },
+        'conn-1',
+      );
+
+      expect(result).toBe('stored-token');
+    });
+
+    it('should deduplicate concurrent refresh calls (mutex)', async () => {
+      let resolveRefresh: (value: any) => void;
+      const refreshPromise = new Promise((resolve) => {
+        resolveRefresh = resolve;
+      });
+
+      mockedAxios.post.mockImplementation(() => refreshPromise as any);
+
+      const authConfig = {
+        accessToken: 'old-token',
+        tokenUrl: 'https://auth/token',
+        refreshToken: 'rt-123',
+        expiresAt: Date.now() - 1000, // expired
+      };
+
+      // Launch two concurrent getAccessToken calls
+      const p1 = service.getAccessToken(authConfig, 'conn-1');
+      const p2 = service.getAccessToken(authConfig, 'conn-1');
+
+      // Resolve the single refresh
+      resolveRefresh!({
+        data: {
+          access_token: 'deduped-token',
+          expires_in: 3600,
+        },
+      });
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      // Both should get the same token
+      expect(r1).toBe('deduped-token');
+      expect(r2).toBe('deduped-token');
+      // Only one POST call should have been made
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -154,7 +265,7 @@ describe('OAuth2TokenService', () => {
       );
 
       // Should return cached token, not the one from authConfig
-      const token = service.getAccessToken(
+      const token = await service.getAccessToken(
         { accessToken: 'old', tokenUrl: 'https://auth/token' },
         'conn-1',
       );
@@ -238,9 +349,6 @@ describe('OAuth2TokenService', () => {
         'conn-1',
       );
 
-      // DB update should have been called (we verify the refresh token was preserved
-      // by checking the mock was called — detailed verification of encrypted content
-      // would require decrypting, which the service handles internally)
       expect(mockPrisma.connector.update).toHaveBeenCalled();
     });
   });

--- a/packages/backend/src/connectors/engines/oauth2-token.service.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.ts
@@ -4,9 +4,15 @@ import axios from 'axios';
 import { PrismaService } from '../../common/prisma.service';
 import { encrypt, decrypt } from '../../common/crypto/encryption.util';
 
+/** Refresh tokens that expire within this window (5 minutes). */
+const PROACTIVE_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
 /**
- * Shared OAuth2 token management: in-memory cache, refresh, and DB persistence.
- * Used by RestEngine and GraphqlEngine to handle OAuth2 token lifecycle.
+ * Shared OAuth2 token management: in-memory cache, proactive refresh, and DB persistence.
+ * Used by RestEngine, GraphqlEngine, and McpClientEngine to handle OAuth2 token lifecycle.
+ *
+ * Proactive refresh: tokens are refreshed *before* they expire so callers never see a 401
+ * due to token expiration.
  */
 @Injectable()
 export class OAuth2TokenService {
@@ -19,6 +25,9 @@ export class OAuth2TokenService {
     { accessToken: string; expiresAt: number }
   >();
 
+  // Per-key mutex to prevent concurrent refresh storms
+  private refreshInFlight = new Map<string, Promise<string | null>>();
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
@@ -29,16 +38,40 @@ export class OAuth2TokenService {
   }
 
   /**
-   * Returns the best available access token:
-   * 1. Cached (refreshed) token if still valid
-   * 2. Original token from authConfig
+   * Returns the best available access token, refreshing proactively if needed.
+   *
+   * 1. Cached token still valid (> 5 min remaining) → return immediately
+   * 2. Token expired or near-expiry AND refreshToken available → refresh first, then return
+   * 3. Refresh fails → fall back to stored token (caller's 401 retry will catch it)
    */
-  getAccessToken(
+  async getAccessToken(
     authConfig: Record<string, unknown>,
     connectorId?: string,
-  ): string {
+  ): Promise<string> {
     const cacheKey = connectorId || String(authConfig.tokenUrl || '');
 
+    // 1. Check cache — return immediately if well within validity
+    if (cacheKey) {
+      const cached = this.tokenCache.get(cacheKey);
+      if (cached && cached.expiresAt > Date.now() + PROACTIVE_REFRESH_BUFFER_MS) {
+        return cached.accessToken;
+      }
+    }
+
+    // 2. Determine if proactive refresh is possible and needed
+    const hasRefreshCapability = !!(authConfig.refreshToken && authConfig.tokenUrl);
+    const tokenNearExpiry = this.isTokenNearExpiry(authConfig, cacheKey);
+
+    if (hasRefreshCapability && tokenNearExpiry) {
+      this.logger.debug('OAuth2: token near expiry, proactive refresh...');
+      const refreshed = await this.refreshTokenWithMutex(authConfig, connectorId);
+      if (refreshed) {
+        return refreshed;
+      }
+      // Refresh failed — fall through to return stored token
+    }
+
+    // 3. Return the best available token (cached or stored)
     if (cacheKey) {
       const cached = this.tokenCache.get(cacheKey);
       if (cached && cached.expiresAt > Date.now()) {
@@ -94,12 +127,12 @@ export class OAuth2TokenService {
         response.data;
       if (!access_token) return null;
 
-      // Cache the new token (default 1 hour, refresh 1 min early)
+      // Cache the new token
       const expiresInMs = (expires_in || 3600) * 1000;
       const cacheKey = connectorId || tokenUrl;
       this.tokenCache.set(cacheKey, {
         accessToken: access_token,
-        expiresAt: Date.now() + expiresInMs - 60000,
+        expiresAt: Date.now() + expiresInMs,
       });
 
       // Persist to DB if connectorId is available
@@ -108,6 +141,7 @@ export class OAuth2TokenService {
           connectorId,
           access_token,
           newRefreshToken || refreshToken,
+          Date.now() + expiresInMs,
         );
       }
 
@@ -120,6 +154,56 @@ export class OAuth2TokenService {
   }
 
   /**
+   * Wraps refreshToken with a per-key mutex to prevent concurrent refresh storms.
+   */
+  private async refreshTokenWithMutex(
+    authConfig: Record<string, unknown>,
+    connectorId?: string,
+  ): Promise<string | null> {
+    const cacheKey = connectorId || String(authConfig.tokenUrl || '');
+
+    // If a refresh is already in-flight for this key, wait for it
+    const inFlight = this.refreshInFlight.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const refreshPromise = this.refreshToken(authConfig, connectorId).finally(() => {
+      this.refreshInFlight.delete(cacheKey);
+    });
+
+    this.refreshInFlight.set(cacheKey, refreshPromise);
+    return refreshPromise;
+  }
+
+  /**
+   * Check if the token is expired or near-expiry.
+   */
+  private isTokenNearExpiry(
+    authConfig: Record<string, unknown>,
+    cacheKey: string,
+  ): boolean {
+    const now = Date.now();
+
+    // Check cached token first
+    if (cacheKey) {
+      const cached = this.tokenCache.get(cacheKey);
+      if (cached) {
+        return cached.expiresAt <= now + PROACTIVE_REFRESH_BUFFER_MS;
+      }
+    }
+
+    // Check expiresAt from authConfig (set during initial OAuth grant or previous refresh)
+    if (authConfig.expiresAt) {
+      const expiresAt = Number(authConfig.expiresAt);
+      return expiresAt <= now + PROACTIVE_REFRESH_BUFFER_MS;
+    }
+
+    // No expiry info — assume token may be stale, try proactive refresh
+    return true;
+  }
+
+  /**
    * Update the connector's encrypted authConfig with the new access token
    * so it survives server restarts.
    */
@@ -127,6 +211,7 @@ export class OAuth2TokenService {
     connectorId: string,
     newAccessToken: string,
     newRefreshToken: string,
+    expiresAt: number,
   ): Promise<void> {
     try {
       const connector = await this.prisma.connector.findUnique({
@@ -141,6 +226,7 @@ export class OAuth2TokenService {
       );
       authConfig.accessToken = newAccessToken;
       authConfig.refreshToken = newRefreshToken;
+      authConfig.expiresAt = expiresAt;
       authConfig.lastRefreshedAt = new Date().toISOString();
 
       await this.prisma.connector.update({

--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -11,7 +11,7 @@ describe('RestEngine', () => {
 
   beforeEach(() => {
     mockOAuth2TokenService = {
-      getAccessToken: jest.fn().mockReturnValue('oauth2-access-token'),
+      getAccessToken: jest.fn().mockResolvedValue('oauth2-access-token'),
       refreshToken: jest.fn().mockResolvedValue('new-access-token'),
     } as any;
     engine = new RestEngine(mockOAuth2TokenService);

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -69,7 +69,7 @@ export class RestEngine {
     };
 
     // Inject authentication
-    this.injectAuth(axiosConfig, config);
+    await this.injectAuth(axiosConfig, config);
 
     // Query parameters
     if (endpointMapping.queryParams) {
@@ -164,14 +164,14 @@ export class RestEngine {
     }
   }
 
-  private injectAuth(
+  private async injectAuth(
     axiosConfig: AxiosRequestConfig,
     config: {
       authType: string;
       authConfig?: Record<string, unknown>;
       connectorId?: string;
     },
-  ): void {
+  ): Promise<void> {
     if (!config.authConfig) return;
 
     switch (config.authType) {
@@ -196,7 +196,7 @@ export class RestEngine {
         };
         break;
       case 'OAUTH2': {
-        const accessToken = this.oauth2TokenService.getAccessToken(
+        const accessToken = await this.oauth2TokenService.getAccessToken(
           config.authConfig,
           config.connectorId,
         );

--- a/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
+++ b/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
@@ -81,6 +81,7 @@ export class McpOAuthCallbackController {
             clientId: flow.clientId,
             clientSecret: flow.clientSecret,
             expiresIn: tokens.expiresIn,
+            expiresAt: Date.now() + (tokens.expiresIn || 3600) * 1000,
             authorizedAt: new Date().toISOString(),
           },
         },

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -8,6 +8,9 @@ interface RequestOptions {
   token?: string;
 }
 
+// Emitted when any authenticated request gets a 401 — auth-context listens for this.
+export const AUTH_EXPIRED_EVENT = 'amcp:auth-expired';
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, token } = options;
 
@@ -26,6 +29,10 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   });
 
   if (!response.ok) {
+    // Auto-logout on 401 for authenticated requests
+    if (response.status === 401 && token) {
+      window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
+    }
     const error = await response.json().catch(() => ({ message: response.statusText }));
     throw new Error(error.message || `API error: ${response.status}`);
   }

--- a/packages/frontend/src/lib/auth-context.tsx
+++ b/packages/frontend/src/lib/auth-context.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { users, AUTH_EXPIRED_EVENT } from './api';
 
 interface User {
   id: string;
@@ -35,15 +36,51 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
 
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('amcp_token');
+    localStorage.removeItem('amcp_user');
+    // Clear cookie
+    document.cookie = 'amcp_token=; path=/; max-age=0';
+    router.push('/login');
+  }, [router]);
+
+  // On mount: restore saved token and validate it against the backend
   useEffect(() => {
     const savedToken = localStorage.getItem('amcp_token');
     const savedUser = localStorage.getItem('amcp_user');
+
     if (savedToken && savedUser) {
+      // Optimistically set state for instant UI
       setToken(savedToken);
       setUser(JSON.parse(savedUser));
+
+      // Validate the token is still accepted by the backend
+      users.me(savedToken).then((freshUser) => {
+        setUser(freshUser);
+        localStorage.setItem('amcp_user', JSON.stringify(freshUser));
+        setIsLoading(false);
+      }).catch(() => {
+        // Token rejected — clear and redirect to login
+        setToken(null);
+        setUser(null);
+        localStorage.removeItem('amcp_token');
+        localStorage.removeItem('amcp_user');
+        document.cookie = 'amcp_token=; path=/; max-age=0';
+        setIsLoading(false);
+      });
+    } else {
+      setIsLoading(false);
     }
-    setIsLoading(false);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Listen for 401 events from api.ts to auto-logout
+  useEffect(() => {
+    const handleAuthExpired = () => logout();
+    window.addEventListener(AUTH_EXPIRED_EVENT, handleAuthExpired);
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, handleAuthExpired);
+  }, [logout]);
 
   useEffect(() => {
     const publicPaths = ['/login', '/register', '/forgot-password', '/reset-password', '/accept-invite', '/verify-email'];
@@ -68,16 +105,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       localStorage.setItem('amcp_user', JSON.stringify(updated));
       return updated;
     });
-  };
-
-  const logout = () => {
-    setToken(null);
-    setUser(null);
-    localStorage.removeItem('amcp_token');
-    localStorage.removeItem('amcp_user');
-    // Clear cookie
-    document.cookie = 'amcp_token=; path=/; max-age=0';
-    router.push('/login');
   };
 
   return (


### PR DESCRIPTION
## Summary
- OAuth2 tokens are now refreshed **proactively before expiry** (5-min buffer) so AI clients never encounter a 401 due to token expiration
- Unified token management: `McpClientEngine` now uses the shared `OAuth2TokenService` instead of duplicate logic, with DB persistence of refreshed tokens
- Frontend auto-validates saved JWT on page load and auto-logs out on 401, fixing the broken session after backend restart

## Test plan
- [x] All 277 backend tests pass (including new proactive refresh, mutex, and fallback tests)
- [x] TypeScript compiles without errors (backend + frontend)
- [x] Backend starts and health check passes
- [ ] Manual: verify auto-logout after backend restart with stale token
- [ ] Manual: verify OAuth2 connector token refresh logs show proactive refresh