### PR TITLE
Add NestJS spec paths to Swagger discovery

### DIFF
--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -119,6 +119,8 @@ export class OpenApiParser {
       '/openapi.json',
       '/swagger.json',
       '/api-docs',
+      '/docs-json',
+      '/docs-yaml',
       '/api/swagger.json',
       '/v1/openapi.json',
       '/v2/openapi.json',


### PR DESCRIPTION
Add /docs-json and /docs-yaml to the common paths probed when resolving an OpenAPI spec from a Swagger UI page. These are the default endpoints used by @nestjs/swagger.