### PR TITLE
Update README: cloud version, pre-configured connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,13 @@
 
 ---
 
-## Deploy in One Click
+## Cloud & Deploy
 
+[![Try on Cloud](docs/assets/cloud-button.svg)](https://cloud.anythingmcp.com)
+&nbsp;&nbsp;
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/8-X4WD?referralCode=k30bPV&utm_medium=integration&utm_source=template&utm_campaign=generic)
 &nbsp;&nbsp;
 [![Install on DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://marketplace.digitalocean.com/apps/anythingmcp)
-
-### Railway
-
-1. Click the Railway button above to open the Railway template.
-2. Fill in the required environment variables (secrets are auto-generated for you).
-3. Click **Deploy** — Railway will build the container and provision a managed PostgreSQL database.
-4. Once the deploy is complete (2-3 minutes), open the generated URL and register your admin account. By default, only the admin can self-register — invite other users from the admin panel. Set `ALLOW_OPEN_REGISTRATION=true` to allow anyone to register.
-
-### DigitalOcean Marketplace
-
-1. Click the DigitalOcean button above to open the [AnythingMCP listing on the DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps/anythingmcp).
-2. Click **Create AnythingMCP Droplet** and choose your preferred droplet size and region.
-3. Once the droplet is ready, open the droplet IP in your browser and register your admin account.
 
 > **Self-hosting instead?** Run `./setup.sh` for the interactive Docker setup. See [Quick Start](#quick-start) below.
 
@@ -113,7 +102,7 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 | Database connectors | ✅ 7 engines | ❌ Build yourself | ⚠️ Limited |
 | Visual tool editor | ✅ | ❌ | ❌ |
 | Auth & audit trail | ✅ OAuth2, RBAC, logs | ❌ DIY | ⚠️ Partial |
-| Self-hosted | ✅ Docker / Railway / DigitalOcean | ✅ | ⚠️ Often SaaS-only |
+| Self-hosted or Cloud | ✅ Docker / Railway / DigitalOcean / [Cloud](https://cloud.anythingmcp.com) | ✅ | ⚠️ Often SaaS-only |
 | Multi-client support | ✅ Claude, ChatGPT, Gemini, Copilot, Cursor | ✅ | ⚠️ Varies |
 
 ---
@@ -131,6 +120,32 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 - **Roles & Access Control** — Tool-level whitelisting per custom role
 - **Per-User MCP API Keys** — Individual keys with usage tracking
 - **Docker Ready** — `docker compose up` and you're running
+
+---
+
+## Pre-configured Connectors
+
+AnythingMCP ships with a catalog of ready-to-use connectors that work out of the box — just provide your API credentials and activate them. Currently available:
+
+| Connector | Category |
+|-----------|----------|
+| **DHL Tracking** | Logistics |
+| **MFR Fieldservice** | Field Service Management |
+| **DATEV** | Accounting / Tax |
+| **Billomat** | Invoicing |
+| **Fastbill** | Invoicing |
+| **Scopevisio** | ERP / Accounting |
+| **weclapp** | ERP / CRM |
+| **Kenjo** | HR |
+| **Payone** | Payments |
+| **N26 Open Banking** | Banking |
+| **ImmobilienScout24** | Real Estate |
+| **TeamViewer** | Remote Access |
+| **Bundesbank** | Financial Data |
+| **DESTATIS Genesis** | Statistics |
+| **NINA Warnung** | Emergency Alerts |
+
+**Want to add your own?** Create a JSON adapter file in `packages/backend/src/adapters/` (organized by region, e.g. `de/`), register it in `catalog.ts`, and it becomes available to all users. See the existing adapters for the expected format.
 
 ---
 

--- a/docs/assets/cloud-button.svg
+++ b/docs/assets/cloud-button.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="220" height="42" viewBox="0 0 220 42" fill="none">
+  <rect width="220" height="42" rx="6" fill="#6C3FE3"/>
+  <path d="M30 14.5c0-3.59 2.91-6.5 6.5-6.5 2.68 0 4.97 1.62 5.96 3.93A4.49 4.49 0 0 1 47 16.5c0 2.49-2.01 4.5-4.5 4.5h-12A3.5 3.5 0 0 1 27 17.5c0-1.58 1.06-2.92 2.5-3.34A6.6 6.6 0 0 1 30 14.5z" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M33 25v4m0 0l-2-2m2 2l2-2M39 25v4m0 0l-2-2m2 2l2-2" stroke="white" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="56" y="26" fill="white" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="15" font-weight="600">Try on Cloud</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add cloud button linking to cloud.anythingmcp.com alongside Railway and DigitalOcean deploy buttons
- Remove verbose deployment instructions for Railway and DigitalOcean (buttons are self-explanatory)
- Add new "Pre-configured Connectors" section listing all 15 built-in adapters with categories
- Update comparison table to reflect Cloud deployment option

## Test plan
- [ ] Verify README renders correctly on GitHub (buttons, tables, links)
- [ ] Confirm cloud-button.svg displays properly