### PR TITLE
Fix Swagger UI URL import for OpenAPI specs

### DIFF
--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -37,7 +37,117 @@ export class OpenApiParser {
     this.logger.debug(`Fetching OpenAPI spec from: ${url}`);
 
     const response = await axios.get(url, { timeout: 15000 });
+
+    // If the response is already a valid spec object, parse directly
+    if (typeof response.data === 'object' && response.data !== null) {
+      return this.parse(response.data);
+    }
+
+    const text = typeof response.data === 'string' ? response.data : '';
+
+    // If it looks like JSON or YAML, try parsing directly
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith('{') || trimmed.startsWith('openapi') || trimmed.startsWith('swagger')) {
+      return this.parse(text);
+    }
+
+    // Response is likely HTML (Swagger UI page) — try to resolve the actual spec
+    if (text.includes('<html') || text.includes('swagger-ui') || text.includes('<!DOCTYPE')) {
+      this.logger.debug('Detected Swagger UI HTML page, attempting to resolve spec URL...');
+      const spec = await this.resolveSpecFromSwaggerUi(url, text);
+      if (spec) {
+        return this.parse(spec);
+      }
+    }
+
+    // Fallback: try parsing as-is (will throw a descriptive error)
     return this.parse(response.data);
+  }
+
+  /**
+   * When a user provides a Swagger UI page URL instead of the raw spec URL,
+   * attempt to find and fetch the actual OpenAPI spec by:
+   *   1. Extracting the spec URL from the HTML (e.g. SwaggerUIBundle({ url: "..." }))
+   *   2. Fetching swagger-ui-init.js for embedded specs (swagger-ui-express / NestJS)
+   *   3. Trying common spec endpoint paths relative to the base URL
+   */
+  private async resolveSpecFromSwaggerUi(
+    pageUrl: string,
+    html: string,
+  ): Promise<Record<string, unknown> | string | null> {
+    const base = new URL(pageUrl);
+
+    // 1. Try to extract a spec URL from the HTML (SwaggerUIBundle({ url: "..." }))
+    const urlMatch = html.match(
+      /SwaggerUIBundle\s*\(\s*\{[^}]*url\s*:\s*["']([^"']+)["']/s,
+    );
+    if (urlMatch?.[1]) {
+      const specUrl = new URL(urlMatch[1], pageUrl).href;
+      this.logger.debug(`Found spec URL in HTML: ${specUrl}`);
+      try {
+        const specResp = await axios.get(specUrl, { timeout: 15000 });
+        return specResp.data;
+      } catch {
+        this.logger.debug(`Failed to fetch spec from extracted URL: ${specUrl}`);
+      }
+    }
+
+    // 2. Try swagger-ui-init.js (swagger-ui-express embeds the spec inline)
+    const initJsUrl = new URL('swagger-ui-init.js', pageUrl.endsWith('/') ? pageUrl : pageUrl + '/').href;
+    try {
+      const initResp = await axios.get(initJsUrl, { timeout: 15000 });
+      const initJs = typeof initResp.data === 'string' ? initResp.data : '';
+      // The spec is embedded as: let defined = { ... "swaggerDoc": { <the spec> }, ... }
+      const docMatch = initJs.match(/"swaggerDoc"\s*:\s*(\{[\s\S]+\})\s*,\s*"customOptions"/);
+      if (docMatch?.[1]) {
+        this.logger.debug('Extracted embedded spec from swagger-ui-init.js');
+        return JSON.parse(docMatch[1]);
+      }
+      // Alternative pattern: spec property in options
+      const specMatch = initJs.match(/"spec"\s*:\s*(\{[\s\S]+\})\s*,\s*"customOptions"/);
+      if (specMatch?.[1]) {
+        this.logger.debug('Extracted embedded spec from swagger-ui-init.js (spec field)');
+        return JSON.parse(specMatch[1]);
+      }
+    } catch {
+      this.logger.debug('No swagger-ui-init.js found');
+    }
+
+    // 3. Try common spec endpoint paths
+    const origin = base.origin;
+    const commonPaths = [
+      '/openapi.json',
+      '/swagger.json',
+      '/api-docs',
+      '/api/swagger.json',
+      '/v1/openapi.json',
+      '/v2/openapi.json',
+      '/v3/openapi.json',
+      '/docs/openapi.json',
+      '/swagger/v1/swagger.json',
+      '/api-docs.json',
+    ];
+    for (const path of commonPaths) {
+      try {
+        const resp = await axios.get(`${origin}${path}`, { timeout: 5000 });
+        if (
+          typeof resp.data === 'object' &&
+          resp.data !== null &&
+          (resp.data.openapi || resp.data.swagger)
+        ) {
+          this.logger.debug(`Found spec at common path: ${origin}${path}`);
+          return resp.data;
+        }
+      } catch {
+        // continue to next path
+      }
+    }
+
+    this.logger.warn(
+      'Could not resolve OpenAPI spec from Swagger UI page. ' +
+        'Please provide the direct URL to the JSON/YAML spec instead of the Swagger UI page.',
+    );
+    return null;
   }
 
   private extractTools(api: any): ParsedTool[] {


### PR DESCRIPTION
## Summary
- Detect when user provides a Swagger UI page URL instead of raw spec URL
- Auto-resolve the actual OpenAPI spec by extracting it from `swagger-ui-init.js` (embedded specs), HTML config, or common endpoint paths
- Fixes import for APIs using `swagger-ui-express` / NestJS where the spec is not exposed as a separate endpoint

## Test plan
- [x] All 18 existing OpenAPI parser tests pass
- [ ] Test with Swagger UI URL (e.g. `/docs`) that embeds spec via `swagger-ui-init.js`
- [ ] Test with Swagger UI URL that references spec via `SwaggerUIBundle({ url: ... })`