### PR TITLE
Built-in adapter store with marketplace integration

### DIFF
--- a/content/guides/de/billomat-to-mcp.mdx
+++ b/content/guides/de/billomat-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "Billomat mit KI-Agenten via MCP verbinden"
+description: "Rechnungen, Kunden, Artikel und Angebote mit KI-Agenten über MCP verwalten. Billomat ist eine deutsche Online-Rechnungs- und Buchhaltungsplattform."
+category: "connectors"
+keyword: "Billomat MCP Server, Billomat API KI, Rechnungen MCP, Billomat mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Billomat Rechnungen mit KI-Agenten
+
+Billomat ist eine deutsche Online-Rechnungs- und Buchhaltungsplattform für Freelancer und KMU. Die Verbindung mit MCP ermöglicht KI-Agenten den Zugriff auf Kunden, Rechnungen, Artikel und Angebote.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den Billomat-Adapter und geben Sie Ihre Subdomain und Ihren API-Key ein.
+
+```json
+{
+  "mcpServers": {
+    "billomat": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Zeige alle überfälligen Rechnungen"**
+- **"Wie viele offene Angebote haben wir?"**
+- **"Liste alle Kunden mit ihren Rechnungsbeträgen"**
+- **"Welche Artikel haben wir im Katalog?"**

--- a/content/guides/de/bundesbank-statistics-to-mcp.mdx
+++ b/content/guides/de/bundesbank-statistics-to-mcp.mdx
@@ -1,0 +1,53 @@
+---
+title: "Deutsche Bundesbank Statistiken mit KI-Agenten via MCP nutzen"
+description: "EZB-Wechselkurse, Zinssätze und makroökonomische Daten der Bundesbank über KI-Agenten und MCP abrufen. Kostenlose öffentliche API, kein Schlüssel erforderlich."
+category: "connectors"
+keyword: "Bundesbank MCP Server, EZB Wechselkurse API KI, Bundesbank Statistik MCP, Deutsche Finanzaten MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "bundesbank"
+---
+
+## Bundesbank-Statistiken mit KI-Agenten
+
+Die Deutsche Bundesbank bietet freien Zugang zu makroökonomischen Daten, Wechselkursen, Zinssätzen und Finanzstatistiken über die SDMX REST API. Kein API-Schlüssel erforderlich — sofort verbinden und abfragen.
+
+## Schnelleinrichtung mit integriertem Adapter
+
+### Schritt 1: AnythingMCP bereitstellen
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Schritt 2: Bundesbank-Adapter importieren
+
+Öffnen Sie `http://localhost:3000/connectors/store` und klicken Sie auf **Import** beim Deutsche Bundesbank Statistics Adapter. Da es sich um eine kostenlose öffentliche API handelt, sind keine Zugangsdaten erforderlich.
+
+### Schritt 3: Mit KI-Agent verbinden
+
+```json
+{
+  "mcpServers": {
+    "bundesbank": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Verfügbare Tools
+
+| Tool | Beschreibung |
+|------|-------------|
+| `bundesbank_get_exchange_rates` | Aktuelle und historische Euro-Wechselkurse abrufen |
+| `bundesbank_get_interest_rates` | EZB-Leitzinsen abrufen (Hauptrefinanzierungssatz, Einlagefazilität) |
+| `bundesbank_search_statistics` | Verfügbare Statistikreihen nach Stichwort suchen |
+| `bundesbank_get_timeseries` | Daten einer bestimmten Zeitreihe nach ID abrufen |
+
+## KI-Anwendungsfälle
+
+- **"Wie ist der aktuelle EUR/USD-Wechselkurs?"**
+- **"Zeige mir die EZB-Zinsentwicklung der letzten 5 Jahre"**
+- **"Was war der EUR/GBP-Kurs am 15. Januar 2025?"**
+- **"Suche nach Geldmengenstatistiken"**

--- a/content/guides/de/connect-billomat-to-chatgpt.mdx
+++ b/content/guides/de/connect-billomat-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "Billomat mit ChatGPT verbinden — KI-gestützte Buchhaltung"
+description: "Billomat mit ChatGPT über MCP verbinden. Rechnungen, Kunden und Angebote per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "Billomat ChatGPT, Billomat KI, Billomat mit ChatGPT nutzen, Billomat MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Billomat mit ChatGPT verbinden
+
+Mit AnythingMCP können Sie Billomat-Daten als MCP-Tools für ChatGPT bereitstellen — Rechnungen, Kunden und Angebote per natürlicher Sprache verwalten.
+
+### Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importieren Sie den **Billomat**-Adapter, geben Sie Ihre Subdomain und Ihren API-Key ein, und verbinden Sie ChatGPT.
+
+### KI-Anwendungsfälle
+
+- **"Zeige alle überfälligen Rechnungen"**
+- **"Wie viele offene Angebote haben wir?"**
+- **"Rechnungsdetails für Rechnung #2024-0042"**

--- a/content/guides/de/connect-billomat-to-claude.mdx
+++ b/content/guides/de/connect-billomat-to-claude.mdx
@@ -1,0 +1,36 @@
+---
+title: "Billomat mit Claude verbinden — KI-gestützte Buchhaltung"
+description: "Billomat mit Claude AI über MCP verbinden. Kunden, Rechnungen, Artikel und Angebote per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "Billomat Claude, Billomat KI, Billomat mit Claude nutzen, Billomat MCP Server"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Billomat mit Claude verbinden
+
+Billomat ist eine deutsche Online-Rechnungsplattform für Freelancer und KMU. Mit AnythingMCP verbinden Sie Billomat direkt mit Claude.
+
+### Was Sie fragen können
+
+- **"Zeige alle überfälligen Rechnungen"**
+- **"Kundendetails für Müller GmbH"**
+- **"Wie viele offene Angebote haben wir?"**
+- **"Welche Artikel sind im Katalog?"**
+
+### Einrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importieren Sie den **Billomat**-Adapter, geben Sie Ihre Subdomain und Ihren API-Key ein, und verbinden Sie Claude.
+
+```json
+{
+  "mcpServers": {
+    "billomat": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```

--- a/content/guides/de/connect-datev-to-chatgpt.mdx
+++ b/content/guides/de/connect-datev-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "DATEV mit ChatGPT verbinden — KI für deutsche Buchhaltung"
+description: "DATEV mit ChatGPT über MCP verbinden. Mandanten und Belege per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "DATEV ChatGPT, DATEV KI, DATEV mit ChatGPT nutzen, DATEV MCP ChatGPT, Steuerberater ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## DATEV mit ChatGPT verbinden
+
+Mit AnythingMCP können Sie DATEV-Daten als MCP-Tools für ChatGPT bereitstellen — Mandanten, Belege und Lohndaten per natürlicher Sprache verwalten.
+
+### Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importieren Sie den **DATEV**-Adapter, konfigurieren Sie Ihre OAuth 2.0 Zugangsdaten und verbinden Sie ChatGPT.
+
+### KI-Anwendungsfälle
+
+- **"Liste meine DATEV-Mandanten"**
+- **"Welche Belege wurden diesen Monat hochgeladen?"**
+- **"Lade diese Rechnung in DATEV hoch"**

--- a/content/guides/de/connect-datev-to-claude.mdx
+++ b/content/guides/de/connect-datev-to-claude.mdx
@@ -1,0 +1,35 @@
+---
+title: "DATEV mit Claude verbinden — KI für deutsche Buchhaltung"
+description: "DATEV mit Claude AI über MCP verbinden. Mandanten, Belege und Lohndaten per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "DATEV Claude, DATEV KI, DATEV mit Claude nutzen, DATEV MCP Server, Steuerberater Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## DATEV mit Claude verbinden
+
+DATEV ist das Rückgrat der deutschen Buchhaltung. Mit AnythingMCP verbinden Sie DATEV direkt mit Claude — der erste DATEV MCP Server überhaupt.
+
+### Was Sie fragen können
+
+- **"Liste alle meine DATEV-Mandanten"**
+- **"Zeige Belege dieses Monats für Mandant Müller"**
+- **"Lade diese Rechnung in DATEV Belege online hoch"**
+
+### Einrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Registrieren Sie sich im [DATEV Developer Portal](https://developer.datev.de), importieren Sie den DATEV-Adapter und geben Sie Ihre OAuth 2.0 Zugangsdaten ein.
+
+```json
+{
+  "mcpServers": {
+    "datev": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```

--- a/content/guides/de/connect-fastbill-to-chatgpt.mdx
+++ b/content/guides/de/connect-fastbill-to-chatgpt.mdx
@@ -1,0 +1,29 @@
+---
+title: "FastBill mit ChatGPT verbinden — KI-gestützte Rechnungsstellung"
+description: "FastBill mit ChatGPT über MCP verbinden. Kunden, Rechnungen und Ausgaben per natürlicher Sprache abfragen."
+category: "connectors"
+keyword: "FastBill ChatGPT, FastBill KI, FastBill mit ChatGPT nutzen, FastBill MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## FastBill mit ChatGPT verbinden
+
+Mit AnythingMCP können Sie FastBill-Daten als MCP-Tools für ChatGPT bereitstellen — Rechnungen, Kunden und Ausgaben per natürlicher Sprache verwalten.
+
+### Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Importieren Sie den **FastBill**-Adapter im Adapter Store
+2. Geben Sie Ihre FastBill-E-Mail und Ihren API-Key ein
+3. Verbinden Sie ChatGPT mit Ihrem MCP-Server
+
+### KI-Anwendungsfälle
+
+- **"Zeige alle unbezahlten Rechnungen dieses Monats"**
+- **"Wie viel Umsatz habe ich in Q1 gemacht?"**
+- **"Welche Kunden haben die meisten offenen Rechnungen?"**

--- a/content/guides/de/connect-fastbill-to-claude.mdx
+++ b/content/guides/de/connect-fastbill-to-claude.mdx
@@ -1,0 +1,41 @@
+---
+title: "FastBill mit Claude verbinden — KI-gestützte Rechnungsstellung"
+description: "FastBill mit Claude AI über MCP verbinden. Kunden, Rechnungen und Ausgaben per natürlicher Sprache abfragen. Schritt-für-Schritt-Anleitung."
+category: "connectors"
+keyword: "FastBill Claude, FastBill KI, FastBill mit Claude nutzen, FastBill MCP Server"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## FastBill mit Claude verbinden
+
+FastBill ist eines der beliebtesten Rechnungstools für Freelancer und Kleinunternehmen in Deutschland. Mit AnythingMCP verbinden Sie FastBill direkt mit Claude.
+
+### Was Sie fragen können
+
+- **"Zeige alle unbezahlten Rechnungen dieses Quartals"**
+- **"Wie viel Umsatz hat Kunde Müller GmbH letztes Jahr gemacht?"**
+- **"Was sind meine Gesamtausgaben für März?"**
+- **"Liste die Top 10 Kunden nach Rechnungsvolumen"**
+
+### Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Öffnen Sie `http://localhost:3000/connectors/store`
+2. Importieren Sie den **FastBill**-Adapter
+3. Geben Sie Ihre FastBill-E-Mail und Ihren API-Key ein
+4. Weisen Sie den Connector einem MCP-Server zu
+
+### Claude verbinden
+
+```json
+{
+  "mcpServers": {
+    "fastbill": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```

--- a/content/guides/de/connect-kenjo-to-chatgpt.mdx
+++ b/content/guides/de/connect-kenjo-to-chatgpt.mdx
@@ -1,0 +1,18 @@
+---
+title: "Kenjo HR mit ChatGPT verbinden — KI für Personalwesen"
+description: "Kenjo HR mit ChatGPT über MCP verbinden. Mitarbeiter und Recruiting per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "Kenjo ChatGPT, Kenjo HR KI, Kenjo mit ChatGPT nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Kenjo mit ChatGPT verbinden
+
+Importieren Sie den **Kenjo**-Adapter, geben Sie Ihren API-Key ein, und verbinden Sie ChatGPT.
+
+### KI-Anwendungsfälle
+
+- **"Mitarbeiter pro Abteilung"**
+- **"Offene Recruiting-Positionen"**
+- **"Teams und ihre Mitglieder"**

--- a/content/guides/de/connect-kenjo-to-claude.mdx
+++ b/content/guides/de/connect-kenjo-to-claude.mdx
@@ -1,0 +1,18 @@
+---
+title: "Kenjo HR mit Claude verbinden — KI für Personalwesen"
+description: "Kenjo HR mit Claude AI über MCP verbinden. Mitarbeiter und Recruiting per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "Kenjo Claude, Kenjo HR KI, Kenjo mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Kenjo mit Claude verbinden
+
+Importieren Sie den **Kenjo**-Adapter, geben Sie Ihren API-Key ein, und verbinden Sie Claude.
+
+### KI-Anwendungsfälle
+
+- **"Wie viele Mitarbeiter pro Abteilung?"**
+- **"Offene Stellen im Engineering"**
+- **"Alle Bürostandorte anzeigen"**

--- a/content/guides/de/connect-mfr-to-chatgpt.mdx
+++ b/content/guides/de/connect-mfr-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "MFR Mobile Field Report mit ChatGPT verbinden — KI für den Außendienst"
+description: "MFR Außendienst-Software mit ChatGPT über MCP verbinden. Serviceaufträge und Techniker per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "MFR ChatGPT, Mobile Field Report ChatGPT, MFR mit ChatGPT nutzen, Außendienst ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## MFR mit ChatGPT verbinden
+
+Mit AnythingMCP können Sie MFR-Daten als MCP-Tools für ChatGPT bereitstellen — Serviceaufträge, Termine und Techniker per natürlicher Sprache verwalten.
+
+### Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importieren Sie den **MFR**-Adapter, geben Sie Ihre Zugangsdaten ein, und verbinden Sie ChatGPT.
+
+### KI-Anwendungsfälle
+
+- **"Zeige alle offenen Serviceaufträge"**
+- **"Welcher Techniker ist morgen verfügbar?"**
+- **"Arbeitszeiteinträge der letzten Woche"**

--- a/content/guides/de/connect-mfr-to-claude.mdx
+++ b/content/guides/de/connect-mfr-to-claude.mdx
@@ -1,0 +1,36 @@
+---
+title: "MFR Mobile Field Report mit Claude verbinden — KI für den Außendienst"
+description: "MFR Außendienst-Software mit Claude AI über MCP verbinden. Serviceaufträge, Termine und Techniker per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "MFR Claude, Mobile Field Report KI, MFR mit Claude nutzen, Außendienst MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## MFR mit Claude verbinden
+
+Mobile Field Report (MFR) ist eine deutsche Plattform für das Field-Service-Management. Mit AnythingMCP verbinden Sie MFR direkt mit Claude.
+
+### Was Sie fragen können
+
+- **"Zeige alle offenen Serviceaufträge dieser Woche"**
+- **"Welcher Techniker hat heute die meisten Termine?"**
+- **"Serviceobjekte der Firma Müller GmbH"**
+- **"Wie viele Stunden hat das Team letzten Monat gearbeitet?"**
+
+### Einrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importieren Sie den **MFR**-Adapter, geben Sie Ihren Benutzernamen und Ihr Passwort ein, und verbinden Sie Claude.
+
+```json
+{
+  "mcpServers": {
+    "mfr": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```

--- a/content/guides/de/connect-scopevisio-to-chatgpt.mdx
+++ b/content/guides/de/connect-scopevisio-to-chatgpt.mdx
@@ -1,0 +1,22 @@
+---
+title: "ScopeVisio mit ChatGPT verbinden — KI für Cloud ERP"
+description: "ScopeVisio mit ChatGPT über MCP verbinden. Kontakte und Rechnungen per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "ScopeVisio ChatGPT, ScopeVisio KI, ScopeVisio mit ChatGPT nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## ScopeVisio mit ChatGPT verbinden
+
+Mit AnythingMCP können Sie ScopeVisio-Daten als MCP-Tools für ChatGPT bereitstellen.
+
+### Schnelleinrichtung
+
+Importieren Sie den **ScopeVisio**-Adapter, geben Sie Ihren Bearer Token ein, und verbinden Sie ChatGPT.
+
+### KI-Anwendungsfälle
+
+- **"Zeige überfällige Rechnungen"**
+- **"Aktive Projekte mit Budget"**
+- **"Kontakte nach Firmenname suchen"**

--- a/content/guides/de/connect-scopevisio-to-claude.mdx
+++ b/content/guides/de/connect-scopevisio-to-claude.mdx
@@ -1,0 +1,22 @@
+---
+title: "ScopeVisio mit Claude verbinden — KI für Cloud ERP"
+description: "ScopeVisio mit Claude AI über MCP verbinden. Kontakte, Rechnungen und Projekte per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "ScopeVisio Claude, ScopeVisio KI, ScopeVisio mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## ScopeVisio mit Claude verbinden
+
+ScopeVisio ist eine deutsche Cloud-ERP-Plattform. Mit AnythingMCP verbinden Sie ScopeVisio direkt mit Claude.
+
+### Einrichtung
+
+Importieren Sie den **ScopeVisio**-Adapter, geben Sie Ihren Bearer Token ein, und verbinden Sie Claude.
+
+### KI-Anwendungsfälle
+
+- **"Zeige alle Kontakte vom Typ Kunde"**
+- **"Ausgangsrechnungen dieses Quartals"**
+- **"Welche Projekte liegen hinter dem Zeitplan?"**

--- a/content/guides/de/datev-to-mcp.mdx
+++ b/content/guides/de/datev-to-mcp.mdx
@@ -1,0 +1,38 @@
+---
+title: "DATEV mit KI-Agenten via MCP verbinden — KI für die Buchhaltung"
+description: "DATEV Buchhaltung über MCP mit KI-Agenten verbinden. Mandanten, Belege und Lohndaten per natürlicher Sprache abrufen. Der erste DATEV MCP Server."
+category: "connectors"
+keyword: "DATEV MCP Server, DATEV KI, DATEV mit Claude, DATEV ChatGPT, DATEV Schnittstelle KI, Steuerberater KI"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## DATEV mit KI-Agenten verbinden
+
+DATEV ist die dominierende Buchhaltungs- und Steuersoftware in Deutschland — genutzt von fast jedem Steuerberater und Tausenden von Unternehmen. Trotz seiner Marktdominanz gab es bisher keinen MCP-Server für DATEV.
+
+Mit AnythingMCP verbinden Sie die offiziellen DATEV Online APIs mit jedem MCP-kompatiblen KI-Agenten (Claude, ChatGPT, Gemini usw.).
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Registrieren Sie sich im [DATEV Developer Portal](https://developer.datev.de), erstellen Sie eine Anwendung und importieren Sie den DATEV-Adapter.
+
+## Verfügbare Tools
+
+| Tool | Beschreibung |
+|------|-------------|
+| `datev_list_clients` | Mandanten auflisten |
+| `datev_list_documents` | Belege eines Mandanten auflisten |
+| `datev_get_document` | Belegdetails per GUID abrufen |
+| `datev_upload_document` | Rechnungen/Belege in DATEV Belege online hochladen |
+
+## KI-Anwendungsfälle
+
+- **"Liste alle meine DATEV-Mandanten"**
+- **"Zeige die Belege dieses Monats für Mandant Müller"**
+- **"Lade diese Rechnung in DATEV Belege online hoch"**

--- a/content/guides/de/destatis-genesis-to-mcp.mdx
+++ b/content/guides/de/destatis-genesis-to-mcp.mdx
@@ -1,0 +1,46 @@
+---
+title: "Destatis GENESIS Statistiken mit KI-Agenten via MCP nutzen"
+description: "Offizielle deutsche Bundesstatistiken vom Statistischen Bundesamt über KI-Agenten und MCP abrufen. Bevölkerung, Wirtschaft, Handel, Arbeitsmarkt."
+category: "connectors"
+keyword: "Destatis MCP Server, GENESIS API KI, Statistisches Bundesamt MCP, deutsche Statistiken KI"
+publishedAt: "2026-03-15"
+adapterSlug: "destatis-genesis"
+---
+
+## Destatis GENESIS Statistiken mit KI-Agenten
+
+Das Statistische Bundesamt (Destatis) bietet über die GENESIS-API Zugang zu offiziellen Daten zu Bevölkerung, Wirtschaft, Handel, Arbeitsmarkt und Preisen.
+
+## Schnelleinrichtung
+
+### Schritt 1: AnythingMCP bereitstellen
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Schritt 2: Destatis-Adapter importieren
+
+Öffnen Sie `http://localhost:3000/connectors/store` und klicken Sie auf **Import**. Geben Sie Ihren GENESIS-Benutzernamen und Passwort ein.
+
+### Schritt 3: GENESIS-Zugangsdaten erhalten
+
+Registrieren Sie sich kostenlos auf [www-genesis.destatis.de](https://www-genesis.destatis.de/).
+
+### Schritt 4: Mit KI-Agent verbinden
+
+```json
+{
+  "mcpServers": {
+    "destatis": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Wie viele Einwohner hat Deutschland aktuell?"**
+- **"Zeige das BIP-Wachstum der letzten 10 Jahre"**
+- **"Wie hoch ist die Arbeitslosenquote in Bayern?"**
+- **"Suche nach Verbraucherpreisindex-Daten"**

--- a/content/guides/de/dhl-tracking-to-mcp.mdx
+++ b/content/guides/de/dhl-tracking-to-mcp.mdx
@@ -1,0 +1,57 @@
+---
+title: "DHL Sendungsverfolgung mit KI-Agenten via MCP verbinden"
+description: "DHL Pakete mit KI-Agenten tracken via MCP. Der integrierte DHL-Adapter in AnythingMCP ermöglicht sofortige Einrichtung ohne Programmierung."
+category: "connectors"
+keyword: "DHL MCP Server, DHL Sendungsverfolgung KI, DHL mit Claude nutzen, DHL API Integration"
+publishedAt: "2026-03-15"
+adapterSlug: "dhl-tracking"
+---
+
+## DHL Sendungsverfolgung mit KI-Agenten
+
+DHL ist das weltweit größte Logistikunternehmen. Durch die Verbindung der DHL Unified Tracking API mit MCP können Ihre KI-Agenten Sendungen verfolgen, den Lieferstatus überwachen und Echtzeit-Logistikupdates bereitstellen.
+
+## Schnelleinrichtung mit integriertem Adapter
+
+AnythingMCP enthält einen vorkonfigurierten DHL-Adapter. Keine manuelle API-Konfiguration erforderlich.
+
+### Schritt 1: AnythingMCP bereitstellen
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Schritt 2: DHL-Adapter importieren
+
+Öffnen Sie das AnythingMCP-Dashboard unter `http://localhost:3000/connectors/store` und klicken Sie auf **Import** beim DHL Shipment Tracking Adapter. Geben Sie Ihren DHL API-Schlüssel ein.
+
+### Schritt 3: DHL API-Schlüssel erhalten
+
+Registrieren Sie sich beim [DHL Developer Portal](https://developer.dhl.com/) und erstellen Sie eine Anwendung für die Unified Tracking API.
+
+### Schritt 4: Mit KI-Agent verbinden
+
+```json
+{
+  "mcpServers": {
+    "dhl": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Verfügbare Tools
+
+| Tool | Beschreibung |
+|------|-------------|
+| `dhl_track_shipment` | Einzelne Sendung per Trackingnummer verfolgen |
+| `dhl_track_multiple` | Mehrere Sendungen gleichzeitig verfolgen (bis zu 20) |
+
+## KI-Anwendungsfälle
+
+- **"Verfolge mein DHL-Paket 1234567890"**
+- **"Was ist der Lieferstatus dieser 5 Pakete?"**
+- **"Wann kommt mein Paket an?"**
+- **"Zeige alle Zustellereignisse für Sendungsnummer XYZ"**

--- a/content/guides/de/fastbill-to-mcp.mdx
+++ b/content/guides/de/fastbill-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "FastBill mit KI-Agenten via MCP verbinden"
+description: "Rechnungen, Kunden und Ausgaben mit KI-Agenten über MCP verwalten. FastBill ist ein beliebtes Rechnungstool für deutsche Freelancer und Kleinunternehmen."
+category: "connectors"
+keyword: "FastBill MCP Server, FastBill API KI, Rechnungen MCP, FastBill mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## FastBill Rechnungen mit KI-Agenten
+
+FastBill ist eine beliebte Rechnungs- und Buchhaltungsplattform für deutsche Freelancer und Kleinunternehmen. Die Verbindung mit MCP ermöglicht KI-Agenten den Zugriff auf Kunden, Rechnungen, Ausgaben und Umsatzdaten.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den FastBill-Adapter und geben Sie Ihre E-Mail und Ihren API-Key ein.
+
+```json
+{
+  "mcpServers": {
+    "fastbill": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Zeige alle unbezahlten Rechnungen dieses Monats"**
+- **"Wie viel Umsatz habe ich in Q1 gemacht?"**
+- **"Liste alle Kunden aus München"**
+- **"Was sind meine Gesamtausgaben für März 2026?"**

--- a/content/guides/de/immobilienscout24-to-mcp.mdx
+++ b/content/guides/de/immobilienscout24-to-mcp.mdx
@@ -1,0 +1,35 @@
+---
+title: "ImmobilienScout24 mit KI-Agenten via MCP verbinden"
+description: "Immobilien auf ImmobilienScout24 über KI-Agenten und MCP suchen und durchstöbern. Wohnungen, Häuser und Gewerbeimmobilien in Deutschland finden."
+category: "connectors"
+keyword: "ImmobilienScout24 MCP Server, IS24 API KI, Immobilien MCP, Immobiliensuche mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "immobilienscout24"
+---
+
+## ImmobilienScout24 mit KI-Agenten
+
+ImmobilienScout24 ist Deutschlands größtes Immobilienportal. Die Verbindung der API mit MCP ermöglicht KI-Agenten die Immobiliensuche und detaillierte Objektinformationen.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den ImmobilienScout24-Adapter und geben Sie Ihre OAuth Client ID und Client Secret ein.
+
+```json
+{
+  "mcpServers": {
+    "is24": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Finde 3-Zimmer-Wohnungen zur Miete in Berlin Mitte unter 1.500 €"**
+- **"Zeige Häuser zum Kauf in München mit Garten"**
+- **"Was ist die durchschnittliche Miete für Wohnungen in Hamburg?"**

--- a/content/guides/de/kenjo-to-mcp.mdx
+++ b/content/guides/de/kenjo-to-mcp.mdx
@@ -1,0 +1,22 @@
+---
+title: "Kenjo HR mit KI-Agenten via MCP verbinden"
+description: "Kenjo HR über MCP mit KI-Agenten verbinden. Mitarbeiter, Abteilungen und Recruiting per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "Kenjo MCP Server, Kenjo HR KI, Kenjo mit Claude nutzen, HR MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Kenjo HR mit KI-Agenten verbinden
+
+Kenjo ist eine deutsche HR-Plattform. Mit AnythingMCP verbinden Sie die API mit KI-Agenten.
+
+### Einrichtung
+
+Importieren Sie den **Kenjo**-Adapter und geben Sie Ihren API-Key ein (Einstellungen → Integrationen → API in Kenjo).
+
+### KI-Anwendungsfälle
+
+- **"Wie viele Mitarbeiter pro Abteilung?"**
+- **"Liste offene Recruiting-Positionen"**
+- **"Zeige Mitarbeiterdetails für Max Mustermann"**

--- a/content/guides/de/mfr-fieldservice-to-mcp.mdx
+++ b/content/guides/de/mfr-fieldservice-to-mcp.mdx
@@ -1,0 +1,37 @@
+---
+title: "MFR Mobile Field Report mit KI-Agenten via MCP verbinden"
+description: "Serviceeinsätze mit KI-Agenten über MCP verwalten. Serviceaufträge, Termine, Techniker und Checklisten von Mobile Field Report abrufen."
+category: "connectors"
+keyword: "MFR MCP Server, Mobile Field Report API KI, Außendienst MCP, MFR mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## MFR Mobile Field Report mit KI-Agenten
+
+Mobile Field Report (MFR) ist eine deutsche Plattform für das Field-Service-Management. Die Verbindung der OData-API mit MCP ermöglicht KI-Agenten den Zugriff auf Serviceaufträge, Termine, Checklisten und Zeiterfassung.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den MFR-Adapter und geben Sie Ihren Benutzernamen und Ihr Passwort ein.
+
+```json
+{
+  "mcpServers": {
+    "mfr": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Zeige alle offenen Serviceaufträge dieser Woche"**
+- **"Welcher Techniker hat heute die meisten Termine?"**
+- **"Liste alle Serviceobjekte der Firma Müller GmbH"**
+- **"Welche Checklisten-Schritte sind bei Auftrag SR-12345 noch offen?"**
+- **"Wie viele Stunden hat Techniker Max letzten Monat gearbeitet?"**

--- a/content/guides/de/n26-openbanking-to-mcp.mdx
+++ b/content/guides/de/n26-openbanking-to-mcp.mdx
@@ -1,0 +1,35 @@
+---
+title: "N26 Open Banking mit KI-Agenten via MCP nutzen"
+description: "N26 Kontodaten über KI-Agenten und MCP via PSD2 Open Banking API abrufen. Kontostände, Transaktionen und Kontodetails."
+category: "connectors"
+keyword: "N26 MCP Server, N26 Open Banking KI, PSD2 MCP Integration, N26 mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "n26-openbanking"
+---
+
+## N26 Open Banking mit KI-Agenten
+
+N26 ist eine führende europäische Neobank. Über die PSD2 Open Banking API können KI-Agenten auf Kontoinformationen, Salden und Transaktionshistorie zugreifen.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den N26-Adapter und geben Sie Ihre OAuth Client ID und Client Secret ein.
+
+```json
+{
+  "mcpServers": {
+    "n26": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Wie ist mein aktueller N26-Kontostand?"**
+- **"Zeige meine Transaktionen der letzten Woche"**
+- **"Liste alle verknüpften Konten auf"**

--- a/content/guides/de/nina-warnings-to-mcp.mdx
+++ b/content/guides/de/nina-warnings-to-mcp.mdx
@@ -1,0 +1,41 @@
+---
+title: "NINA Warnungen mit KI-Agenten via MCP nutzen"
+description: "Offizielle deutsche Katastrophenwarnungen und Notfallmeldungen über KI-Agenten und MCP abrufen. Hochwasser, Stürme, Brände in Echtzeit."
+category: "connectors"
+keyword: "NINA MCP Server, BBK Warnungen KI, Katastrophenwarnungen MCP, NINA Warn-App API"
+publishedAt: "2026-03-15"
+adapterSlug: "nina-warnung"
+---
+
+## NINA Katastrophenwarnungen mit KI-Agenten
+
+NINA (Notfall-Informations- und Nachrichten-App) ist das offizielle Warnsystem des BBK. Die API bietet Echtzeit-Zugang zu Warnungen über Hochwasser, Stürme, Brände und andere Notfälle. Kein API-Schlüssel erforderlich.
+
+## Schnelleinrichtung
+
+### Schritt 1: AnythingMCP bereitstellen
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Schritt 2: NINA-Adapter importieren
+
+Öffnen Sie `http://localhost:3000/connectors/store` und klicken Sie auf **Import**. Keine Zugangsdaten erforderlich.
+
+### Schritt 3: Mit KI-Agent verbinden
+
+```json
+{
+  "mcpServers": {
+    "nina": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Gibt es aktuelle Hochwasserwarnungen in Berlin?"**
+- **"Zeige alle aktuellen Warnmeldungen in Deutschland"**
+- **"Gibt es Sturmwarnungen für Hamburg heute?"**

--- a/content/guides/de/payone-payments-to-mcp.mdx
+++ b/content/guides/de/payone-payments-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "PAYONE Zahlungen mit KI-Agenten via MCP verwalten"
+description: "E-Commerce-Zahlungen über KI-Agenten und MCP verarbeiten. Transaktionen auflisten, Zahlungen erfassen und Rückerstattungen über die PAYONE API."
+category: "connectors"
+keyword: "PAYONE MCP Server, PAYONE API KI, Zahlungsabwicklung MCP, PAYONE mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "payone"
+---
+
+## PAYONE Zahlungen mit KI-Agenten
+
+PAYONE ist ein führender europäischer Zahlungsdienstleister. Die Verbindung mit MCP ermöglicht KI-Agenten die Überwachung von Transaktionen, Zahlungserfassung und Rückerstattungen.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den PAYONE-Adapter und geben Sie Merchant ID, API Key, Portal ID und Account ID ein.
+
+```json
+{
+  "mcpServers": {
+    "payone": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Zeige alle Transaktionen von heute"**
+- **"Was ist der Status der Transaktion XYZ?"**
+- **"Erfasse die ausstehende Zahlung für Bestellung 12345"**
+- **"Erstatte die letzte Transaktion für Kunde Müller"**

--- a/content/guides/de/scopevisio-to-mcp.mdx
+++ b/content/guides/de/scopevisio-to-mcp.mdx
@@ -1,0 +1,27 @@
+---
+title: "ScopeVisio mit KI-Agenten via MCP verbinden"
+description: "ScopeVisio Cloud ERP über MCP mit KI-Agenten verbinden. Kontakte, Rechnungen und Projekte per natürlicher Sprache verwalten."
+category: "connectors"
+keyword: "ScopeVisio MCP Server, ScopeVisio KI, ScopeVisio mit Claude nutzen, ScopeVisio API"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## ScopeVisio mit KI-Agenten verbinden
+
+ScopeVisio ist eine deutsche Cloud-ERP- und CRM-Plattform. Mit AnythingMCP verbinden Sie die REST API mit jedem MCP-kompatiblen KI-Agenten.
+
+### Einrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importieren Sie den **ScopeVisio**-Adapter und geben Sie Ihren Bearer Token ein.
+
+### KI-Anwendungsfälle
+
+- **"Zeige alle überfälligen Ausgangsrechnungen"**
+- **"Liste Kontakte nach Firmenname"**
+- **"Welche Projekte sind aktuell aktiv?"**

--- a/content/guides/de/teamviewer-to-mcp.mdx
+++ b/content/guides/de/teamviewer-to-mcp.mdx
@@ -1,0 +1,45 @@
+---
+title: "TeamViewer mit KI-Agenten via MCP verbinden"
+description: "TeamViewer-Geräte, Kontakte und Remote-Sitzungen über KI-Agenten und MCP verwalten. Gerätestatus überwachen und Support-Sitzungen erstellen."
+category: "connectors"
+keyword: "TeamViewer MCP Server, TeamViewer API KI, Fernzugriff MCP, TeamViewer mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "teamviewer"
+---
+
+## TeamViewer mit KI-Agenten
+
+TeamViewer ist eine führende Plattform für Fernzugriff und Support. Die Verbindung der Web API mit MCP ermöglicht KI-Agenten die Verwaltung von Geräten und Remote-Support-Sitzungen.
+
+## Schnelleinrichtung
+
+### Schritt 1: AnythingMCP bereitstellen
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Schritt 2: TeamViewer-Adapter importieren
+
+Öffnen Sie `http://localhost:3000/connectors/store` und klicken Sie auf **Import**. Geben Sie Ihren TeamViewer Access Token ein.
+
+### Schritt 3: Access Token generieren
+
+Erstellen Sie einen Script Token in der TeamViewer Management Console unter **Profil > Apps > Script Token erstellen**.
+
+### Schritt 4: Mit KI-Agent verbinden
+
+```json
+{
+  "mcpServers": {
+    "teamviewer": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Welche meiner Geräte sind gerade online?"**
+- **"Zeige mir die Details von Gerät XYZ"**
+- **"Liste alle aktiven Remote-Support-Sitzungen"**

--- a/content/guides/de/weclapp-erp-to-mcp.mdx
+++ b/content/guides/de/weclapp-erp-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "weclapp Cloud ERP mit KI-Agenten via MCP verbinden"
+description: "weclapp ERP-Daten wie Kunden, Bestellungen, Rechnungen und Artikel über KI-Agenten und MCP abrufen. Beliebtes Cloud-ERP für deutsche KMU."
+category: "connectors"
+keyword: "weclapp MCP Server, weclapp API KI, Cloud ERP MCP, weclapp mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "weclapp"
+---
+
+## weclapp Cloud ERP mit KI-Agenten
+
+weclapp ist eine beliebte Cloud-ERP-Lösung für deutsche KMU. Die Verbindung mit MCP ermöglicht KI-Agenten Zugriff auf Kunden, Bestellungen, Rechnungen und Lagerbestandsdaten.
+
+## Schnelleinrichtung
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffnen Sie `http://localhost:3000/connectors/store`, importieren Sie den weclapp-Adapter und geben Sie Ihren Tenant-Namen und API-Token ein.
+
+```json
+{
+  "mcpServers": {
+    "weclapp": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## KI-Anwendungsfälle
+
+- **"Zeige alle offenen Bestellungen dieses Monats"**
+- **"Wie ist der aktuelle Bestand für Artikel ABC?"**
+- **"Liste alle unbezahlten Rechnungen über 1.000 €"**
+- **"Wie viele Kunden haben wir in München?"**

--- a/content/guides/en/billomat-to-mcp.mdx
+++ b/content/guides/en/billomat-to-mcp.mdx
@@ -1,0 +1,47 @@
+---
+title: "How to Connect Billomat to MCP for AI Agents"
+description: "Manage invoices, clients, articles, and offers with AI agents via MCP. Billomat is a German online invoicing and accounting platform."
+category: "connectors"
+keyword: "Billomat MCP Server, Billomat API AI, invoicing MCP, Billomat mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Billomat Invoicing with AI Agents
+
+Billomat is a German online invoicing and accounting platform for freelancers and SMBs. By connecting its REST API to MCP, AI agents can manage clients, create and track invoices, view articles, and handle offers.
+
+## Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, import the Billomat adapter, and enter your Billomat subdomain and API key.
+
+```json
+{
+  "mcpServers": {
+    "billomat": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `billomat_list_clients` | List clients with name filtering |
+| `billomat_get_client` | Get detailed client information |
+| `billomat_list_invoices` | List invoices filtered by client or status |
+| `billomat_get_invoice` | Get full invoice details with line items |
+| `billomat_list_articles` | List products and services |
+| `billomat_list_offers` | List quotes/offers by client |
+
+## Use Cases
+
+- **"Show all overdue invoices"**
+- **"How many open offers do we have?"**
+- **"List all clients and their total invoice amounts"**
+- **"What articles do we have in the catalog?"**

--- a/content/guides/en/bundesbank-statistics-to-mcp.mdx
+++ b/content/guides/en/bundesbank-statistics-to-mcp.mdx
@@ -1,0 +1,53 @@
+---
+title: "How to Connect Deutsche Bundesbank Statistics to MCP"
+description: "Access ECB exchange rates, interest rates, and macroeconomic data from the Bundesbank via AI agents and MCP. Free public API, no key required."
+category: "connectors"
+keyword: "Bundesbank MCP Server, ECB exchange rates API, Bundesbank statistics AI, German financial data MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "bundesbank"
+---
+
+## Bundesbank Statistics with AI Agents
+
+The Deutsche Bundesbank provides free access to macroeconomic data, exchange rates, interest rates, and financial statistics via the SDMX REST API. No API key required — connect and start querying immediately.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the Bundesbank Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the Deutsche Bundesbank Statistics adapter. Since this is a free public API, no credentials are needed — the connector is ready immediately.
+
+### Step 3: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "bundesbank": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `bundesbank_get_exchange_rates` | Get current and historical euro exchange rates (USD, GBP, CHF, JPY, etc.) |
+| `bundesbank_get_interest_rates` | Get ECB key interest rates (refinancing rate, deposit facility, marginal lending) |
+| `bundesbank_search_statistics` | Search for available statistical series by keyword |
+| `bundesbank_get_timeseries` | Retrieve data for a specific time series by ID |
+
+## AI Agent Use Cases
+
+- **"What's the current EUR/USD exchange rate?"**
+- **"Show me the ECB interest rate history for the last 5 years"**
+- **"What was the EUR/GBP rate on January 15, 2025?"**
+- **"Search for money supply statistics"**

--- a/content/guides/en/connect-billomat-to-chatgpt.mdx
+++ b/content/guides/en/connect-billomat-to-chatgpt.mdx
@@ -1,0 +1,40 @@
+---
+title: "How to Connect Billomat to ChatGPT for AI-Powered Accounting"
+description: "Connect Billomat invoicing to ChatGPT using MCP. Query clients, invoices, and offers with natural language. No coding required."
+category: "connectors"
+keyword: "Billomat ChatGPT, Billomat AI, connect Billomat to ChatGPT, Billomat MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Connect Billomat to ChatGPT
+
+Billomat is a German invoicing platform for freelancers and SMBs. Using AnythingMCP, you can expose Billomat data to ChatGPT through MCP — ask questions about invoices, clients, and quotes in natural language.
+
+### Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Open `http://localhost:3000/connectors/store` and import the **Billomat** adapter
+2. Enter your Billomat subdomain and API key
+3. Assign to an MCP server
+
+### Connect to ChatGPT
+
+```json
+{
+  "mcpServers": {
+    "billomat": { "url": "https://your-anythingmcp-instance.com/mcp" }
+  }
+}
+```
+
+### Use Cases
+
+- **"Show all overdue invoices"** — Instant overview of payment status
+- **"List clients with total revenue over 10,000€"** — Customer analysis
+- **"What open offers do we have?"** — Pipeline visibility
+- **"Get invoice #2024-0042 details"** — Quick lookup with line items

--- a/content/guides/en/connect-billomat-to-claude.mdx
+++ b/content/guides/en/connect-billomat-to-claude.mdx
@@ -1,0 +1,51 @@
+---
+title: "How to Connect Billomat to Claude for AI-Powered Accounting"
+description: "Connect Billomat invoicing to Claude AI using MCP. Manage clients, invoices, articles, and offers with natural language. Step-by-step setup guide."
+category: "connectors"
+keyword: "Billomat Claude, Billomat AI, Billomat MCP, connect Billomat to Claude, Billomat API Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Connect Billomat to Claude
+
+Billomat is a German online invoicing and accounting platform. With AnythingMCP, you can connect Billomat to Claude AI and manage your invoices, clients, and quotes using natural language.
+
+### What You Can Do
+
+- "List all overdue invoices"
+- "Show me client details for Müller GmbH"
+- "How many open offers do we have this month?"
+- "What articles are in our catalog?"
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Open `http://localhost:3000/connectors/store` and import the **Billomat** adapter
+2. Enter your **Billomat subdomain** (e.g., `mycompany` from `mycompany.billomat.net`) and **API key**
+3. Assign the connector to an MCP server
+
+### Connect Claude
+
+```json
+{
+  "mcpServers": {
+    "billomat": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `billomat_list_clients` | List and search clients |
+| `billomat_get_client` | Get client details |
+| `billomat_list_invoices` | Filter invoices by status or client |
+| `billomat_get_invoice` | Full invoice with line items |
+| `billomat_list_articles` | List products and services |
+| `billomat_list_offers` | List quotes and offers |

--- a/content/guides/en/connect-datev-to-chatgpt.mdx
+++ b/content/guides/en/connect-datev-to-chatgpt.mdx
@@ -1,0 +1,29 @@
+---
+title: "How to Connect DATEV to ChatGPT — AI for German Accounting"
+description: "Connect DATEV to ChatGPT using MCP. Access accounting documents and client data with natural language. No MCP server needed — use AnythingMCP."
+category: "connectors"
+keyword: "DATEV ChatGPT, DATEV AI, connect DATEV to ChatGPT, DATEV MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## Connect DATEV to ChatGPT
+
+DATEV is Germany's most widely used accounting platform. Using AnythingMCP, you can expose DATEV data to ChatGPT through MCP — no custom code needed.
+
+### Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Import the **DATEV** adapter and enter your OAuth 2.0 credentials
+2. Assign to an MCP server
+3. Connect ChatGPT to your AnythingMCP endpoint
+
+### Use Cases
+
+- **"List all my accounting clients"** — Quick client overview
+- **"Show recent documents for client 12345"** — Document tracking
+- **"Upload this invoice to DATEV"** — Automated document processing

--- a/content/guides/en/connect-datev-to-claude.mdx
+++ b/content/guides/en/connect-datev-to-claude.mdx
@@ -1,0 +1,45 @@
+---
+title: "How to Connect DATEV to Claude — AI for German Accounting"
+description: "Connect DATEV to Claude AI using MCP. Access accounting clients, documents, and payroll data with natural language. Step-by-step guide."
+category: "connectors"
+keyword: "DATEV Claude, DATEV AI, connect DATEV to Claude, DATEV MCP Claude, DATEV Steuerberater KI"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## Connect DATEV to Claude
+
+DATEV is the backbone of German accounting — used by nearly every tax consultant. With AnythingMCP, you can connect DATEV's Online APIs to Claude and manage accounting data with natural language.
+
+### What You Can Do
+
+- "List all my DATEV clients"
+- "Show documents uploaded this month for client Müller"
+- "Upload this receipt to DATEV Belege online"
+- "Which clients have pending documents?"
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Register at the [DATEV Developer Portal](https://developer.datev.de) and create an application
+2. Import the **DATEV** adapter in the store
+3. Enter your OAuth 2.0 credentials (Client ID, Client Secret, Auth URL, Token URL)
+4. Assign to an MCP server
+
+### Connect Claude
+
+```json
+{
+  "mcpServers": {
+    "datev": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+### Why This Matters
+
+DATEV has 15+ REST APIs but no MCP server. AnythingMCP bridges this gap, giving tax consultants and businesses AI-powered access to their DATEV data for the first time.

--- a/content/guides/en/connect-fastbill-to-chatgpt.mdx
+++ b/content/guides/en/connect-fastbill-to-chatgpt.mdx
@@ -1,0 +1,53 @@
+---
+title: "How to Connect FastBill to ChatGPT for AI-Powered Invoicing"
+description: "Connect FastBill invoicing to ChatGPT using MCP. Query customers, invoices, and expenses with natural language. Works with ChatGPT Desktop and API."
+category: "connectors"
+keyword: "FastBill ChatGPT, FastBill AI, connect FastBill to ChatGPT, FastBill MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## Connect FastBill to ChatGPT
+
+FastBill is a popular German invoicing platform. With AnythingMCP, you can expose FastBill data as MCP tools that ChatGPT can call directly — no custom code needed.
+
+### What You Can Do
+
+Once connected, ask ChatGPT:
+- "Show all unpaid invoices from this month"
+- "How much revenue did I make in Q1?"
+- "List expenses over 500€ from last quarter"
+- "Which customers have the most open invoices?"
+
+### Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Open `http://localhost:3000/connectors/store` and import the **FastBill** adapter
+2. Enter your FastBill email and API key
+3. Assign the connector to an MCP server
+
+### Connect to ChatGPT
+
+ChatGPT supports MCP servers via its remote server configuration. Point it at your AnythingMCP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "fastbill": { "url": "https://your-anythingmcp-instance.com/mcp" }
+  }
+}
+```
+
+For ChatGPT Desktop, add the server URL in Settings → Connected Tools → Add MCP Server.
+
+### Available Tools
+
+- **fastbill_list_customers** — Search customers
+- **fastbill_list_invoices** — Filter invoices by customer, month, year
+- **fastbill_get_invoice** — Full invoice details with line items
+- **fastbill_list_expenses** — Expenses by period
+- **fastbill_list_revenues** — Revenue tracking

--- a/content/guides/en/connect-fastbill-to-claude.mdx
+++ b/content/guides/en/connect-fastbill-to-claude.mdx
@@ -1,0 +1,66 @@
+---
+title: "How to Connect FastBill to Claude for AI-Powered Invoicing"
+description: "Connect FastBill invoicing to Claude AI using MCP. Query customers, invoices, expenses and revenue data with natural language. Step-by-step guide."
+category: "connectors"
+keyword: "FastBill Claude, FastBill AI, FastBill MCP, connect FastBill to Claude, FastBill API Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## Connect FastBill to Claude
+
+FastBill is one of Germany's most popular invoicing tools for freelancers and small businesses. With AnythingMCP, you can connect FastBill's API directly to Claude, enabling natural language queries over your financial data.
+
+### What You Can Do
+
+Once connected, ask Claude things like:
+- "Show me all unpaid invoices from this quarter"
+- "How much revenue did customer Müller GmbH generate last year?"
+- "List my top 10 customers by invoice volume"
+- "What are my total expenses for March?"
+
+### Step 1: Set Up AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Or use [AnythingMCP Cloud](https://cloud.anythingmcp.com) for instant setup without Docker.
+
+### Step 2: Import the FastBill Adapter
+
+1. Open `http://localhost:3000/connectors/store`
+2. Find **FastBill Invoicing** in the adapter list
+3. Click **Import** — you'll be prompted for your credentials
+4. Enter your **FastBill email** and **API key** (find it in FastBill under Settings → API)
+
+### Step 3: Assign to an MCP Server
+
+After import, choose which MCP server should expose FastBill tools. You can select an existing one or create a new MCP server.
+
+### Step 4: Connect Claude
+
+Add the MCP server to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "fastbill": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `fastbill_list_customers` | Search and list customers |
+| `fastbill_list_invoices` | List invoices by customer, month, or year |
+| `fastbill_get_invoice` | Get full invoice details with line items |
+| `fastbill_list_expenses` | List expenses by period |
+| `fastbill_list_revenues` | List revenue entries |
+
+### Why AnythingMCP?
+
+Unlike building a custom integration, AnythingMCP gives you a pre-built FastBill adapter with one-click import. Your API credentials are encrypted, and all requests are logged in the audit trail. You can combine FastBill with other connectors (DHL, weclapp, etc.) in a single MCP server.

--- a/content/guides/en/connect-kenjo-to-chatgpt.mdx
+++ b/content/guides/en/connect-kenjo-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "How to Connect Kenjo HR to ChatGPT for AI-Powered HR Management"
+description: "Connect Kenjo HR to ChatGPT using MCP. Query employees and recruiting data with natural language."
+category: "connectors"
+keyword: "Kenjo ChatGPT, Kenjo HR AI, connect Kenjo to ChatGPT, Kenjo MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Connect Kenjo to ChatGPT
+
+Kenjo is a German HR platform. Using AnythingMCP, expose Kenjo data to ChatGPT through MCP.
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Import the **Kenjo** adapter, enter your API key, and connect ChatGPT.
+
+### Use Cases
+
+- **"How many employees per department?"**
+- **"Show open recruiting positions"**
+- **"List all teams and their members"**

--- a/content/guides/en/connect-kenjo-to-claude.mdx
+++ b/content/guides/en/connect-kenjo-to-claude.mdx
@@ -1,0 +1,35 @@
+---
+title: "How to Connect Kenjo HR to Claude for AI-Powered HR Management"
+description: "Connect Kenjo HR to Claude AI using MCP. Query employees, departments, and recruiting data with natural language."
+category: "connectors"
+keyword: "Kenjo Claude, Kenjo HR AI, connect Kenjo to Claude, Kenjo MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Connect Kenjo to Claude
+
+Kenjo is a German HR platform. With AnythingMCP, connect it to Claude and manage HR data with natural language.
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Import the **Kenjo** adapter, enter your API key, and connect Claude.
+
+```json
+{
+  "mcpServers": {
+    "kenjo": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+### Use Cases
+
+- **"How many employees per department?"**
+- **"List open positions in engineering"**
+- **"Show all office locations"**

--- a/content/guides/en/connect-mfr-to-chatgpt.mdx
+++ b/content/guides/en/connect-mfr-to-chatgpt.mdx
@@ -1,0 +1,41 @@
+---
+title: "How to Connect MFR Mobile Field Report to ChatGPT for AI Field Service"
+description: "Connect MFR field service to ChatGPT using MCP. Manage service requests, appointments, and technician schedules with natural language."
+category: "connectors"
+keyword: "MFR ChatGPT, Mobile Field Report ChatGPT, MFR MCP, connect MFR to ChatGPT, field service ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## Connect MFR to ChatGPT
+
+Mobile Field Report (MFR) is a field service management platform. Using AnythingMCP, you can expose MFR's OData API to ChatGPT through MCP — manage service operations with natural language.
+
+### Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Open `http://localhost:3000/connectors/store` and import the **MFR** adapter
+2. Enter your MFR username and password
+3. Assign to an MCP server
+
+### Connect to ChatGPT
+
+```json
+{
+  "mcpServers": {
+    "mfr": { "url": "https://your-anythingmcp-instance.com/mcp" }
+  }
+}
+```
+
+### Use Cases
+
+- **"Show all open service requests"** — Overview of pending work
+- **"Which technician is available tomorrow?"** — Schedule planning
+- **"List all service objects at Müller GmbH"** — Equipment tracking
+- **"Show time entries for last week"** — Workload analysis
+- **"What's the status of request SR-12345?"** — Quick lookup

--- a/content/guides/en/connect-mfr-to-claude.mdx
+++ b/content/guides/en/connect-mfr-to-claude.mdx
@@ -1,0 +1,64 @@
+---
+title: "How to Connect MFR Mobile Field Report to Claude for AI-Powered Field Service"
+description: "Connect MFR field service management to Claude AI using MCP. Query service requests, appointments, technicians, and checklists with natural language."
+category: "connectors"
+keyword: "MFR Claude, Mobile Field Report AI, MFR MCP, connect MFR to Claude, field service AI"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## Connect MFR to Claude
+
+Mobile Field Report (MFR) is a German field service management platform used by technicians and service companies. With AnythingMCP, you can connect MFR's OData API to Claude and manage field operations with natural language.
+
+### What You Can Do
+
+- "Show all open service requests for this week"
+- "Which technician has the most appointments today?"
+- "List service objects for company Müller GmbH"
+- "What checklist steps are incomplete for request SR-12345?"
+- "How many hours did the team work last month?"
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+1. Open `http://localhost:3000/connectors/store` and import the **MFR Mobile Field Report** adapter
+2. Enter your **MFR username** and **password**
+3. Assign to an MCP server
+
+### Connect Claude
+
+```json
+{
+  "mcpServers": {
+    "mfr": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `mfr_list_service_requests` | List work orders with OData filtering |
+| `mfr_get_service_request` | Get request details with linked data |
+| `mfr_list_appointments` | View scheduled technician appointments |
+| `mfr_list_companies` | List customer companies |
+| `mfr_list_contacts` | List contacts for companies |
+| `mfr_list_users` | List technicians and users |
+| `mfr_list_service_objects` | List equipment being serviced |
+| `mfr_list_steps` | View checklist steps |
+| `mfr_list_time_events` | Track working hours |
+| `mfr_list_invoices` | View service invoices |
+
+### OData Filtering
+
+MFR's OData API supports powerful filtering. Claude can use expressions like:
+- `$filter=Status eq 'Open'` — Filter by status
+- `$orderby=CreatedDate desc` — Sort by date
+- `$expand=Company,Appointments` — Include related data
+- `$top=10` — Limit results

--- a/content/guides/en/connect-scopevisio-to-chatgpt.mdx
+++ b/content/guides/en/connect-scopevisio-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "How to Connect ScopeVisio to ChatGPT for AI-Powered ERP"
+description: "Connect ScopeVisio cloud ERP to ChatGPT using MCP. Query contacts, invoices, and projects with natural language."
+category: "connectors"
+keyword: "ScopeVisio ChatGPT, ScopeVisio AI, connect ScopeVisio to ChatGPT, ScopeVisio MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## Connect ScopeVisio to ChatGPT
+
+ScopeVisio is a German cloud ERP and CRM platform. Using AnythingMCP, expose ScopeVisio data to ChatGPT through MCP.
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Import the **ScopeVisio** adapter, enter your Bearer token, and connect ChatGPT.
+
+### Use Cases
+
+- **"Show overdue invoices"**
+- **"List active projects with budget"**
+- **"Search contacts by company name"**

--- a/content/guides/en/connect-scopevisio-to-claude.mdx
+++ b/content/guides/en/connect-scopevisio-to-claude.mdx
@@ -1,0 +1,35 @@
+---
+title: "How to Connect ScopeVisio to Claude for AI-Powered ERP"
+description: "Connect ScopeVisio cloud ERP to Claude AI using MCP. Manage contacts, invoices, and projects with natural language."
+category: "connectors"
+keyword: "ScopeVisio Claude, ScopeVisio AI, connect ScopeVisio to Claude, ScopeVisio MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## Connect ScopeVisio to Claude
+
+ScopeVisio is a German cloud ERP platform. With AnythingMCP, connect it to Claude and query your business data in natural language.
+
+### Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Import the **ScopeVisio** adapter, enter your Bearer token, and connect Claude.
+
+```json
+{
+  "mcpServers": {
+    "scopevisio": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+### Use Cases
+
+- **"List all contacts tagged as customers"**
+- **"Show outgoing invoices from this quarter"**
+- **"What projects are behind schedule?"**

--- a/content/guides/en/datev-to-mcp.mdx
+++ b/content/guides/en/datev-to-mcp.mdx
@@ -1,0 +1,44 @@
+---
+title: "How to Connect DATEV to MCP for AI-Powered Accounting"
+description: "Connect DATEV accounting to MCP. Access clients, documents, payroll data, and HR reporting with AI agents. The first DATEV MCP integration."
+category: "connectors"
+keyword: "DATEV MCP Server, DATEV API AI, DATEV mit Claude, DATEV ChatGPT, DATEV Schnittstelle KI"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## DATEV with AI Agents via MCP
+
+DATEV is the dominant accounting and tax software platform in Germany, used by nearly every tax consultant (Steuerberater) and thousands of businesses. Despite its market dominance, there has been no MCP server for DATEV — until now.
+
+With AnythingMCP, you can connect DATEV's official Online APIs to any MCP-compatible AI agent (Claude, ChatGPT, Gemini, etc.).
+
+## Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, import the DATEV adapter, and configure your OAuth 2.0 credentials from the [DATEV Developer Portal](https://developer.datev.de).
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `datev_list_clients` | List accounting clients |
+| `datev_list_documents` | List accounting documents for a client |
+| `datev_get_document` | Get document details by GUID |
+| `datev_upload_document` | Upload invoices/receipts to DATEV Belege online |
+
+## Prerequisites
+
+1. Register at the [DATEV Developer Portal](https://developer.datev.de)
+2. Create an application to get OAuth 2.0 credentials
+3. Your clients must be on DATEV Unternehmen online
+
+## Use Cases
+
+- **"List all accounting clients"**
+- **"Show documents uploaded this month for client 12345"**
+- **"Upload this invoice to DATEV Belege online"**

--- a/content/guides/en/destatis-genesis-to-mcp.mdx
+++ b/content/guides/en/destatis-genesis-to-mcp.mdx
@@ -1,0 +1,57 @@
+---
+title: "How to Connect Destatis GENESIS Statistics to MCP"
+description: "Access official German federal statistics from the Statistisches Bundesamt via AI agents and MCP. Population, economy, trade, labor market data."
+category: "connectors"
+keyword: "Destatis MCP Server, GENESIS API AI, German statistics MCP, Statistisches Bundesamt API"
+publishedAt: "2026-03-15"
+adapterSlug: "destatis-genesis"
+---
+
+## Destatis GENESIS Statistics with AI Agents
+
+Destatis (Statistisches Bundesamt) is Germany's federal statistics office. The GENESIS API provides access to official data on population, economy, trade, labor market, prices, and more.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the Destatis Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the Destatis GENESIS Statistics adapter. Enter your GENESIS username and password when prompted.
+
+### Step 3: Get GENESIS Credentials
+
+Register for a free account at [www-genesis.destatis.de](https://www-genesis.destatis.de/) to get API access credentials.
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "destatis": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `destatis_search_tables` | Search for statistical tables by keyword |
+| `destatis_get_table` | Retrieve data from a specific statistical table |
+| `destatis_get_metadata` | Get metadata and definitions for a table |
+| `destatis_list_statistics` | List all available statistics catalogs |
+
+## AI Agent Use Cases
+
+- **"What is Germany's current population?"**
+- **"Show GDP growth for the last 10 years"**
+- **"What's the unemployment rate in Bavaria?"**
+- **"Search for consumer price index data"**

--- a/content/guides/en/dhl-tracking-to-mcp.mdx
+++ b/content/guides/en/dhl-tracking-to-mcp.mdx
@@ -1,0 +1,61 @@
+---
+title: "How to Connect DHL Tracking to MCP for AI Agents"
+description: "Track DHL shipments with AI agents via MCP. Use the built-in DHL adapter in AnythingMCP for instant setup — no code required."
+category: "connectors"
+keyword: "DHL MCP Server, DHL tracking AI, DHL shipment tracking API, connect DHL to Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "dhl-tracking"
+---
+
+## DHL Shipment Tracking with AI Agents
+
+DHL is the world's largest logistics company, handling millions of shipments daily. By connecting DHL's Unified Tracking API to MCP, your AI agents can track shipments, monitor delivery status, and provide real-time logistics updates.
+
+## Quick Setup with Built-in Adapter
+
+AnythingMCP includes a pre-configured DHL adapter. No manual API configuration needed.
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the DHL Adapter
+
+Open the AnythingMCP dashboard at `http://localhost:3000/connectors/store` and click **Import** on the DHL Shipment Tracking adapter. Enter your DHL API key when prompted.
+
+### Step 3: Get Your DHL API Key
+
+Register at the [DHL Developer Portal](https://developer.dhl.com/) and create an application to get your API key for the Unified Tracking API.
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "dhl": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `dhl_track_shipment` | Track a single shipment by tracking number |
+| `dhl_track_multiple` | Track multiple shipments at once (up to 20) |
+
+## AI Agent Use Cases
+
+- **"Track my DHL shipment 1234567890"**
+- **"What's the delivery status of these 5 packages?"**
+- **"When will my parcel arrive?"**
+- **"Show all delivery events for tracking number XYZ"**
+
+## Next Steps
+
+- [REST API to MCP Guide](/guides/rest-api-to-mcp) — Custom REST connector patterns

--- a/content/guides/en/fastbill-to-mcp.mdx
+++ b/content/guides/en/fastbill-to-mcp.mdx
@@ -1,0 +1,46 @@
+---
+title: "How to Connect FastBill to MCP for AI Agents"
+description: "Manage invoices, customers, and expenses with AI agents via MCP. FastBill is a popular invoicing tool for German freelancers and small businesses."
+category: "connectors"
+keyword: "FastBill MCP Server, FastBill API AI, invoicing MCP, FastBill mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## FastBill Invoicing with AI Agents
+
+FastBill is a popular invoicing and bookkeeping platform for German freelancers and small businesses. By connecting its API to MCP, AI agents can query customers, list invoices, track expenses, and analyze revenue.
+
+## Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, import the FastBill adapter, and enter your FastBill email and API key.
+
+```json
+{
+  "mcpServers": {
+    "fastbill": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `fastbill_list_customers` | List customers with search filtering |
+| `fastbill_list_invoices` | List invoices filtered by customer, month, or year |
+| `fastbill_get_invoice` | Get full invoice details with line items |
+| `fastbill_list_expenses` | List expenses filtered by period |
+| `fastbill_list_revenues` | List revenue entries |
+
+## Use Cases
+
+- **"Show all unpaid invoices from this month"**
+- **"How much revenue did I generate in Q1?"**
+- **"List all customers from Munich"**
+- **"What are my total expenses for March 2026?"**

--- a/content/guides/en/immobilienscout24-to-mcp.mdx
+++ b/content/guides/en/immobilienscout24-to-mcp.mdx
@@ -1,0 +1,56 @@
+---
+title: "How to Connect ImmobilienScout24 to MCP for AI Agents"
+description: "Search and browse real estate listings on ImmobilienScout24 via AI agents and MCP. Find apartments, houses, and commercial properties in Germany."
+category: "connectors"
+keyword: "ImmobilienScout24 MCP Server, IS24 API AI, real estate MCP, Immobilien mit Claude suchen"
+publishedAt: "2026-03-15"
+adapterSlug: "immobilienscout24"
+---
+
+## ImmobilienScout24 with AI Agents
+
+ImmobilienScout24 is Germany's largest real estate portal. Connecting its API to MCP enables AI agents to search properties, browse listings, and get detailed property information.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the ImmobilienScout24 Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the ImmobilienScout24 API adapter. Enter your OAuth Client ID and Client Secret when prompted.
+
+### Step 3: Get API Access
+
+Register at the [IS24 Developer Center](https://api.immobilienscout24.de/) and create an application to get OAuth credentials.
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "is24": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `is24_search_properties` | Search listings by location, type, price, size |
+| `is24_search_locations` | Find GeoCode IDs for locations (needed for search) |
+| `is24_get_property` | Get full details of a specific listing |
+
+## AI Agent Use Cases
+
+- **"Find 3-room apartments for rent in Berlin Mitte under €1,500"**
+- **"Show me houses for sale in Munich with a garden"**
+- **"What's the average rent for apartments in Hamburg?"**
+- **"Get details for listing 123456789"**

--- a/content/guides/en/kenjo-to-mcp.mdx
+++ b/content/guides/en/kenjo-to-mcp.mdx
@@ -1,0 +1,38 @@
+---
+title: "How to Connect Kenjo HR to MCP for AI-Powered Human Resources"
+description: "Connect Kenjo HR to MCP. Access employees, departments, teams, and recruiting data with AI agents. German HR software meets AI."
+category: "connectors"
+keyword: "Kenjo MCP Server, Kenjo HR API AI, Kenjo Claude, Kenjo ChatGPT, HR MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Kenjo HR with AI Agents
+
+Kenjo is a German HR platform for manufacturing, services, and retail companies. With AnythingMCP, connect its API to any MCP-compatible AI agent.
+
+## Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Import the Kenjo adapter and enter your API key (Settings → Integrations → API in Kenjo).
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `kenjo_list_employees` | List all employees |
+| `kenjo_get_employee` | Get employee details |
+| `kenjo_list_departments` | List departments |
+| `kenjo_list_offices` | List office locations |
+| `kenjo_list_positions` | List open job positions |
+| `kenjo_list_teams` | List teams |
+
+## Use Cases
+
+- **"How many employees do we have per department?"**
+- **"List all open recruiting positions"**
+- **"Show employee details for Max Mustermann"**

--- a/content/guides/en/mfr-fieldservice-to-mcp.mdx
+++ b/content/guides/en/mfr-fieldservice-to-mcp.mdx
@@ -1,0 +1,52 @@
+---
+title: "How to Connect MFR Mobile Field Report to MCP for AI Agents"
+description: "Manage field service operations with AI agents via MCP. Access service requests, appointments, technicians, and checklists from Mobile Field Report."
+category: "connectors"
+keyword: "MFR MCP Server, Mobile Field Report API AI, field service MCP, MFR mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## MFR Mobile Field Report with AI Agents
+
+Mobile Field Report (MFR) is a German field service management platform used by technicians and service companies. By connecting its OData API to MCP, AI agents can query service requests, manage appointments, view checklists, and track technician time.
+
+## Quick Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, import the MFR adapter, and enter your MFR username and password.
+
+```json
+{
+  "mcpServers": {
+    "mfr": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `mfr_list_service_requests` | List work orders with OData filtering and sorting |
+| `mfr_get_service_request` | Get details of a specific service request |
+| `mfr_list_appointments` | View scheduled technician appointments |
+| `mfr_list_companies` | List customer companies |
+| `mfr_list_contacts` | List contacts associated with companies |
+| `mfr_list_users` | List technicians and system users |
+| `mfr_list_service_objects` | List equipment and devices being serviced |
+| `mfr_list_steps` | View checklist steps for a service request |
+| `mfr_list_time_events` | Track technician working hours |
+| `mfr_list_invoices` | View invoices from service requests |
+
+## Use Cases
+
+- **"Show all open service requests for this week"**
+- **"Which technician has the most appointments today?"**
+- **"List all service objects for company Müller GmbH"**
+- **"What checklist steps are incomplete for request SR-12345?"**
+- **"How many hours did technician Max work last month?"**

--- a/content/guides/en/n26-openbanking-to-mcp.mdx
+++ b/content/guides/en/n26-openbanking-to-mcp.mdx
@@ -1,0 +1,55 @@
+---
+title: "How to Connect N26 Open Banking to MCP for AI Agents"
+description: "Access N26 bank account data via AI agents and MCP using the PSD2 Open Banking API. View balances, transactions, and account details."
+category: "connectors"
+keyword: "N26 MCP Server, N26 Open Banking API, PSD2 MCP integration, N26 mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "n26-openbanking"
+---
+
+## N26 Open Banking with AI Agents
+
+N26 is a leading European neobank. Through the PSD2 Open Banking API, AI agents can access account information, balances, and transaction history with proper authorization.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the N26 Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the N26 Open Banking (PSD2) adapter. Enter your OAuth Client ID and Client Secret when prompted.
+
+### Step 3: Get PSD2 API Access
+
+Apply for API access through N26's PSD2 developer portal. You'll need to be a registered AISP (Account Information Service Provider) under PSD2 regulation.
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "n26": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `n26_get_accounts` | List all accounts linked to the consent |
+| `n26_get_balances` | Get current account balances |
+| `n26_get_transactions` | Get transaction history with filters |
+
+## AI Agent Use Cases
+
+- **"What's my current N26 account balance?"**
+- **"Show my transactions from last week"**
+- **"List all accounts linked to my profile"**

--- a/content/guides/en/nina-warnings-to-mcp.mdx
+++ b/content/guides/en/nina-warnings-to-mcp.mdx
@@ -1,0 +1,53 @@
+---
+title: "How to Connect NINA Emergency Warnings to MCP"
+description: "Get official German emergency warnings and alerts via AI agents and MCP. Monitor floods, storms, fires, and other emergencies in real-time."
+category: "connectors"
+keyword: "NINA MCP Server, BBK Warnungen API, German emergency warnings AI, NINA Warn-App MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "nina-warnung"
+---
+
+## NINA Emergency Warnings with AI Agents
+
+NINA (Notfall-Informations- und Nachrichten-App) is Germany's official emergency warning system by the BBK (Bundesamt für Bevölkerungsschutz). The API provides real-time access to warnings about floods, storms, fires, and other emergencies. No API key required.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the NINA Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the NINA Emergency Warnings adapter. No credentials needed — this is a free public API.
+
+### Step 3: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "nina": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `nina_get_dashboard` | Get current national warning overview |
+| `nina_get_warnings_by_region` | Get active warnings for a specific region (AGS code) |
+| `nina_get_warning_detail` | Get full details of a specific warning |
+| `nina_get_covid_rules` | Get current COVID rules for a region |
+
+## AI Agent Use Cases
+
+- **"Are there any active flood warnings in Berlin?"**
+- **"Show me all current emergency warnings in Germany"**
+- **"What are the details of warning XYZ?"**
+- **"Any storm warnings for Hamburg today?"**

--- a/content/guides/en/payone-payments-to-mcp.mdx
+++ b/content/guides/en/payone-payments-to-mcp.mdx
@@ -1,0 +1,57 @@
+---
+title: "How to Connect PAYONE Payments to MCP for AI Agents"
+description: "Process and manage e-commerce payments via AI agents and MCP. List transactions, capture and refund payments through the PAYONE API."
+category: "connectors"
+keyword: "PAYONE MCP Server, PAYONE API AI, payment processing MCP, PAYONE mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "payone"
+---
+
+## PAYONE Payments with AI Agents
+
+PAYONE is a leading European payment service provider. Connecting its API to MCP enables AI agents to monitor transactions, capture payments, and process refunds.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the PAYONE Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the PAYONE Payments adapter. Enter your Merchant ID, API Key, Portal ID, and Account ID when prompted.
+
+### Step 3: Get PAYONE API Credentials
+
+Log in to the [PAYONE Merchant Interface](https://pmi.pay1.de/) to find your API credentials under Configuration > Payment portals.
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "payone": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `payone_list_transactions` | List recent payment transactions |
+| `payone_get_transaction` | Get details of a specific transaction |
+| `payone_capture_payment` | Capture an authorized payment |
+| `payone_refund_payment` | Refund a captured payment |
+
+## AI Agent Use Cases
+
+- **"Show me all transactions from today"**
+- **"What's the status of transaction XYZ?"**
+- **"Capture the pending payment for order 12345"**
+- **"Refund the last transaction for customer Müller"**

--- a/content/guides/en/scopevisio-to-mcp.mdx
+++ b/content/guides/en/scopevisio-to-mcp.mdx
@@ -1,0 +1,38 @@
+---
+title: "How to Connect ScopeVisio to MCP for AI-Powered ERP"
+description: "Connect ScopeVisio cloud ERP to MCP. Access contacts, invoices, projects, and tasks with AI agents. German cloud business software meets AI."
+category: "connectors"
+keyword: "ScopeVisio MCP Server, ScopeVisio API AI, ScopeVisio Claude, ScopeVisio ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## ScopeVisio Cloud ERP with AI Agents
+
+ScopeVisio is a German cloud ERP and CRM platform. With AnythingMCP, connect its REST API to any MCP-compatible AI agent.
+
+## Setup
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Import the ScopeVisio adapter and enter your Bearer token.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `scopevisio_list_contacts` | List customers, suppliers, leads |
+| `scopevisio_get_contact` | Get contact details |
+| `scopevisio_list_outgoing_invoices` | List outgoing invoices |
+| `scopevisio_list_incoming_invoices` | List incoming invoices |
+| `scopevisio_list_projects` | List projects |
+| `scopevisio_list_tasks` | List tasks |
+
+## Use Cases
+
+- **"Show all overdue outgoing invoices"**
+- **"List contacts tagged as leads"**
+- **"What projects are currently active?"**

--- a/content/guides/en/teamviewer-to-mcp.mdx
+++ b/content/guides/en/teamviewer-to-mcp.mdx
@@ -1,0 +1,59 @@
+---
+title: "How to Connect TeamViewer to MCP for AI Agents"
+description: "Manage TeamViewer devices, contacts, and remote sessions via AI agents and MCP. Monitor device status and create support sessions."
+category: "connectors"
+keyword: "TeamViewer MCP Server, TeamViewer API AI, remote access MCP, TeamViewer mit Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "teamviewer"
+---
+
+## TeamViewer with AI Agents
+
+TeamViewer is a leading remote access and support platform. Connecting its Web API to MCP enables AI agents to manage devices, monitor online status, and create remote support sessions.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the TeamViewer Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the TeamViewer API adapter. Enter your TeamViewer access token when prompted.
+
+### Step 3: Get Your Access Token
+
+Generate a Script Token in TeamViewer Management Console under **Profile > Apps > Create script token**. Grant access to devices, contacts, and sessions.
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "teamviewer": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `teamviewer_list_devices` | List all managed devices with online status |
+| `teamviewer_get_device` | Get details of a specific device |
+| `teamviewer_list_contacts` | List contacts in your address book |
+| `teamviewer_list_groups` | List device groups |
+| `teamviewer_get_account` | Get current account information |
+| `teamviewer_list_sessions` | List active remote sessions |
+
+## AI Agent Use Cases
+
+- **"Which of my devices are currently online?"**
+- **"Show me the details of device XYZ"**
+- **"How many devices are in the 'Servers' group?"**
+- **"List all active remote support sessions"**

--- a/content/guides/en/weclapp-erp-to-mcp.mdx
+++ b/content/guides/en/weclapp-erp-to-mcp.mdx
@@ -1,0 +1,59 @@
+---
+title: "How to Connect weclapp Cloud ERP to MCP for AI Agents"
+description: "Access weclapp ERP data including customers, orders, invoices, and articles via AI agents and MCP. Popular cloud ERP for German SMBs."
+category: "connectors"
+keyword: "weclapp MCP Server, weclapp API AI, Cloud ERP MCP, weclapp mit Claude nutzen"
+publishedAt: "2026-03-15"
+adapterSlug: "weclapp"
+---
+
+## weclapp Cloud ERP with AI Agents
+
+weclapp is a popular cloud ERP solution for German small and medium businesses. Connecting its API to MCP enables AI agents to query customers, orders, invoices, and inventory data.
+
+## Quick Setup with Built-in Adapter
+
+### Step 1: Deploy AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Step 2: Import the weclapp Adapter
+
+Open `http://localhost:3000/connectors/store` and click **Import** on the weclapp Cloud ERP adapter. Enter your weclapp tenant name and API token when prompted.
+
+### Step 3: Get weclapp API Token
+
+In weclapp, go to **My Settings > API Tokens** and generate a new token. Your tenant name is the subdomain (e.g., `yourcompany` from `yourcompany.weclapp.com`).
+
+### Step 4: Connect to Your AI Agent
+
+```json
+{
+  "mcpServers": {
+    "weclapp": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `weclapp_list_customers` | List customers with contact info and IDs |
+| `weclapp_get_customer` | Get detailed customer information |
+| `weclapp_list_sales_orders` | List sales orders with amounts and status |
+| `weclapp_list_invoices` | List invoices with payment status |
+| `weclapp_list_articles` | List articles/products with stock levels |
+| `weclapp_get_article` | Get detailed article info including warehouse data |
+
+## AI Agent Use Cases
+
+- **"Show me all open orders from this month"**
+- **"What's the current stock for article ABC?"**
+- **"List all unpaid invoices over €1,000"**
+- **"How many customers do we have in Munich?"**

--- a/content/guides/it/billomat-to-mcp.mdx
+++ b/content/guides/it/billomat-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "Come collegare Billomat a MCP per agenti AI"
+description: "Gestisci fatture, clienti, articoli e preventivi con agenti AI via MCP. Billomat è una piattaforma tedesca di fatturazione e contabilità online."
+category: "connectors"
+keyword: "Billomat MCP Server, Billomat API AI, fatturazione MCP, Billomat con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Fatturazione Billomat con Agenti AI
+
+Billomat è una piattaforma tedesca di fatturazione e contabilità online per freelancer e PMI. Collegando la sua API REST a MCP, gli agenti AI possono gestire clienti, fatture, articoli e preventivi.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore Billomat e inserisci il sottodominio e l'API key.
+
+```json
+{
+  "mcpServers": {
+    "billomat": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Mostra tutte le fatture scadute"**
+- **"Quanti preventivi aperti abbiamo?"**
+- **"Lista tutti i clienti con i relativi importi fatturati"**
+- **"Quali articoli abbiamo nel catalogo?"**

--- a/content/guides/it/bundesbank-statistics-to-mcp.mdx
+++ b/content/guides/it/bundesbank-statistics-to-mcp.mdx
@@ -1,0 +1,52 @@
+---
+title: "Come collegare le Statistiche Bundesbank a MCP per agenti AI"
+description: "Accedi ai tassi di cambio BCE, tassi di interesse e dati macroeconomici dalla Bundesbank via agenti AI e MCP. API pubblica gratuita."
+category: "connectors"
+keyword: "Bundesbank MCP Server, tassi cambio BCE AI, statistiche Bundesbank MCP, dati finanziari tedeschi"
+publishedAt: "2026-03-15"
+adapterSlug: "bundesbank"
+---
+
+## Statistiche Bundesbank con Agenti AI
+
+La Deutsche Bundesbank offre accesso gratuito a dati macroeconomici, tassi di cambio, tassi di interesse e statistiche finanziarie tramite l'API REST SDMX. Nessuna chiave API necessaria — collegati e inizia subito a interrogare i dati.
+
+## Configurazione Rapida con Adattatore Integrato
+
+### Passo 1: Distribuisci AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Passo 2: Importa l'Adattatore Bundesbank
+
+Apri `http://localhost:3000/connectors/store` e clicca **Import** sull'adattatore Deutsche Bundesbank Statistics. Essendo un'API pubblica gratuita, non servono credenziali.
+
+### Passo 3: Collega al Tuo Agente AI
+
+```json
+{
+  "mcpServers": {
+    "bundesbank": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Tools Disponibili
+
+| Tool | Descrizione |
+|------|-------------|
+| `bundesbank_get_exchange_rates` | Tassi di cambio euro attuali e storici |
+| `bundesbank_get_interest_rates` | Tassi di interesse chiave BCE |
+| `bundesbank_search_statistics` | Cerca serie statistiche per parola chiave |
+| `bundesbank_get_timeseries` | Recupera dati di una specifica serie temporale |
+
+## Casi d'Uso con Agenti AI
+
+- **"Qual è il tasso di cambio EUR/USD attuale?"**
+- **"Mostrami la storia dei tassi BCE degli ultimi 5 anni"**
+- **"Cerca statistiche sulla massa monetaria"**

--- a/content/guides/it/connect-billomat-to-chatgpt.mdx
+++ b/content/guides/it/connect-billomat-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare Billomat a ChatGPT per contabilità con AI"
+description: "Collega Billomat a ChatGPT tramite MCP. Gestisci fatture e clienti in linguaggio naturale."
+category: "connectors"
+keyword: "Billomat ChatGPT, Billomat AI, collegare Billomat a ChatGPT, Billomat MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Collegare Billomat a ChatGPT
+
+Con AnythingMCP, esponi i dati Billomat come strumenti MCP per ChatGPT.
+
+### Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importa l'adattatore **Billomat**, inserisci le credenziali e collega ChatGPT.
+
+### Casi d'Uso
+
+- **"Mostra tutte le fatture scadute"**
+- **"Quanti preventivi aperti abbiamo?"**
+- **"Dettagli fattura #2024-0042"**

--- a/content/guides/it/connect-billomat-to-claude.mdx
+++ b/content/guides/it/connect-billomat-to-claude.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare Billomat a Claude per contabilità con AI"
+description: "Collega Billomat a Claude AI tramite MCP. Gestisci clienti, fatture e preventivi in linguaggio naturale."
+category: "connectors"
+keyword: "Billomat Claude, Billomat AI, collegare Billomat a Claude, Billomat MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "billomat"
+---
+
+## Collegare Billomat a Claude
+
+Billomat è una piattaforma tedesca di fatturazione online. Con AnythingMCP, colleghi Billomat a Claude AI per gestire fatture e clienti in linguaggio naturale.
+
+### Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importa l'adattatore **Billomat**, inserisci sottodominio e API key, e collega Claude.
+
+### Casi d'Uso
+
+- **"Mostra tutte le fatture scadute"**
+- **"Dettagli del cliente Müller GmbH"**
+- **"Quanti preventivi aperti abbiamo?"**

--- a/content/guides/it/connect-datev-to-chatgpt.mdx
+++ b/content/guides/it/connect-datev-to-chatgpt.mdx
@@ -1,0 +1,22 @@
+---
+title: "Come collegare DATEV a ChatGPT per contabilità con AI"
+description: "Collega DATEV a ChatGPT tramite MCP. Gestisci clienti e documenti contabili in linguaggio naturale."
+category: "connectors"
+keyword: "DATEV ChatGPT, DATEV AI, collegare DATEV a ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## Collegare DATEV a ChatGPT
+
+Con AnythingMCP, esponi i dati DATEV come strumenti MCP per ChatGPT.
+
+### Configurazione
+
+Importa l'adattatore **DATEV**, configura le credenziali OAuth 2.0 e collega ChatGPT.
+
+### Casi d'Uso
+
+- **"Lista i miei clienti DATEV"**
+- **"Documenti caricati questo mese"**
+- **"Carica questa fattura su DATEV"**

--- a/content/guides/it/connect-datev-to-claude.mdx
+++ b/content/guides/it/connect-datev-to-claude.mdx
@@ -1,0 +1,22 @@
+---
+title: "Come collegare DATEV a Claude per contabilità con AI"
+description: "Collega DATEV a Claude AI tramite MCP. Gestisci clienti e documenti contabili in linguaggio naturale."
+category: "connectors"
+keyword: "DATEV Claude, DATEV AI, collegare DATEV a Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## Collegare DATEV a Claude
+
+DATEV è la piattaforma contabile dominante in Germania. Con AnythingMCP, colleghi DATEV a Claude AI.
+
+### Configurazione
+
+Registrati al [DATEV Developer Portal](https://developer.datev.de), importa l'adattatore e configura le credenziali OAuth 2.0.
+
+### Casi d'Uso
+
+- **"Lista tutti i miei clienti DATEV"**
+- **"Documenti caricati questo mese"**
+- **"Carica questa fattura su DATEV"**

--- a/content/guides/it/connect-fastbill-to-chatgpt.mdx
+++ b/content/guides/it/connect-fastbill-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare FastBill a ChatGPT per fatturazione con AI"
+description: "Collega FastBill a ChatGPT tramite MCP. Gestisci fatture e clienti in linguaggio naturale."
+category: "connectors"
+keyword: "FastBill ChatGPT, FastBill AI, collegare FastBill a ChatGPT, FastBill MCP ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## Collegare FastBill a ChatGPT
+
+Con AnythingMCP, esponi i dati FastBill come strumenti MCP per ChatGPT — fatture, clienti e spese gestiti in linguaggio naturale.
+
+### Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importa l'adattatore **FastBill**, inserisci le credenziali e collega ChatGPT.
+
+### Casi d'Uso
+
+- **"Mostra le fatture non pagate di questo mese"**
+- **"Quanti ricavi ho generato nel Q1?"**
+- **"Quali clienti hanno più fatture aperte?"**

--- a/content/guides/it/connect-fastbill-to-claude.mdx
+++ b/content/guides/it/connect-fastbill-to-claude.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare FastBill a Claude per fatturazione con AI"
+description: "Collega FastBill a Claude AI tramite MCP. Interroga clienti, fatture e spese in linguaggio naturale."
+category: "connectors"
+keyword: "FastBill Claude, FastBill AI, collegare FastBill a Claude, FastBill MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## Collegare FastBill a Claude
+
+FastBill è uno strumento di fatturazione popolare per freelancer e piccole imprese tedesche. Con AnythingMCP, colleghi FastBill direttamente a Claude AI.
+
+### Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importa l'adattatore **FastBill**, inserisci email e API key, e collega Claude.
+
+### Casi d'Uso
+
+- **"Mostra tutte le fatture non pagate di questo trimestre"**
+- **"Quanti ricavi ha generato il cliente Müller GmbH?"**
+- **"Lista le spese totali di marzo"**

--- a/content/guides/it/connect-mfr-to-chatgpt.mdx
+++ b/content/guides/it/connect-mfr-to-chatgpt.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare MFR Mobile Field Report a ChatGPT per assistenza tecnica AI"
+description: "Collega MFR a ChatGPT tramite MCP. Gestisci richieste di servizio e tecnici in linguaggio naturale."
+category: "connectors"
+keyword: "MFR ChatGPT, Mobile Field Report ChatGPT, collegare MFR a ChatGPT, assistenza tecnica ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## Collegare MFR a ChatGPT
+
+Con AnythingMCP, esponi i dati MFR come strumenti MCP per ChatGPT — richieste di servizio, appuntamenti e tecnici gestiti in linguaggio naturale.
+
+### Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importa l'adattatore **MFR**, inserisci le credenziali e collega ChatGPT.
+
+### Casi d'Uso
+
+- **"Mostra le richieste di servizio aperte"**
+- **"Quale tecnico è disponibile domani?"**
+- **"Registrazioni ore dell'ultima settimana"**

--- a/content/guides/it/connect-mfr-to-claude.mdx
+++ b/content/guides/it/connect-mfr-to-claude.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare MFR Mobile Field Report a Claude per assistenza tecnica AI"
+description: "Collega MFR a Claude AI tramite MCP. Gestisci richieste di servizio, appuntamenti e tecnici in linguaggio naturale."
+category: "connectors"
+keyword: "MFR Claude, Mobile Field Report AI, collegare MFR a Claude, assistenza tecnica AI"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## Collegare MFR a Claude
+
+Mobile Field Report (MFR) è una piattaforma tedesca per la gestione del servizio tecnico. Con AnythingMCP, colleghi MFR a Claude AI.
+
+### Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Importa l'adattatore **MFR**, inserisci nome utente e password, e collega Claude.
+
+### Casi d'Uso
+
+- **"Mostra le richieste di servizio aperte di questa settimana"**
+- **"Quale tecnico ha più appuntamenti oggi?"**
+- **"Ore lavorate dal team il mese scorso"**

--- a/content/guides/it/datev-to-mcp.mdx
+++ b/content/guides/it/datev-to-mcp.mdx
@@ -1,0 +1,27 @@
+---
+title: "Come collegare DATEV a MCP per contabilità con AI"
+description: "Collega DATEV a MCP. Accedi a clienti, documenti contabili e dati HR con agenti AI. Il primo server MCP per DATEV."
+category: "connectors"
+keyword: "DATEV MCP Server, DATEV AI, DATEV con Claude, DATEV ChatGPT"
+publishedAt: "2026-03-15"
+adapterSlug: "datev"
+---
+
+## DATEV con Agenti AI via MCP
+
+DATEV è la piattaforma contabile dominante in Germania. Con AnythingMCP, colleghi le API REST ufficiali DATEV a qualsiasi agente AI compatibile MCP.
+
+## Configurazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Registrati al [DATEV Developer Portal](https://developer.datev.de), importa l'adattatore e configura le credenziali OAuth 2.0.
+
+## Casi d'Uso
+
+- **"Lista tutti i miei clienti DATEV"**
+- **"Mostra i documenti caricati questo mese"**
+- **"Carica questa fattura su DATEV Belege online"**

--- a/content/guides/it/destatis-genesis-to-mcp.mdx
+++ b/content/guides/it/destatis-genesis-to-mcp.mdx
@@ -1,0 +1,41 @@
+---
+title: "Come collegare Destatis GENESIS a MCP per agenti AI"
+description: "Accedi alle statistiche federali tedesche ufficiali dal Statistisches Bundesamt via agenti AI e MCP. Popolazione, economia, commercio."
+category: "connectors"
+keyword: "Destatis MCP Server, GENESIS API AI, statistiche tedesche MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "destatis-genesis"
+---
+
+## Statistiche Destatis GENESIS con Agenti AI
+
+Il Destatis (Statistisches Bundesamt) offre accesso a dati ufficiali su popolazione, economia, commercio e mercato del lavoro tedesco tramite l'API GENESIS.
+
+## Configurazione Rapida
+
+### Passo 1: Distribuisci AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Passo 2: Importa l'Adattatore Destatis
+
+Apri `http://localhost:3000/connectors/store` e clicca **Import**. Inserisci username e password GENESIS.
+
+### Passo 3: Collega al Tuo Agente AI
+
+```json
+{
+  "mcpServers": {
+    "destatis": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Qual è la popolazione attuale della Germania?"**
+- **"Mostra la crescita del PIL degli ultimi 10 anni"**
+- **"Cerca dati sull'indice dei prezzi al consumo"**

--- a/content/guides/it/dhl-tracking-to-mcp.mdx
+++ b/content/guides/it/dhl-tracking-to-mcp.mdx
@@ -1,0 +1,57 @@
+---
+title: "Come collegare DHL Tracking a MCP per agenti AI"
+description: "Traccia le spedizioni DHL con agenti AI via MCP. L'adattatore DHL integrato in AnythingMCP permette la configurazione istantanea senza codice."
+category: "connectors"
+keyword: "DHL MCP Server, DHL tracking AI, DHL tracciamento spedizioni, DHL con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "dhl-tracking"
+---
+
+## Tracciamento Spedizioni DHL con Agenti AI
+
+DHL è la più grande azienda di logistica al mondo. Collegando l'API DHL Unified Tracking a MCP, i tuoi agenti AI possono tracciare spedizioni, monitorare lo stato delle consegne e fornire aggiornamenti logistici in tempo reale.
+
+## Configurazione Rapida con Adattatore Integrato
+
+AnythingMCP include un adattatore DHL preconfigurato. Nessuna configurazione API manuale necessaria.
+
+### Passo 1: Distribuisci AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Passo 2: Importa l'Adattatore DHL
+
+Apri la dashboard AnythingMCP su `http://localhost:3000/connectors/store` e clicca **Import** sull'adattatore DHL Shipment Tracking. Inserisci la tua chiave API DHL quando richiesto.
+
+### Passo 3: Ottieni la Chiave API DHL
+
+Registrati sul [DHL Developer Portal](https://developer.dhl.com/) e crea un'applicazione per la Unified Tracking API.
+
+### Passo 4: Collega al Tuo Agente AI
+
+```json
+{
+  "mcpServers": {
+    "dhl": {
+      "url": "http://localhost:4000/mcp"
+    }
+  }
+}
+```
+
+## Tools Disponibili
+
+| Tool | Descrizione |
+|------|-------------|
+| `dhl_track_shipment` | Traccia una singola spedizione per numero di tracciamento |
+| `dhl_track_multiple` | Traccia più spedizioni contemporaneamente (fino a 20) |
+
+## Casi d'Uso con Agenti AI
+
+- **"Traccia il mio pacco DHL 1234567890"**
+- **"Qual è lo stato di consegna di questi 5 pacchi?"**
+- **"Quando arriverà il mio pacco?"**
+- **"Mostra tutti gli eventi di consegna per il tracking XYZ"**

--- a/content/guides/it/fastbill-to-mcp.mdx
+++ b/content/guides/it/fastbill-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "Come collegare FastBill a MCP per agenti AI"
+description: "Gestisci fatture, clienti e spese con agenti AI via MCP. FastBill è un popolare strumento di fatturazione per freelancer e piccole imprese tedesche."
+category: "connectors"
+keyword: "FastBill MCP Server, FastBill API AI, fatturazione MCP, FastBill con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "fastbill"
+---
+
+## Fatturazione FastBill con Agenti AI
+
+FastBill è una piattaforma di fatturazione e contabilità popolare tra freelancer e piccole imprese tedesche. Collegando la sua API a MCP, gli agenti AI possono consultare clienti, fatture, spese e ricavi.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore FastBill e inserisci email e API key.
+
+```json
+{
+  "mcpServers": {
+    "fastbill": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Mostra tutte le fatture non pagate di questo mese"**
+- **"Quanti ricavi ho generato nel Q1?"**
+- **"Lista tutti i clienti di Monaco"**
+- **"Quali sono le spese totali per marzo 2026?"**

--- a/content/guides/it/immobilienscout24-to-mcp.mdx
+++ b/content/guides/it/immobilienscout24-to-mcp.mdx
@@ -1,0 +1,35 @@
+---
+title: "Come collegare ImmobilienScout24 a MCP per agenti AI"
+description: "Cerca e sfoglia annunci immobiliari su ImmobilienScout24 via agenti AI e MCP. Trova appartamenti, case e immobili commerciali in Germania."
+category: "connectors"
+keyword: "ImmobilienScout24 MCP Server, IS24 API AI, immobili MCP, cercare immobili con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "immobilienscout24"
+---
+
+## ImmobilienScout24 con Agenti AI
+
+ImmobilienScout24 è il più grande portale immobiliare tedesco. Collegando la sua API a MCP, gli agenti AI possono cercare proprietà, sfogliare annunci e ottenere informazioni dettagliate.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore ImmobilienScout24 e inserisci Client ID e Client Secret OAuth.
+
+```json
+{
+  "mcpServers": {
+    "is24": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Trova appartamenti di 3 stanze in affitto a Berlino Mitte sotto 1.500 €"**
+- **"Mostra case in vendita a Monaco con giardino"**
+- **"Qual è l'affitto medio per appartamenti ad Amburgo?"**

--- a/content/guides/it/kenjo-to-mcp.mdx
+++ b/content/guides/it/kenjo-to-mcp.mdx
@@ -1,0 +1,22 @@
+---
+title: "Come collegare Kenjo HR a MCP per gestione personale con AI"
+description: "Collega Kenjo HR a MCP. Gestisci dipendenti, dipartimenti e recruiting con agenti AI."
+category: "connectors"
+keyword: "Kenjo MCP Server, Kenjo HR AI, Kenjo con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "kenjo"
+---
+
+## Kenjo HR con Agenti AI
+
+Kenjo è una piattaforma HR tedesca. Con AnythingMCP, colleghi la sua API a qualsiasi agente AI.
+
+### Configurazione
+
+Importa l'adattatore **Kenjo**, inserisci la API key e collega il tuo agente AI.
+
+### Casi d'Uso
+
+- **"Quanti dipendenti per dipartimento?"**
+- **"Posizioni di recruiting aperte"**
+- **"Dettagli dipendente Max Mustermann"**

--- a/content/guides/it/mfr-fieldservice-to-mcp.mdx
+++ b/content/guides/it/mfr-fieldservice-to-mcp.mdx
@@ -1,0 +1,36 @@
+---
+title: "Come collegare MFR Mobile Field Report a MCP per agenti AI"
+description: "Gestisci operazioni di assistenza tecnica con agenti AI via MCP. Accedi a richieste di servizio, appuntamenti, tecnici e checklist da Mobile Field Report."
+category: "connectors"
+keyword: "MFR MCP Server, Mobile Field Report API AI, assistenza tecnica MCP, MFR con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "mfr-fieldservice"
+---
+
+## MFR Mobile Field Report con Agenti AI
+
+Mobile Field Report (MFR) è una piattaforma tedesca per la gestione del servizio tecnico sul campo. Collegando la sua API OData a MCP, gli agenti AI possono accedere a richieste di servizio, appuntamenti, checklist e tracciamento ore.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore MFR e inserisci nome utente e password.
+
+```json
+{
+  "mcpServers": {
+    "mfr": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Mostra tutte le richieste di servizio aperte di questa settimana"**
+- **"Quale tecnico ha più appuntamenti oggi?"**
+- **"Lista tutti gli oggetti di servizio della ditta Müller GmbH"**
+- **"Quali passi della checklist sono incompleti per la richiesta SR-12345?"**

--- a/content/guides/it/n26-openbanking-to-mcp.mdx
+++ b/content/guides/it/n26-openbanking-to-mcp.mdx
@@ -1,0 +1,35 @@
+---
+title: "Come collegare N26 Open Banking a MCP per agenti AI"
+description: "Accedi ai dati del conto N26 via agenti AI e MCP usando l'API PSD2 Open Banking. Saldi, transazioni e dettagli del conto."
+category: "connectors"
+keyword: "N26 MCP Server, N26 Open Banking AI, PSD2 MCP, N26 con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "n26-openbanking"
+---
+
+## N26 Open Banking con Agenti AI
+
+N26 è una neobank europea leader. Tramite l'API PSD2 Open Banking, gli agenti AI possono accedere a informazioni sul conto, saldi e storico transazioni.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore N26 e inserisci Client ID e Client Secret OAuth.
+
+```json
+{
+  "mcpServers": {
+    "n26": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Qual è il mio saldo N26 attuale?"**
+- **"Mostra le transazioni dell'ultima settimana"**
+- **"Lista tutti i conti collegati"**

--- a/content/guides/it/nina-warnings-to-mcp.mdx
+++ b/content/guides/it/nina-warnings-to-mcp.mdx
@@ -1,0 +1,41 @@
+---
+title: "Come collegare NINA Avvisi Emergenza a MCP per agenti AI"
+description: "Ricevi avvisi di emergenza tedeschi ufficiali via agenti AI e MCP. Alluvioni, tempeste, incendi in tempo reale. API pubblica gratuita."
+category: "connectors"
+keyword: "NINA MCP Server, avvisi emergenza Germania AI, BBK MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "nina-warnung"
+---
+
+## Avvisi Emergenza NINA con Agenti AI
+
+NINA è il sistema ufficiale di avvisi di emergenza tedesco del BBK. L'API fornisce accesso in tempo reale ad avvisi su alluvioni, tempeste, incendi e altre emergenze. Nessuna chiave API necessaria.
+
+## Configurazione Rapida
+
+### Passo 1: Distribuisci AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Passo 2: Importa l'Adattatore NINA
+
+Apri `http://localhost:3000/connectors/store` e clicca **Import**. Non servono credenziali.
+
+### Passo 3: Collega al Tuo Agente AI
+
+```json
+{
+  "mcpServers": {
+    "nina": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Ci sono avvisi di alluvione a Berlino?"**
+- **"Mostra tutti gli avvisi di emergenza attivi in Germania"**
+- **"Ci sono avvisi di tempesta per Amburgo oggi?"**

--- a/content/guides/it/payone-payments-to-mcp.mdx
+++ b/content/guides/it/payone-payments-to-mcp.mdx
@@ -1,0 +1,35 @@
+---
+title: "Come collegare PAYONE Pagamenti a MCP per agenti AI"
+description: "Gestisci pagamenti e-commerce via agenti AI e MCP. Lista transazioni, cattura e rimborsa pagamenti tramite l'API PAYONE."
+category: "connectors"
+keyword: "PAYONE MCP Server, PAYONE API AI, pagamenti MCP, PAYONE con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "payone"
+---
+
+## Pagamenti PAYONE con Agenti AI
+
+PAYONE è un fornitore leader di servizi di pagamento europeo. Collegando la sua API a MCP, gli agenti AI possono monitorare transazioni, catturare pagamenti ed elaborare rimborsi.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore PAYONE e inserisci Merchant ID, API Key, Portal ID e Account ID.
+
+```json
+{
+  "mcpServers": {
+    "payone": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Mostra tutte le transazioni di oggi"**
+- **"Qual è lo stato della transazione XYZ?"**
+- **"Cattura il pagamento pendente per l'ordine 12345"**

--- a/content/guides/it/scopevisio-to-mcp.mdx
+++ b/content/guides/it/scopevisio-to-mcp.mdx
@@ -1,0 +1,22 @@
+---
+title: "Come collegare ScopeVisio a MCP per ERP con AI"
+description: "Collega ScopeVisio ERP a MCP. Gestisci contatti, fatture e progetti con agenti AI."
+category: "connectors"
+keyword: "ScopeVisio MCP Server, ScopeVisio AI, ScopeVisio con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "scopevisio"
+---
+
+## ScopeVisio con Agenti AI
+
+ScopeVisio è una piattaforma cloud ERP tedesca. Con AnythingMCP, colleghi la sua API REST a qualsiasi agente AI.
+
+### Configurazione
+
+Importa l'adattatore **ScopeVisio**, inserisci il Bearer token e collega il tuo agente AI.
+
+### Casi d'Uso
+
+- **"Mostra le fatture in uscita scadute"**
+- **"Lista i contatti per tipo"**
+- **"Quali progetti sono attivi?"**

--- a/content/guides/it/teamviewer-to-mcp.mdx
+++ b/content/guides/it/teamviewer-to-mcp.mdx
@@ -1,0 +1,41 @@
+---
+title: "Come collegare TeamViewer a MCP per agenti AI"
+description: "Gestisci dispositivi TeamViewer, contatti e sessioni remote via agenti AI e MCP. Monitora lo stato dei dispositivi."
+category: "connectors"
+keyword: "TeamViewer MCP Server, TeamViewer API AI, accesso remoto MCP"
+publishedAt: "2026-03-15"
+adapterSlug: "teamviewer"
+---
+
+## TeamViewer con Agenti AI
+
+TeamViewer è una piattaforma leader per l'accesso remoto. Collegando la sua Web API a MCP, gli agenti AI possono gestire dispositivi, monitorare lo stato online e creare sessioni di supporto.
+
+## Configurazione Rapida
+
+### Passo 1: Distribuisci AnythingMCP
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+### Passo 2: Importa l'Adattatore TeamViewer
+
+Apri `http://localhost:3000/connectors/store` e clicca **Import**. Inserisci il tuo access token TeamViewer.
+
+### Passo 3: Collega al Tuo Agente AI
+
+```json
+{
+  "mcpServers": {
+    "teamviewer": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Quali dei miei dispositivi sono online?"**
+- **"Mostra i dettagli del dispositivo XYZ"**
+- **"Lista tutte le sessioni di supporto remoto attive"**

--- a/content/guides/it/weclapp-erp-to-mcp.mdx
+++ b/content/guides/it/weclapp-erp-to-mcp.mdx
@@ -1,0 +1,35 @@
+---
+title: "Come collegare weclapp Cloud ERP a MCP per agenti AI"
+description: "Accedi ai dati ERP weclapp inclusi clienti, ordini, fatture e articoli via agenti AI e MCP. ERP cloud popolare per PMI tedesche."
+category: "connectors"
+keyword: "weclapp MCP Server, weclapp API AI, Cloud ERP MCP, weclapp con Claude"
+publishedAt: "2026-03-15"
+adapterSlug: "weclapp"
+---
+
+## weclapp Cloud ERP con Agenti AI
+
+weclapp è una soluzione ERP cloud popolare per le PMI tedesche. Collegando la sua API a MCP, gli agenti AI possono interrogare clienti, ordini, fatture e dati di inventario.
+
+## Configurazione Rapida
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, importa l'adattatore weclapp e inserisci il nome del tenant e il token API.
+
+```json
+{
+  "mcpServers": {
+    "weclapp": { "url": "http://localhost:4000/mcp" }
+  }
+}
+```
+
+## Casi d'Uso
+
+- **"Mostra tutti gli ordini aperti di questo mese"**
+- **"Qual è lo stock attuale per l'articolo ABC?"**
+- **"Lista tutte le fatture non pagate sopra i 1.000 €"**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.1",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.1",
+      "version": "0.1.6",
       "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -19841,7 +19841,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.1",
+      "version": "0.1.6",
       "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -19925,7 +19925,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.1",
+      "version": "0.1.6",
       "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/src/adapters/adapters.controller.ts
+++ b/packages/backend/src/adapters/adapters.controller.ts
@@ -12,6 +12,24 @@ import { AuthGuard } from '@nestjs/passport';
 import { AdaptersService } from './adapters.service';
 import { LicenseGuardService } from '../license/license-guard.service';
 
+// Public endpoints (no auth required) — used by the marketing website
+@ApiTags('Adapters')
+@Controller('api/adapters')
+export class AdaptersPublicController {
+  constructor(private readonly adaptersService: AdaptersService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List all available built-in adapters',
+    description:
+      'Returns metadata for all pre-configured adapters. This endpoint is public so the marketing website can render the marketplace dynamically.',
+  })
+  list() {
+    return this.adaptersService.listAll();
+  }
+}
+
+// Authenticated endpoints
 @ApiTags('Adapters')
 @ApiBearerAuth()
 @UseGuards(AuthGuard('jwt'))
@@ -21,16 +39,6 @@ export class AdaptersController {
     private readonly adaptersService: AdaptersService,
     private readonly licenseGuard: LicenseGuardService,
   ) {}
-
-  @Get()
-  @ApiOperation({
-    summary: 'List all available built-in adapters',
-    description:
-      'Returns metadata for all pre-configured adapters that can be imported with a single click.',
-  })
-  list() {
-    return this.adaptersService.listAll();
-  }
 
   @Get(':slug')
   @ApiOperation({

--- a/packages/backend/src/adapters/adapters.controller.ts
+++ b/packages/backend/src/adapters/adapters.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { AdaptersService } from './adapters.service';
+import { LicenseGuardService } from '../license/license-guard.service';
+
+@ApiTags('Adapters')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'))
+@Controller('api/adapters')
+export class AdaptersController {
+  constructor(
+    private readonly adaptersService: AdaptersService,
+    private readonly licenseGuard: LicenseGuardService,
+  ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List all available built-in adapters',
+    description:
+      'Returns metadata for all pre-configured adapters that can be imported with a single click.',
+  })
+  list() {
+    return this.adaptersService.listAll();
+  }
+
+  @Get(':slug')
+  @ApiOperation({
+    summary: 'Get adapter details including tool definitions',
+    description:
+      'Returns the full adapter definition with connector config and all tool mappings.',
+  })
+  getBySlug(@Param('slug') slug: string) {
+    return this.adaptersService.getBySlug(slug);
+  }
+
+  @Post(':slug/import')
+  @ApiOperation({
+    summary: 'Import a built-in adapter as a new connector',
+    description:
+      'Creates a new connector and its tools from a pre-configured adapter recipe. ' +
+      'Optionally provide credentials in the request body to make the connector immediately functional.',
+  })
+  async importAdapter(
+    @Req() req: any,
+    @Param('slug') slug: string,
+    @Body() body: { credentials?: Record<string, string> },
+  ) {
+    await this.licenseGuard.checkCanCreateConnector(req.user.sub);
+    const result = await this.adaptersService.importAdapter(
+      slug,
+      req.user.sub,
+      body?.credentials,
+    );
+    return {
+      message: `Adapter "${slug}" imported successfully with ${result.toolsCreated} tools.`,
+      connectorId: result.connectorId,
+      toolsCreated: result.toolsCreated,
+    };
+  }
+}

--- a/packages/backend/src/adapters/adapters.module.ts
+++ b/packages/backend/src/adapters/adapters.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AdaptersController } from './adapters.controller';
+import { AdaptersService } from './adapters.service';
+import { McpServerModule } from '../mcp-server/mcp-server.module';
+import { LicenseModule } from '../license/license.module';
+
+@Module({
+  imports: [McpServerModule, LicenseModule],
+  controllers: [AdaptersController],
+  providers: [AdaptersService],
+})
+export class AdaptersModule {}

--- a/packages/backend/src/adapters/adapters.module.ts
+++ b/packages/backend/src/adapters/adapters.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
-import { AdaptersController } from './adapters.controller';
+import {
+  AdaptersController,
+  AdaptersPublicController,
+} from './adapters.controller';
 import { AdaptersService } from './adapters.service';
 import { McpServerModule } from '../mcp-server/mcp-server.module';
 import { LicenseModule } from '../license/license.module';
 
 @Module({
   imports: [McpServerModule, LicenseModule],
-  controllers: [AdaptersController],
+  controllers: [AdaptersPublicController, AdaptersController],
   providers: [AdaptersService],
 })
 export class AdaptersModule {}

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { McpServerService } from '../mcp-server/mcp-server.service';
+import { encrypt } from '../common/crypto/encryption.util';
+import { ConfigService } from '@nestjs/config';
+import { listAdapters, getAdapter, AdapterMeta, AdapterDefinition } from './catalog';
+
+@Injectable()
+export class AdaptersService {
+  private readonly logger = new Logger(AdaptersService.name);
+  private readonly encryptionKey: string;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mcpServer: McpServerService,
+    private readonly configService: ConfigService,
+  ) {
+    this.encryptionKey =
+      this.configService.get<string>('ENCRYPTION_KEY') ||
+      'default-dev-key-change-in-prod!!';
+  }
+
+  listAll(): AdapterMeta[] {
+    return listAdapters();
+  }
+
+  getBySlug(slug: string): AdapterDefinition {
+    const adapter = getAdapter(slug);
+    if (!adapter) {
+      throw new NotFoundException(`Adapter "${slug}" not found`);
+    }
+    return adapter;
+  }
+
+  async importAdapter(
+    slug: string,
+    userId: string,
+    credentials?: Record<string, string>,
+  ): Promise<{ connectorId: string; toolsCreated: number }> {
+    const adapter = this.getBySlug(slug);
+
+    // Resolve {{VAR}} placeholders in authConfig with provided credentials
+    const resolvedAuthConfig = adapter.connector.authConfig
+      ? this.resolveTemplate(adapter.connector.authConfig, credentials)
+      : null;
+
+    const encryptedAuth = resolvedAuthConfig
+      ? encrypt(JSON.stringify(resolvedAuthConfig), this.encryptionKey)
+      : null;
+
+    // Resolve {{VAR}} placeholders in baseUrl (e.g. weclapp tenant)
+    const resolvedBaseUrl = this.resolveString(adapter.connector.baseUrl, credentials);
+
+    const connector = await this.prisma.connector.create({
+      data: {
+        userId,
+        name: adapter.connector.name,
+        type: adapter.connector.type as any,
+        baseUrl: resolvedBaseUrl,
+        isActive: true,
+        authType: (adapter.connector.authType as any) || 'NONE',
+        authConfig: encryptedAuth,
+      },
+    });
+
+    let toolsCreated = 0;
+
+    for (const tool of adapter.tools) {
+      try {
+        await this.prisma.mcpTool.create({
+          data: {
+            connectorId: connector.id,
+            name: tool.name,
+            description: tool.description,
+            isEnabled: true,
+            parameters: tool.parameters as any,
+            endpointMapping: tool.endpointMapping as any,
+            responseMapping: tool.responseMapping as any,
+          },
+        });
+        toolsCreated++;
+      } catch (err: any) {
+        if (err.code !== 'P2002') {
+          this.logger.warn(`Failed to create tool ${tool.name}: ${err.message}`);
+        }
+      }
+    }
+
+    await this.mcpServer.reloadConnectorTools(connector.id);
+
+    this.logger.log(
+      `Imported adapter "${slug}" as connector ${connector.id} with ${toolsCreated} tools`,
+    );
+
+    return { connectorId: connector.id, toolsCreated };
+  }
+
+  /** Replace {{VAR}} placeholders in a string with credential values */
+  private resolveString(
+    str: string,
+    credentials?: Record<string, string>,
+  ): string {
+    if (!credentials) return str;
+    return str.replace(/\{\{(\w+)\}\}/g, (_, key) => credentials[key] || `{{${key}}}`);
+  }
+
+  /** Deep-replace {{VAR}} placeholders in an object/value */
+  private resolveTemplate(
+    obj: unknown,
+    credentials?: Record<string, string>,
+  ): unknown {
+    if (!credentials) return obj;
+    if (typeof obj === 'string') return this.resolveString(obj, credentials);
+    if (Array.isArray(obj)) return obj.map((v) => this.resolveTemplate(v, credentials));
+    if (obj && typeof obj === 'object') {
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        result[k] = this.resolveTemplate(v, credentials);
+      }
+      return result;
+    }
+    return obj;
+  }
+}

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -10,6 +10,9 @@ import * as immobilienscout24 from './de/immobilienscout24.json';
 import * as mfrFieldservice from './de/mfr-fieldservice.json';
 import * as fastbill from './de/fastbill.json';
 import * as billomat from './de/billomat.json';
+import * as datev from './de/datev.json';
+import * as scopevisio from './de/scopevisio.json';
+import * as kenjo from './de/kenjo.json';
 
 export interface AdapterMeta {
   slug: string;
@@ -57,6 +60,9 @@ const ALL_ADAPTERS: AdapterDefinition[] = [
   mfrFieldservice as unknown as AdapterDefinition,
   fastbill as unknown as AdapterDefinition,
   billomat as unknown as AdapterDefinition,
+  datev as unknown as AdapterDefinition,
+  scopevisio as unknown as AdapterDefinition,
+  kenjo as unknown as AdapterDefinition,
 ];
 
 export function listAdapters(): AdapterMeta[] {

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -1,0 +1,78 @@
+import * as dhlTracking from './de/dhl-tracking.json';
+import * as bundesbank from './de/bundesbank.json';
+import * as destatisGenesis from './de/destatis-genesis.json';
+import * as ninaWarnung from './de/nina-warnung.json';
+import * as teamviewer from './de/teamviewer.json';
+import * as n26OpenBanking from './de/n26-openbanking.json';
+import * as payone from './de/payone.json';
+import * as weclapp from './de/weclapp.json';
+import * as immobilienscout24 from './de/immobilienscout24.json';
+import * as mfrFieldservice from './de/mfr-fieldservice.json';
+import * as fastbill from './de/fastbill.json';
+import * as billomat from './de/billomat.json';
+
+export interface AdapterMeta {
+  slug: string;
+  name: string;
+  description: string;
+  region: string;
+  category: string;
+  icon: string;
+  docsUrl: string;
+  requiredEnvVars: string[];
+  toolCount: number;
+}
+
+export interface AdapterDefinition extends AdapterMeta {
+  connector: {
+    name: string;
+    type: string;
+    baseUrl: string;
+    authType: string;
+    authConfig?: Record<string, unknown>;
+  };
+  tools: Array<{
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    endpointMapping: Record<string, unknown>;
+    responseMapping?: Record<string, unknown>;
+  }>;
+}
+
+// Register all adapters here. To add a new adapter:
+// 1. Create the JSON file in the appropriate region folder
+// 2. Import it above
+// 3. Add it to this array
+const ALL_ADAPTERS: AdapterDefinition[] = [
+  dhlTracking as unknown as AdapterDefinition,
+  bundesbank as unknown as AdapterDefinition,
+  destatisGenesis as unknown as AdapterDefinition,
+  ninaWarnung as unknown as AdapterDefinition,
+  teamviewer as unknown as AdapterDefinition,
+  n26OpenBanking as unknown as AdapterDefinition,
+  payone as unknown as AdapterDefinition,
+  weclapp as unknown as AdapterDefinition,
+  immobilienscout24 as unknown as AdapterDefinition,
+  mfrFieldservice as unknown as AdapterDefinition,
+  fastbill as unknown as AdapterDefinition,
+  billomat as unknown as AdapterDefinition,
+];
+
+export function listAdapters(): AdapterMeta[] {
+  return ALL_ADAPTERS.map((adapter) => ({
+    slug: adapter.slug,
+    name: adapter.name,
+    description: adapter.description,
+    region: adapter.region,
+    category: adapter.category,
+    icon: adapter.icon,
+    docsUrl: adapter.docsUrl,
+    requiredEnvVars: adapter.requiredEnvVars,
+    toolCount: adapter.tools.length,
+  }));
+}
+
+export function getAdapter(slug: string): AdapterDefinition | null {
+  return ALL_ADAPTERS.find((a) => a.slug === slug) || null;
+}

--- a/packages/backend/src/adapters/de/billomat.json
+++ b/packages/backend/src/adapters/de/billomat.json
@@ -1,0 +1,196 @@
+{
+  "slug": "billomat",
+  "name": "Billomat Invoicing",
+  "description": "Manage invoices, clients, articles, and accounting with Billomat. German online invoicing and bookkeeping platform for freelancers and SMBs.",
+  "region": "de",
+  "category": "finance",
+  "icon": "billomat",
+  "docsUrl": "https://www.billomat.com/en/api/",
+  "requiredEnvVars": ["BILLOMAT_SUBDOMAIN", "BILLOMAT_API_KEY"],
+  "connector": {
+    "name": "Billomat",
+    "type": "REST",
+    "baseUrl": "https://{{BILLOMAT_SUBDOMAIN}}.billomat.net/api",
+    "authType": "API_KEY",
+    "authConfig": {
+      "headerName": "X-BillomatApiKey",
+      "apiKey": "{{BILLOMAT_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "billomat_list_clients",
+      "description": "List clients from Billomat. Returns client name, number, address, email, and payment terms.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Filter by client name"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/clients",
+        "queryParams": {
+          "page": "${page}",
+          "per_page": "${per_page}",
+          "name": "${name}"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "billomat_get_client",
+      "description": "Get detailed information about a specific client by ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "The Billomat client ID"
+          }
+        },
+        "required": ["clientId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/clients/${clientId}",
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "billomat_list_invoices",
+      "description": "List invoices from Billomat. Returns invoice number, date, total, status, and client info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          },
+          "client_id": {
+            "type": "string",
+            "description": "Filter by client ID"
+          },
+          "status": {
+            "type": "string",
+            "description": "Filter by status: DRAFT, OPEN, OVERDUE, PAID, CANCELED"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/invoices",
+        "queryParams": {
+          "page": "${page}",
+          "per_page": "${per_page}",
+          "client_id": "${client_id}",
+          "status": "${status}"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "billomat_get_invoice",
+      "description": "Get detailed information about a specific invoice including line items, taxes, and payment info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "description": "The Billomat invoice ID"
+          }
+        },
+        "required": ["invoiceId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/invoices/${invoiceId}",
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "billomat_list_articles",
+      "description": "List articles (products/services) from Billomat. Returns article number, title, unit price, and tax info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/articles",
+        "queryParams": {
+          "page": "${page}",
+          "per_page": "${per_page}"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "billomat_list_offers",
+      "description": "List offers (quotes) from Billomat. Returns offer number, date, total, status, and client info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          },
+          "client_id": {
+            "type": "string",
+            "description": "Filter by client ID"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/offers",
+        "queryParams": {
+          "page": "${page}",
+          "per_page": "${per_page}",
+          "client_id": "${client_id}"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/bundesbank.json
+++ b/packages/backend/src/adapters/de/bundesbank.json
@@ -1,0 +1,144 @@
+{
+  "slug": "bundesbank",
+  "name": "Deutsche Bundesbank Statistics",
+  "description": "Access macroeconomic data, exchange rates, interest rates, and financial statistics from the Deutsche Bundesbank via the SDMX REST API.",
+  "region": "de",
+  "category": "finance",
+  "icon": "bundesbank",
+  "docsUrl": "https://api.statistiken.bundesbank.de/doc/index.html",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Bundesbank Statistics",
+    "type": "REST",
+    "baseUrl": "https://api.statistiken.bundesbank.de/rest",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "bundesbank_get_exchange_rates",
+      "description": "Get current and historical euro exchange rates from the Bundesbank. Returns daily exchange rates for major currencies (USD, GBP, CHF, JPY, etc.).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code (e.g. 'USD', 'GBP', 'CHF', 'JPY'). Use 'USD' for EUR/USD rate."
+          },
+          "startPeriod": {
+            "type": "string",
+            "description": "Start date in YYYY-MM-DD format (e.g. '2024-01-01')"
+          },
+          "endPeriod": {
+            "type": "string",
+            "description": "End date in YYYY-MM-DD format (e.g. '2024-12-31')"
+          }
+        },
+        "required": ["currency"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/data/BBEX3/D.${currency}.EUR.BB.AC.000",
+        "queryParams": {
+          "startPeriod": "${startPeriod}",
+          "endPeriod": "${endPeriod}",
+          "detail": "dataonly"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "bundesbank_get_interest_rates",
+      "description": "Get key interest rate data from the Bundesbank and ECB, including the main refinancing rate, deposit facility rate, and marginal lending rate.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "startPeriod": {
+            "type": "string",
+            "description": "Start date in YYYY-MM-DD format"
+          },
+          "endPeriod": {
+            "type": "string",
+            "description": "End date in YYYY-MM-DD format"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/data/BBK01/SU0202",
+        "queryParams": {
+          "startPeriod": "${startPeriod}",
+          "endPeriod": "${endPeriod}",
+          "detail": "dataonly"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "bundesbank_search_statistics",
+      "description": "Search for available statistical series in the Bundesbank database by keyword. Returns matching time series with their IDs, titles, and metadata.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search keyword (e.g. 'inflation', 'GDP', 'money supply', 'Geldmenge')"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of results to return (default: 10, max: 100)"
+          }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/metadata/series",
+        "queryParams": {
+          "q": "${query}",
+          "limit": "${limit}"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "bundesbank_get_timeseries",
+      "description": "Retrieve data for a specific Bundesbank time series by its ID. Use bundesbank_search_statistics first to find the series ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "seriesId": {
+            "type": "string",
+            "description": "The Bundesbank time series ID (e.g. 'BBEX3.D.USD.EUR.BB.AC.000')"
+          },
+          "startPeriod": {
+            "type": "string",
+            "description": "Start date in YYYY-MM-DD format"
+          },
+          "endPeriod": {
+            "type": "string",
+            "description": "End date in YYYY-MM-DD format"
+          }
+        },
+        "required": ["seriesId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/data/${seriesId}",
+        "queryParams": {
+          "startPeriod": "${startPeriod}",
+          "endPeriod": "${endPeriod}",
+          "detail": "dataonly"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/datev.json
+++ b/packages/backend/src/adapters/de/datev.json
@@ -1,0 +1,111 @@
+{
+  "slug": "datev",
+  "name": "DATEV Accounting",
+  "description": "Connect to DATEV accounting systems via the official DATEV Online APIs. Access accounting documents, clients, payroll data, and HR reporting. Used by nearly every German tax consultant.",
+  "region": "de",
+  "category": "accounting",
+  "icon": "datev",
+  "docsUrl": "https://developer.datev.de/en/products",
+  "requiredEnvVars": ["DATEV_CLIENT_ID", "DATEV_CLIENT_SECRET", "DATEV_TOKEN_URL", "DATEV_AUTH_URL"],
+  "connector": {
+    "name": "DATEV Online APIs",
+    "type": "REST",
+    "baseUrl": "https://accounting-documents.api.datev.de/platform/v2",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "clientId": "{{DATEV_CLIENT_ID}}",
+      "clientSecret": "{{DATEV_CLIENT_SECRET}}",
+      "tokenUrl": "{{DATEV_TOKEN_URL}}",
+      "authorizationUrl": "{{DATEV_AUTH_URL}}",
+      "scopes": "openid accounting:documents"
+    }
+  },
+  "tools": [
+    {
+      "name": "datev_list_clients",
+      "description": "List DATEV accounting clients. Returns client number, name, and ID for use with other DATEV API calls.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/clients",
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "datev_upload_document",
+      "description": "Upload an accounting document (invoice, receipt) to DATEV Belege online for a specific client.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "The DATEV client ID"
+          },
+          "documentGuid": {
+            "type": "string",
+            "description": "Unique GUID for the document (RFC4122 format: 8-4-4-4-12)"
+          }
+        },
+        "required": ["clientId", "documentGuid"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/clients/${clientId}/documents/${documentGuid}",
+        "headers": {
+          "Content-Type": "application/octet-stream"
+        }
+      }
+    },
+    {
+      "name": "datev_list_documents",
+      "description": "List accounting documents for a DATEV client. Returns document metadata including type, date, and processing status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "The DATEV client ID"
+          }
+        },
+        "required": ["clientId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/clients/${clientId}/documents",
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "datev_get_document",
+      "description": "Get details of a specific accounting document by GUID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "The DATEV client ID"
+          },
+          "documentGuid": {
+            "type": "string",
+            "description": "The document GUID"
+          }
+        },
+        "required": ["clientId", "documentGuid"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/clients/${clientId}/documents/${documentGuid}",
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/destatis-genesis.json
+++ b/packages/backend/src/adapters/de/destatis-genesis.json
@@ -1,0 +1,140 @@
+{
+  "slug": "destatis-genesis",
+  "name": "Destatis GENESIS Statistics",
+  "description": "Access official German federal statistics from Destatis (Statistisches Bundesamt) via the GENESIS API. Population, economy, trade, labor market, prices, and more.",
+  "region": "de",
+  "category": "government",
+  "icon": "destatis",
+  "docsUrl": "https://www-genesis.destatis.de/genesis/misc/GENESIS-Webservices_Einfuehrung.pdf",
+  "requiredEnvVars": ["DESTATIS_USERNAME", "DESTATIS_PASSWORD"],
+  "connector": {
+    "name": "Destatis GENESIS",
+    "type": "REST",
+    "baseUrl": "https://www-genesis.destatis.de/genesisWS/rest/2020",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "destatis_search_tables",
+      "description": "Search for statistical tables in the Destatis GENESIS database by keyword. Returns table codes, titles, and metadata. Use this to find the right table before retrieving data.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "searchterm": {
+            "type": "string",
+            "description": "Search keyword (e.g. 'Bevölkerung', 'Inflation', 'Arbeitsmarkt', 'BIP')"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language: 'de' for German or 'en' for English. Default: 'de'"
+          }
+        },
+        "required": ["searchterm"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/find/find",
+        "queryParams": {
+          "username": "{{DESTATIS_USERNAME}}",
+          "password": "{{DESTATIS_PASSWORD}}",
+          "term": "${searchterm}",
+          "category": "tables",
+          "language": "${language}"
+        }
+      }
+    },
+    {
+      "name": "destatis_get_table",
+      "description": "Retrieve data from a specific Destatis GENESIS table by its code. Use destatis_search_tables first to find the table code.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "GENESIS table code (e.g. '12411-0001' for population data, '61111-0001' for consumer price index)"
+          },
+          "startyear": {
+            "type": "string",
+            "description": "Start year (e.g. '2020')"
+          },
+          "endyear": {
+            "type": "string",
+            "description": "End year (e.g. '2024')"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language: 'de' or 'en'. Default: 'de'"
+          }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/data/table",
+        "queryParams": {
+          "username": "{{DESTATIS_USERNAME}}",
+          "password": "{{DESTATIS_PASSWORD}}",
+          "name": "${name}",
+          "startyear": "${startyear}",
+          "endyear": "${endyear}",
+          "language": "${language}"
+        }
+      }
+    },
+    {
+      "name": "destatis_get_table_metadata",
+      "description": "Get metadata and structure of a Destatis GENESIS table, including available dimensions, time ranges, and variable descriptions.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "GENESIS table code (e.g. '12411-0001')"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language: 'de' or 'en'. Default: 'de'"
+          }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/metadata/table",
+        "queryParams": {
+          "username": "{{DESTATIS_USERNAME}}",
+          "password": "{{DESTATIS_PASSWORD}}",
+          "name": "${name}",
+          "language": "${language}"
+        }
+      }
+    },
+    {
+      "name": "destatis_list_statistics",
+      "description": "List available statistics categories in the Destatis GENESIS database. Returns statistic codes and descriptions that can be used to browse available data.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "searchterm": {
+            "type": "string",
+            "description": "Optional filter keyword"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language: 'de' or 'en'. Default: 'de'"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/catalogue/statistics",
+        "queryParams": {
+          "username": "{{DESTATIS_USERNAME}}",
+          "password": "{{DESTATIS_PASSWORD}}",
+          "selection": "${searchterm}",
+          "language": "${language}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/dhl-tracking.json
+++ b/packages/backend/src/adapters/de/dhl-tracking.json
@@ -1,0 +1,74 @@
+{
+  "slug": "dhl-tracking",
+  "name": "DHL Shipment Tracking",
+  "description": "Track DHL shipments worldwide using the official DHL Unified Tracking API. Get real-time shipment status, delivery events, and estimated delivery dates.",
+  "region": "de",
+  "category": "logistics",
+  "icon": "dhl",
+  "docsUrl": "https://developer.dhl.com/api-reference/shipment-tracking",
+  "requiredEnvVars": ["DHL_API_KEY"],
+  "connector": {
+    "name": "DHL Tracking",
+    "type": "REST",
+    "baseUrl": "https://api-eu.dhl.com",
+    "authType": "API_KEY",
+    "authConfig": {
+      "headerName": "DHL-API-Key",
+      "apiKey": "{{DHL_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "dhl_track_shipment",
+      "description": "Track a DHL shipment by its tracking number. Returns the current status, all tracking events, and estimated delivery time. Supports DHL Express, DHL Parcel, DHL eCommerce, DHL Freight, and other DHL business units.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "trackingNumber": {
+            "type": "string",
+            "description": "The DHL tracking number (e.g. 7777777770 for DHL Parcel DE, 1234567890 for DHL Express)"
+          },
+          "language": {
+            "type": "string",
+            "description": "ISO 639-1 language code for event descriptions (e.g. 'en', 'de'). Defaults to 'en'."
+          }
+        },
+        "required": ["trackingNumber"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/track/shipments",
+        "queryParams": {
+          "trackingNumber": "${trackingNumber}",
+          "language": "${language}"
+        }
+      }
+    },
+    {
+      "name": "dhl_track_multiple_shipments",
+      "description": "Track multiple DHL shipments at once by providing a comma-separated list of tracking numbers. Returns status and events for all shipments. Maximum 20 tracking numbers per request.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "trackingNumbers": {
+            "type": "string",
+            "description": "Comma-separated list of DHL tracking numbers (max 20)"
+          },
+          "language": {
+            "type": "string",
+            "description": "ISO 639-1 language code for event descriptions. Defaults to 'en'."
+          }
+        },
+        "required": ["trackingNumbers"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/track/shipments",
+        "queryParams": {
+          "trackingNumber": "${trackingNumbers}",
+          "language": "${language}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/fastbill.json
+++ b/packages/backend/src/adapters/de/fastbill.json
@@ -1,0 +1,186 @@
+{
+  "slug": "fastbill",
+  "name": "FastBill Invoicing",
+  "description": "Manage invoices, customers, expenses, and revenue with FastBill. Popular invoicing and bookkeeping tool for German freelancers and small businesses.",
+  "region": "de",
+  "category": "finance",
+  "icon": "fastbill",
+  "docsUrl": "https://apidocs.fastbill.com/fastbill/",
+  "requiredEnvVars": ["FASTBILL_EMAIL", "FASTBILL_API_KEY"],
+  "connector": {
+    "name": "FastBill",
+    "type": "REST",
+    "baseUrl": "https://my.fastbill.com/api/1.0",
+    "authType": "BASIC",
+    "authConfig": {
+      "username": "{{FASTBILL_EMAIL}}",
+      "password": "{{FASTBILL_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "fastbill_list_customers",
+      "description": "List customers from FastBill. Returns customer number, name, address, email, and payment terms.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "LIMIT": {
+            "type": "number",
+            "description": "Maximum number of results (default: 25)"
+          },
+          "OFFSET": {
+            "type": "number",
+            "description": "Offset for pagination"
+          },
+          "TERM": {
+            "type": "string",
+            "description": "Search term to filter customers"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api.php",
+        "body": {
+          "SERVICE": "customer.get",
+          "LIMIT": "${LIMIT}",
+          "OFFSET": "${OFFSET}",
+          "FILTER": {
+            "TERM": "${TERM}"
+          }
+        }
+      }
+    },
+    {
+      "name": "fastbill_list_invoices",
+      "description": "List invoices from FastBill. Returns invoice number, date, amount, tax, payment status, and customer info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "LIMIT": {
+            "type": "number",
+            "description": "Maximum number of results (default: 25)"
+          },
+          "OFFSET": {
+            "type": "number",
+            "description": "Offset for pagination"
+          },
+          "CUSTOMER_ID": {
+            "type": "string",
+            "description": "Filter by customer ID"
+          },
+          "MONTH": {
+            "type": "number",
+            "description": "Filter by month (1-12)"
+          },
+          "YEAR": {
+            "type": "number",
+            "description": "Filter by year"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api.php",
+        "body": {
+          "SERVICE": "invoice.get",
+          "LIMIT": "${LIMIT}",
+          "OFFSET": "${OFFSET}",
+          "FILTER": {
+            "CUSTOMER_ID": "${CUSTOMER_ID}",
+            "MONTH": "${MONTH}",
+            "YEAR": "${YEAR}"
+          }
+        }
+      }
+    },
+    {
+      "name": "fastbill_list_expenses",
+      "description": "List expenses from FastBill. Returns expense date, amount, category, and vendor info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "LIMIT": {
+            "type": "number",
+            "description": "Maximum number of results (default: 25)"
+          },
+          "OFFSET": {
+            "type": "number",
+            "description": "Offset for pagination"
+          },
+          "MONTH": {
+            "type": "number",
+            "description": "Filter by month (1-12)"
+          },
+          "YEAR": {
+            "type": "number",
+            "description": "Filter by year"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api.php",
+        "body": {
+          "SERVICE": "expense.get",
+          "LIMIT": "${LIMIT}",
+          "OFFSET": "${OFFSET}",
+          "FILTER": {
+            "MONTH": "${MONTH}",
+            "YEAR": "${YEAR}"
+          }
+        }
+      }
+    },
+    {
+      "name": "fastbill_list_revenues",
+      "description": "List revenue entries from FastBill. Returns revenue date, amount, invoice reference, and category.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "LIMIT": {
+            "type": "number",
+            "description": "Maximum number of results (default: 25)"
+          },
+          "OFFSET": {
+            "type": "number",
+            "description": "Offset for pagination"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api.php",
+        "body": {
+          "SERVICE": "revenue.get",
+          "LIMIT": "${LIMIT}",
+          "OFFSET": "${OFFSET}"
+        }
+      }
+    },
+    {
+      "name": "fastbill_get_invoice",
+      "description": "Get a specific invoice by ID with full details including line items, taxes, and payment information.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "INVOICE_ID": {
+            "type": "string",
+            "description": "The FastBill invoice ID"
+          }
+        },
+        "required": ["INVOICE_ID"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api.php",
+        "body": {
+          "SERVICE": "invoice.get",
+          "FILTER": {
+            "INVOICE_ID": "${INVOICE_ID}"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/immobilienscout24.json
+++ b/packages/backend/src/adapters/de/immobilienscout24.json
@@ -1,0 +1,124 @@
+{
+  "slug": "immobilienscout24",
+  "name": "ImmobilienScout24 API",
+  "description": "Search and manage real estate listings on ImmobilienScout24, Germany's largest property portal. Browse apartments, houses, and commercial properties.",
+  "region": "de",
+  "category": "real-estate",
+  "icon": "immobilienscout24",
+  "docsUrl": "https://api.immobilienscout24.de/our-apis.html",
+  "requiredEnvVars": ["IS24_CLIENT_ID", "IS24_CLIENT_SECRET"],
+  "connector": {
+    "name": "ImmobilienScout24",
+    "type": "REST",
+    "baseUrl": "https://rest.immobilienscout24.de/restapi/api",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "clientId": "{{IS24_CLIENT_ID}}",
+      "clientSecret": "{{IS24_CLIENT_SECRET}}",
+      "authorizationUrl": "https://rest.immobilienscout24.de/restapi/security/oauth/confirm_access",
+      "tokenUrl": "https://rest.immobilienscout24.de/restapi/security/oauth/access_token"
+    }
+  },
+  "tools": [
+    {
+      "name": "is24_search_properties",
+      "description": "Search for real estate listings on ImmobilienScout24 by location and filters. Returns property titles, prices, sizes, and listing IDs.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "geocode": {
+            "type": "string",
+            "description": "GeoCode ID for the search location (e.g. '1276003001' for Berlin Mitte). Use is24_search_locations to find the code."
+          },
+          "realestatetype": {
+            "type": "string",
+            "description": "Property type: 'apartmentrent', 'apartmentbuy', 'houserent', 'housebuy', 'office', 'store', 'gastronomy'"
+          },
+          "price_min": {
+            "type": "number",
+            "description": "Minimum price (rent per month or purchase price)"
+          },
+          "price_max": {
+            "type": "number",
+            "description": "Maximum price"
+          },
+          "livingspace_min": {
+            "type": "number",
+            "description": "Minimum living space in sqm"
+          },
+          "numberofrooms_min": {
+            "type": "number",
+            "description": "Minimum number of rooms"
+          },
+          "pagenumber": {
+            "type": "number",
+            "description": "Page number for pagination (default: 1)"
+          }
+        },
+        "required": ["geocode", "realestatetype"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/search/v1.0/search/region",
+        "queryParams": {
+          "geocodes": "${geocode}",
+          "realestatetype": "${realestatetype}",
+          "price.min": "${price_min}",
+          "price.max": "${price_max}",
+          "livingspace.min": "${livingspace_min}",
+          "numberofrooms.min": "${numberofrooms_min}",
+          "pagenumber": "${pagenumber}",
+          "pagesize": "20"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "is24_search_locations",
+      "description": "Search for ImmobilienScout24 GeoCode IDs by location name. Use this to find the geocode parameter needed for property searches.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Location name to search (e.g. 'Berlin', 'München Schwabing', 'Hamburg Altona')"
+          }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/gis/v1.0/geo/autocomplete",
+        "queryParams": {
+          "i": "${query}"
+        },
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    },
+    {
+      "name": "is24_get_property",
+      "description": "Get detailed information about a specific real estate listing by its expose ID. Returns full property details including description, equipment, energy certificate, and contact info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "exposeId": {
+            "type": "string",
+            "description": "The ImmobilienScout24 expose ID (listing ID)"
+          }
+        },
+        "required": ["exposeId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/search/v1.0/expose/${exposeId}",
+        "headers": {
+          "Accept": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/kenjo.json
+++ b/packages/backend/src/adapters/de/kenjo.json
@@ -1,0 +1,125 @@
+{
+  "slug": "kenjo",
+  "name": "Kenjo HR",
+  "description": "Access Kenjo HR data including employees, absences, time tracking, departments, and recruiting. German HR software for manufacturing, services, and retail companies.",
+  "region": "de",
+  "category": "hr",
+  "icon": "kenjo",
+  "docsUrl": "https://kenjo.readme.io/reference",
+  "requiredEnvVars": ["KENJO_API_KEY"],
+  "connector": {
+    "name": "Kenjo HR",
+    "type": "REST",
+    "baseUrl": "https://api.kenjo.io/api/v1",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{KENJO_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "kenjo_list_employees",
+      "description": "List employees from Kenjo HR. Returns employee name, email, department, position, and status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Results per page (default: 25)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/employees",
+        "queryParams": {
+          "page": "${page}",
+          "limit": "${limit}"
+        }
+      }
+    },
+    {
+      "name": "kenjo_get_employee",
+      "description": "Get detailed information about a specific employee including personal data, work info, and department.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "employeeId": {
+            "type": "string",
+            "description": "The Kenjo employee ID"
+          }
+        },
+        "required": ["employeeId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/employees/${employeeId}"
+      }
+    },
+    {
+      "name": "kenjo_list_departments",
+      "description": "List departments from Kenjo HR. Returns department name, head, and employee count.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/departments"
+      }
+    },
+    {
+      "name": "kenjo_list_offices",
+      "description": "List office locations from Kenjo HR.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/offices"
+      }
+    },
+    {
+      "name": "kenjo_list_positions",
+      "description": "List open recruiting positions (job openings) from Kenjo. Returns position title, department, and status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Results per page (default: 25)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/recruiting/positions",
+        "queryParams": {
+          "page": "${page}",
+          "limit": "${limit}"
+        }
+      }
+    },
+    {
+      "name": "kenjo_list_teams",
+      "description": "List teams from Kenjo HR.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/teams"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/mfr-fieldservice.json
+++ b/packages/backend/src/adapters/de/mfr-fieldservice.json
@@ -1,0 +1,320 @@
+{
+  "slug": "mfr-fieldservice",
+  "name": "MFR Mobile Field Report",
+  "description": "Manage field service operations with Mobile Field Report (MFR). Access service requests, appointments, companies, contacts, technicians, checklists, and reports via OData API.",
+  "region": "de",
+  "category": "field-service",
+  "icon": "mfr",
+  "docsUrl": "https://portal.mobilefieldreport.com/",
+  "requiredEnvVars": ["MFR_USERNAME", "MFR_PASSWORD"],
+  "connector": {
+    "name": "MFR Field Service",
+    "type": "REST",
+    "baseUrl": "https://portal.mobilefieldreport.com/odata",
+    "authType": "BASIC",
+    "authConfig": {
+      "username": "{{MFR_USERNAME}}",
+      "password": "{{MFR_PASSWORD}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "mfr_list_service_requests",
+      "description": "List service requests (work orders). Returns request number, status, description, assigned technician, and linked company. Supports OData filtering and sorting.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return (default: 20)"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Number of results to skip for pagination"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter expression (e.g. \"Status eq 'Open'\")"
+          },
+          "$orderby": {
+            "type": "string",
+            "description": "OData ordering (e.g. \"CreatedDate desc\")"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand related entities (e.g. \"Company,Appointments\")"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/ServiceRequests",
+        "queryParams": {
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$orderby": "${$orderby}",
+          "$expand": "${$expand}"
+        }
+      }
+    },
+    {
+      "name": "mfr_get_service_request",
+      "description": "Get detailed information about a specific service request by ID, including all fields, linked company, and appointments.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string",
+            "description": "The service request ID (GUID)"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand related entities (e.g. \"Company,Appointments,Steps\")"
+          }
+        },
+        "required": ["requestId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/ServiceRequests(guid'${requestId}')",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_appointments",
+      "description": "List scheduled appointments for field technicians. Returns date, time, duration, assigned technician, and linked service request.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return (default: 20)"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Number of results to skip"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter (e.g. \"StartDateTime ge datetime'2026-03-01T00:00:00'\")"
+          },
+          "$orderby": {
+            "type": "string",
+            "description": "OData ordering (e.g. \"StartDateTime asc\")"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Appointments",
+        "queryParams": {
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$orderby": "${$orderby}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_companies",
+      "description": "List companies (customers/clients) in MFR. Returns company name, address, contact info, and ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return (default: 20)"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Number of results to skip"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter (e.g. \"Name eq 'Mustermann GmbH'\")"
+          },
+          "$search": {
+            "type": "string",
+            "description": "Free text search across company fields"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Companies",
+        "queryParams": {
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$search": "${$search}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_contacts",
+      "description": "List contacts (people associated with companies). Returns name, email, phone, role, and linked company.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return (default: 20)"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Number of results to skip"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter expression"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Contacts",
+        "queryParams": {
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_users",
+      "description": "List technicians and users in the MFR system. Returns name, email, role, and qualifications.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter expression"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Users",
+        "queryParams": {
+          "$top": "${$top}",
+          "$filter": "${$filter}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_service_objects",
+      "description": "List service objects (equipment, machines, devices being serviced). Returns object name, serial number, location, and linked company.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Number of results to skip"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter expression"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand related entities (e.g. \"Company\")"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/ServiceObjects",
+        "queryParams": {
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$expand": "${$expand}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_steps",
+      "description": "List checklist steps for a service request. Returns step name, type, status (done/not done), and any entered values.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "serviceRequestId": {
+            "type": "string",
+            "description": "The service request ID (GUID) to get steps for"
+          }
+        },
+        "required": ["serviceRequestId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/ServiceRequests(guid'${serviceRequestId}')/Steps"
+      }
+    },
+    {
+      "name": "mfr_list_time_events",
+      "description": "List time tracking events. Returns start/end times, duration, technician, and linked service request.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter (e.g. \"StartDateTime ge datetime'2026-03-01T00:00:00'\")"
+          },
+          "$orderby": {
+            "type": "string",
+            "description": "OData ordering"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/TimeEvents",
+        "queryParams": {
+          "$top": "${$top}",
+          "$filter": "${$filter}",
+          "$orderby": "${$orderby}"
+        }
+      }
+    },
+    {
+      "name": "mfr_list_invoices",
+      "description": "List invoices generated from service requests. Returns invoice number, amount, date, and payment status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "$top": {
+            "type": "number",
+            "description": "Number of results to return"
+          },
+          "$filter": {
+            "type": "string",
+            "description": "OData filter expression"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Invoices",
+        "queryParams": {
+          "$top": "${$top}",
+          "$filter": "${$filter}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/n26-openbanking.json
+++ b/packages/backend/src/adapters/de/n26-openbanking.json
@@ -1,0 +1,90 @@
+{
+  "slug": "n26-openbanking",
+  "name": "N26 Open Banking (PSD2)",
+  "description": "Access N26 bank account data via the PSD2 Open Banking API. View account balances, transactions, and account details with proper authorization.",
+  "region": "de",
+  "category": "banking",
+  "icon": "n26",
+  "docsUrl": "https://docs.tech26.de/",
+  "requiredEnvVars": ["N26_CLIENT_ID", "N26_CLIENT_SECRET"],
+  "connector": {
+    "name": "N26 Open Banking",
+    "type": "REST",
+    "baseUrl": "https://xs2a.tech26.de",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "clientId": "{{N26_CLIENT_ID}}",
+      "clientSecret": "{{N26_CLIENT_SECRET}}",
+      "authorizationUrl": "https://xs2a.tech26.de/oauth2/authorize",
+      "tokenUrl": "https://xs2a.tech26.de/oauth2/token",
+      "scopes": "aisp"
+    }
+  },
+  "tools": [
+    {
+      "name": "n26_get_accounts",
+      "description": "List all accounts associated with the authorized N26 user. Returns account IDs, IBANs, currency, and account type.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v1/berlin-group/accounts"
+      }
+    },
+    {
+      "name": "n26_get_account_balances",
+      "description": "Get current balances for a specific N26 account including booked balance and available balance.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "string",
+            "description": "The N26 account ID (obtained from n26_get_accounts)"
+          }
+        },
+        "required": ["accountId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v1/berlin-group/accounts/${accountId}/balances"
+      }
+    },
+    {
+      "name": "n26_get_transactions",
+      "description": "Get transactions for a specific N26 account. Returns transaction details including amount, date, counterparty, and booking status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "string",
+            "description": "The N26 account ID"
+          },
+          "dateFrom": {
+            "type": "string",
+            "description": "Start date in YYYY-MM-DD format"
+          },
+          "dateTo": {
+            "type": "string",
+            "description": "End date in YYYY-MM-DD format"
+          },
+          "bookingStatus": {
+            "type": "string",
+            "description": "Filter by booking status: 'booked', 'pending', or 'both'. Default: 'booked'"
+          }
+        },
+        "required": ["accountId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v1/berlin-group/accounts/${accountId}/transactions",
+        "queryParams": {
+          "dateFrom": "${dateFrom}",
+          "dateTo": "${dateTo}",
+          "bookingStatus": "${bookingStatus}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/nina-warnung.json
+++ b/packages/backend/src/adapters/de/nina-warnung.json
@@ -1,0 +1,84 @@
+{
+  "slug": "nina-warnung",
+  "name": "NINA Emergency Warnings",
+  "description": "Access official German emergency warnings and alerts from the NINA Warn-App (BBK). Get current warnings for floods, storms, fires, and other emergencies by region.",
+  "region": "de",
+  "category": "government",
+  "icon": "nina",
+  "docsUrl": "https://nina.api.bund.dev/",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "NINA Warnungen",
+    "type": "REST",
+    "baseUrl": "https://nina.api.proxy.bund.dev/api31",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "nina_get_dashboard",
+      "description": "Get the current overview of all active emergency warnings across Germany. Returns a summary dashboard with warning counts and categories.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/dashboard/overview.json"
+      }
+    },
+    {
+      "name": "nina_get_warnings_by_region",
+      "description": "Get current emergency warnings for a specific German region (Kreis/Stadt) by its AGS code. AGS is the official municipality key (Amtlicher Gemeindeschlüssel). Use the first 5 digits for Kreis level.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "ags": {
+            "type": "string",
+            "description": "The 12-digit AGS code of the region (e.g. '091620000000' for Munich, '110000000000' for Berlin). Use 5 digits + trailing zeros."
+          }
+        },
+        "required": ["ags"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/dashboard/${ags}.json"
+      }
+    },
+    {
+      "name": "nina_get_warning_detail",
+      "description": "Get detailed information about a specific warning by its ID. Returns the full warning text, affected areas, instructions, and severity level.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "warningId": {
+            "type": "string",
+            "description": "The warning ID (obtained from dashboard or region warnings)"
+          }
+        },
+        "required": ["warningId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/warnings/${warningId}.json"
+      }
+    },
+    {
+      "name": "nina_get_covid_rules",
+      "description": "Get current COVID-19 rules and regulations for a specific German region by AGS code.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "ags": {
+            "type": "string",
+            "description": "The 12-digit AGS code of the region"
+          }
+        },
+        "required": ["ags"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/appdata/covid/covidrules/DE/${ags}.json"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/payone.json
+++ b/packages/backend/src/adapters/de/payone.json
@@ -1,0 +1,121 @@
+{
+  "slug": "payone",
+  "name": "PAYONE Payments",
+  "description": "Process and manage e-commerce payments via the PAYONE API. Create transactions, check payment status, capture and refund payments.",
+  "region": "de",
+  "category": "finance",
+  "icon": "payone",
+  "docsUrl": "https://docs.payone.com/",
+  "requiredEnvVars": ["PAYONE_MERCHANT_ID", "PAYONE_API_KEY", "PAYONE_PORTAL_ID", "PAYONE_ACCOUNT_ID"],
+  "connector": {
+    "name": "PAYONE Payments",
+    "type": "REST",
+    "baseUrl": "https://payment.payone.com/v1",
+    "authType": "API_KEY",
+    "authConfig": {
+      "headerName": "Authorization",
+      "apiKey": "{{PAYONE_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "payone_list_transactions",
+      "description": "List recent payment transactions. Returns transaction IDs, amounts, status, and payment methods.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Number of transactions to return (default: 25, max: 100)"
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination (default: 0)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/transactions",
+        "queryParams": {
+          "limit": "${limit}",
+          "offset": "${offset}",
+          "merchant_id": "{{PAYONE_MERCHANT_ID}}"
+        }
+      }
+    },
+    {
+      "name": "payone_get_transaction",
+      "description": "Get detailed information about a specific payment transaction by its ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "description": "The PAYONE transaction ID"
+          }
+        },
+        "required": ["transactionId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/transactions/${transactionId}"
+      }
+    },
+    {
+      "name": "payone_capture_payment",
+      "description": "Capture (settle) a previously authorized payment transaction.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "description": "The PAYONE transaction ID to capture"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Amount to capture in smallest currency unit (cents). Leave empty for full capture."
+          }
+        },
+        "required": ["transactionId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/transactions/${transactionId}/capture",
+        "bodyMapping": {
+          "amount": "${amount}"
+        }
+      }
+    },
+    {
+      "name": "payone_refund_payment",
+      "description": "Refund a captured payment transaction fully or partially.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "description": "The PAYONE transaction ID to refund"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Amount to refund in smallest currency unit (cents). Leave empty for full refund."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for the refund"
+          }
+        },
+        "required": ["transactionId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/transactions/${transactionId}/refund",
+        "bodyMapping": {
+          "amount": "${amount}",
+          "reason": "${reason}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/scopevisio.json
+++ b/packages/backend/src/adapters/de/scopevisio.json
@@ -1,0 +1,169 @@
+{
+  "slug": "scopevisio",
+  "name": "ScopeVisio Cloud ERP",
+  "description": "Access ScopeVisio cloud ERP and CRM data including contacts, invoices, projects, and accounting. German cloud business software for SMBs.",
+  "region": "de",
+  "category": "erp",
+  "icon": "scopevisio",
+  "docsUrl": "https://appload.scopevisio.com/static/swagger/index.html",
+  "requiredEnvVars": ["SCOPEVISIO_BEARER_TOKEN"],
+  "connector": {
+    "name": "ScopeVisio ERP",
+    "type": "REST",
+    "baseUrl": "https://appload.scopevisio.com/rest",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{SCOPEVISIO_BEARER_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "scopevisio_list_contacts",
+      "description": "List contacts (customers, suppliers, leads) from ScopeVisio. Returns name, company, email, phone, and contact type.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageSize": {
+            "type": "number",
+            "description": "Number of results per page (default: 50)"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 0)"
+          },
+          "search": {
+            "type": "string",
+            "description": "Full-text search across contact fields"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/contacts/list",
+        "body": {
+          "pageSize": "${pageSize}",
+          "page": "${page}",
+          "search": "${search}"
+        }
+      }
+    },
+    {
+      "name": "scopevisio_get_contact",
+      "description": "Get detailed information about a specific contact by ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "contactId": {
+            "type": "string",
+            "description": "The ScopeVisio contact ID"
+          }
+        },
+        "required": ["contactId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/contacts/${contactId}"
+      }
+    },
+    {
+      "name": "scopevisio_list_outgoing_invoices",
+      "description": "List outgoing invoices (Ausgangsrechnungen) from ScopeVisio. Returns invoice number, date, amount, customer, and payment status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageSize": {
+            "type": "number",
+            "description": "Number of results per page (default: 50)"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 0)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/outgoinginvoice/list",
+        "body": {
+          "pageSize": "${pageSize}",
+          "page": "${page}"
+        }
+      }
+    },
+    {
+      "name": "scopevisio_list_incoming_invoices",
+      "description": "List incoming invoices (Eingangsrechnungen) from ScopeVisio. Returns invoice number, date, amount, vendor, and status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageSize": {
+            "type": "number",
+            "description": "Number of results per page (default: 50)"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 0)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/incominginvoice/list",
+        "body": {
+          "pageSize": "${pageSize}",
+          "page": "${page}"
+        }
+      }
+    },
+    {
+      "name": "scopevisio_list_projects",
+      "description": "List projects from ScopeVisio. Returns project name, status, budget, and assigned team.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageSize": {
+            "type": "number",
+            "description": "Number of results per page (default: 50)"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 0)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/project/list",
+        "body": {
+          "pageSize": "${pageSize}",
+          "page": "${page}"
+        }
+      }
+    },
+    {
+      "name": "scopevisio_list_tasks",
+      "description": "List tasks from ScopeVisio. Returns task title, status, due date, and assignee.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageSize": {
+            "type": "number",
+            "description": "Number of results per page (default: 50)"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 0)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/task/list",
+        "body": {
+          "pageSize": "${pageSize}",
+          "page": "${page}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/teamviewer.json
+++ b/packages/backend/src/adapters/de/teamviewer.json
@@ -1,0 +1,107 @@
+{
+  "slug": "teamviewer",
+  "name": "TeamViewer API",
+  "description": "Manage TeamViewer devices, contacts, and sessions via the TeamViewer Web API. List devices, check online status, create remote support sessions.",
+  "region": "de",
+  "category": "remote",
+  "icon": "teamviewer",
+  "docsUrl": "https://www.teamviewer.com/en/for-developers/",
+  "requiredEnvVars": ["TEAMVIEWER_API_TOKEN"],
+  "connector": {
+    "name": "TeamViewer",
+    "type": "REST",
+    "baseUrl": "https://webapi.teamviewer.com/api/v1",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{TEAMVIEWER_API_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "teamviewer_list_devices",
+      "description": "List all devices registered in your TeamViewer account. Returns device IDs, aliases, online status, and last seen timestamps.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "online_state": {
+            "type": "string",
+            "description": "Filter by online status: 'online' or 'offline'. Leave empty for all."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/devices",
+        "queryParams": {
+          "online_state": "${online_state}"
+        }
+      }
+    },
+    {
+      "name": "teamviewer_get_device",
+      "description": "Get detailed information about a specific TeamViewer device by its ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "deviceId": {
+            "type": "string",
+            "description": "The TeamViewer device ID"
+          }
+        },
+        "required": ["deviceId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/devices/${deviceId}"
+      }
+    },
+    {
+      "name": "teamviewer_list_contacts",
+      "description": "List all contacts in your TeamViewer account. Returns contact names, IDs, and online status.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/contacts"
+      }
+    },
+    {
+      "name": "teamviewer_list_groups",
+      "description": "List all device groups in your TeamViewer account.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/groups"
+      }
+    },
+    {
+      "name": "teamviewer_get_account_info",
+      "description": "Get information about the TeamViewer account associated with the API token, including name, email, and company.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/account"
+      }
+    },
+    {
+      "name": "teamviewer_list_sessions",
+      "description": "List active and recent remote support sessions.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sessions"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/weclapp.json
+++ b/packages/backend/src/adapters/de/weclapp.json
@@ -1,0 +1,158 @@
+{
+  "slug": "weclapp",
+  "name": "weclapp Cloud ERP",
+  "description": "Access weclapp Cloud ERP data including customers, orders, invoices, articles, and warehouse management. Popular ERP for German SMBs.",
+  "region": "de",
+  "category": "erp",
+  "icon": "weclapp",
+  "docsUrl": "https://www.weclapp.com/api2/",
+  "requiredEnvVars": ["WECLAPP_TENANT", "WECLAPP_API_TOKEN"],
+  "connector": {
+    "name": "weclapp ERP",
+    "type": "REST",
+    "baseUrl": "https://{{WECLAPP_TENANT}}.weclapp.com/webapp/api/v1",
+    "authType": "API_KEY",
+    "authConfig": {
+      "headerName": "AuthenticationToken",
+      "apiKey": "{{WECLAPP_API_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "weclapp_list_customers",
+      "description": "List customers from weclapp ERP. Returns customer names, IDs, contact info, and customer numbers.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customer",
+        "queryParams": {
+          "page": "${page}",
+          "pageSize": "${pageSize}"
+        }
+      }
+    },
+    {
+      "name": "weclapp_get_customer",
+      "description": "Get detailed information about a specific customer by ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "description": "The weclapp customer ID"
+          }
+        },
+        "required": ["customerId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customer/id/${customerId}"
+      }
+    },
+    {
+      "name": "weclapp_list_sales_orders",
+      "description": "List sales orders from weclapp ERP. Returns order numbers, customer info, amounts, and status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/salesOrder",
+        "queryParams": {
+          "page": "${page}",
+          "pageSize": "${pageSize}"
+        }
+      }
+    },
+    {
+      "name": "weclapp_list_invoices",
+      "description": "List invoices from weclapp ERP. Returns invoice numbers, amounts, due dates, and payment status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/salesInvoice",
+        "queryParams": {
+          "page": "${page}",
+          "pageSize": "${pageSize}"
+        }
+      }
+    },
+    {
+      "name": "weclapp_list_articles",
+      "description": "List articles (products) from weclapp ERP. Returns article numbers, names, prices, and stock levels.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)"
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)"
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/article",
+        "queryParams": {
+          "page": "${page}",
+          "pageSize": "${pageSize}"
+        }
+      }
+    },
+    {
+      "name": "weclapp_get_article",
+      "description": "Get detailed information about a specific article (product) by ID, including stock, pricing, and warehouse data.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "articleId": {
+            "type": "string",
+            "description": "The weclapp article ID"
+          }
+        },
+        "required": ["articleId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/article/id/${articleId}"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { LocalOAuthProvider } from './auth/local-oauth.provider';
 import { PrismaOAuthStore } from './auth/prisma-oauth.store';
 import { PrismaService } from './common/prisma.service';
 import { OAuthUrlRewriteInterceptor } from './auth/oauth-url-rewrite.interceptor';
+import { AdaptersModule } from './adapters/adapters.module';
 import { CloudModule } from './cloud/cloud.module';
 
 // Determine deployment and auth mode from env
@@ -110,6 +111,7 @@ if (useOAuth) {
     AuthModule,
     UsersModule,
     ConnectorsModule,
+    AdaptersModule,
     McpServerModule,
 
     AuditModule,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/lib/auth-context';
 import { connectors } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
 import { Footer } from '@/components/footer';
+import { McpAssignModal } from '@/components/mcp-assign-modal';
 
 const CONNECTOR_TYPES = [
   { id: 'REST', name: 'REST API', description: 'Connect to any REST API. Import from OpenAPI/Swagger spec or configure manually.', color: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-500/10 dark:text-blue-400 dark:border-blue-500/30', iconBg: 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400' },
@@ -42,6 +43,7 @@ export default function NewConnectorPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const [createdConnector, setCreatedConnector] = useState<{ id: string; name: string } | null>(null);
 
   const buildAuthConfig = () => {
     switch (authType) {
@@ -95,12 +97,8 @@ export default function NewConnectorPage() {
         } catch {}
       }
 
-      // For OAuth2 connectors, redirect to the detail page so the user can authorize
-      if (authType === 'OAUTH2') {
-        router.push(`/connectors/${created.id}`);
-      } else {
-        router.push('/connectors');
-      }
+      // Show MCP assignment modal so the user can assign the connector to an MCP server
+      setCreatedConnector({ id: created.id, name: name || created.name });
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -376,6 +374,28 @@ export default function NewConnectorPage() {
           </div>
         )}
       </main>
+
+      {/* MCP Server Assignment Modal */}
+      {createdConnector && token && (
+        <McpAssignModal
+          connectorId={createdConnector.id}
+          connectorName={createdConnector.name}
+          token={token}
+          onDone={(mcpServerId) => {
+            setCreatedConnector(null);
+            if (mcpServerId) {
+              router.push(`/mcp-server/${mcpServerId}`);
+            } else {
+              router.push(`/connectors/${createdConnector.id}`);
+            }
+          }}
+          onClose={() => {
+            setCreatedConnector(null);
+            router.push(`/connectors/${createdConnector.id}`);
+          }}
+        />
+      )}
+
       <Footer />
     </div>
   );

--- a/packages/frontend/src/app/connectors/page.tsx
+++ b/packages/frontend/src/app/connectors/page.tsx
@@ -175,6 +175,14 @@ export default function ConnectorsPage() {
               <span className="hidden sm:inline">Import</span>
             </button>
             <Link
+              href="/connectors/store"
+              className="border border-[var(--border)] px-3 py-2 rounded-md text-sm hover:bg-[var(--accent)] flex items-center gap-1.5"
+              title="Browse pre-built adapter recipes"
+            >
+              <StoreIcon />
+              <span className="hidden sm:inline">Adapters</span>
+            </Link>
+            <Link
               href="/connectors/new"
               className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 flex items-center gap-1.5"
             >
@@ -339,6 +347,13 @@ export default function ConnectorsPage() {
                 <PlusIcon />
                 Add Connector
               </Link>
+              <Link
+                href="/connectors/store"
+                className="inline-flex items-center gap-1.5 border border-[var(--border)] px-4 py-2 rounded-md text-sm hover:bg-[var(--accent)]"
+              >
+                <StoreIcon />
+                Browse Adapters
+              </Link>
               <button
                 onClick={() => setShowImportModal(true)}
                 className="inline-flex items-center gap-1.5 border border-[var(--border)] px-4 py-2 rounded-md text-sm hover:bg-[var(--accent)]"
@@ -485,6 +500,18 @@ function CloseIcon() {
     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M18 6 6 18" />
       <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+function StoreIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m2 7 4.41-4.41A2 2 0 0 1 7.83 2h8.34a2 2 0 0 1 1.42.59L22 7" />
+      <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+      <path d="M15 22v-4a2 2 0 0 0-2-2h-2a2 2 0 0 0-2 2v4" />
+      <path d="M2 7h20" />
+      <path d="M22 7v3a2 2 0 0 1-2 2a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 16 12a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 12 12a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 8 12a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 4 12a2 2 0 0 1-2-2V7" />
     </svg>
   );
 }

--- a/packages/frontend/src/app/connectors/store/page.tsx
+++ b/packages/frontend/src/app/connectors/store/page.tsx
@@ -1,0 +1,446 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth-context';
+import { adapters } from '@/lib/api';
+import { NavBar } from '@/components/nav-bar';
+import { Footer } from '@/components/footer';
+
+const REGION_LABELS: Record<string, string> = {
+  de: 'Germany',
+  eu: 'Europe',
+  us: 'United States',
+  global: 'Global',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  logistics: 'Logistics',
+  finance: 'Finance',
+  government: 'Government',
+  erp: 'ERP',
+  banking: 'Banking',
+  remote: 'Remote Access',
+  'real-estate': 'Real Estate',
+  'field-service': 'Field Service',
+};
+
+const AUTH_LABELS: Record<string, string> = {
+  API_KEY: 'API Key',
+  BEARER_TOKEN: 'Bearer Token',
+  OAUTH2: 'OAuth 2.0',
+  BASIC: 'Basic Auth',
+  NONE: 'None (Public API)',
+};
+
+interface AdapterItem {
+  slug: string;
+  name: string;
+  description: string;
+  region: string;
+  category: string;
+  icon: string;
+  docsUrl: string;
+  requiredEnvVars: string[];
+  toolCount: number;
+}
+
+interface AdapterDetail extends AdapterItem {
+  connector: {
+    name: string;
+    type: string;
+    baseUrl: string;
+    authType: string;
+    authConfig?: Record<string, unknown>;
+  };
+}
+
+export default function AdapterStorePage() {
+  const { token } = useAuth();
+  const router = useRouter();
+  const [list, setList] = useState<AdapterItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [importing, setImporting] = useState<string | null>(null);
+  const [msg, setMsg] = useState('');
+
+  // Credential modal state
+  const [configAdapter, setConfigAdapter] = useState<AdapterDetail | null>(null);
+  const [credentialValues, setCredentialValues] = useState<Record<string, string>>({});
+  const [configLoading, setConfigLoading] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    adapters
+      .list(token)
+      .then(setList)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  const handleImportClick = async (adapter: AdapterItem) => {
+    if (!token) return;
+
+    // If no auth required, import directly
+    if (!adapter.requiredEnvVars || adapter.requiredEnvVars.length === 0) {
+      await doImport(adapter.slug);
+      return;
+    }
+
+    // Fetch full adapter detail to show in modal
+    setConfigLoading(true);
+    try {
+      const detail = await adapters.get(adapter.slug, token);
+      setConfigAdapter(detail);
+      setCredentialValues({});
+    } catch {
+      // Fallback: use list data
+      setConfigAdapter({
+        ...adapter,
+        connector: { name: adapter.name, type: 'REST', baseUrl: '', authType: 'API_KEY' },
+      } as AdapterDetail);
+      setCredentialValues({});
+    } finally {
+      setConfigLoading(false);
+    }
+  };
+
+  const doImport = async (slug: string, credentials?: Record<string, string>) => {
+    if (!token) return;
+    setImporting(slug);
+    setMsg('');
+    setConfigAdapter(null);
+    try {
+      const result = await adapters.import(slug, token, credentials);
+      setMsg(result.message);
+      setTimeout(() => {
+        router.push(`/connectors/${result.connectorId}`);
+      }, 1500);
+    } catch (err: any) {
+      setMsg(`Import failed: ${err.message}`);
+      setImporting(null);
+    }
+  };
+
+  const handleConfigSubmit = () => {
+    if (!configAdapter) return;
+    const creds = Object.keys(credentialValues).length > 0 ? credentialValues : undefined;
+    doImport(configAdapter.slug, creds);
+  };
+
+  // Derive unique categories from the loaded adapters
+  const categories = [...new Set(list.map((a) => a.category).filter(Boolean))];
+
+  const filtered = list.filter((a) => {
+    if (activeCategory && a.category !== activeCategory) return false;
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      a.name.toLowerCase().includes(q) ||
+      a.description.toLowerCase().includes(q) ||
+      a.category?.toLowerCase().includes(q) ||
+      a.region?.toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="min-h-screen bg-[var(--background)] flex flex-col">
+      <NavBar
+        breadcrumbs={[
+          { label: 'Dashboard', href: '/' },
+          { label: 'Connectors', href: '/connectors' },
+        ]}
+        title="Adapter Store"
+        actions={
+          <Link
+            href="/connectors/new"
+            className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 flex items-center gap-1.5"
+          >
+            <PlusIcon />
+            Custom Connector
+          </Link>
+        }
+      />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full">
+        {msg && (
+          <div className="mb-4 p-3 rounded-md bg-[var(--info-bg)] text-[var(--info-text)] text-sm border border-[var(--info-border)] flex items-center justify-between">
+            <span>{msg}</span>
+            <button
+              onClick={() => setMsg('')}
+              className="ml-3 text-[var(--info-text)] hover:opacity-70 text-xs underline"
+            >
+              dismiss
+            </button>
+          </div>
+        )}
+
+        <div className="mb-8 text-center">
+          <h2 className="text-2xl font-bold mb-2">Built-in Adapters</h2>
+          <p className="text-[var(--muted-foreground)] text-sm max-w-lg mx-auto">
+            Pre-configured connector recipes for popular APIs. Import with one click and just add your API key.
+          </p>
+        </div>
+
+        {/* Search + Category Filters */}
+        <div className="flex items-center gap-3 mb-4 justify-center">
+          <div className="relative w-full max-w-sm">
+            <SearchIcon />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search adapters..."
+              aria-label="Search adapters"
+              autoComplete="off"
+              className="w-full border border-[var(--input)] rounded-md pl-9 pr-3 py-2 text-sm bg-[var(--background)]"
+            />
+          </div>
+        </div>
+
+        {categories.length > 1 && (
+          <div className="flex flex-wrap items-center gap-2 mb-6 justify-center">
+            <button
+              onClick={() => setActiveCategory(null)}
+              className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                activeCategory === null
+                  ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                  : 'border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--brand)] hover:text-[var(--foreground)]'
+              }`}
+            >
+              All
+            </button>
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
+                className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                  activeCategory === cat
+                    ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                    : 'border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--brand)] hover:text-[var(--foreground)]'
+                }`}
+              >
+                {CATEGORY_LABELS[cat] || cat}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="border border-[var(--border)] rounded-lg p-6 animate-pulse"
+              >
+                <div className="h-6 w-32 rounded bg-[var(--muted)] mb-3" />
+                <div className="h-4 w-full rounded bg-[var(--muted)] mb-2" />
+                <div className="h-4 w-2/3 rounded bg-[var(--muted)]" />
+              </div>
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-16 border border-dashed border-[var(--border)] rounded-lg">
+            <p className="text-[var(--muted-foreground)]">
+              {list.length === 0
+                ? 'No adapters available yet.'
+                : 'No adapters match your search.'}
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((adapter) => (
+              <div
+                key={adapter.slug}
+                className="border border-[var(--border)] rounded-lg p-6 hover:border-[var(--brand)] transition-colors flex flex-col"
+              >
+                <div className="flex items-start justify-between mb-3">
+                  <h3 className="font-semibold text-lg">{adapter.name}</h3>
+                  <div className="flex gap-1.5 flex-shrink-0">
+                    {adapter.region && (
+                      <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400 uppercase">
+                        {REGION_LABELS[adapter.region] || adapter.region}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <p className="text-sm text-[var(--muted-foreground)] mb-4 flex-1">
+                  {adapter.description}
+                </p>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]">
+                    {adapter.category && (
+                      <span>{CATEGORY_LABELS[adapter.category] || adapter.category}</span>
+                    )}
+                    <span>{adapter.toolCount} tool{adapter.toolCount !== 1 ? 's' : ''}</span>
+                  </div>
+
+                  <button
+                    onClick={() => handleImportClick(adapter)}
+                    disabled={importing === adapter.slug || configLoading}
+                    className="bg-[var(--brand)] text-white px-3 py-1.5 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50 flex items-center gap-1.5"
+                  >
+                    {importing === adapter.slug ? (
+                      'Importing...'
+                    ) : (
+                      <>
+                        <DownloadIcon />
+                        Import
+                      </>
+                    )}
+                  </button>
+                </div>
+
+                {adapter.docsUrl && (
+                  <a
+                    href={adapter.docsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-3 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] underline"
+                  >
+                    API Documentation
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+
+      {/* Credential Configuration Modal */}
+      {configAdapter && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setConfigAdapter(null)}
+          />
+          <div className="relative bg-[var(--background)] border border-[var(--border)] rounded-lg shadow-lg w-full max-w-md mx-4 p-6">
+            <button
+              onClick={() => setConfigAdapter(null)}
+              className="absolute top-3 right-3 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+              aria-label="Close"
+            >
+              <CloseIcon />
+            </button>
+
+            <h3 className="text-lg font-semibold mb-1">
+              Configure {configAdapter.name}
+            </h3>
+            <p className="text-sm text-[var(--muted-foreground)] mb-4">
+              This adapter requires credentials to work. Enter them now or skip and configure later.
+            </p>
+
+            <div className="mb-3 flex items-center gap-2 text-xs text-[var(--muted-foreground)]">
+              <LockIcon />
+              <span>Auth type: {AUTH_LABELS[configAdapter.connector?.authType] || configAdapter.connector?.authType}</span>
+            </div>
+
+            <div className="space-y-3 mb-6">
+              {configAdapter.requiredEnvVars.map((envVar) => (
+                <div key={envVar}>
+                  <label
+                    htmlFor={`cred-${envVar}`}
+                    className="block text-sm font-medium mb-1"
+                  >
+                    {formatEnvVarLabel(envVar)}
+                  </label>
+                  <input
+                    id={`cred-${envVar}`}
+                    type={envVar.toLowerCase().includes('secret') || envVar.toLowerCase().includes('password') || envVar.toLowerCase().includes('token') || envVar.toLowerCase().includes('key') ? 'password' : 'text'}
+                    value={credentialValues[envVar] || ''}
+                    onChange={(e) =>
+                      setCredentialValues((prev) => ({
+                        ...prev,
+                        [envVar]: e.target.value,
+                      }))
+                    }
+                    placeholder={envVar}
+                    className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => doImport(configAdapter.slug)}
+                className="px-4 py-2 rounded-md text-sm border border-[var(--border)] hover:bg-[var(--muted)]"
+              >
+                Skip for now
+              </button>
+              <button
+                onClick={handleConfigSubmit}
+                disabled={configAdapter.requiredEnvVars.some(
+                  (v) => !credentialValues[v]?.trim(),
+                )}
+                className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
+              >
+                Import with credentials
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Footer />
+    </div>
+  );
+}
+
+/** Convert ENV_VAR_NAME to a human-readable label */
+function formatEnvVarLabel(envVar: string): string {
+  return envVar
+    .replace(/^(PAYONE_|DHL_|IS24_|WECLAPP_|DESTATIS_|N26_|TEAMVIEWER_|MFR_|FASTBILL_|BILLOMAT_)/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function PlusIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M5 12h14" />
+      <path d="M12 5v14" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--muted-foreground)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" x2="12" y1="15" y2="3" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}

--- a/packages/frontend/src/app/connectors/store/page.tsx
+++ b/packages/frontend/src/app/connectors/store/page.tsx
@@ -25,6 +25,8 @@ const CATEGORY_LABELS: Record<string, string> = {
   remote: 'Remote Access',
   'real-estate': 'Real Estate',
   'field-service': 'Field Service',
+  accounting: 'Accounting',
+  hr: 'HR',
 };
 
 const AUTH_LABELS: Record<string, string> = {
@@ -420,7 +422,7 @@ export default function AdapterStorePage() {
 /** Convert ENV_VAR_NAME to a human-readable label */
 function formatEnvVarLabel(envVar: string): string {
   return envVar
-    .replace(/^(PAYONE_|DHL_|IS24_|WECLAPP_|DESTATIS_|N26_|TEAMVIEWER_|MFR_|FASTBILL_|BILLOMAT_)/, '')
+    .replace(/^(PAYONE_|DHL_|IS24_|WECLAPP_|DESTATIS_|N26_|TEAMVIEWER_|MFR_|FASTBILL_|BILLOMAT_|DATEV_|SCOPEVISIO_|KENJO_)/, '')
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/packages/frontend/src/app/connectors/store/page.tsx
+++ b/packages/frontend/src/app/connectors/store/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState, useRef } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
 import { adapters } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
@@ -62,6 +62,7 @@ interface AdapterDetail extends AdapterItem {
 export default function AdapterStorePage() {
   const { token } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [list, setList] = useState<AdapterItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
@@ -77,6 +78,9 @@ export default function AdapterStorePage() {
   // MCP assignment modal state
   const [importedConnector, setImportedConnector] = useState<{ id: string; name: string } | null>(null);
 
+  // Track whether auto-install from ?install= param has been triggered
+  const autoInstallTriggered = useRef(false);
+
   useEffect(() => {
     if (!token) return;
     adapters
@@ -85,6 +89,17 @@ export default function AdapterStorePage() {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [token]);
+
+  // Auto-import when ?install=<slug> is present (e.g. from website marketplace)
+  useEffect(() => {
+    if (autoInstallTriggered.current || loading || !token || list.length === 0) return;
+    const installSlug = searchParams.get('install');
+    if (!installSlug) return;
+    const adapter = list.find((a) => a.slug === installSlug);
+    if (!adapter) return;
+    autoInstallTriggered.current = true;
+    handleImportClick(adapter);
+  }, [loading, list, token, searchParams]);
 
   const handleImportClick = async (adapter: AdapterItem) => {
     if (!token) return;

--- a/packages/frontend/src/app/connectors/store/page.tsx
+++ b/packages/frontend/src/app/connectors/store/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/lib/auth-context';
 import { adapters } from '@/lib/api';
 import { NavBar } from '@/components/nav-bar';
 import { Footer } from '@/components/footer';
+import { McpAssignModal } from '@/components/mcp-assign-modal';
 
 const REGION_LABELS: Record<string, string> = {
   de: 'Germany',
@@ -71,6 +72,9 @@ export default function AdapterStorePage() {
   const [credentialValues, setCredentialValues] = useState<Record<string, string>>({});
   const [configLoading, setConfigLoading] = useState(false);
 
+  // MCP assignment modal state
+  const [importedConnector, setImportedConnector] = useState<{ id: string; name: string } | null>(null);
+
   useEffect(() => {
     if (!token) return;
     adapters
@@ -113,11 +117,12 @@ export default function AdapterStorePage() {
     setMsg('');
     setConfigAdapter(null);
     try {
+      const adapter = list.find((a) => a.slug === slug);
       const result = await adapters.import(slug, token, credentials);
       setMsg(result.message);
-      setTimeout(() => {
-        router.push(`/connectors/${result.connectorId}`);
-      }, 1500);
+      setImporting(null);
+      // Show MCP assignment modal
+      setImportedConnector({ id: result.connectorId, name: adapter?.name || slug });
     } catch (err: any) {
       setMsg(`Import failed: ${err.message}`);
       setImporting(null);
@@ -384,6 +389,27 @@ export default function AdapterStorePage() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* MCP Server Assignment Modal */}
+      {importedConnector && token && (
+        <McpAssignModal
+          connectorId={importedConnector.id}
+          connectorName={importedConnector.name}
+          token={token}
+          onDone={(mcpServerId) => {
+            setImportedConnector(null);
+            if (mcpServerId) {
+              router.push(`/mcp-server/${mcpServerId}`);
+            } else {
+              router.push(`/connectors/${importedConnector.id}`);
+            }
+          }}
+          onClose={() => {
+            setImportedConnector(null);
+            router.push(`/connectors/${importedConnector.id}`);
+          }}
+        />
       )}
 
       <Footer />

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -36,6 +36,7 @@ function LoginForm() {
 
   const redirectTo = searchParams.get('redirect') || '/';
   const emailVerifiedParam = searchParams.get('emailVerified');
+  const modeParam = searchParams.get('mode'); // 'register' or 'login'
 
   useEffect(() => {
     server.info().then((info) => {
@@ -43,9 +44,13 @@ function LoginForm() {
       setIsCloudMode(info.deploymentMode === 'cloud');
       if (!info.hasUsers) {
         setIsRegister(true);
+      } else if (modeParam === 'register' && info.registrationEnabled) {
+        setIsRegister(true);
+      } else if (modeParam === 'login') {
+        setIsRegister(false);
       }
     }).catch(() => {});
-  }, []);
+  }, [modeParam]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/packages/frontend/src/components/mcp-assign-modal.tsx
+++ b/packages/frontend/src/components/mcp-assign-modal.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { mcpServers } from '@/lib/api';
+
+interface McpAssignModalProps {
+  connectorId: string;
+  connectorName: string;
+  token: string;
+  onDone: (mcpServerId?: string) => void;
+  onClose: () => void;
+}
+
+export function McpAssignModal({ connectorId, connectorName, token, onDone, onClose }: McpAssignModalProps) {
+  const [servers, setServers] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [createNew, setCreateNew] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    mcpServers.list(token).then((list) => {
+      setServers(list);
+      if (list.length === 0) {
+        setCreateNew(true);
+      }
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, [token]);
+
+  const filtered = servers.filter((s) =>
+    !search || s.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      let targetId: string;
+
+      if (createNew) {
+        if (!newName.trim()) {
+          setError('Enter a name for the new MCP server');
+          setSaving(false);
+          return;
+        }
+        const created = await mcpServers.create({ name: newName.trim() }, token);
+        targetId = created.id;
+      } else if (selectedId) {
+        targetId = selectedId;
+      } else {
+        setError('Select an MCP server or create a new one');
+        setSaving(false);
+        return;
+      }
+
+      // Get existing connectors for this MCP server, then add the new one
+      const srv = await mcpServers.get(targetId, token);
+      const existingIds = srv.connectors?.map((c: any) => c.connector.id) || [];
+      if (!existingIds.includes(connectorId)) {
+        existingIds.push(connectorId);
+      }
+      await mcpServers.assignConnectors(targetId, existingIds, token);
+
+      onDone(targetId);
+    } catch (err: any) {
+      setError(err.message || 'Failed to assign connector');
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative bg-[var(--background)] border border-[var(--border)] rounded-lg shadow-lg w-full max-w-md mx-4 p-6 max-h-[80vh] flex flex-col">
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+          aria-label="Close"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+          </svg>
+        </button>
+
+        <h3 className="text-lg font-semibold mb-1">Add to MCP Server</h3>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Choose which MCP server should expose <strong>{connectorName}</strong> tools to AI agents.
+        </p>
+
+        {error && (
+          <div className="mb-3 p-2.5 rounded-md bg-[var(--destructive-bg)] text-[var(--destructive-text)] text-sm border border-[var(--destructive-border)]">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">Loading MCP servers...</div>
+        ) : (
+          <div className="flex-1 overflow-y-auto min-h-0">
+            {/* Existing servers */}
+            {servers.length > 0 && (
+              <>
+                {servers.length > 5 && (
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search MCP servers..."
+                    autoComplete="off"
+                    className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] mb-3"
+                  />
+                )}
+
+                <div className="space-y-2 mb-4">
+                  {filtered.map((srv) => {
+                    const connCount = srv.connectors?.length || srv._count?.connectors || 0;
+                    return (
+                      <label
+                        key={srv.id}
+                        className={`flex items-center gap-3 p-3 rounded-md border cursor-pointer transition-colors ${
+                          selectedId === srv.id && !createNew
+                            ? 'border-[var(--brand)] bg-[var(--brand-light)]'
+                            : 'border-[var(--border)] hover:border-[var(--brand)]'
+                        }`}
+                        onClick={() => { setSelectedId(srv.id); setCreateNew(false); }}
+                      >
+                        <input
+                          type="radio"
+                          name="mcp-server"
+                          checked={selectedId === srv.id && !createNew}
+                          onChange={() => { setSelectedId(srv.id); setCreateNew(false); }}
+                          className="accent-[var(--brand)]"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium text-sm truncate">{srv.name}</div>
+                          <div className="text-xs text-[var(--muted-foreground)]">
+                            {connCount} connector{connCount !== 1 ? 's' : ''}
+                            {srv.description && ` · ${srv.description}`}
+                          </div>
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+
+                <div className="border-t border-[var(--border)] pt-3 mb-3">
+                  <label
+                    className={`flex items-center gap-3 p-3 rounded-md border cursor-pointer transition-colors ${
+                      createNew
+                        ? 'border-[var(--brand)] bg-[var(--brand-light)]'
+                        : 'border-[var(--border)] hover:border-[var(--brand)]'
+                    }`}
+                    onClick={() => setCreateNew(true)}
+                  >
+                    <input
+                      type="radio"
+                      name="mcp-server"
+                      checked={createNew}
+                      onChange={() => setCreateNew(true)}
+                      className="accent-[var(--brand)]"
+                    />
+                    <div className="flex-1">
+                      <div className="font-medium text-sm flex items-center gap-1.5">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M5 12h14" /><path d="M12 5v14" />
+                        </svg>
+                        Create new MCP server
+                      </div>
+                    </div>
+                  </label>
+                </div>
+              </>
+            )}
+
+            {/* New server name input */}
+            {createNew && (
+              <div className="mb-3">
+                <label className="block text-sm font-medium mb-1">Server name</label>
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="e.g. My API Server"
+                  autoFocus
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex gap-3 justify-end pt-3 border-t border-[var(--border)] mt-auto">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-md text-sm border border-[var(--border)] hover:bg-[var(--muted)]"
+          >
+            Skip for now
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={saving || (!selectedId && !createNew) || (createNew && !newName.trim())}
+            className="bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? 'Assigning...' : 'Assign to MCP Server'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -147,6 +147,19 @@ export const connectors = {
     ),
 };
 
+// Adapters (built-in connector recipes)
+export const adapters = {
+  list: (token: string) =>
+    request<any[]>('/api/adapters', { token }),
+  get: (slug: string, token: string) =>
+    request<any>(`/api/adapters/${slug}`, { token }),
+  import: (slug: string, token: string, credentials?: Record<string, string>) =>
+    request<{ message: string; connectorId: string; toolsCreated: number }>(
+      `/api/adapters/${slug}/import`,
+      { method: 'POST', token, body: credentials ? { credentials } : undefined },
+    ),
+};
+
 // Tools
 export const tools = {
   list: (connectorId: string, token: string) =>

--- a/packages/frontend/src/lib/auth-context.tsx
+++ b/packages/frontend/src/lib/auth-context.tsx
@@ -95,7 +95,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const publicPaths = ['/login', '/register', '/forgot-password', '/reset-password', '/accept-invite', '/verify-email'];
     if (!isLoading && !token && !publicPaths.includes(pathname)) {
-      router.push('/login');
+      const currentUrl = typeof window !== 'undefined' ? window.location.pathname + window.location.search : pathname;
+      router.push(`/login?redirect=${encodeURIComponent(currentUrl)}`);
     }
   }, [isLoading, token, pathname, router]);
 

--- a/scripts/sync-guides-to-website.sh
+++ b/scripts/sync-guides-to-website.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# sync-guides-to-website.sh
+#
+# Syncs adapter guide MDX files from the AnythingMCP repo to the website repo.
+# This script is meant to be run as a prebuild step in the website project,
+# or manually when adapter guides are updated.
+#
+# Usage:
+#   From the website repo root:
+#     ANYTHINGMCP_REPO=https://github.com/HelpCode-ai/anythingmcp.git ./scripts/sync-guides.sh
+#
+#   Or with a local path:
+#     ANYTHINGMCP_PATH=/path/to/anythingmcp ./scripts/sync-guides.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WEBSITE_CONTENT="${WEBSITE_CONTENT_DIR:-}"
+ANYTHINGMCP_PATH="${ANYTHINGMCP_PATH:-}"
+ANYTHINGMCP_REPO="${ANYTHINGMCP_REPO:-https://github.com/HelpCode-ai/anythingmcp.git}"
+ANYTHINGMCP_BRANCH="${ANYTHINGMCP_BRANCH:-main}"
+
+# If WEBSITE_CONTENT_DIR is not set, try to detect it
+if [ -z "$WEBSITE_CONTENT" ]; then
+  # If run from the website repo
+  if [ -d "./content/en/guides" ]; then
+    WEBSITE_CONTENT="./content"
+  else
+    echo "Error: Could not detect website content directory. Set WEBSITE_CONTENT_DIR." >&2
+    exit 1
+  fi
+fi
+
+# Source: either local path or cloned repo
+if [ -n "$ANYTHINGMCP_PATH" ]; then
+  SOURCE_GUIDES="$ANYTHINGMCP_PATH/content/guides"
+else
+  # Clone to temp dir
+  TMPDIR=$(mktemp -d)
+  trap "rm -rf $TMPDIR" EXIT
+  echo "Cloning AnythingMCP repo (sparse checkout)..."
+  git clone --depth 1 --filter=blob:none --sparse "$ANYTHINGMCP_REPO" -b "$ANYTHINGMCP_BRANCH" "$TMPDIR/repo" 2>/dev/null
+  cd "$TMPDIR/repo"
+  git sparse-checkout set content/guides 2>/dev/null
+  cd - > /dev/null
+  SOURCE_GUIDES="$TMPDIR/repo/content/guides"
+fi
+
+if [ ! -d "$SOURCE_GUIDES" ]; then
+  echo "Error: Source guides directory not found at $SOURCE_GUIDES" >&2
+  exit 1
+fi
+
+# Sync guides for each locale
+SYNCED=0
+for locale_dir in "$SOURCE_GUIDES"/*/; do
+  locale=$(basename "$locale_dir")
+  target_dir="$WEBSITE_CONTENT/$locale/guides"
+
+  if [ ! -d "$target_dir" ]; then
+    echo "Skipping locale '$locale' — no matching content directory in website"
+    continue
+  fi
+
+  for guide in "$locale_dir"*.mdx; do
+    [ -f "$guide" ] || continue
+    filename=$(basename "$guide")
+    cp "$guide" "$target_dir/$filename"
+    SYNCED=$((SYNCED + 1))
+  done
+done
+
+echo "Synced $SYNCED guide files from AnythingMCP to website."


### PR DESCRIPTION
## Summary
- Add built-in adapter store with 15 pre-configured connectors (DHL, DATEV, TeamViewer, N26, weclapp, etc.)
- Add MCP server assignment modal after connector creation/import
- Add auto-install via `?install=<slug>` URL parameter for website marketplace integration
- Add login URL `?mode=register|login` parameter for deep linking
- Add 80+ SEO guide pages (EN/DE/IT) for all adapters
- Make adapter list endpoint public for website marketplace
- Preserve redirect path through auth flow
- Bump version to 0.1.7

## Test plan
- [ ] Visit `/connectors/store` and verify all 15 adapters appear
- [ ] Import an adapter and verify MCP assignment modal appears
- [ ] Visit `/connectors/store?install=dhl-tracking` and verify auto-import triggers
- [ ] Visit `/login?mode=register` and verify registration toggle is active
- [ ] Verify `GET /api/adapters` returns adapter list without auth