### PR TITLE
Add multi-tenant organization system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -19841,7 +19841,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -19925,7 +19925,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/prisma/migrations/20260408000000_add_organizations/migration.sql
+++ b/packages/backend/prisma/migrations/20260408000000_add_organizations/migration.sql
@@ -1,0 +1,150 @@
+-- =============================================================================
+-- Migration: Add Organizations (multi-tenancy)
+-- =============================================================================
+-- Creates an Organization model and adds organization_id to:
+-- users, connectors, mcp_server_configs, roles, mcp_api_keys, invitation_tokens
+-- Groups existing users by invitation chains into shared organizations.
+-- =============================================================================
+
+-- 1. Create organizations table
+CREATE TABLE "organizations" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id")
+);
+
+-- 2. Add nullable organization_id columns (will be made NOT NULL after data migration)
+ALTER TABLE "users" ADD COLUMN "organization_id" TEXT;
+ALTER TABLE "connectors" ADD COLUMN "organization_id" TEXT;
+ALTER TABLE "mcp_server_configs" ADD COLUMN "organization_id" TEXT;
+ALTER TABLE "roles" ADD COLUMN "organization_id" TEXT;
+ALTER TABLE "mcp_api_keys" ADD COLUMN "organization_id" TEXT;
+ALTER TABLE "invitation_tokens" ADD COLUMN "organization_id" TEXT;
+
+-- 3. Data migration: create organizations and assign users
+-- 3a. Build a temp table mapping each user to their "root admin" via invitation chains
+CREATE TEMP TABLE user_org_root AS
+WITH RECURSIVE invite_chain AS (
+    -- Base case: users who were NOT invited (self-registered) → they are their own root
+    SELECT u.id AS user_id, u.id AS root_id
+    FROM users u
+    WHERE NOT EXISTS (
+        SELECT 1 FROM invitation_tokens it
+        WHERE it.email = u.email AND it.used_at IS NOT NULL
+    )
+
+    UNION ALL
+
+    -- Recursive case: follow the invitation chain upward
+    SELECT u.id AS user_id, ic.root_id
+    FROM users u
+    JOIN invitation_tokens it ON it.email = u.email AND it.used_at IS NOT NULL
+    JOIN invite_chain ic ON ic.user_id = it.invited_by
+)
+SELECT DISTINCT ON (user_id) user_id, root_id
+FROM invite_chain;
+
+-- 3b. Create one organization per unique root user
+INSERT INTO organizations (id, name, created_at, updated_at)
+SELECT DISTINCT
+    'org_' || root_id,
+    COALESCE(u.name, split_part(u.email, '@', 1)) || '''s Workspace',
+    NOW(),
+    NOW()
+FROM user_org_root uor
+JOIN users u ON u.id = uor.root_id;
+
+-- 3c. Assign organization_id to users
+UPDATE users SET organization_id = 'org_' || uor.root_id
+FROM user_org_root uor
+WHERE users.id = uor.user_id;
+
+-- 3d. Handle any users not covered by the recursive CTE (edge case)
+-- Create personal orgs for them
+INSERT INTO organizations (id, name, created_at, updated_at)
+SELECT
+    'org_' || u.id,
+    COALESCE(u.name, split_part(u.email, '@', 1)) || '''s Workspace',
+    NOW(),
+    NOW()
+FROM users u
+WHERE u.organization_id IS NULL
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE users SET organization_id = 'org_' || id
+WHERE organization_id IS NULL;
+
+-- 3e. Set organization_id on connectors from their owner
+UPDATE connectors SET organization_id = u.organization_id
+FROM users u WHERE connectors.user_id = u.id;
+
+-- 3f. Set organization_id on mcp_server_configs from their owner
+UPDATE mcp_server_configs SET organization_id = u.organization_id
+FROM users u WHERE mcp_server_configs.user_id = u.id;
+
+-- 3g. Set organization_id on mcp_api_keys from their owner
+UPDATE mcp_api_keys SET organization_id = u.organization_id
+FROM users u WHERE mcp_api_keys.user_id = u.id;
+
+-- 3h. Set organization_id on roles (non-system roles get the first admin's org)
+UPDATE roles SET organization_id = (
+    SELECT u.organization_id FROM users u WHERE u.role = 'ADMIN' ORDER BY u.created_at ASC LIMIT 1
+)
+WHERE is_system = false AND organization_id IS NULL;
+
+-- 3i. Set organization_id on invitation_tokens from the inviter
+UPDATE invitation_tokens SET organization_id = u.organization_id
+FROM users u WHERE invitation_tokens.invited_by = u.id;
+
+-- Handle orphan invitation tokens (inviter deleted)
+UPDATE invitation_tokens SET organization_id = (
+    SELECT id FROM organizations ORDER BY created_at ASC LIMIT 1
+)
+WHERE organization_id IS NULL;
+
+-- Clean up temp table
+DROP TABLE IF EXISTS user_org_root;
+
+-- 4. Make columns NOT NULL (except roles.organization_id which stays nullable for system roles)
+ALTER TABLE "users" ALTER COLUMN "organization_id" SET NOT NULL;
+ALTER TABLE "connectors" ALTER COLUMN "organization_id" SET NOT NULL;
+ALTER TABLE "mcp_server_configs" ALTER COLUMN "organization_id" SET NOT NULL;
+ALTER TABLE "mcp_api_keys" ALTER COLUMN "organization_id" SET NOT NULL;
+ALTER TABLE "invitation_tokens" ALTER COLUMN "organization_id" SET NOT NULL;
+
+-- 5. Add foreign key constraints
+ALTER TABLE "users" ADD CONSTRAINT "users_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "connectors" ADD CONSTRAINT "connectors_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "mcp_server_configs" ADD CONSTRAINT "mcp_server_configs_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "roles" ADD CONSTRAINT "roles_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "mcp_api_keys" ADD CONSTRAINT "mcp_api_keys_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "invitation_tokens" ADD CONSTRAINT "invitation_tokens_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 6. Add indexes
+CREATE INDEX "users_organization_id_idx" ON "users"("organization_id");
+CREATE INDEX "connectors_organization_id_idx" ON "connectors"("organization_id");
+CREATE INDEX "mcp_server_configs_organization_id_idx" ON "mcp_server_configs"("organization_id");
+CREATE INDEX "mcp_api_keys_organization_id_idx" ON "mcp_api_keys"("organization_id");
+
+-- 7. Update unique constraints
+-- Role name must be unique per organization (or globally for system roles)
+DROP INDEX IF EXISTS "roles_name_key";
+CREATE UNIQUE INDEX "roles_organization_id_name_key" ON "roles"("organization_id", "name");
+
+-- MCP server slug must be unique per organization (was per user)
+DROP INDEX IF EXISTS "mcp_server_configs_user_id_slug_key";
+CREATE UNIQUE INDEX "mcp_server_configs_organization_id_slug_key" ON "mcp_server_configs"("organization_id", "slug");

--- a/packages/backend/prisma/migrations/20260408100000_add_org_members_settings/migration.sql
+++ b/packages/backend/prisma/migrations/20260408100000_add_org_members_settings/migration.sql
@@ -1,0 +1,90 @@
+-- =============================================================================
+-- Migration: Add OrganizationMember, OrgSettings, License.organizationId
+-- =============================================================================
+-- Adds multi-org membership, per-org settings, and per-org licensing support.
+-- =============================================================================
+
+-- 1. Create organization_members table
+CREATE TABLE "organization_members" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "organization_id" TEXT NOT NULL,
+    "role" "UserRole" NOT NULL DEFAULT 'EDITOR',
+    "joined_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "organization_members_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "organization_members_user_id_organization_id_key" ON "organization_members"("user_id", "organization_id");
+CREATE INDEX "organization_members_user_id_idx" ON "organization_members"("user_id");
+CREATE INDEX "organization_members_organization_id_idx" ON "organization_members"("organization_id");
+
+ALTER TABLE "organization_members" ADD CONSTRAINT "organization_members_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "organization_members" ADD CONSTRAINT "organization_members_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 2. Create org_settings table
+CREATE TABLE "org_settings" (
+    "id" TEXT NOT NULL,
+    "organization_id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "org_settings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "org_settings_organization_id_key_key" ON "org_settings"("organization_id", "key");
+
+ALTER TABLE "org_settings" ADD CONSTRAINT "org_settings_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 3. Add organization_id to licenses
+ALTER TABLE "licenses" ADD COLUMN "organization_id" TEXT;
+
+ALTER TABLE "licenses" ADD CONSTRAINT "licenses_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "licenses_organization_id_idx" ON "licenses"("organization_id");
+
+-- 4. Backfill organization_members from existing users
+INSERT INTO organization_members (id, user_id, organization_id, role, joined_at)
+SELECT
+    gen_random_uuid()::text,
+    id,
+    organization_id,
+    role,
+    created_at
+FROM users
+WHERE organization_id IS NOT NULL;
+
+-- 5. Assign existing license to the user's org (if license and org exist)
+UPDATE licenses SET organization_id = (
+    SELECT organization_id FROM users WHERE role = 'ADMIN' ORDER BY created_at ASC LIMIT 1
+)
+WHERE organization_id IS NULL;
+
+-- 6. Copy smtp_config from site_settings to org_settings for each org
+INSERT INTO org_settings (id, organization_id, key, value, updated_at)
+SELECT
+    gen_random_uuid()::text,
+    o.id,
+    'smtp_config',
+    ss.value,
+    ss.updated_at
+FROM site_settings ss
+CROSS JOIN organizations o
+WHERE ss.key = 'smtp_config';
+
+-- 7. Copy footer_links from site_settings to org_settings for each org
+INSERT INTO org_settings (id, organization_id, key, value, updated_at)
+SELECT
+    gen_random_uuid()::text,
+    o.id,
+    'footer_links',
+    ss.value,
+    ss.updated_at
+FROM site_settings ss
+CROSS JOIN organizations o
+WHERE ss.key = 'footer_links';

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -12,6 +12,58 @@ datasource db {
   provider = "postgresql"
 }
 
+// ── Organization (multi-tenancy) ────────────────────────────────────────────
+
+model Organization {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  users            User[]
+  members          OrganizationMember[]
+  connectors       Connector[]
+  mcpServers       McpServerConfig[]
+  roles            Role[]
+  mcpApiKeys       McpApiKey[]
+  invitationTokens InvitationToken[]
+  licenses         License[]
+  orgSettings      OrgSettings[]
+
+  @@map("organizations")
+}
+
+// ── Organization Membership (many-to-many with per-org role) ────────────────
+
+model OrganizationMember {
+  id             String       @id @default(cuid())
+  userId         String       @map("user_id")
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String       @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  role           UserRole     @default(EDITOR)
+  joinedAt       DateTime     @default(now()) @map("joined_at")
+
+  @@unique([userId, organizationId])
+  @@index([userId])
+  @@index([organizationId])
+  @@map("organization_members")
+}
+
+// ── Per-Organization Settings (key-value store) ─────────────────────────────
+
+model OrgSettings {
+  id             String       @id @default(cuid())
+  organizationId String       @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  key            String
+  value          String       @db.Text
+  updatedAt      DateTime     @updatedAt @map("updated_at")
+
+  @@unique([organizationId, key])
+  @@map("org_settings")
+}
+
 // ── User Management ─────────────────────────────────────────────────────────
 
 enum UserRole {
@@ -21,12 +73,14 @@ enum UserRole {
 }
 
 model User {
-  id            String   @id @default(cuid())
-  email         String   @unique
-  passwordHash  String   @map("password_hash")
-  name          String?
-  role          UserRole @default(EDITOR)
-  emailVerified Boolean  @default(false) @map("email_verified")
+  id             String   @id @default(cuid())
+  email          String   @unique
+  passwordHash   String   @map("password_hash")
+  name           String?
+  role           UserRole @default(EDITOR)
+  emailVerified  Boolean  @default(false) @map("email_verified")
+  organizationId String   @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
@@ -35,6 +89,7 @@ model User {
   mcpRoleId String? @map("mcp_role_id")
   mcpRole   Role?   @relation(fields: [mcpRoleId], references: [id], onDelete: SetNull)
 
+  memberships              OrganizationMember[]
   connectors               Connector[]
   mcpServers               McpServerConfig[]
   toolInvocations          ToolInvocation[]
@@ -42,6 +97,7 @@ model User {
   mcpApiKeys               McpApiKey[]
   emailVerificationTokens  EmailVerificationToken[]
 
+  @@index([organizationId])
   @@map("users")
 }
 
@@ -89,33 +145,38 @@ model SiteSettings {
 // ── License Management ──────────────────────────────────────────────────────
 
 model License {
-  id             String    @id @default(cuid())
-  licenseKey     String    @unique @map("license_key")
-  plan           String    @default("community")
-  status         String    @default("active")
+  id             String        @id @default(cuid())
+  licenseKey     String        @unique @map("license_key")
+  plan           String        @default("community")
+  status         String        @default("active")
   features       Json?
-  expiresAt      DateTime? @map("expires_at")
-  activatedAt    DateTime? @map("activated_at")
-  instanceId     String?   @map("instance_id")
-  lastVerifiedAt DateTime? @map("last_verified_at")
-  createdAt      DateTime  @default(now()) @map("created_at")
-  updatedAt      DateTime  @updatedAt @map("updated_at")
+  expiresAt      DateTime?     @map("expires_at")
+  activatedAt    DateTime?     @map("activated_at")
+  instanceId     String?       @map("instance_id")
+  organizationId String?       @map("organization_id")
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  lastVerifiedAt DateTime?     @map("last_verified_at")
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @updatedAt @map("updated_at")
 
+  @@index([organizationId])
   @@map("licenses")
 }
 
 // ── User Invitation Tokens ──────────────────────────────────────────────────
 
 model InvitationToken {
-  id        String    @id @default(cuid())
-  email     String
-  token     String    @unique
-  role      UserRole  @default(EDITOR)
-  mcpRoleId String?   @map("mcp_role_id")
-  invitedBy String    @map("invited_by") // admin user id
-  expiresAt DateTime  @map("expires_at")
-  usedAt    DateTime? @map("used_at")
-  createdAt DateTime  @default(now()) @map("created_at")
+  id             String    @id @default(cuid())
+  email          String
+  token          String    @unique
+  role           UserRole  @default(EDITOR)
+  mcpRoleId      String?   @map("mcp_role_id")
+  invitedBy      String    @map("invited_by") // admin user id
+  organizationId String    @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  expiresAt      DateTime  @map("expires_at")
+  usedAt         DateTime? @map("used_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
 
   @@map("invitation_tokens")
 }
@@ -123,16 +184,19 @@ model InvitationToken {
 // ── MCP Governance: Custom Roles ────────────────────────────────────────────
 
 model Role {
-  id          String   @id @default(cuid())
-  name        String   @unique
-  description String?  @db.Text
-  isSystem    Boolean  @default(false) @map("is_system")
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  id             String        @id @default(cuid())
+  name           String
+  description    String?       @db.Text
+  isSystem       Boolean       @default(false) @map("is_system")
+  organizationId String?       @map("organization_id")
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @updatedAt @map("updated_at")
 
   users      User[]
   toolAccess ToolRoleAccess[]
 
+  @@unique([organizationId, name])
   @@map("roles")
 }
 
@@ -154,17 +218,20 @@ model ToolRoleAccess {
 // ── Per-User MCP API Keys ───────────────────────────────────────────────────
 
 model McpApiKey {
-  id          String           @id @default(cuid())
-  userId      String           @map("user_id")
-  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-  mcpServerId String?          @map("mcp_server_id")
-  mcpServer   McpServerConfig? @relation(fields: [mcpServerId], references: [id], onDelete: SetNull)
-  key         String           @unique
-  name        String           // label: "Claude Desktop", "Cursor", etc.
-  isActive    Boolean          @default(true) @map("is_active")
-  lastUsedAt  DateTime?        @map("last_used_at")
-  createdAt   DateTime         @default(now()) @map("created_at")
+  id             String           @id @default(cuid())
+  userId         String           @map("user_id")
+  user           User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String           @map("organization_id")
+  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  mcpServerId    String?          @map("mcp_server_id")
+  mcpServer      McpServerConfig? @relation(fields: [mcpServerId], references: [id], onDelete: SetNull)
+  key            String           @unique
+  name           String           // label: "Claude Desktop", "Cursor", etc.
+  isActive       Boolean          @default(true) @map("is_active")
+  lastUsedAt     DateTime?        @map("last_used_at")
+  createdAt      DateTime         @default(now()) @map("created_at")
 
+  @@index([organizationId])
   @@map("mcp_api_keys")
 }
 
@@ -190,9 +257,11 @@ enum AuthType {
 }
 
 model Connector {
-  id   String        @id @default(cuid())
-  userId String      @map("user_id")
-  user   User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             String        @id @default(cuid())
+  userId         String        @map("user_id")
+  user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String        @map("organization_id")
+  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   name     String
   type     ConnectorType
@@ -225,6 +294,7 @@ model Connector {
   prompts    McpPrompt[]
   mcpServers McpServerConnector[]
 
+  @@index([organizationId])
   @@map("connectors")
 }
 
@@ -314,9 +384,11 @@ model McpPrompt {
 // ── MCP Server Configuration ────────────────────────────────────────────────
 
 model McpServerConfig {
-  id     String @id @default(cuid())
-  userId String @map("user_id")
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  userId         String       @map("user_id")
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organizationId String       @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   name         String  @default("Default")
   slug         String  @default("default")
@@ -332,7 +404,8 @@ model McpServerConfig {
   apiKeys         McpApiKey[]
   toolInvocations ToolInvocation[]
 
-  @@unique([userId, slug])
+  @@unique([organizationId, slug])
+  @@index([organizationId])
   @@map("mcp_server_configs")
 }
 

--- a/packages/backend/src/adapters/adapters.controller.ts
+++ b/packages/backend/src/adapters/adapters.controller.ts
@@ -62,10 +62,11 @@ export class AdaptersController {
     @Param('slug') slug: string,
     @Body() body: { credentials?: Record<string, string> },
   ) {
-    await this.licenseGuard.checkCanCreateConnector(req.user.sub);
+    await this.licenseGuard.checkCanCreateConnector(req.user.sub, req.user.organizationId);
     const result = await this.adaptersService.importAdapter(
       slug,
       req.user.sub,
+      req.user.organizationId,
       body?.credentials,
     );
     return {

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -35,6 +35,7 @@ export class AdaptersService {
   async importAdapter(
     slug: string,
     userId: string,
+    organizationId: string,
     credentials?: Record<string, string>,
   ): Promise<{ connectorId: string; toolsCreated: number }> {
     const adapter = this.getBySlug(slug);
@@ -54,6 +55,7 @@ export class AdaptersService {
     const connector = await this.prisma.connector.create({
       data: {
         userId,
+        organizationId,
         name: adapter.connector.name,
         type: adapter.connector.type as any,
         baseUrl: resolvedBaseUrl,

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { PrismaOAuthStore } from './auth/prisma-oauth.store';
 import { PrismaService } from './common/prisma.service';
 import { OAuthUrlRewriteInterceptor } from './auth/oauth-url-rewrite.interceptor';
 import { AdaptersModule } from './adapters/adapters.module';
+import { OrganizationsModule } from './organizations/organizations.module';
 import { CloudModule } from './cloud/cloud.module';
 
 // Determine deployment and auth mode from env
@@ -114,6 +115,7 @@ if (useOAuth) {
     AdaptersModule,
     McpServerModule,
 
+    OrganizationsModule,
     AuditModule,
     HealthModule,
     SettingsModule,

--- a/packages/backend/src/audit/audit.controller.ts
+++ b/packages/backend/src/audit/audit.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { AuditService } from './audit.service';
@@ -20,6 +20,7 @@ export class AuditController {
   @ApiQuery({ name: 'connectorId', required: false, type: String })
   @ApiQuery({ name: 'mcpServerId', required: false, type: String })
   async listInvocations(
+    @Req() req: any,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
     @Query('toolId') toolId?: string,
@@ -31,14 +32,14 @@ export class AuditController {
     return this.auditService.getRecentInvocations(
       limit ? parseInt(limit, 10) : 100,
       offset ? parseInt(offset, 10) : 0,
-      { toolId, status: status as any, search, connectorId, mcpServerId },
+      { toolId, status: status as any, search, connectorId, mcpServerId, organizationId: req.user.organizationId },
     );
   }
 
   @Get('stats')
   @ApiOperation({ summary: 'Get invocation statistics' })
-  async getStats() {
-    return this.auditService.getStats();
+  async getStats(@Req() req: any) {
+    return this.auditService.getStats(req.user.organizationId);
   }
 
   @Get('analytics')
@@ -48,7 +49,7 @@ export class AuditController {
       'Returns 7-day daily breakdown of invocations by status, ' +
       'top 10 most-used tools, success rate, and average duration.',
   })
-  async getAnalytics() {
-    return this.auditService.getAnalytics();
+  async getAnalytics(@Req() req: any) {
+    return this.auditService.getAnalytics(req.user.organizationId);
   }
 }

--- a/packages/backend/src/audit/audit.service.ts
+++ b/packages/backend/src/audit/audit.service.ts
@@ -66,6 +66,11 @@ export class AuditService {
     );
   }
 
+  private orgScope(organizationId?: string): any {
+    if (!organizationId) return {};
+    return { tool: { connector: { organizationId } } };
+  }
+
   async getRecentInvocations(
     limit = 100,
     offset = 0,
@@ -75,14 +80,15 @@ export class AuditService {
       search?: string;
       connectorId?: string;
       mcpServerId?: string;
+      organizationId?: string;
     },
   ) {
-    const where: any = {};
+    const where: any = { ...this.orgScope(filters?.organizationId) };
     if (filters?.toolId) where.toolId = filters.toolId;
     if (filters?.status) where.status = filters.status;
     if (filters?.mcpServerId) where.mcpServerId = filters.mcpServerId;
     if (filters?.search) {
-      where.tool = { name: { contains: filters.search, mode: 'insensitive' } };
+      where.tool = { ...where.tool, name: { contains: filters.search, mode: 'insensitive' } };
     }
     if (filters?.connectorId) {
       where.tool = { ...where.tool, connectorId: filters.connectorId };
@@ -111,22 +117,23 @@ export class AuditService {
     });
   }
 
-  async getStats() {
+  async getStats(organizationId?: string) {
     const now = new Date();
     const last24h = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     const last7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const scope = this.orgScope(organizationId);
 
     const [total24h, errors24h, total7d, totalAll] = await Promise.all([
       this.prisma.toolInvocation.count({
-        where: { createdAt: { gte: last24h } },
+        where: { createdAt: { gte: last24h }, ...scope },
       }),
       this.prisma.toolInvocation.count({
-        where: { createdAt: { gte: last24h }, status: 'ERROR' },
+        where: { createdAt: { gte: last24h }, status: 'ERROR', ...scope },
       }),
       this.prisma.toolInvocation.count({
-        where: { createdAt: { gte: last7d } },
+        where: { createdAt: { gte: last7d }, ...scope },
       }),
-      this.prisma.toolInvocation.count(),
+      this.prisma.toolInvocation.count({ where: scope }),
     ]);
 
     return {
@@ -141,13 +148,14 @@ export class AuditService {
    * Analytics: time-series invocation data for the last 7 days,
    * grouped by day and status. Also returns top tools by usage.
    */
-  async getAnalytics() {
+  async getAnalytics(organizationId?: string) {
     const now = new Date();
     const last7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const scope = this.orgScope(organizationId);
 
     // Get all invocations for the last 7 days
     const invocations = await this.prisma.toolInvocation.findMany({
-      where: { createdAt: { gte: last7d } },
+      where: { createdAt: { gte: last7d }, ...scope },
       select: {
         status: true,
         durationMs: true,

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -28,6 +28,7 @@ import { McpServersService } from '../mcp-servers/mcp-servers.service';
 import { PrismaService } from '../common/prisma.service';
 import { EmailService } from '../settings/email.service';
 import { SiteSettingsService } from '../settings/site-settings.service';
+import { OrganizationsService } from '../organizations/organizations.service';
 import { Roles, RolesGuard } from './roles.guard';
 
 class LoginDto {
@@ -118,6 +119,7 @@ export class AuthController {
     private readonly emailService: EmailService,
     private readonly configService: ConfigService,
     private readonly siteSettings: SiteSettingsService,
+    private readonly organizationsService: OrganizationsService,
   ) {}
 
   private getFrontendUrl(req?: any): string {
@@ -194,6 +196,7 @@ export class AuthController {
       sub: user.id,
       email: user.email,
       role: user.role,
+      organizationId: user.organizationId,
       mcpRoleId: user.mcpRoleId,
     });
 
@@ -218,6 +221,7 @@ export class AuthController {
         email: user.email,
         name: user.name,
         role: user.role,
+        organizationId: user.organizationId,
         emailVerified: user.emailVerified,
       },
       ...(needsLicenseSetup && { needsLicenseSetup: true }),
@@ -242,21 +246,42 @@ export class AuthController {
       );
     }
 
+    // In self-hosted mode with open registration, join the existing org
+    // In cloud mode (or first user), create a new organization
+    const isCloud = this.configService.get<string>('DEPLOYMENT_MODE') === 'cloud';
+    let organizationId: string;
+
+    if (!isCloud && userCount > 0) {
+      // Self-hosted: join the existing (first) organization
+      const existingOrg = await this.prisma.organization.findFirst({ orderBy: { createdAt: 'asc' } });
+      organizationId = existingOrg!.id;
+    } else {
+      // Cloud or first user: create a new organization
+      const orgName = `${dto.name || dto.email.split('@')[0]}'s Workspace`;
+      const org = await this.organizationsService.create(orgName);
+      organizationId = org.id;
+    }
+
     const passwordHash = await this.authService.hashPassword(dto.password);
     const user = await this.usersService.create({
       email: dto.email,
       passwordHash,
       name: dto.name,
       role: role as any,
+      organizationId,
     });
 
+    // Create organization membership
+    await this.organizationsService.addMember(user.id, organizationId, role as any);
+
     // Create default MCP server for new user
-    await this.mcpServersService.createDefaultForUser(user.id);
+    await this.mcpServersService.createDefaultForUser(user.id, organizationId);
 
     const token = this.authService.generateToken({
       sub: user.id,
       email: user.email,
       role: user.role,
+      organizationId,
       mcpRoleId: user.mcpRoleId,
     });
 
@@ -270,6 +295,7 @@ export class AuthController {
         email: user.email,
         name: user.name,
         role: user.role,
+        organizationId,
         emailVerified: false,
       },
       isFirstUser: role === 'ADMIN',
@@ -376,16 +402,21 @@ export class AuthController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Invite a user to the workspace (ADMIN only)' })
   async inviteUser(@Req() req: any, @Body() dto: InviteUserDto) {
-    // Check if user already exists
+    // Check if user already exists in THIS organization
     const existing = await this.usersService.findByEmail(dto.email);
     if (existing) {
-      throw new ConflictException('A user with this email already exists');
+      const membership = await this.organizationsService.getMembership(existing.id, req.user.organizationId);
+      if (membership) {
+        throw new ConflictException('This user is already a member of your organization');
+      }
+      // User exists but not in this org — allow invitation for multi-org membership
     }
 
-    // Check for existing pending invitation
+    // Check for existing pending invitation to this org
     const existingInvite = await this.prisma.invitationToken.findFirst({
       where: {
         email: dto.email,
+        organizationId: req.user.organizationId,
         usedAt: null,
         expiresAt: { gt: new Date() },
       },
@@ -405,6 +436,7 @@ export class AuthController {
         role: dto.role,
         mcpRoleId: dto.mcpRoleId || null,
         invitedBy: req.user.sub,
+        organizationId: req.user.organizationId,
         expiresAt,
       },
     });
@@ -476,28 +508,41 @@ export class AuthController {
 
     // Check if email already registered
     const existing = await this.usersService.findByEmail(invite.email);
+
+    let user: any;
     if (existing) {
-      throw new ConflictException('An account with this email already exists');
-    }
+      // Existing user — add to the new organization (multi-org)
+      const alreadyMember = await this.organizationsService.getMembership(existing.id, invite.organizationId);
+      if (alreadyMember) {
+        throw new ConflictException('You are already a member of this organization');
+      }
+      await this.organizationsService.addMember(existing.id, invite.organizationId, invite.role);
+      // Switch their active org to the newly joined one
+      user = await this.organizationsService.switchOrg(existing.id, invite.organizationId);
+    } else {
+      // New user — create account and join the organization
+      const passwordHash = await this.authService.hashPassword(dto.password);
+      user = await this.usersService.create({
+        email: invite.email,
+        passwordHash,
+        name: dto.name,
+        role: invite.role,
+        organizationId: invite.organizationId,
+      });
 
-    // Create the user — invited users are already verified (they received the invite email)
-    const passwordHash = await this.authService.hashPassword(dto.password);
-    const user = await this.usersService.create({
-      email: invite.email,
-      passwordHash,
-      name: dto.name,
-      role: invite.role,
-    });
+      // Create organization membership
+      await this.organizationsService.addMember(user.id, invite.organizationId, invite.role);
 
-    // Mark email as verified (invited users don't need to verify)
-    await this.usersService.update(user.id, { emailVerified: true });
+      // Mark email as verified (invited users don't need to verify)
+      await this.usersService.update(user.id, { emailVerified: true });
 
-    // Create default MCP server for new user
-    await this.mcpServersService.createDefaultForUser(user.id);
+      // Create default MCP server for new user
+      await this.mcpServersService.createDefaultForUser(user.id, invite.organizationId);
 
-    // Assign MCP role if specified
-    if (invite.mcpRoleId) {
-      await this.usersService.update(user.id, { mcpRoleId: invite.mcpRoleId });
+      // Assign MCP role if specified
+      if (invite.mcpRoleId) {
+        await this.usersService.update(user.id, { mcpRoleId: invite.mcpRoleId });
+      }
     }
 
     // Mark invitation as used
@@ -511,7 +556,8 @@ export class AuthController {
       sub: user.id,
       email: user.email,
       role: user.role,
-      mcpRoleId: invite.mcpRoleId,
+      organizationId: invite.organizationId,
+      mcpRoleId: user.mcpRoleId,
     });
 
     return {
@@ -521,6 +567,7 @@ export class AuthController {
         email: user.email,
         name: user.name,
         role: user.role,
+        organizationId: invite.organizationId,
         emailVerified: true,
       },
     };

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -15,6 +15,7 @@ import { ClientCredentialsMiddleware } from './client-credentials.middleware';
 import { UsersModule } from '../users/users.module';
 import { SettingsModule } from '../settings/settings.module';
 import { McpServersModule } from '../mcp-servers/mcp-servers.module';
+import { OrganizationsModule } from '../organizations/organizations.module';
 
 @Global()
 @Module({
@@ -22,6 +23,7 @@ import { McpServersModule } from '../mcp-servers/mcp-servers.module';
     UsersModule,
     SettingsModule,
     McpServersModule,
+    OrganizationsModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/packages/backend/src/auth/auth.service.spec.ts
+++ b/packages/backend/src/auth/auth.service.spec.ts
@@ -31,7 +31,7 @@ describe('AuthService', () => {
 
   describe('generateToken / verifyToken', () => {
     it('should generate and verify a JWT token', () => {
-      const payload = { sub: 'user-1', email: 'a@b.com', role: 'ADMIN' };
+      const payload = { sub: 'user-1', email: 'a@b.com', role: 'ADMIN', organizationId: 'org-1' };
       const token = authService.generateToken(payload);
 
       expect(typeof token).toBe('string');

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ export interface JwtPayload {
   sub: string;
   email: string;
   role: string;
+  organizationId: string;
   mcpRoleId?: string | null;
 }
 

--- a/packages/backend/src/auth/jwt.strategy.ts
+++ b/packages/backend/src/auth/jwt.strategy.ts
@@ -25,6 +25,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException('User no longer exists');
     }
-    return { sub: user.id, email: user.email, role: user.role };
+    return { sub: user.id, email: user.email, role: user.role, organizationId: user.organizationId };
   }
 }

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -43,6 +43,7 @@ export class McpCombinedAuthGuard implements CanActivate {
           sub: user.id,
           email: user.email,
           role: user.role,
+          organizationId: user.organizationId,
           mcpRoleId: user.mcpRoleId,
           mcpServerId: user.mcpServerId,
           authMethod: 'mcp_api_key',

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -153,23 +153,33 @@ export class ConnectorsController {
 
   private readonly encryptionKey: string;
 
-  private assertOwnerOrAdmin(connector: any, req: any) {
+  private assertOrgMatch(connector: any, req: any) {
+    if (connector.organizationId !== req.user.organizationId) {
+      throw new ForbiddenException('Resource not found');
+    }
+  }
+
+  private assertCanWrite(connector: any, req: any) {
+    this.assertOrgMatch(connector, req);
+    if (req.user.role === 'VIEWER') {
+      throw new ForbiddenException('Viewers cannot modify connectors');
+    }
     if (connector.userId !== req.user.sub && req.user.role !== 'ADMIN') {
       throw new ForbiddenException('Only the connector owner or an admin can modify this connector');
     }
   }
 
   @Get()
-  @ApiOperation({ summary: 'List all connectors' })
-  async list() {
-    return this.connectorsService.findAll();
+  @ApiOperation({ summary: 'List connectors for current organization' })
+  async list(@Req() req: any) {
+    return this.connectorsService.findByOrg(req.user.organizationId);
   }
 
   @Post()
   @ApiOperation({ summary: 'Create a new connector' })
   async create(@Req() req: any, @Body() dto: CreateConnectorDto) {
-    await this.licenseGuard.checkCanCreateConnector(req.user.sub);
-    const connector = await this.connectorsService.create(req.user.sub, dto);
+    await this.licenseGuard.checkCanCreateConnector(req.user.sub, req.user.organizationId);
+    const connector = await this.connectorsService.create(req.user.sub, req.user.organizationId, dto);
 
     // Auto-create default tools for DATABASE connectors
     if (dto.type === 'DATABASE') {
@@ -203,8 +213,8 @@ export class ConnectorsController {
     description:
       'Runs a health check against all active connectors and returns their status.',
   })
-  async healthCheck() {
-    const allConnectors = await this.connectorsService.findAll();
+  async healthCheck(@Req() req: any) {
+    const allConnectors = await this.connectorsService.findByOrg(req.user.organizationId);
     const active = allConnectors.filter((c) => c.isActive);
 
     const results = await Promise.allSettled(
@@ -254,8 +264,9 @@ export class ConnectorsController {
       'Returns all connectors with their tools, environment variables, ' +
       'and configuration. Auth credentials are excluded for security.',
   })
-  async exportAll() {
+  async exportAll(@Req() req: any) {
     const allConnectors = await this.prisma.connector.findMany({
+      where: { organizationId: req.user.organizationId },
       include: { tools: true },
     });
 
@@ -288,8 +299,10 @@ export class ConnectorsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get connector details' })
-  async findOne(@Param('id') id: string) {
-    return this.connectorsService.findById(id);
+  async findOne(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id);
+    this.assertOrgMatch(connector, req);
+    return connector;
   }
 
   @Put(':id')
@@ -300,7 +313,7 @@ export class ConnectorsController {
     @Body() dto: UpdateConnectorDto,
   ) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
     return this.connectorsService.update(id, dto);
   }
 
@@ -308,7 +321,7 @@ export class ConnectorsController {
   @ApiOperation({ summary: 'Delete connector' })
   async remove(@Req() req: any, @Param('id') id: string) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
     await this.connectorsService.remove(id);
     // Unregister tools from in-memory MCP registries after DB cascade delete
     await this.mcpServer.reloadConnectorTools(id);
@@ -317,7 +330,9 @@ export class ConnectorsController {
 
   @Post(':id/test')
   @ApiOperation({ summary: 'Test connector connection' })
-  async test(@Param('id') id: string) {
+  async test(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id);
+    this.assertCanWrite(connector, req);
     return this.connectorsService.testConnection(id);
   }
 
@@ -331,7 +346,7 @@ export class ConnectorsController {
   })
   async initiateOAuth(@Req() req: any, @Param('id') id: string) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
 
     if (connector.authType !== 'OAUTH2') {
       return { error: 'Connector auth type must be OAUTH2' };
@@ -428,7 +443,7 @@ export class ConnectorsController {
   })
   async discoverMcpTools(@Req() req: any, @Param('id') id: string) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
 
     if (connector.type !== 'MCP') {
       return { error: 'Tool discovery is only available for MCP connectors' };
@@ -482,6 +497,7 @@ export class ConnectorsController {
         const connector = await this.prisma.connector.create({
           data: {
             userId: req.user.sub,
+            organizationId: req.user.organizationId,
             name: c.name,
             type: c.type,
             baseUrl: c.baseUrl,
@@ -537,7 +553,7 @@ export class ConnectorsController {
   @ApiOperation({ summary: 'Auto-generate MCP tools from API specification' })
   async importSpec(@Req() req: any, @Param('id') id: string) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
 
     let parsedTools: any[] = [];
 
@@ -581,7 +597,7 @@ export class ConnectorsController {
     @Body() dto: ImportToolsDto,
   ) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
 
     let parsedTools: any[] = [];
 
@@ -699,7 +715,7 @@ export class ConnectorsController {
     @Body() body: { envVars: Record<string, string> },
   ) {
     const connector = await this.connectorsService.findById(id);
-    this.assertOwnerOrAdmin(connector, req);
+    this.assertCanWrite(connector, req);
     const updated = await this.connectorsService.update(id, {
       envVars: body.envVars,
     });

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -35,6 +35,22 @@ export class ConnectorsService {
     });
   }
 
+  async findByUser(userId: string): Promise<Connector[]> {
+    return this.prisma.connector.findMany({
+      where: { userId },
+      include: { tools: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findByOrg(organizationId: string): Promise<Connector[]> {
+    return this.prisma.connector.findMany({
+      where: { organizationId },
+      include: { tools: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
   async findById(id: string): Promise<Connector> {
     const connector = await this.prisma.connector.findUnique({
       where: { id },
@@ -59,6 +75,7 @@ export class ConnectorsService {
 
   async create(
     userId: string,
+    organizationId: string,
     data: {
       name: string;
       type: ConnectorType;
@@ -79,6 +96,7 @@ export class ConnectorsService {
     return this.prisma.connector.create({
       data: {
         userId,
+        organizationId,
         name: data.name,
         type: data.type,
         baseUrl: data.baseUrl,

--- a/packages/backend/src/connectors/tools.controller.ts
+++ b/packages/backend/src/connectors/tools.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Req,
   UseGuards,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -79,9 +80,28 @@ export class ToolsController {
     private readonly connectorsService: ConnectorsService,
   ) {}
 
+  private async assertConnectorOrgMatch(connectorId: string, req: any) {
+    const connector = await this.connectorsService.findById(connectorId);
+    if (connector.organizationId !== req.user.organizationId) {
+      throw new ForbiddenException('Resource not found');
+    }
+    return connector;
+  }
+
+  private async assertCanWriteConnector(connectorId: string, req: any) {
+    const connector = await this.assertConnectorOrgMatch(connectorId, req);
+    if (req.user.role === 'VIEWER') {
+      throw new ForbiddenException('Viewers cannot modify tools');
+    }
+    if (connector.userId !== req.user.sub && req.user.role !== 'ADMIN') {
+      throw new ForbiddenException('Only the connector owner or an admin can modify this resource');
+    }
+  }
+
   @Get()
   @ApiOperation({ summary: 'List tools for a connector' })
-  async list(@Param('connectorId') connectorId: string) {
+  async list(@Req() req: any, @Param('connectorId') connectorId: string) {
+    await this.assertConnectorOrgMatch(connectorId, req);
     return this.prisma.mcpTool.findMany({
       where: { connectorId },
       orderBy: { createdAt: 'desc' },
@@ -91,9 +111,11 @@ export class ToolsController {
   @Post()
   @ApiOperation({ summary: 'Create a new MCP tool for a connector' })
   async create(
+    @Req() req: any,
     @Param('connectorId') connectorId: string,
     @Body() dto: CreateToolDto,
   ) {
+    await this.assertCanWriteConnector(connectorId, req);
     const tool = await this.prisma.mcpTool.create({
       data: {
         connectorId,
@@ -118,9 +140,11 @@ export class ToolsController {
       'Skips duplicates (by name) and returns created + skipped counts.',
   })
   async bulkCreate(
+    @Req() req: any,
     @Param('connectorId') connectorId: string,
     @Body() body: { tools: CreateToolDto[] },
   ) {
+    await this.assertCanWriteConnector(connectorId, req);
     const toolDefs = body.tools;
     if (!Array.isArray(toolDefs) || toolDefs.length === 0) {
       return { error: 'Provide a "tools" array with at least one tool definition' };
@@ -163,10 +187,12 @@ export class ToolsController {
   @Put(':toolId')
   @ApiOperation({ summary: 'Update an MCP tool' })
   async update(
+    @Req() req: any,
     @Param('toolId') toolId: string,
     @Param('connectorId') connectorId: string,
     @Body() dto: UpdateToolDto,
   ) {
+    await this.assertCanWriteConnector(connectorId, req);
     const tool = await this.prisma.mcpTool.update({
       where: { id: toolId },
       data: dto as any,
@@ -189,6 +215,8 @@ export class ToolsController {
     @Req() req: any,
     @Body() body: { params?: Record<string, unknown> },
   ) {
+    await this.assertCanWriteConnector(connectorId, req);
+
     const tool = await this.prisma.mcpTool.findUnique({
       where: { id: toolId },
       include: { connector: true },
@@ -239,9 +267,11 @@ export class ToolsController {
   @Delete(':toolId')
   @ApiOperation({ summary: 'Delete an MCP tool' })
   async remove(
+    @Req() req: any,
     @Param('toolId') toolId: string,
     @Param('connectorId') connectorId: string,
   ) {
+    await this.assertCanWriteConnector(connectorId, req);
     await this.prisma.mcpTool.delete({ where: { id: toolId } });
     await this.mcpServer.reloadConnectorTools(connectorId);
     return { message: 'Tool deleted' };

--- a/packages/backend/src/license/license-guard.service.ts
+++ b/packages/backend/src/license/license-guard.service.ts
@@ -11,13 +11,10 @@ export class LicenseGuardService {
     private readonly deployment: DeploymentService,
   ) {}
 
-  /**
-   * Check if the license is active. Only enforced in cloud mode.
-   */
-  async checkLicenseActive(): Promise<void> {
+  async checkLicenseActive(organizationId?: string): Promise<void> {
     if (!this.deployment.isCloud()) return;
 
-    const license = await this.licenseService.getCurrentLicense();
+    const license = await this.licenseService.getCurrentLicense(organizationId);
     if (!license) {
       throw new ForbiddenException(
         'No active license. Please purchase a license at anythingmcp.com/pricing',
@@ -30,7 +27,6 @@ export class LicenseGuardService {
       );
     }
 
-    // Check if trial has expired by date
     if (license.plan === 'trial' && license.expiresAt) {
       if (new Date(license.expiresAt) < new Date()) {
         throw new ForbiddenException(
@@ -40,18 +36,17 @@ export class LicenseGuardService {
     }
   }
 
-  /**
-   * Check if the user can create a new connector. Only enforced in cloud mode.
-   */
-  async checkCanCreateConnector(userId: string): Promise<void> {
+  async checkCanCreateConnector(userId: string, organizationId?: string): Promise<void> {
     if (!this.deployment.isCloud()) return;
 
-    await this.checkLicenseActive();
+    await this.checkLicenseActive(organizationId);
 
-    const license = await this.licenseService.getCurrentLicense();
+    const license = await this.licenseService.getCurrentLicense(organizationId);
     const maxConnectors = (license?.features as any)?.maxConnectors;
     if (maxConnectors != null) {
-      const count = await this.prisma.connector.count({ where: { userId } });
+      const count = await this.prisma.connector.count({
+        where: organizationId ? { organizationId } : { userId },
+      });
       if (count >= maxConnectors) {
         throw new ForbiddenException(
           `You have reached the maximum of ${maxConnectors} connectors on your current plan. Upgrade at anythingmcp.com/pricing`,
@@ -60,18 +55,17 @@ export class LicenseGuardService {
     }
   }
 
-  /**
-   * Check if the user can create a new MCP server. Only enforced in cloud mode.
-   */
-  async checkCanCreateMcpServer(userId: string): Promise<void> {
+  async checkCanCreateMcpServer(userId: string, organizationId?: string): Promise<void> {
     if (!this.deployment.isCloud()) return;
 
-    await this.checkLicenseActive();
+    await this.checkLicenseActive(organizationId);
 
-    const license = await this.licenseService.getCurrentLicense();
+    const license = await this.licenseService.getCurrentLicense(organizationId);
     const maxMcpServers = (license?.features as any)?.maxMcpServers;
     if (maxMcpServers != null) {
-      const count = await this.prisma.mcpServerConfig.count({ where: { userId } });
+      const count = await this.prisma.mcpServerConfig.count({
+        where: organizationId ? { organizationId } : { userId },
+      });
       if (count >= maxMcpServers) {
         throw new ForbiddenException(
           `You have reached the maximum of ${maxMcpServers} MCP servers on your current plan. Upgrade at anythingmcp.com/pricing`,

--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -38,9 +38,11 @@ export class LicenseController {
   ) {}
 
   @Get('status')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get current license status' })
-  async getStatus() {
-    const license = await this.licenseService.getCurrentLicense();
+  async getStatus(@Req() req: any) {
+    const license = await this.licenseService.getCurrentLicense(req.user?.organizationId);
     if (!license) {
       return { plan: null, status: 'none', features: null, expiresAt: null, instanceId: null };
     }
@@ -73,9 +75,9 @@ export class LicenseController {
   @Roles('ADMIN')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Set and activate a license key (ADMIN)' })
-  async setLicenseKey(@Body() dto: SetLicenseKeyDto) {
+  async setLicenseKey(@Req() req: any, @Body() dto: SetLicenseKeyDto) {
     try {
-      const license = await this.licenseService.setLicenseKey(dto.licenseKey);
+      const license = await this.licenseService.setLicenseKey(dto.licenseKey, req.user.organizationId);
       return { message: 'License activated successfully', license };
     } catch (err: any) {
       throw new BadRequestException(err.message || 'Failed to activate license');

--- a/packages/backend/src/license/license.service.ts
+++ b/packages/backend/src/license/license.service.ts
@@ -244,7 +244,7 @@ export class LicenseService implements OnModuleInit {
 
   // ── Admin: Set License Key ─────────────────────────────────────────────────
 
-  async setLicenseKey(licenseKey: string): Promise<LicenseInfo> {
+  async setLicenseKey(licenseKey: string, organizationId?: string): Promise<LicenseInfo> {
     // Verify remotely first
     const verification = await this.verifyLicense(licenseKey);
 
@@ -266,6 +266,7 @@ export class LicenseService implements OnModuleInit {
           : null,
         lastVerifiedAt: new Date(),
         instanceId,
+        organizationId: organizationId || undefined,
       },
       create: {
         licenseKey,
@@ -277,6 +278,7 @@ export class LicenseService implements OnModuleInit {
           : null,
         lastVerifiedAt: new Date(),
         instanceId,
+        organizationId: organizationId || undefined,
       },
     });
 
@@ -292,7 +294,17 @@ export class LicenseService implements OnModuleInit {
 
   // ── Get Current License ────────────────────────────────────────────────────
 
-  async getCurrentLicense(): Promise<LicenseInfo | null> {
+  async getCurrentLicense(organizationId?: string): Promise<LicenseInfo | null> {
+    // Per-org: find license by organizationId
+    if (organizationId) {
+      const license = await this.prisma.license.findFirst({
+        where: { organizationId, status: 'active' },
+        orderBy: { createdAt: 'desc' },
+      });
+      if (license) return this.toLicenseInfo(license);
+    }
+
+    // Fallback to global license (self-hosted or no org-specific license)
     const licenseKey = await this.siteSettings.get('license_key');
     if (!licenseKey) return null;
 

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -106,6 +106,16 @@ export class McpEndpointController {
       });
     }
 
+    // Verify the authenticated user belongs to the same organization as the MCP server
+    const user = (req as any).user;
+    if (user?.organizationId && mcpServerConfig.organizationId !== user.organizationId) {
+      return res.status(403).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Access denied' },
+        id: null,
+      });
+    }
+
     // 2. Get connector IDs and composed instructions for this server
     const [connectorIds, instructions] = await Promise.all([
       this.mcpServersService.getConnectorIds(serverId),
@@ -117,7 +127,6 @@ export class McpEndpointController {
     const serverTools = allTools.filter((t) => connectorIds.includes(t.connectorId));
 
     // 4. Further filter by role-based access if user is identified
-    const user = (req as any).user;
     let allowedToolIds: string[] | null = null;
     if (user?.sub) {
       allowedToolIds = await this.rolesService.getAllowedToolIds(user.sub);

--- a/packages/backend/src/mcp-servers/mcp-servers.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.controller.ts
@@ -16,6 +16,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional, IsBoolean, IsArray } from 'class-validator';
 import { McpServersService } from './mcp-servers.service';
 import { LicenseGuardService } from '../license/license-guard.service';
+import { PrismaService } from '../common/prisma.service';
 
 class CreateMcpServerDto {
   @IsString()
@@ -70,19 +71,36 @@ export class McpServersController {
   constructor(
     private readonly mcpServersService: McpServersService,
     private readonly licenseGuard: LicenseGuardService,
+    private readonly prisma: PrismaService,
   ) {}
 
+  private assertOrgMatch(server: any, req: any) {
+    if (server.organizationId !== req.user.organizationId) {
+      throw new NotFoundException('MCP server not found');
+    }
+  }
+
+  private assertCanWrite(server: any, req: any) {
+    this.assertOrgMatch(server, req);
+    if (req.user.role === 'VIEWER') {
+      throw new ForbiddenException('Viewers cannot modify MCP servers');
+    }
+    if (server.userId !== req.user.sub && req.user.role !== 'ADMIN') {
+      throw new ForbiddenException();
+    }
+  }
+
   @Get()
-  @ApiOperation({ summary: 'List MCP servers for current user' })
+  @ApiOperation({ summary: 'List MCP servers for current organization' })
   async list(@Req() req: any) {
-    return this.mcpServersService.findAllByUser(req.user.sub);
+    return this.mcpServersService.findAllByOrg(req.user.organizationId);
   }
 
   @Post()
   @ApiOperation({ summary: 'Create a new MCP server' })
   async create(@Req() req: any, @Body() dto: CreateMcpServerDto) {
-    await this.licenseGuard.checkCanCreateMcpServer(req.user.sub);
-    return this.mcpServersService.create(req.user.sub, dto);
+    await this.licenseGuard.checkCanCreateMcpServer(req.user.sub, req.user.organizationId);
+    return this.mcpServersService.create(req.user.sub, req.user.organizationId, dto);
   }
 
   @Get(':id')
@@ -90,7 +108,7 @@ export class McpServersController {
   async get(@Req() req: any, @Param('id') id: string) {
     const server = await this.mcpServersService.findById(id);
     if (!server) throw new NotFoundException('MCP server not found');
-    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    this.assertOrgMatch(server, req);
     return server;
   }
 
@@ -99,7 +117,7 @@ export class McpServersController {
   async update(@Req() req: any, @Param('id') id: string, @Body() dto: UpdateMcpServerDto) {
     const server = await this.mcpServersService.findById(id);
     if (!server) throw new NotFoundException('MCP server not found');
-    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    this.assertCanWrite(server, req);
     return this.mcpServersService.update(id, dto);
   }
 
@@ -108,7 +126,7 @@ export class McpServersController {
   async delete(@Req() req: any, @Param('id') id: string) {
     const server = await this.mcpServersService.findById(id);
     if (!server) throw new NotFoundException('MCP server not found');
-    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    this.assertCanWrite(server, req);
     await this.mcpServersService.delete(id);
     return { message: 'MCP server deleted' };
   }
@@ -122,7 +140,18 @@ export class McpServersController {
   ) {
     const server = await this.mcpServersService.findById(id);
     if (!server) throw new NotFoundException('MCP server not found');
-    if (server.userId !== req.user.sub) throw new ForbiddenException();
+    this.assertCanWrite(server, req);
+
+    // Validate that all connectors belong to the same organization
+    if (dto.connectorIds.length > 0) {
+      const orgCount = await this.prisma.connector.count({
+        where: { id: { in: dto.connectorIds }, organizationId: req.user.organizationId },
+      });
+      if (orgCount !== dto.connectorIds.length) {
+        throw new NotFoundException('One or more connectors not found');
+      }
+    }
+
     await this.mcpServersService.assignConnectors(id, dto.connectorIds);
     return { message: 'Connectors assigned' };
   }

--- a/packages/backend/src/mcp-servers/mcp-servers.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.service.ts
@@ -17,6 +17,16 @@ export class McpServersService {
     });
   }
 
+  async findAllByOrg(organizationId: string) {
+    return this.prisma.mcpServerConfig.findMany({
+      where: { organizationId },
+      include: {
+        _count: { select: { connectors: true, apiKeys: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
   async findById(id: string) {
     return this.prisma.mcpServerConfig.findUnique({
       where: { id },
@@ -44,11 +54,12 @@ export class McpServersService {
     });
   }
 
-  async create(userId: string, data: { name: string; slug?: string; description?: string; instructions?: string }) {
+  async create(userId: string, organizationId: string, data: { name: string; slug?: string; description?: string; instructions?: string }) {
     const slug = data.slug || this.generateSlug(data.name);
     return this.prisma.mcpServerConfig.create({
       data: {
         userId,
+        organizationId,
         name: data.name,
         slug,
         description: data.description,
@@ -130,18 +141,32 @@ export class McpServersService {
     return parts.length > 0 ? parts.join('\n\n') : undefined;
   }
 
-  async createDefaultForUser(userId: string) {
+  async createDefaultForUser(userId: string, organizationId: string) {
     // Check if user already has a default server (idempotent)
     const existing = await this.prisma.mcpServerConfig.findFirst({
-      where: { userId, slug: 'default' },
+      where: { userId, slug: { startsWith: 'default' } },
     });
     if (existing) return existing;
+
+    // Generate a unique slug within the org
+    const user = await this.prisma.user.findUnique({ where: { id: userId }, select: { name: true, email: true } });
+    const userLabel = user?.name || user?.email?.split('@')[0] || userId.slice(-6);
+    let slug = 'default';
+
+    // Check if 'default' slug already exists in this org
+    const slugExists = await this.prisma.mcpServerConfig.findFirst({
+      where: { organizationId, slug: 'default' },
+    });
+    if (slugExists) {
+      slug = `default-${this.generateSlug(userLabel)}`;
+    }
 
     return this.prisma.mcpServerConfig.create({
       data: {
         userId,
-        name: 'Default',
-        slug: 'default',
+        organizationId,
+        name: `Default (${userLabel})`,
+        slug,
       },
     });
   }

--- a/packages/backend/src/organizations/organizations.controller.ts
+++ b/packages/backend/src/organizations/organizations.controller.ts
@@ -1,0 +1,105 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Body,
+  Req,
+  UseGuards,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { IsString, IsOptional } from 'class-validator';
+import { OrganizationsService } from './organizations.service';
+import { AuthService } from '../auth/auth.service';
+import { ConfigService } from '@nestjs/config';
+
+class UpdateOrganizationDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+
+class SwitchOrgDto {
+  @IsString()
+  organizationId: string;
+}
+
+class CreateOrgDto {
+  @IsString()
+  name: string;
+}
+
+@ApiTags('Organizations')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'))
+@Controller('api/organizations')
+export class OrganizationsController {
+  constructor(
+    private readonly organizationsService: OrganizationsService,
+    private readonly authService: AuthService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Get('mine')
+  @ApiOperation({ summary: 'List organizations the current user belongs to' })
+  async listMine(@Req() req: any) {
+    return this.organizationsService.listUserOrgs(req.user.sub);
+  }
+
+  @Get('current')
+  @ApiOperation({ summary: 'Get current active organization' })
+  async getCurrent(@Req() req: any) {
+    const org = await this.organizationsService.findById(req.user.organizationId);
+    if (!org) throw new NotFoundException('Organization not found');
+    return org;
+  }
+
+  @Put('current')
+  @ApiOperation({ summary: 'Update current organization (ADMIN only)' })
+  async updateCurrent(@Req() req: any, @Body() dto: UpdateOrganizationDto) {
+    if (req.user.role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can update the organization');
+    }
+    return this.organizationsService.update(req.user.organizationId, dto);
+  }
+
+  @Post('switch')
+  @ApiOperation({ summary: 'Switch active organization' })
+  async switchOrg(@Req() req: any, @Body() dto: SwitchOrgDto) {
+    const user = await this.organizationsService.switchOrg(req.user.sub, dto.organizationId);
+    const org = await this.organizationsService.findById(dto.organizationId);
+
+    // Issue a new JWT with the updated organizationId and role
+    const token = this.authService.generateToken({
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+      organizationId: user.organizationId,
+      mcpRoleId: user.mcpRoleId,
+    });
+
+    return {
+      accessToken: token,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        organizationId: user.organizationId,
+      },
+      organization: org,
+    };
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new organization (cloud mode)' })
+  async createOrg(@Req() req: any, @Body() dto: CreateOrgDto) {
+    const org = await this.organizationsService.create(dto.name);
+    // Add creator as ADMIN member
+    await this.organizationsService.addMember(req.user.sub, org.id, 'ADMIN' as any);
+    return org;
+  }
+}

--- a/packages/backend/src/organizations/organizations.module.ts
+++ b/packages/backend/src/organizations/organizations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OrganizationsService } from './organizations.service';
+import { OrganizationsController } from './organizations.controller';
+import { PrismaService } from '../common/prisma.service';
+
+@Module({
+  controllers: [OrganizationsController],
+  providers: [OrganizationsService, PrismaService],
+  exports: [OrganizationsService],
+})
+export class OrganizationsModule {}

--- a/packages/backend/src/organizations/organizations.service.ts
+++ b/packages/backend/src/organizations/organizations.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { UserRole } from '../generated/prisma/client';
+
+@Injectable()
+export class OrganizationsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(name: string) {
+    return this.prisma.organization.create({
+      data: { name },
+    });
+  }
+
+  async findById(id: string) {
+    return this.prisma.organization.findUnique({ where: { id } });
+  }
+
+  async update(id: string, data: { name?: string }) {
+    return this.prisma.organization.update({ where: { id }, data });
+  }
+
+  async listUserOrgs(userId: string) {
+    const memberships = await this.prisma.organizationMember.findMany({
+      where: { userId },
+      include: {
+        organization: { select: { id: true, name: true, createdAt: true } },
+      },
+      orderBy: { joinedAt: 'asc' },
+    });
+    return memberships.map((m) => ({
+      id: m.organization.id,
+      name: m.organization.name,
+      role: m.role,
+      joinedAt: m.joinedAt,
+      createdAt: m.organization.createdAt,
+    }));
+  }
+
+  async getMembership(userId: string, organizationId: string) {
+    return this.prisma.organizationMember.findUnique({
+      where: { userId_organizationId: { userId, organizationId } },
+    });
+  }
+
+  async switchOrg(userId: string, organizationId: string) {
+    const membership = await this.getMembership(userId, organizationId);
+    if (!membership) {
+      throw new ForbiddenException('Not a member of this organization');
+    }
+
+    // Update the cached active org and role on the User record
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { organizationId, role: membership.role },
+    });
+  }
+
+  async addMember(userId: string, organizationId: string, role: UserRole = 'EDITOR' as UserRole) {
+    return this.prisma.organizationMember.create({
+      data: { userId, organizationId, role },
+    });
+  }
+
+  async removeMember(userId: string, organizationId: string) {
+    await this.prisma.organizationMember.delete({
+      where: { userId_organizationId: { userId, organizationId } },
+    });
+
+    // If this was the user's active org, switch to another
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (user?.organizationId === organizationId) {
+      const remaining = await this.prisma.organizationMember.findFirst({
+        where: { userId },
+        orderBy: { joinedAt: 'asc' },
+      });
+      if (remaining) {
+        await this.switchOrg(userId, remaining.organizationId);
+      }
+    }
+  }
+
+  async updateMemberRole(userId: string, organizationId: string, role: UserRole) {
+    const membership = await this.prisma.organizationMember.update({
+      where: { userId_organizationId: { userId, organizationId } },
+      data: { role },
+    });
+
+    // Sync cache if this is the user's active org
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (user?.organizationId === organizationId) {
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: { role },
+      });
+    }
+
+    return membership;
+  }
+
+  async getMembers(organizationId: string) {
+    const memberships = await this.prisma.organizationMember.findMany({
+      where: { organizationId },
+      include: {
+        user: { select: { id: true, email: true, name: true, mcpRoleId: true } },
+      },
+      orderBy: { joinedAt: 'asc' },
+    });
+    return memberships.map((m) => ({
+      id: m.user.id,
+      email: m.user.email,
+      name: m.user.name,
+      role: m.role,
+      mcpRoleId: m.user.mcpRoleId,
+      joinedAt: m.joinedAt,
+    }));
+  }
+}

--- a/packages/backend/src/roles/mcp-api-keys.controller.ts
+++ b/packages/backend/src/roles/mcp-api-keys.controller.ts
@@ -44,7 +44,7 @@ export class McpApiKeysController {
   @ApiOperation({ summary: 'Generate a new MCP API key' })
   async generateKey(@Req() req: any, @Body() dto: CreateKeyDto) {
     // Returns the full key — user must save it, it won't be shown again
-    return this.keysService.generate(req.user.sub, dto.name, dto.mcpServerId);
+    return this.keysService.generate(req.user.sub, req.user.organizationId, dto.name, dto.mcpServerId);
   }
 
   @Post(':id/revoke')

--- a/packages/backend/src/roles/mcp-api-keys.service.spec.ts
+++ b/packages/backend/src/roles/mcp-api-keys.service.spec.ts
@@ -31,7 +31,7 @@ describe('McpApiKeysService', () => {
         });
       });
 
-      const result = await service.generate('user-1', 'My Key');
+      const result = await service.generate('user-1', 'org-1', 'My Key');
       expect(result.key).toMatch(/^mcp_[0-9a-f]{64}$/);
       expect(result.name).toBe('My Key');
     });
@@ -41,7 +41,7 @@ describe('McpApiKeysService', () => {
         Promise.resolve({ id: 'key-1', key: args.data.key, mcpServerId: args.data.mcpServerId }),
       );
 
-      const result = await service.generate('user-1', 'Key');
+      const result = await service.generate('user-1', 'org-1', 'Key');
       expect(result.mcpServerId).toBeNull();
     });
 
@@ -50,7 +50,7 @@ describe('McpApiKeysService', () => {
         Promise.resolve({ id: 'key-1', key: args.data.key, mcpServerId: args.data.mcpServerId }),
       );
 
-      const result = await service.generate('user-1', 'Key', 'server-1');
+      const result = await service.generate('user-1', 'org-1', 'Key', 'server-1');
       expect(result.mcpServerId).toBe('server-1');
     });
   });

--- a/packages/backend/src/roles/mcp-api-keys.service.ts
+++ b/packages/backend/src/roles/mcp-api-keys.service.ts
@@ -12,11 +12,11 @@ export class McpApiKeysService {
    * Generate a new MCP API key for a user.
    * Key format: mcp_<32 random hex chars>
    */
-  async generate(userId: string, name: string, mcpServerId?: string) {
+  async generate(userId: string, organizationId: string, name: string, mcpServerId?: string) {
     const key = `mcp_${randomBytes(32).toString('hex')}`;
 
     return this.prisma.mcpApiKey.create({
-      data: { userId, key, name, mcpServerId: mcpServerId || null },
+      data: { userId, organizationId, key, name, mcpServerId: mcpServerId || null },
       select: { id: true, key: true, name: true, isActive: true, mcpServerId: true, createdAt: true },
     });
   }
@@ -64,6 +64,7 @@ export class McpApiKeysService {
             id: true,
             email: true,
             role: true,
+            organizationId: true,
             mcpRoleId: true,
           },
         },

--- a/packages/backend/src/roles/roles.controller.ts
+++ b/packages/backend/src/roles/roles.controller.ts
@@ -58,14 +58,14 @@ export class RolesController {
 
   @Get()
   @ApiOperation({ summary: 'List all roles (ADMIN)' })
-  async listRoles() {
-    return this.rolesService.findAll();
+  async listRoles(@Req() req: any) {
+    return this.rolesService.findAll(req.user.organizationId);
   }
 
   @Post()
   @ApiOperation({ summary: 'Create a custom role (ADMIN)' })
-  async createRole(@Body() dto: CreateRoleDto) {
-    return this.rolesService.create(dto);
+  async createRole(@Req() req: any, @Body() dto: CreateRoleDto) {
+    return this.rolesService.create({ ...dto, organizationId: req.user.organizationId });
   }
 
   @Get(':id')

--- a/packages/backend/src/roles/roles.service.ts
+++ b/packages/backend/src/roles/roles.service.ts
@@ -7,8 +7,11 @@ export class RolesService {
 
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll() {
+  async findAll(organizationId?: string) {
     return this.prisma.role.findMany({
+      where: organizationId
+        ? { OR: [{ organizationId }, { isSystem: true }] }
+        : undefined,
       include: {
         _count: { select: { users: true, toolAccess: true } },
       },
@@ -28,9 +31,9 @@ export class RolesService {
     });
   }
 
-  async create(data: { name: string; description?: string }) {
+  async create(data: { name: string; description?: string; organizationId?: string }) {
     return this.prisma.role.create({
-      data: { name: data.name, description: data.description },
+      data: { name: data.name, description: data.description, organizationId: data.organizationId },
     });
   }
 
@@ -140,11 +143,14 @@ export class RolesService {
     ];
 
     for (const role of systemRoles) {
-      await this.prisma.role.upsert({
-        where: { name: role.name },
-        create: { ...role, isSystem: true },
-        update: {},
+      const existing = await this.prisma.role.findFirst({
+        where: { name: role.name, isSystem: true },
       });
+      if (!existing) {
+        await this.prisma.role.create({
+          data: { ...role, isSystem: true },
+        });
+      }
     }
   }
 }

--- a/packages/backend/src/settings/org-settings.service.ts
+++ b/packages/backend/src/settings/org-settings.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { SiteSettingsService } from './site-settings.service';
+
+@Injectable()
+export class OrgSettingsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly siteSettings: SiteSettingsService,
+  ) {}
+
+  async get(organizationId: string, key: string): Promise<string | null> {
+    const row = await this.prisma.orgSettings.findUnique({
+      where: { organizationId_key: { organizationId, key } },
+    });
+    return row?.value ?? null;
+  }
+
+  async getJson<T = unknown>(organizationId: string, key: string): Promise<T | null> {
+    const value = await this.get(organizationId, key);
+    if (!value) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(organizationId: string, key: string, value: string): Promise<void> {
+    await this.prisma.orgSettings.upsert({
+      where: { organizationId_key: { organizationId, key } },
+      create: { organizationId, key, value },
+      update: { value },
+    });
+  }
+
+  async setJson(organizationId: string, key: string, value: unknown): Promise<void> {
+    await this.set(organizationId, key, JSON.stringify(value));
+  }
+
+  /**
+   * Get SMTP config for an org, falling back to global SiteSettings if not configured.
+   */
+  async getSmtpConfig(organizationId: string) {
+    const orgSmtp = await this.getJson<any>(organizationId, 'smtp_config');
+    if (orgSmtp) return orgSmtp;
+    // Fallback to global
+    return this.siteSettings.getJson<any>('smtp_config');
+  }
+
+  /**
+   * Get footer links for an org, falling back to global SiteSettings.
+   */
+  async getFooterLinks(organizationId: string) {
+    const orgLinks = await this.getJson<any[]>(organizationId, 'footer_links');
+    if (orgLinks) return orgLinks;
+    return this.siteSettings.getJson<any[]>('footer_links');
+  }
+}

--- a/packages/backend/src/settings/settings.module.ts
+++ b/packages/backend/src/settings/settings.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { SiteSettingsService } from './site-settings.service';
+import { OrgSettingsService } from './org-settings.service';
 import { EmailService } from './email.service';
 import { SiteSettingsPublicController, SiteSettingsAdminController } from './site-settings.controller';
 
 @Module({
   controllers: [SiteSettingsPublicController, SiteSettingsAdminController],
-  providers: [SiteSettingsService, EmailService],
-  exports: [SiteSettingsService, EmailService],
+  providers: [SiteSettingsService, OrgSettingsService, EmailService],
+  exports: [SiteSettingsService, OrgSettingsService, EmailService],
 })
 export class SettingsModule {}

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -4,6 +4,7 @@ import {
   Put,
   Post,
   Body,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
@@ -12,6 +13,7 @@ import { IsString, IsNumber, IsOptional, IsBoolean, IsArray, ValidateNested } fr
 import { Type } from 'class-transformer';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 import { SiteSettingsService } from './site-settings.service';
+import { OrgSettingsService } from './org-settings.service';
 import { EmailService } from './email.service';
 
 class SmtpConfigDto {
@@ -75,15 +77,15 @@ export class SiteSettingsPublicController {
 export class SiteSettingsAdminController {
   constructor(
     private readonly siteSettings: SiteSettingsService,
+    private readonly orgSettings: OrgSettingsService,
     private readonly emailService: EmailService,
   ) {}
 
   @Get('smtp')
-  @ApiOperation({ summary: 'Get SMTP configuration (ADMIN)' })
-  async getSmtpConfig() {
-    const config = await this.siteSettings.getSmtpConfig();
+  @ApiOperation({ summary: 'Get SMTP configuration for current organization (ADMIN)' })
+  async getSmtpConfig(@Req() req: any) {
+    const config = await this.orgSettings.getSmtpConfig(req.user.organizationId);
     if (!config) return { configured: false };
-    // Mask password
     return {
       configured: true,
       host: config.host,
@@ -95,9 +97,9 @@ export class SiteSettingsAdminController {
   }
 
   @Put('smtp')
-  @ApiOperation({ summary: 'Update SMTP configuration (ADMIN)' })
-  async updateSmtpConfig(@Body() dto: SmtpConfigDto) {
-    await this.siteSettings.setJson('smtp_config', {
+  @ApiOperation({ summary: 'Update SMTP configuration for current organization (ADMIN)' })
+  async updateSmtpConfig(@Req() req: any, @Body() dto: SmtpConfigDto) {
+    await this.orgSettings.setJson(req.user.organizationId, 'smtp_config', {
       host: dto.host,
       port: dto.port,
       user: dto.user,
@@ -115,15 +117,15 @@ export class SiteSettingsAdminController {
   }
 
   @Get('footer-links')
-  @ApiOperation({ summary: 'Get footer links (ADMIN)' })
-  async getFooterLinks() {
-    return this.siteSettings.getFooterLinks();
+  @ApiOperation({ summary: 'Get footer links for current organization (ADMIN)' })
+  async getFooterLinks(@Req() req: any) {
+    return this.orgSettings.getFooterLinks(req.user.organizationId) || [];
   }
 
   @Put('footer-links')
-  @ApiOperation({ summary: 'Update footer links (ADMIN)' })
-  async updateFooterLinks(@Body() dto: FooterLinksDto) {
-    await this.siteSettings.setJson('footer_links', dto.links);
+  @ApiOperation({ summary: 'Update footer links for current organization (ADMIN)' })
+  async updateFooterLinks(@Req() req: any, @Body() dto: FooterLinksDto) {
+    await this.orgSettings.setJson(req.user.organizationId, 'footer_links', dto.links);
     return { message: 'Footer links saved' };
   }
 }

--- a/packages/backend/src/users/users.controller.ts
+++ b/packages/backend/src/users/users.controller.ts
@@ -101,17 +101,17 @@ export class UsersController {
   @Get()
   @UseGuards(RolesGuard)
   @Roles('ADMIN')
-  @ApiOperation({ summary: 'List all users (ADMIN only)' })
-  async listUsers() {
-    return this.usersService.findAll();
+  @ApiOperation({ summary: 'List all users in organization (ADMIN only)' })
+  async listUsers(@Req() req: any) {
+    return this.usersService.findAll(req.user.organizationId);
   }
 
   @Get('invitations')
   @UseGuards(RolesGuard)
   @Roles('ADMIN')
   @ApiOperation({ summary: 'List pending/expired invitations (ADMIN only)' })
-  async listInvitations() {
-    return this.usersService.findAllInvitations();
+  async listInvitations(@Req() req: any) {
+    return this.usersService.findAllInvitations(req.user.organizationId);
   }
 
   @Delete('invitations/:id')

--- a/packages/backend/src/users/users.service.spec.ts
+++ b/packages/backend/src/users/users.service.spec.ts
@@ -63,6 +63,7 @@ describe('UsersService', () => {
         email: 'new@example.com',
         passwordHash: 'hash',
         name: 'New User',
+        organizationId: 'org-1',
       };
       mockPrisma.user.create.mockResolvedValue({ ...mockUser, ...data });
       const result = await service.create(data);

--- a/packages/backend/src/users/users.service.ts
+++ b/packages/backend/src/users/users.service.ts
@@ -21,6 +21,7 @@ export class UsersService {
     passwordHash: string;
     name: string;
     role?: UserRole;
+    organizationId: string;
   }): Promise<User> {
     return this.prisma.user.create({ data });
   }
@@ -29,13 +30,15 @@ export class UsersService {
     return this.prisma.user.count();
   }
 
-  async findAll() {
+  async findAll(organizationId?: string) {
     return this.prisma.user.findMany({
+      where: organizationId ? { organizationId } : undefined,
       select: {
         id: true,
         email: true,
         name: true,
         role: true,
+        organizationId: true,
         mcpRoleId: true,
         mcpRole: { select: { id: true, name: true } },
         createdAt: true,
@@ -55,9 +58,9 @@ export class UsersService {
     await this.prisma.user.delete({ where: { id: userId } });
   }
 
-  async findAllInvitations() {
+  async findAllInvitations(organizationId?: string) {
     return this.prisma.invitationToken.findMany({
-      where: { usedAt: null },
+      where: { usedAt: null, ...(organizationId ? { organizationId } : {}) },
       orderBy: { createdAt: 'desc' },
     });
   }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -12,23 +12,39 @@ interface SidebarItem {
   description: string;
   icon: React.ComponentType<{ size?: number }>;
   exact?: boolean;
-  adminOnly?: boolean;
 }
 
-const SIDEBAR_ITEMS: SidebarItem[] = [
-  { href: '/settings', label: 'General', description: 'Profile, password, AI & MCP keys', icon: GearIcon, exact: true },
-  { href: '/settings/users', label: 'Users', description: 'Manage users and invitations', icon: UsersIcon, adminOnly: true },
-  { href: '/settings/roles', label: 'Roles', description: 'MCP tool access control', icon: ShieldIcon, adminOnly: true },
-  { href: '/settings/license', label: 'License', description: 'Plan, license key, features', icon: KeyIcon, adminOnly: true },
-  { href: '/settings/admin', label: 'Administration', description: 'SMTP, footer links', icon: WrenchIcon, adminOnly: true },
+interface SidebarSection {
+  title?: string;
+  icon?: React.ComponentType<{ size?: number }>;
+  adminOnly?: boolean;
+  items: SidebarItem[];
+}
+
+const SIDEBAR_SECTIONS: SidebarSection[] = [
+  {
+    items: [
+      { href: '/settings', label: 'Profile', description: 'Name, email, password', icon: GearIcon, exact: true },
+    ],
+  },
+  {
+    title: 'Organization',
+    icon: BuildingIcon,
+    adminOnly: true,
+    items: [
+      { href: '/settings/organization', label: 'General', description: 'Workspace name and info', icon: BuildingIcon },
+      { href: '/settings/users', label: 'Users', description: 'Members and invitations', icon: UsersIcon },
+      { href: '/settings/roles', label: 'Roles', description: 'MCP tool access control', icon: ShieldIcon },
+      { href: '/settings/license', label: 'License', description: 'Plan, features', icon: KeyIcon },
+      { href: '/settings/admin', label: 'Administration', description: 'SMTP, footer links', icon: WrenchIcon },
+    ],
+  },
 ];
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { user } = useAuth();
   const isAdmin = user?.role === 'ADMIN';
-
-  const visibleItems = SIDEBAR_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
   return (
     <div className="min-h-screen bg-[var(--background)] flex flex-col">
@@ -40,27 +56,43 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 flex-1 w-full flex flex-col lg:flex-row gap-6 lg:gap-8">
         {/* Sidebar navigation */}
         <aside className="w-full lg:w-56 flex-shrink-0">
-          <nav className="flex lg:flex-col gap-1.5 overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0">
-            {visibleItems.map((item) => {
-              const isActive = item.exact
-                ? pathname === item.href
-                : pathname.startsWith(item.href);
+          <nav className="flex lg:flex-col gap-1 overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0">
+            {SIDEBAR_SECTIONS.map((section, si) => {
+              if (section.adminOnly && !isAdmin) return null;
+
               return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm transition-colors flex-shrink-0 ${
-                    isActive
-                      ? 'bg-[var(--brand-light)] text-[var(--brand)] font-medium'
-                      : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--accent)]'
-                  }`}
-                >
-                  <item.icon size={16} />
-                  <div className="min-w-0">
-                    <div className="truncate">{item.label}</div>
-                    <div className="text-xs opacity-70 truncate hidden lg:block">{item.description}</div>
-                  </div>
-                </Link>
+                <div key={si}>
+                  {section.title && (
+                    <div className="hidden lg:flex items-center gap-1.5 px-3 pt-4 pb-1.5 text-[10px] uppercase tracking-wider font-semibold text-[var(--muted-foreground)]">
+                      {section.icon && <section.icon size={12} />}
+                      {section.title}
+                    </div>
+                  )}
+                  {section.items.map((item) => {
+                    const isActive = item.exact
+                      ? pathname === item.href
+                      : pathname.startsWith(item.href);
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors flex-shrink-0 ${
+                          section.title ? 'lg:pl-5' : ''
+                        } ${
+                          isActive
+                            ? 'bg-[var(--brand-light)] text-[var(--brand)] font-medium'
+                            : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--accent)]'
+                        }`}
+                      >
+                        <item.icon size={15} />
+                        <div className="min-w-0">
+                          <div className="truncate">{item.label}</div>
+                          <div className="text-xs opacity-70 truncate hidden lg:block">{item.description}</div>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
               );
             })}
           </nav>
@@ -78,6 +110,18 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
 }
 
 /* Sidebar icon components */
+
+function BuildingIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
+      <path d="M9 22v-4h6v4" />
+      <path d="M8 6h.01" /><path d="M16 6h.01" />
+      <path d="M8 10h.01" /><path d="M16 10h.01" />
+      <path d="M8 14h.01" /><path d="M16 14h.01" />
+    </svg>
+  );
+}
 
 function GearIcon({ size = 16 }: { size?: number }) {
   return (

--- a/packages/frontend/src/app/settings/organization/page.tsx
+++ b/packages/frontend/src/app/settings/organization/page.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/lib/auth-context';
+import { organizations } from '@/lib/api';
+
+export default function OrganizationSettingsPage() {
+  const { token, user, orgName, orgs, setOrgName, switchOrg } = useAuth();
+  const [name, setName] = useState('');
+  const [orgId, setOrgId] = useState('');
+  const [createdAt, setCreatedAt] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+
+  // Create new org
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newOrgName, setNewOrgName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createMessage, setCreateMessage] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    organizations.getCurrent(token).then((org) => {
+      setName(org.name);
+      setOrgId(org.id);
+      setCreatedAt(org.createdAt);
+    }).catch(() => {});
+  }, [token]);
+
+  const handleSave = async () => {
+    if (!token || !name.trim()) return;
+    setSaving(true);
+    setMessage('');
+    try {
+      const updated = await organizations.updateCurrent({ name: name.trim() }, token);
+      setName(updated.name);
+      setOrgName(updated.name);
+      setMessage('Organization updated successfully');
+    } catch (err: any) {
+      setMessage(err.message || 'Failed to update organization');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCreateOrg = async () => {
+    if (!token || !newOrgName.trim()) return;
+    setCreating(true);
+    setCreateMessage('');
+    try {
+      const newOrg = await organizations.create(newOrgName.trim(), token);
+      setCreateMessage('Organization created! Switching...');
+      setNewOrgName('');
+      setShowCreateForm(false);
+      // Switch to the new org
+      await switchOrg(newOrg.id);
+    } catch (err: any) {
+      setCreateMessage(err.message || 'Failed to create organization');
+      setCreating(false);
+    }
+  };
+
+  if (user?.role !== 'ADMIN') {
+    return (
+      <div className="text-center py-12 text-[var(--muted-foreground)]">
+        <p className="text-lg font-medium">Access Denied</p>
+        <p className="text-sm mt-1">Only administrators can manage the organization.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h2 className="text-lg font-semibold">Organization</h2>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Manage your workspace settings. All members of this organization share connectors, MCP servers, and tools.
+        </p>
+      </div>
+
+      {/* Current organization */}
+      <div className="bg-[var(--card)] border border-[var(--border)] rounded-lg p-5 space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Organization Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--background)] border border-[var(--border)] rounded-lg text-sm focus:ring-2 focus:ring-[var(--brand)] focus:border-transparent outline-none"
+            placeholder="My Workspace"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Organization ID</label>
+          <input
+            type="text"
+            value={orgId}
+            readOnly
+            className="w-full px-3 py-2 bg-[var(--accent)] border border-[var(--border)] rounded-lg text-sm text-[var(--muted-foreground)] cursor-not-allowed"
+          />
+        </div>
+
+        {createdAt && (
+          <div>
+            <label className="block text-sm font-medium mb-1">Created</label>
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {new Date(createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+            </p>
+          </div>
+        )}
+
+        {message && (
+          <p className={`text-sm ${message.includes('success') ? 'text-green-600' : 'text-[var(--destructive)]'}`}>
+            {message}
+          </p>
+        )}
+
+        <div className="pt-2">
+          <button
+            onClick={handleSave}
+            disabled={saving || !name.trim()}
+            className="px-4 py-2 bg-[var(--brand)] text-white rounded-lg text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {saving ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+
+      {/* Create new organization */}
+      <div className="bg-[var(--card)] border border-[var(--border)] rounded-lg p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">Create New Organization</h3>
+            <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+              Create a separate workspace with its own connectors, MCP servers, and team.
+            </p>
+          </div>
+          {!showCreateForm && (
+            <button
+              onClick={() => { setShowCreateForm(true); setCreateMessage(''); }}
+              className="px-3 py-1.5 border border-[var(--border)] rounded-lg text-sm hover:bg-[var(--accent)] transition-colors"
+            >
+              + New Organization
+            </button>
+          )}
+        </div>
+
+        {showCreateForm && (
+          <div className="space-y-3 pt-2 border-t border-[var(--border)]">
+            <div>
+              <label className="block text-sm font-medium mb-1">Name</label>
+              <input
+                type="text"
+                value={newOrgName}
+                onChange={(e) => setNewOrgName(e.target.value)}
+                className="w-full px-3 py-2 bg-[var(--background)] border border-[var(--border)] rounded-lg text-sm focus:ring-2 focus:ring-[var(--brand)] focus:border-transparent outline-none"
+                placeholder="My New Workspace"
+                autoFocus
+                onKeyDown={(e) => { if (e.key === 'Enter') handleCreateOrg(); }}
+              />
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={handleCreateOrg}
+                disabled={creating || !newOrgName.trim()}
+                className="px-4 py-2 bg-[var(--brand)] text-white rounded-lg text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+              >
+                {creating ? 'Creating...' : 'Create & Switch'}
+              </button>
+              <button
+                onClick={() => { setShowCreateForm(false); setNewOrgName(''); setCreateMessage(''); }}
+                className="px-4 py-2 border border-[var(--border)] rounded-lg text-sm hover:bg-[var(--accent)] transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {createMessage && (
+          <p className={`text-sm ${createMessage.includes('created') ? 'text-green-600' : 'text-[var(--destructive)]'}`}>
+            {createMessage}
+          </p>
+        )}
+      </div>
+
+      {/* My organizations list */}
+      {orgs && orgs.length > 1 && (
+        <div className="bg-[var(--card)] border border-[var(--border)] rounded-lg p-5 space-y-3">
+          <h3 className="text-sm font-semibold">My Organizations</h3>
+          <div className="divide-y divide-[var(--border)]">
+            {orgs.map((org) => {
+              const isActive = org.id === user?.organizationId;
+              return (
+                <div key={org.id} className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0">
+                  <div className="min-w-0">
+                    <p className={`text-sm truncate ${isActive ? 'font-medium text-[var(--brand)]' : ''}`}>
+                      {org.name}
+                    </p>
+                    <p className="text-xs text-[var(--muted-foreground)]">
+                      {org.role} &middot; Joined {new Date(org.joinedAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  {isActive ? (
+                    <span className="text-xs bg-[var(--brand-light)] text-[var(--brand)] px-2 py-0.5 rounded-full font-medium flex-shrink-0">
+                      Active
+                    </span>
+                  ) : (
+                    <button
+                      onClick={() => switchOrg(org.id)}
+                      className="text-xs px-3 py-1 border border-[var(--border)] rounded-lg hover:bg-[var(--accent)] transition-colors flex-shrink-0"
+                    >
+                      Switch
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/nav-bar.tsx
+++ b/packages/frontend/src/components/nav-bar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState, useRef, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
+import { organizations } from '@/lib/api';
 
 /* Inline SVG logo component */
 function LogoIcon({ size = 28 }: { size?: number }) {
@@ -43,7 +44,7 @@ interface NavBarProps {
 }
 
 export function NavBar({ breadcrumbs, title, actions }: NavBarProps) {
-  const { user, logout } = useAuth();
+  const { user, orgName, orgs, switchOrg, logout } = useAuth();
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
@@ -105,7 +106,36 @@ export function NavBar({ breadcrumbs, title, actions }: NavBarProps) {
               </div>
             </button>
             {userMenuOpen && (
-              <div className="absolute right-0 mt-1 w-48 bg-[var(--background)] border border-[var(--border)] rounded-lg shadow-lg py-1 z-50">
+              <div className="absolute right-0 mt-1 w-64 bg-[var(--background)] border border-[var(--border)] rounded-lg shadow-lg py-1 z-50">
+                {/* Organization switcher */}
+                {orgs && orgs.length > 0 && (
+                  <div className="border-b border-[var(--border)]">
+                    <p className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-[var(--muted-foreground)]">Organizations</p>
+                    {orgs.map((org) => {
+                      const isActive = org.id === user?.organizationId;
+                      return (
+                        <button
+                          key={org.id}
+                          onClick={() => {
+                            if (!isActive) {
+                              setUserMenuOpen(false);
+                              switchOrg(org.id);
+                            }
+                          }}
+                          className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between gap-2 transition-colors ${
+                            isActive
+                              ? 'bg-[var(--brand-light)] text-[var(--brand)] font-medium'
+                              : 'text-[var(--foreground)] hover:bg-[var(--accent)]'
+                          }`}
+                        >
+                          <span className="truncate">{org.name}</span>
+                          <span className="text-[10px] uppercase tracking-wider opacity-60 flex-shrink-0">{org.role}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {/* User info */}
                 <div className="px-3 py-2 border-b border-[var(--border)]">
                   <p className="text-xs font-medium truncate">{user?.name || user?.email}</p>
                   {user?.name && <p className="text-xs text-[var(--muted-foreground)] truncate">{user?.email}</p>}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -109,6 +109,22 @@ export const users = {
     request(`/api/users/invitations/${id}`, { method: 'DELETE', token }),
 };
 
+// Organizations
+export const organizations = {
+  getCurrent: (token: string) =>
+    request<{ id: string; name: string; createdAt: string }>('/api/organizations/current', { token }),
+  updateCurrent: (data: { name?: string }, token: string) =>
+    request<{ id: string; name: string }>('/api/organizations/current', { method: 'PUT', body: data, token }),
+  listMine: (token: string) =>
+    request<Array<{ id: string; name: string; role: string; joinedAt: string }>>('/api/organizations/mine', { token }),
+  switchOrg: (organizationId: string, token: string) =>
+    request<{ accessToken: string; user: any; organization: any }>('/api/organizations/switch', {
+      method: 'POST', body: { organizationId }, token,
+    }),
+  create: (name: string, token: string) =>
+    request<{ id: string; name: string }>('/api/organizations', { method: 'POST', body: { name }, token }),
+};
+
 // Connectors
 export const connectors = {
   list: (token: string) =>

--- a/packages/frontend/src/lib/auth-context.tsx
+++ b/packages/frontend/src/lib/auth-context.tsx
@@ -2,18 +2,30 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { users, server, AUTH_EXPIRED_EVENT } from './api';
+import { users, server, organizations, AUTH_EXPIRED_EVENT } from './api';
 
 interface User {
   id: string;
   email: string;
   name: string;
   role: string;
+  organizationId: string;
+}
+
+interface OrgInfo {
+  id: string;
+  name: string;
+  role: string;
+  joinedAt: string;
 }
 
 interface AuthContextType {
   token: string | null;
   user: User | null;
+  orgName: string | null;
+  orgs: OrgInfo[] | null;
+  setOrgName: (name: string) => void;
+  switchOrg: (organizationId: string) => Promise<void>;
   login: (token: string, user: User) => void;
   logout: () => void;
   updateUser: (updates: Partial<User>) => void;
@@ -24,6 +36,10 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType>({
   token: null,
   user: null,
+  orgName: null,
+  orgs: null,
+  setOrgName: () => {},
+  switchOrg: async () => {},
   login: () => {},
   logout: () => {},
   updateUser: () => {},
@@ -35,16 +51,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [orgName, setOrgName] = useState<string | null>(null);
+  const [orgs, setOrgs] = useState<OrgInfo[] | null>(null);
   const [deploymentMode, setDeploymentMode] = useState('self-hosted');
   const router = useRouter();
   const pathname = usePathname();
 
+  const fetchOrgData = useCallback(async (t: string) => {
+    try {
+      const [orgInfo, orgList] = await Promise.all([
+        organizations.getCurrent(t),
+        organizations.listMine(t),
+      ]);
+      setOrgName(orgInfo.name);
+      setOrgs(orgList);
+    } catch {}
+  }, []);
+
   const logout = useCallback(() => {
     setToken(null);
     setUser(null);
+    setOrgName(null);
+    setOrgs(null);
     localStorage.removeItem('amcp_token');
     localStorage.removeItem('amcp_user');
-    // Clear cookie
     document.cookie = 'amcp_token=; path=/; max-age=0';
     router.push('/login');
   }, [router]);
@@ -55,17 +85,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const savedUser = localStorage.getItem('amcp_user');
 
     if (savedToken && savedUser) {
-      // Optimistically set state for instant UI
       setToken(savedToken);
       setUser(JSON.parse(savedUser));
 
-      // Validate the token is still accepted by the backend
       users.me(savedToken).then((freshUser) => {
         setUser(freshUser);
         localStorage.setItem('amcp_user', JSON.stringify(freshUser));
+        fetchOrgData(savedToken);
         setIsLoading(false);
       }).catch(() => {
-        // Token rejected — clear and redirect to login
         setToken(null);
         setUser(null);
         localStorage.removeItem('amcp_token');
@@ -105,8 +133,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(newUser);
     localStorage.setItem('amcp_token', newToken);
     localStorage.setItem('amcp_user', JSON.stringify(newUser));
-    // Set cookie for middleware auth check
     document.cookie = `amcp_token=${newToken}; path=/; max-age=${7 * 24 * 60 * 60}; SameSite=Lax`;
+    fetchOrgData(newToken);
+  };
+
+  const switchOrg = async (organizationId: string) => {
+    if (!token) return;
+    try {
+      const result = await organizations.switchOrg(organizationId, token);
+      // Store new token and user from the switch response
+      setToken(result.accessToken);
+      setUser(result.user);
+      localStorage.setItem('amcp_token', result.accessToken);
+      localStorage.setItem('amcp_user', JSON.stringify(result.user));
+      document.cookie = `amcp_token=${result.accessToken}; path=/; max-age=${7 * 24 * 60 * 60}; SameSite=Lax`;
+      // Update org data
+      setOrgName(result.organization?.name || null);
+      await fetchOrgData(result.accessToken);
+      // Reload the page to refresh all data
+      window.location.href = '/';
+    } catch (err) {
+      console.error('Failed to switch org:', err);
+    }
   };
 
   const updateUser = (updates: Partial<User>) => {
@@ -119,7 +167,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, user, login, logout, updateUser, isLoading, deploymentMode }}>
+    <AuthContext.Provider value={{ token, user, orgName, orgs, setOrgName, switchOrg, login, logout, updateUser, isLoading, deploymentMode }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Multi-tenant organization model with complete data isolation
- Multi-org membership with per-org roles (ADMIN/EDITOR/VIEWER)
- Org switcher in navbar (Slack/GitHub style)
- Per-org licensing, SMTP settings, and footer configuration
- 24/24 API tests passing

## Changes
- **Schema**: Organization, OrganizationMember, OrgSettings models + organizationId on License
- **Auth**: Register creates org, invite stores orgId, accept-invite supports multi-org
- **Isolation**: All controllers filter by organizationId, MCP endpoint validates org
- **Frontend**: Org switcher dropdown, Settings > Organization page
- **Website**: License MongoDB schema supports organizationId

## Test plan
- [x] Registration creates new org (cloud mode)
- [x] Connector/MCP server/audit isolation between orgs
- [x] Cross-org access blocked (403/404)
- [x] Multi-org invite + accept for existing users
- [x] Org switch with JWT refresh
- [x] Create new org from settings
- [x] Per-org license status
- [x] Frontend org switcher tested in Chrome