### PR TITLE
Add cloud deployment mode with trial licensing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,6 @@
 NODE_ENV=production
 PORT=4000
 
-# ── Deployment Mode ─────────────────────────────────────────────────────────
-# self-hosted (default) — standard self-hosted deployment with license setup
-# cloud — managed SaaS deployment with trial-based onboarding
-DEPLOYMENT_MODE=self-hosted
-
 # ── Database ─────────────────────────────────────────────────────────────────
 POSTGRES_PASSWORD=change-me-in-production
 DATABASE_URL=postgresql://amcp:${POSTGRES_PASSWORD}@postgres:5432/anythingmcp

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@
 NODE_ENV=production
 PORT=4000
 
+# ── Deployment Mode ─────────────────────────────────────────────────────────
+# self-hosted (default) — standard self-hosted deployment with license setup
+# cloud — managed SaaS deployment with trial-based onboarding
+DEPLOYMENT_MODE=self-hosted
+
 # ── Database ─────────────────────────────────────────────────────────────────
 POSTGRES_PASSWORD=change-me-in-production
 DATABASE_URL=postgresql://amcp:${POSTGRES_PASSWORD}@postgres:5432/anythingmcp

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,0 +1,45 @@
+name: Deploy Cloud
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag to deploy (default: latest)"
+        required: false
+        default: "latest"
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy to Cloud Droplet
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CLOUD_HOST }}
+          username: root
+          key: ${{ secrets.CLOUD_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/anythingmcp-cloud
+
+            # Pull latest image
+            docker pull helpcodeai/anythingmcp:${{ inputs.tag }}
+
+            # Update compose and Caddyfile from repo
+            curl -fsSL -H "Authorization: token ${{ secrets.GH_DEPLOY_TOKEN }}" \
+              -o docker-compose.cloud.yml \
+              "https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/${{ github.sha }}/docker-compose.cloud.yml"
+            curl -fsSL -H "Authorization: token ${{ secrets.GH_DEPLOY_TOKEN }}" \
+              -o Caddyfile \
+              "https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/${{ github.sha }}/deploy/cloud/Caddyfile"
+
+            # Restart services
+            docker compose -f docker-compose.cloud.yml up -d --remove-orphans
+            docker image prune -f
+
+            echo "Deployment complete"

--- a/deploy/cloud/Caddyfile
+++ b/deploy/cloud/Caddyfile
@@ -1,0 +1,20 @@
+{$DOMAIN} {
+	# Backend API, health, MCP endpoints
+	handle /api/* {
+		reverse_proxy app:4000
+	}
+	handle /health* {
+		reverse_proxy app:4000
+	}
+	handle /mcp* {
+		reverse_proxy app:4000
+	}
+	handle /.well-known/* {
+		reverse_proxy app:4000
+	}
+
+	# Frontend (Next.js)
+	handle {
+		reverse_proxy app:3000
+	}
+}

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -1,0 +1,97 @@
+# =============================================================================
+# AnythingMCP Cloud — Managed SaaS Deployment
+# =============================================================================
+# Usage:  docker compose -f docker-compose.cloud.yml up -d
+# Domain: cloud.anythingmcp.com
+# =============================================================================
+
+name: amcp-cloud
+
+services:
+
+  # Caddy Reverse Proxy — automatic HTTPS via Let's Encrypt
+  caddy:
+    image: caddy:2-alpine
+    container_name: amcp-cloud-caddy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # NestJS Backend + Next.js Frontend (single container)
+  app:
+    image: helpcodeai/anythingmcp:latest
+    container_name: amcp-cloud-app
+    expose:
+      - "3000"
+      - "4000"
+    environment:
+      - NODE_ENV=production
+      - PORT=4000
+      - DEPLOYMENT_MODE=cloud
+      - NEXT_PUBLIC_API_URL=https://${DOMAIN}
+      - DATABASE_URL=postgresql://amcp:${POSTGRES_PASSWORD}@postgres:5432/anythingmcp
+      - REDIS_URL=redis://redis:6379
+      - JWT_SECRET=${JWT_SECRET}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - CORS_ORIGIN=https://${DOMAIN}
+      - SERVER_URL=https://${DOMAIN}
+      - FRONTEND_URL=https://${DOMAIN}
+      - MCP_AUTH_MODE=${MCP_AUTH_MODE:-oauth2}
+      - ALLOW_OPEN_REGISTRATION=${ALLOW_OPEN_REGISTRATION:-true}
+      - LICENSE_API_URL=${LICENSE_API_URL:-https://anythingmcp.com}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # PostgreSQL Database
+  postgres:
+    image: postgres:17-alpine
+    container_name: amcp-cloud-postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=amcp
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=anythingmcp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U amcp -d anythingmcp"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  # Redis Cache — caching & rate limiting
+  redis:
+    image: redis:7-alpine
+    container_name: amcp-cloud-redis
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:
+  caddy_data:
+  caddy_config:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -19841,7 +19841,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -19925,7 +19925,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -29,6 +29,11 @@ import { LocalOAuthProvider } from './auth/local-oauth.provider';
 import { PrismaOAuthStore } from './auth/prisma-oauth.store';
 import { PrismaService } from './common/prisma.service';
 import { OAuthUrlRewriteInterceptor } from './auth/oauth-url-rewrite.interceptor';
+import { CloudModule } from './cloud/cloud.module';
+
+// Determine deployment and auth mode from env
+const useCloud = process.env.DEPLOYMENT_MODE === 'cloud';
+const cloudImports = useCloud ? [CloudModule] : [];
 
 // Determine auth mode from env
 const authMode = process.env.MCP_AUTH_MODE || 'none';
@@ -113,6 +118,9 @@ if (useOAuth) {
     RolesModule,
     McpServersModule,
     LicenseModule,
+
+    // Cloud-specific modules (conditionally loaded)
+    ...cloudImports,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/packages/backend/src/cloud/cloud.module.ts
+++ b/packages/backend/src/cloud/cloud.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+/**
+ * CloudModule — loaded only when DEPLOYMENT_MODE=cloud.
+ *
+ * Groups cloud-specific providers and controllers. Future additions:
+ * - Usage metering
+ * - Multi-tenant routing
+ * - Cloud-specific billing webhooks
+ */
+@Module({})
+export class CloudModule {}

--- a/packages/backend/src/common/deployment.service.ts
+++ b/packages/backend/src/common/deployment.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+
+export type DeploymentMode = 'self-hosted' | 'cloud';
+
+@Injectable()
+export class DeploymentService {
+  readonly mode: DeploymentMode =
+    (process.env.DEPLOYMENT_MODE as DeploymentMode) || 'self-hosted';
+
+  isCloud(): boolean {
+    return this.mode === 'cloud';
+  }
+
+  isSelfHosted(): boolean {
+    return this.mode !== 'cloud';
+  }
+}

--- a/packages/backend/src/common/prisma.module.ts
+++ b/packages/backend/src/common/prisma.module.ts
@@ -1,9 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
+import { DeploymentService } from './deployment.service';
 
 @Global()
 @Module({
-  providers: [PrismaService],
-  exports: [PrismaService],
+  providers: [PrismaService, DeploymentService],
+  exports: [PrismaService, DeploymentService],
 })
 export class PrismaModule {}

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -32,6 +32,7 @@ import { McpClientEngine } from './engines/mcp-client.engine';
 import { McpOAuthService } from './mcp-oauth.service';
 import { PrismaService } from '../common/prisma.service';
 import { McpServerService } from '../mcp-server/mcp-server.service';
+import { LicenseGuardService } from '../license/license-guard.service';
 import { decrypt } from '../common/crypto/encryption.util';
 
 class CreateConnectorDto {
@@ -135,6 +136,7 @@ export class ConnectorsController {
     private readonly prisma: PrismaService,
     private readonly mcpServer: McpServerService,
     private readonly configService: ConfigService,
+    private readonly licenseGuard: LicenseGuardService,
   ) {
     this.encryptionKey =
       this.configService.get<string>('ENCRYPTION_KEY') ||
@@ -158,6 +160,7 @@ export class ConnectorsController {
   @Post()
   @ApiOperation({ summary: 'Create a new connector' })
   async create(@Req() req: any, @Body() dto: CreateConnectorDto) {
+    await this.licenseGuard.checkCanCreateConnector(req.user.sub);
     const connector = await this.connectorsService.create(req.user.sub, dto);
 
     // Auto-create default tools for DATABASE connectors

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -16,6 +16,7 @@ import { PostmanParser } from './parsers/postman.parser';
 import { CurlParser } from './parsers/curl.parser';
 import { McpOAuthService } from './mcp-oauth.service';
 import { McpOAuthCallbackController } from './mcp-oauth-callback.controller';
+import { LicenseModule } from '../license/license.module';
 
 const ENGINES = [
   RestEngine,
@@ -28,7 +29,7 @@ const ENGINES = [
 const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlParser];
 
 @Module({
-  imports: [McpServerModule],
+  imports: [McpServerModule, LicenseModule],
   controllers: [ConnectorsController, McpOAuthCallbackController, ToolsController],
   providers: [ConnectorsService, McpOAuthService, OAuth2TokenService, ...ENGINES, ...PARSERS],
   exports: [ConnectorsService, McpOAuthService, OAuth2TokenService, ...ENGINES],

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -10,6 +10,7 @@ import {
 import { PrismaService } from '../common/prisma.service';
 import { RedisService } from '../common/redis.service';
 import { UsersService } from '../users/users.service';
+import { DeploymentService } from '../common/deployment.service';
 
 @ApiTags('Health')
 @Controller('health')
@@ -20,6 +21,7 @@ export class HealthController {
     private readonly redis: RedisService,
     private readonly configService: ConfigService,
     private readonly usersService: UsersService,
+    private readonly deployment: DeploymentService,
   ) {}
 
   @Get('server-info')
@@ -32,6 +34,7 @@ export class HealthController {
       mcpAuthMode: authMode,
       serverUrl,
       mcpEndpoint: '/mcp',
+      deploymentMode: this.deployment.mode,
       hasUsers: userCount > 0,
       registrationEnabled: userCount === 0 || allowOpen,
       oauthEndpoints: authMode === 'oauth2' || authMode === 'both'

--- a/packages/backend/src/license/license-guard.service.ts
+++ b/packages/backend/src/license/license-guard.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { LicenseService } from './license.service';
+import { DeploymentService } from '../common/deployment.service';
+
+@Injectable()
+export class LicenseGuardService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly licenseService: LicenseService,
+    private readonly deployment: DeploymentService,
+  ) {}
+
+  /**
+   * Check if the license is active. Only enforced in cloud mode.
+   */
+  async checkLicenseActive(): Promise<void> {
+    if (!this.deployment.isCloud()) return;
+
+    const license = await this.licenseService.getCurrentLicense();
+    if (!license) {
+      throw new ForbiddenException(
+        'No active license. Please purchase a license at anythingmcp.com/pricing',
+      );
+    }
+
+    if (license.status !== 'active') {
+      throw new ForbiddenException(
+        'Your license has expired. Please purchase a license at anythingmcp.com/pricing',
+      );
+    }
+
+    // Check if trial has expired by date
+    if (license.plan === 'trial' && license.expiresAt) {
+      if (new Date(license.expiresAt) < new Date()) {
+        throw new ForbiddenException(
+          'Your trial has expired. Please purchase a license at anythingmcp.com/pricing',
+        );
+      }
+    }
+  }
+
+  /**
+   * Check if the user can create a new connector. Only enforced in cloud mode.
+   */
+  async checkCanCreateConnector(userId: string): Promise<void> {
+    if (!this.deployment.isCloud()) return;
+
+    await this.checkLicenseActive();
+
+    const license = await this.licenseService.getCurrentLicense();
+    const maxConnectors = (license?.features as any)?.maxConnectors;
+    if (maxConnectors != null) {
+      const count = await this.prisma.connector.count({ where: { userId } });
+      if (count >= maxConnectors) {
+        throw new ForbiddenException(
+          `You have reached the maximum of ${maxConnectors} connectors on your current plan. Upgrade at anythingmcp.com/pricing`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Check if the user can create a new MCP server. Only enforced in cloud mode.
+   */
+  async checkCanCreateMcpServer(userId: string): Promise<void> {
+    if (!this.deployment.isCloud()) return;
+
+    await this.checkLicenseActive();
+
+    const license = await this.licenseService.getCurrentLicense();
+    const maxMcpServers = (license?.features as any)?.maxMcpServers;
+    if (maxMcpServers != null) {
+      const count = await this.prisma.mcpServerConfig.count({ where: { userId } });
+      if (count >= maxMcpServers) {
+        throw new ForbiddenException(
+          `You have reached the maximum of ${maxMcpServers} MCP servers on your current plan. Upgrade at anythingmcp.com/pricing`,
+        );
+      }
+    }
+  }
+}

--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -7,6 +7,7 @@ import {
   Req,
   UseGuards,
   BadRequestException,
+  ForbiddenException,
   Logger,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
@@ -15,6 +16,7 @@ import { IsString, Matches } from 'class-validator';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 import { LicenseService } from './license.service';
 import { UsersService } from '../users/users.service';
+import { DeploymentService } from '../common/deployment.service';
 
 class SetLicenseKeyDto {
   @IsString()
@@ -32,6 +34,7 @@ export class LicenseController {
   constructor(
     private readonly licenseService: LicenseService,
     private readonly usersService: UsersService,
+    private readonly deployment: DeploymentService,
   ) {}
 
   @Get('status')
@@ -41,6 +44,12 @@ export class LicenseController {
     if (!license) {
       return { plan: null, status: 'none', features: null, expiresAt: null, instanceId: null };
     }
+
+    const trialDaysLeft =
+      license.plan === 'trial' && license.expiresAt
+        ? Math.max(0, Math.ceil((new Date(license.expiresAt).getTime() - Date.now()) / 86400000))
+        : undefined;
+
     return {
       plan: license.plan,
       status: license.status,
@@ -48,6 +57,7 @@ export class LicenseController {
       expiresAt: license.expiresAt,
       lastVerifiedAt: license.lastVerifiedAt,
       instanceId: license.instanceId,
+      ...(trialDaysLeft !== undefined && { trialDaysLeft }),
     };
   }
 
@@ -80,6 +90,35 @@ export class LicenseController {
   async verifyLicense() {
     const result = await this.licenseService.verifyLicense();
     return result;
+  }
+
+  @Post('activate-trial')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Start a 7-day cloud trial (cloud mode only)' })
+  async activateTrial(@Req() req: any) {
+    if (!this.deployment.isCloud()) {
+      throw new ForbiddenException('Trial activation is only available in cloud mode');
+    }
+
+    const user = await this.usersService.findById(req.user.sub);
+    if (!user) {
+      throw new BadRequestException('User not found');
+    }
+
+    try {
+      const result = await this.licenseService.requestTrialLicense(
+        user.email,
+        user.name || user.email,
+      );
+      return {
+        message: 'Trial activated successfully',
+        trialStarted: true,
+        ...result,
+      };
+    } catch (err: any) {
+      throw new BadRequestException(err.message || 'Failed to activate trial');
+    }
   }
 
   @Post('register-community')

--- a/packages/backend/src/license/license.module.ts
+++ b/packages/backend/src/license/license.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { LicenseService } from './license.service';
+import { LicenseGuardService } from './license-guard.service';
 import { LicenseController } from './license.controller';
 import { SettingsModule } from '../settings/settings.module';
 import { UsersModule } from '../users/users.module';
@@ -7,7 +8,7 @@ import { UsersModule } from '../users/users.module';
 @Module({
   imports: [SettingsModule, UsersModule],
   controllers: [LicenseController],
-  providers: [LicenseService],
-  exports: [LicenseService],
+  providers: [LicenseService, LicenseGuardService],
+  exports: [LicenseService, LicenseGuardService],
 })
 export class LicenseModule {}

--- a/packages/backend/src/license/license.service.ts
+++ b/packages/backend/src/license/license.service.ts
@@ -89,6 +89,63 @@ export class LicenseService implements OnModuleInit {
     }
   }
 
+  // ── Cloud Trial License ──────────────────────────────────────────────────
+
+  async requestTrialLicense(
+    email: string,
+    name: string,
+  ): Promise<{ licenseKey: string; plan: string; expiresAt: string; trialDaysLeft: number }> {
+    const instanceId = await this.getInstanceId();
+
+    try {
+      const { data } = await axios.post(
+        `${this.apiBase}/api/license/trial`,
+        { email, name, instanceId },
+        { timeout: 10000 },
+      );
+
+      // Auto-activate the trial key locally
+      await this.prisma.license.upsert({
+        where: { licenseKey: data.licenseKey },
+        update: {
+          plan: 'trial',
+          status: 'active',
+          features: data.features || undefined,
+          expiresAt: new Date(data.expiresAt),
+          lastVerifiedAt: new Date(),
+          instanceId,
+        },
+        create: {
+          licenseKey: data.licenseKey,
+          plan: 'trial',
+          status: 'active',
+          features: data.features || undefined,
+          expiresAt: new Date(data.expiresAt),
+          lastVerifiedAt: new Date(),
+          instanceId,
+        },
+      });
+
+      await this.siteSettings.set('license_key', data.licenseKey);
+
+      return {
+        licenseKey: data.licenseKey,
+        plan: data.plan,
+        expiresAt: data.expiresAt,
+        trialDaysLeft: data.trialDaysLeft,
+      };
+    } catch (err: any) {
+      if (err.response?.status === 409) {
+        throw new Error('A trial license already exists for this email.');
+      }
+      if (err.response?.status === 429) {
+        throw new Error('Too many requests. Please try again later.');
+      }
+      this.logger.warn(`Trial license request failed: ${err.message}`);
+      throw new Error('Failed to start trial. Please try again later.');
+    }
+  }
+
   // ── License Activation ─────────────────────────────────────────────────────
 
   async activateLicense(licenseKey: string): Promise<boolean> {

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -9,6 +9,7 @@ import { McpClientEngine } from '../connectors/engines/mcp-client.engine';
 import { DatabaseEngine } from '../connectors/engines/database.engine';
 import { AuditService } from '../audit/audit.service';
 import { RedisService } from '../common/redis.service';
+import { LicenseGuardService } from '../license/license-guard.service';
 import { interpolateConnectorConfig } from '../common/env-interpolation.util';
 
 /**
@@ -25,6 +26,7 @@ export class DynamicMcpTools {
     private readonly toolRegistry: ToolRegistry,
     private readonly auditService: AuditService,
     private readonly redisService: RedisService,
+    private readonly licenseGuard: LicenseGuardService,
     private readonly restEngine: RestEngine,
     private readonly graphqlEngine: GraphqlEngine,
     private readonly soapEngine: SoapEngine,
@@ -48,6 +50,23 @@ export class DynamicMcpTools {
       mcpServerName?: string;
     },
   ): Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }> {
+    // Check license before executing tool (cloud mode only)
+    try {
+      await this.licenseGuard.checkLicenseActive();
+    } catch (err: any) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: err.message || 'Your license has expired. Please purchase a license at anythingmcp.com/pricing',
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
+
     const tool = this.toolRegistry.getTool(toolName);
     if (!tool) {
       return {

--- a/packages/backend/src/mcp-server/mcp-server.module.ts
+++ b/packages/backend/src/mcp-server/mcp-server.module.ts
@@ -11,6 +11,7 @@ import { McpClientEngine } from '../connectors/engines/mcp-client.engine';
 import { DatabaseEngine } from '../connectors/engines/database.engine';
 import { OAuth2TokenService } from '../connectors/engines/oauth2-token.service';
 import { McpServersModule } from '../mcp-servers/mcp-servers.module';
+import { LicenseModule } from '../license/license.module';
 
 const ENGINES = [
   RestEngine,
@@ -21,7 +22,7 @@ const ENGINES = [
 ];
 
 @Module({
-  imports: [McpServersModule],
+  imports: [McpServersModule, LicenseModule],
   controllers: [McpEndpointController],
   providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, OAuth2TokenService, ...ENGINES],
   exports: [McpServerService, ToolRegistry],

--- a/packages/backend/src/mcp-servers/mcp-servers.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.controller.ts
@@ -15,6 +15,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional, IsBoolean, IsArray } from 'class-validator';
 import { McpServersService } from './mcp-servers.service';
+import { LicenseGuardService } from '../license/license-guard.service';
 
 class CreateMcpServerDto {
   @IsString()
@@ -58,7 +59,10 @@ class AssignConnectorsDto {
 @UseGuards(AuthGuard('jwt'))
 @Controller('api/mcp-servers')
 export class McpServersController {
-  constructor(private readonly mcpServersService: McpServersService) {}
+  constructor(
+    private readonly mcpServersService: McpServersService,
+    private readonly licenseGuard: LicenseGuardService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'List MCP servers for current user' })
@@ -69,6 +73,7 @@ export class McpServersController {
   @Post()
   @ApiOperation({ summary: 'Create a new MCP server' })
   async create(@Req() req: any, @Body() dto: CreateMcpServerDto) {
+    await this.licenseGuard.checkCanCreateMcpServer(req.user.sub);
     return this.mcpServersService.create(req.user.sub, dto);
   }
 

--- a/packages/backend/src/mcp-servers/mcp-servers.module.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { McpServersService } from './mcp-servers.service';
 import { McpServersController } from './mcp-servers.controller';
+import { LicenseModule } from '../license/license.module';
 
 @Module({
+  imports: [LicenseModule],
   providers: [McpServersService],
   controllers: [McpServersController],
   exports: [McpServersService],

--- a/packages/frontend/next-env.d.ts
+++ b/packages/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { Providers } from './providers';
+import { TrialBanner } from '@/components/trial-banner';
+import { LicenseWall } from '@/components/license-wall';
 
 export const metadata: Metadata = {
   title: 'Anything MCP',
@@ -22,7 +24,11 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <TrialBanner />
+          <LicenseWall />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import { auth, license, server } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { LogoIcon } from '@/components/nav-bar';
 
-type SetupStep = 'auth' | 'verify-email' | 'license-choice' | 'license-email-sent' | 'license-key';
+type SetupStep = 'auth' | 'verify-email' | 'license-choice' | 'license-email-sent' | 'license-key' | 'trial-activated';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -28,6 +28,8 @@ function LoginForm() {
   const [resendMessage, setResendMessage] = useState('');
   const [resendCooldown, setResendCooldown] = useState(0);
   const [registrationEnabled, setRegistrationEnabled] = useState(false);
+  const [isCloudMode, setIsCloudMode] = useState(false);
+  const [trialDaysLeft, setTrialDaysLeft] = useState(0);
   const router = useRouter();
   const searchParams = useSearchParams();
   const { login } = useAuth();
@@ -38,6 +40,7 @@ function LoginForm() {
   useEffect(() => {
     server.info().then((info) => {
       setRegistrationEnabled(info.registrationEnabled);
+      setIsCloudMode(info.deploymentMode === 'cloud');
       if (!info.hasUsers) {
         setIsRegister(true);
       }
@@ -90,7 +93,17 @@ function LoginForm() {
         setSetupStep('verify-email');
       } else {
         login(result.accessToken, result.user);
-        if (needsLicenseSetup) {
+        if (isCloudMode && needsLicenseSetup) {
+          // Cloud mode: auto-activate trial for verified users
+          setAuthToken(result.accessToken);
+          try {
+            const trialResult = await license.activateTrial(result.accessToken);
+            setTrialDaysLeft(trialResult.trialDaysLeft);
+            setSetupStep('trial-activated');
+          } catch {
+            router.push(redirectTo);
+          }
+        } else if (needsLicenseSetup) {
           setAuthToken(result.accessToken);
           setSetupStep('license-choice');
         } else {
@@ -113,7 +126,18 @@ function LoginForm() {
       // Email verified — now log in and proceed
       const verifiedUser = { ...storedUser, emailVerified: true };
       login(authToken, verifiedUser);
-      if (isFirstUserFlag) {
+
+      if (isCloudMode) {
+        // Cloud mode: auto-activate trial
+        try {
+          const trialResult = await license.activateTrial(authToken);
+          setTrialDaysLeft(trialResult.trialDaysLeft);
+          setSetupStep('trial-activated');
+        } catch (trialErr: any) {
+          // Trial may already exist (e.g. returning user) — go to dashboard
+          router.push(redirectTo);
+        }
+      } else if (isFirstUserFlag) {
         setSetupStep('license-choice');
       } else {
         router.push(redirectTo);
@@ -254,6 +278,62 @@ function LoginForm() {
               </button>
             </div>
           )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Trial Activated Step (Cloud Mode) ───────────────────────────────────
+
+  if (setupStep === 'trial-activated') {
+    return (
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="flex justify-center mb-4">
+            <LogoIcon size={56} />
+          </div>
+          <h1 className="text-2xl font-bold">Trial Activated!</h1>
+          <p className="text-[var(--muted-foreground)] mt-1 text-sm">
+            Your 7-day free trial is now active
+          </p>
+        </div>
+
+        <div className="border border-[var(--border)] rounded-lg p-6 bg-[var(--card)]">
+          <div className="text-center mb-4">
+            <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-100 dark:bg-green-900 mb-3">
+              <svg className="w-6 h-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <p className="text-sm text-[var(--muted-foreground)]">
+              You have <strong>{trialDaysLeft} days</strong> to explore AnythingMCP Cloud.
+            </p>
+          </div>
+
+          <div className="bg-[var(--background)] rounded-md p-4 mb-4">
+            <p className="text-xs font-medium text-[var(--muted-foreground)] mb-2">YOUR TRIAL INCLUDES</p>
+            <ul className="space-y-1.5 text-sm">
+              <li className="flex items-center gap-2">
+                <span className="text-green-500">&#10003;</span> Up to 2 connectors
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="text-green-500">&#10003;</span> Up to 2 MCP servers
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="text-green-500">&#10003;</span> 1 user seat
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="text-green-500">&#10003;</span> Full audit log
+              </li>
+            </ul>
+          </div>
+
+          <button
+            onClick={() => router.push(redirectTo)}
+            className="w-full bg-[var(--brand)] text-white px-4 py-2.5 rounded-md text-sm font-medium hover:brightness-90"
+          >
+            Get Started
+          </button>
         </div>
       </div>
     );

--- a/packages/frontend/src/components/license-wall.tsx
+++ b/packages/frontend/src/components/license-wall.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { license } from '@/lib/api';
+import { useAuth } from '@/lib/auth-context';
+import { LogoIcon } from '@/components/nav-bar';
+
+export function LicenseWall() {
+  const { token } = useAuth();
+  const [blocked, setBlocked] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+
+    license.getStatus().then((status) => {
+      if (!status.plan) return;
+      // Block when trial is expired
+      if (status.plan === 'trial' && status.trialDaysLeft !== undefined && status.trialDaysLeft <= 0) {
+        setBlocked(true);
+      }
+      // Block when any license is expired/revoked
+      if (status.status === 'expired' || status.status === 'revoked') {
+        setBlocked(true);
+      }
+    }).catch(() => {});
+  }, [token]);
+
+  if (!blocked) return null;
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-[var(--card)] border border-[var(--border)] rounded-lg p-8 max-w-md w-full mx-4 text-center shadow-2xl">
+        <div className="flex justify-center mb-4">
+          <LogoIcon size={48} />
+        </div>
+
+        <h1 className="text-2xl font-bold mb-2">Your Trial Has Expired</h1>
+
+        <p className="text-[var(--muted-foreground)] text-sm mb-6">
+          Your 7-day trial period has ended. Purchase a license to continue using
+          AnythingMCP Cloud. Your connectors and configurations are preserved.
+        </p>
+
+        <div className="space-y-3">
+          <a
+            href="https://anythingmcp.com/pricing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block w-full bg-[var(--brand)] text-white px-4 py-2.5 rounded-md text-sm font-medium hover:brightness-90 text-center"
+          >
+            View Plans &amp; Purchase License
+          </a>
+
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Already purchased?{' '}
+            <a
+              href="/settings/license"
+              className="text-[var(--brand)] hover:underline"
+            >
+              Enter your license key
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/trial-banner.tsx
+++ b/packages/frontend/src/components/trial-banner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { license } from '@/lib/api';
+import { useAuth } from '@/lib/auth-context';
+
+export function TrialBanner() {
+  const { token } = useAuth();
+  const [daysLeft, setDaysLeft] = useState<number | null>(null);
+  const [plan, setPlan] = useState<string | null>(null);
+
+  useEffect(() => {
+    license.getStatus().then((status) => {
+      setPlan(status.plan);
+      if (status.trialDaysLeft !== undefined) {
+        setDaysLeft(status.trialDaysLeft);
+      }
+    }).catch(() => {});
+  }, [token]);
+
+  if (plan !== 'trial' || daysLeft === null) return null;
+
+  const isUrgent = daysLeft <= 1;
+  const isWarning = daysLeft <= 3;
+
+  const bgColor = isUrgent
+    ? 'bg-red-600'
+    : isWarning
+      ? 'bg-amber-500'
+      : 'bg-blue-600';
+
+  return (
+    <div className={`${bgColor} text-white text-sm py-2 px-4 text-center`}>
+      <span>
+        {daysLeft === 0
+          ? 'Your trial expires today.'
+          : daysLeft === 1
+            ? 'Your trial expires tomorrow.'
+            : `Trial: ${daysLeft} days left.`}
+      </span>
+      {' '}
+      <a
+        href="https://anythingmcp.com/pricing"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline font-medium hover:no-underline"
+      >
+        Upgrade now
+      </a>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 // Use relative paths so requests go to the same origin.
 // In production (Docker / Railway) Next.js rewrites proxy /api/* to the backend.
-const API_BASE = '';
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 
 interface RequestOptions {
   method?: string;
@@ -202,6 +202,7 @@ export const server = {
       mcpAuthMode: string;
       serverUrl: string;
       mcpEndpoint: string;
+      deploymentMode: string;
       hasUsers: boolean;
       registrationEnabled: boolean;
       oauthEndpoints: { wellKnown: string; authorize: string; token: string; register: string } | null;
@@ -267,7 +268,12 @@ export const mcpKeys = {
 // License
 export const license = {
   getStatus: () =>
-    request<{ plan: string | null; status: string; features: any; expiresAt: string | null; lastVerifiedAt: string | null; instanceId: string | null }>('/api/license/status'),
+    request<{ plan: string | null; status: string; features: any; expiresAt: string | null; lastVerifiedAt: string | null; instanceId: string | null; trialDaysLeft?: number }>('/api/license/status'),
+  activateTrial: (token: string) =>
+    request<{ message: string; trialStarted: boolean; licenseKey: string; plan: string; expiresAt: string; trialDaysLeft: number }>('/api/license/activate-trial', {
+      method: 'POST',
+      token,
+    }),
   setKey: (licenseKey: string, token: string) =>
     request<{ message: string; license: any }>('/api/license/key', {
       method: 'PUT',


### PR DESCRIPTION
## Summary
- Introduces `DEPLOYMENT_MODE` env var (`self-hosted` | `cloud`) to support managed SaaS deployments
- Adds `DeploymentService` and `CloudModule` (conditionally loaded in cloud mode)
- Adds trial license activation endpoint (`POST /api/license/activate-trial`) with 7-day trial via the license website API
- Adds `LicenseGuardService` to enforce plan-based limits on connectors and MCP servers
- Frontend: `LicenseWall` blocks access without active license, `TrialBanner` shows remaining days, login page supports cloud trial onboarding

## Test plan
- [ ] Verify self-hosted mode is unchanged (default behavior)
- [ ] Set `DEPLOYMENT_MODE=cloud` and test trial activation flow
- [ ] Verify license guards enforce connector/MCP server limits per plan
- [ ] Test `trialDaysLeft` in license status response
- [ ] Verify `deploymentMode` appears in `/health/server-info`