### PR TITLE
Improve first-user onboarding and email deliverability

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -159,8 +159,10 @@ export class AuthController {
       data: { userId, token: linkToken, code, expiresAt },
     });
 
-    // Build verification link URL
-    const verifyUrl = `${this.getFrontendUrl(req)}/verify-email?token=${linkToken}`;
+    // Build verification link URL — route through anythingmcp.com so the
+    // link domain matches the Resend sending domain (avoids spam filters).
+    const instanceUrl = this.getFrontendUrl(req);
+    const verifyUrl = `https://anythingmcp.com/verify-email?token=${linkToken}&instance=${encodeURIComponent(instanceUrl)}`;
 
     // Send email
     try {
@@ -407,8 +409,10 @@ export class AuthController {
       },
     });
 
-    // Build invitation URL
-    const inviteUrl = `${this.getFrontendUrl(req)}/accept-invite?token=${inviteToken}`;
+    // Build invitation URL — route through anythingmcp.com so the
+    // link domain matches the Resend sending domain (avoids spam filters).
+    const instanceUrl = this.getFrontendUrl(req);
+    const inviteUrl = `https://anythingmcp.com/accept-invite?token=${inviteToken}&instance=${encodeURIComponent(instanceUrl)}`;
 
     // Get inviter's name for the email
     const inviter = await this.usersService.findById(req.user.sub);

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -32,6 +32,7 @@ export class HealthController {
       mcpAuthMode: authMode,
       serverUrl,
       mcpEndpoint: '/mcp',
+      hasUsers: userCount > 0,
       registrationEnabled: userCount === 0 || allowOpen,
       oauthEndpoints: authMode === 'oauth2' || authMode === 'both'
         ? {

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -38,6 +38,9 @@ function LoginForm() {
   useEffect(() => {
     server.info().then((info) => {
       setRegistrationEnabled(info.registrationEnabled);
+      if (!info.hasUsers) {
+        setIsRegister(true);
+      }
     }).catch(() => {});
   }, []);
 
@@ -237,6 +240,20 @@ function LoginForm() {
               {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : 'Resend code'}
             </button>
           </p>
+
+          {isFirstUserFlag && (
+            <div className="text-center mt-3">
+              <button
+                onClick={() => {
+                  login(authToken, storedUser);
+                  setSetupStep('license-choice');
+                }}
+                className="text-sm text-[var(--muted-foreground)] hover:text-[var(--brand)] hover:underline"
+              >
+                Skip for now
+              </button>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -202,6 +202,7 @@ export const server = {
       mcpAuthMode: string;
       serverUrl: string;
       mcpEndpoint: string;
+      hasUsers: boolean;
       registrationEnabled: boolean;
       oauthEndpoints: { wellKnown: string; authorize: string; token: string; register: string } | null;
     }>('/health/server-info'),


### PR DESCRIPTION
## Summary
- Auto-show registration form on first visit when no users exist yet
- Allow first user (admin) to skip email verification during initial setup
- Route verification and invitation email links through anythingmcp.com to match the Resend sending domain and avoid spam filters

## Test plan
- [ ] Fresh instance: login page shows registration form by default
- [ ] First user can skip email verification step
- [ ] Email verification and invitation links route through anythingmcp.com
- [ ] Existing instances with users still show sign-in form by default