### PR TITLE
Fix Caddy routing: /mcp-server frontend route was hitting backend

### DIFF
--- a/deploy/cloud/Caddyfile
+++ b/deploy/cloud/Caddyfile
@@ -6,7 +6,10 @@
 	handle /health* {
 		reverse_proxy app:4000
 	}
-	handle /mcp* {
+	handle /mcp {
+		reverse_proxy app:4000
+	}
+	handle /mcp/* {
 		reverse_proxy app:4000
 	}
 	handle /.well-known/* {


### PR DESCRIPTION
The /mcp* pattern in Caddyfile matched both /mcp (backend) and /mcp-server (frontend). Split into exact /mcp and /mcp/* patterns.