### PR TITLE
Refresh :latest tag in Deploy Cloud workflow

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -37,8 +37,11 @@ jobs:
             set -e
             cd /opt/anythingmcp-cloud
 
-            # Pull latest image
+            # Pull the requested tag AND refresh :latest, since
+            # docker-compose.cloud.yml references :latest. Without this
+            # the local :latest tag can point to an older image.
             docker pull helpcodeai/anythingmcp:${{ inputs.tag }}
+            docker pull helpcodeai/anythingmcp:latest
 
             # Update compose and Caddyfile from checkout
             cp /tmp/anythingmcp-deploy/docker-compose.cloud.yml ./docker-compose.cloud.yml


### PR DESCRIPTION
The `Deploy Cloud` workflow pulled `helpcodeai/anythingmcp:${inputs.tag}` but `docker-compose.cloud.yml` references `:latest`. The droplet's local `:latest` tag therefore stayed pinned to whatever was last explicitly pulled — in this incident it had been stuck on 0.1.12 for ten days, so the 0.1.15 deploy appeared to succeed but containers came back up on the old image. Fix: also pull `:latest` so compose's `--force-recreate` picks up the new build.