### PR TITLE
Fix adapter bugs and add 13 new connectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.10",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.10",
+      "version": "0.1.15",
       "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -19841,7 +19841,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.10",
+      "version": "0.1.15",
       "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -19925,7 +19925,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.10",
+      "version": "0.1.15",
       "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/packages/backend/src/adapters/catalog.spec.ts
+++ b/packages/backend/src/adapters/catalog.spec.ts
@@ -1,0 +1,100 @@
+import { listAdapters, getAdapter } from './catalog';
+
+const VALID_AUTH_TYPES = new Set([
+  'NONE',
+  'API_KEY',
+  'BEARER_TOKEN',
+  'BASIC_AUTH',
+  'OAUTH2',
+  'QUERY_AUTH',
+]);
+
+const VALID_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * Recursively collect every string value in an object/array, together with the
+ * JSON path to that value. Used to scan endpointMapping fields for broken
+ * placeholder syntax.
+ */
+function collectStrings(
+  value: unknown,
+  path: string,
+  out: Array<{ path: string; value: string }>,
+): void {
+  if (typeof value === 'string') {
+    out.push({ path, value });
+  } else if (Array.isArray(value)) {
+    value.forEach((v, i) => collectStrings(v, `${path}[${i}]`, out));
+  } else if (value && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      collectStrings(v, `${path}.${k}`, out);
+    }
+  }
+}
+
+describe('adapter catalog', () => {
+  const adapters = listAdapters();
+
+  it('registers at least one adapter', () => {
+    expect(adapters.length).toBeGreaterThan(0);
+  });
+
+  it('has unique slugs', () => {
+    const slugs = adapters.map((a) => a.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  describe.each(adapters)('$slug', (meta) => {
+    const adapter = getAdapter(meta.slug)!;
+
+    it('has a valid connector authType', () => {
+      expect(VALID_AUTH_TYPES.has(adapter.connector.authType)).toBe(true);
+    });
+
+    it('declares at least one tool', () => {
+      expect(adapter.tools.length).toBeGreaterThan(0);
+    });
+
+    it.each(adapter.tools.map((t) => [t.name, t]))(
+      '%s has a well-formed endpointMapping',
+      (_name, tool) => {
+        const em = tool.endpointMapping as Record<string, unknown>;
+
+        expect(VALID_METHODS.has(String(em.method).toUpperCase())).toBe(true);
+        expect(typeof em.path).toBe('string');
+
+        // Legacy `body` field must be renamed to `bodyMapping`/`bodyTemplate`
+        expect(em).not.toHaveProperty('body');
+
+        // Path placeholders must be {x} (engine resolves path via `{name}` interpolation),
+        // not ${x} (which the engine would leave literal in URLs).
+        expect(em.path as string).not.toMatch(/\$\{[\w$]+\}/);
+
+        // queryParams / bodyMapping / headers: verify every `$x` or `${x}` reference
+        // points to a parameter the tool declares (catches typos in placeholder names).
+        const declaredParams = new Set(
+          Object.keys(
+            ((tool.parameters as Record<string, unknown>)?.properties as
+              | Record<string, unknown>
+              | undefined) ?? {},
+          ),
+        );
+        for (const field of ['queryParams', 'bodyMapping', 'headers']) {
+          const strings: Array<{ path: string; value: string }> = [];
+          collectStrings(em[field], field, strings);
+          for (const { value } of strings) {
+            // Full-string reference: "$foo" → must be declared, unless it's an env placeholder
+            const full = /^\$([\w$]+)$/.exec(value);
+            if (full && !value.startsWith('$$')) {
+              expect(declaredParams.has(full[1])).toBe(true);
+            }
+            // Embedded references: "...${foo}..." — all names must be declared
+            for (const match of value.matchAll(/\$\{([\w$]+)\}/g)) {
+              expect(declaredParams.has(match[1])).toBe(true);
+            }
+          }
+        }
+      },
+    );
+  });
+});

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -14,6 +14,19 @@ import * as datev from './de/datev.json';
 import * as scopevisio from './de/scopevisio.json';
 import * as kenjo from './de/kenjo.json';
 import * as planradar from './de/planradar.json';
+import * as viesVat from './de/vies-vat.json';
+import * as handelsregister from './de/handelsregister.json';
+import * as deutscheBahn from './de/deutsche-bahn.json';
+import * as openplz from './de/openplz.json';
+import * as oxomi from './de/oxomi.json';
+import * as dpdGermany from './de/dpd-germany.json';
+import * as glsTracking from './de/gls-tracking.json';
+import * as shipcloud from './de/shipcloud.json';
+import * as sendcloud from './de/sendcloud.json';
+import * as xentral from './de/xentral.json';
+import * as shopware6 from './de/shopware-6.json';
+import * as hereGeocoding from './de/here-geocoding.json';
+import * as personio from './de/personio.json';
 
 export interface AdapterMeta {
   slug: string;
@@ -67,6 +80,19 @@ const ALL_ADAPTERS: AdapterDefinition[] = [
   scopevisio as unknown as AdapterDefinition,
   kenjo as unknown as AdapterDefinition,
   planradar as unknown as AdapterDefinition,
+  viesVat as unknown as AdapterDefinition,
+  handelsregister as unknown as AdapterDefinition,
+  deutscheBahn as unknown as AdapterDefinition,
+  openplz as unknown as AdapterDefinition,
+  oxomi as unknown as AdapterDefinition,
+  dpdGermany as unknown as AdapterDefinition,
+  glsTracking as unknown as AdapterDefinition,
+  shipcloud as unknown as AdapterDefinition,
+  sendcloud as unknown as AdapterDefinition,
+  xentral as unknown as AdapterDefinition,
+  shopware6 as unknown as AdapterDefinition,
+  hereGeocoding as unknown as AdapterDefinition,
+  personio as unknown as AdapterDefinition,
 ];
 
 export function listAdapters(): AdapterMeta[] {

--- a/packages/backend/src/adapters/de/billomat.json
+++ b/packages/backend/src/adapters/de/billomat.json
@@ -6,7 +6,10 @@
   "category": "finance",
   "icon": "billomat",
   "docsUrl": "https://www.billomat.com/en/api/",
-  "requiredEnvVars": ["BILLOMAT_SUBDOMAIN", "BILLOMAT_API_KEY"],
+  "requiredEnvVars": [
+    "BILLOMAT_SUBDOMAIN",
+    "BILLOMAT_API_KEY"
+  ],
   "connector": {
     "name": "Billomat",
     "type": "REST",
@@ -42,9 +45,9 @@
         "method": "GET",
         "path": "/clients",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}",
-          "name": "${name}"
+          "page": "$page",
+          "per_page": "$per_page",
+          "name": "$name"
         },
         "headers": {
           "Accept": "application/json"
@@ -62,11 +65,13 @@
             "description": "The Billomat client ID"
           }
         },
-        "required": ["clientId"]
+        "required": [
+          "clientId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/clients/${clientId}",
+        "path": "/clients/{clientId}",
         "headers": {
           "Accept": "application/json"
         }
@@ -100,10 +105,10 @@
         "method": "GET",
         "path": "/invoices",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}",
-          "client_id": "${client_id}",
-          "status": "${status}"
+          "page": "$page",
+          "per_page": "$per_page",
+          "client_id": "$client_id",
+          "status": "$status"
         },
         "headers": {
           "Accept": "application/json"
@@ -121,11 +126,13 @@
             "description": "The Billomat invoice ID"
           }
         },
-        "required": ["invoiceId"]
+        "required": [
+          "invoiceId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/invoices/${invoiceId}",
+        "path": "/invoices/{invoiceId}",
         "headers": {
           "Accept": "application/json"
         }
@@ -151,8 +158,8 @@
         "method": "GET",
         "path": "/articles",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}"
+          "page": "$page",
+          "per_page": "$per_page"
         },
         "headers": {
           "Accept": "application/json"
@@ -183,9 +190,9 @@
         "method": "GET",
         "path": "/offers",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}",
-          "client_id": "${client_id}"
+          "page": "$page",
+          "per_page": "$per_page",
+          "client_id": "$client_id"
         },
         "headers": {
           "Accept": "application/json"

--- a/packages/backend/src/adapters/de/bundesbank.json
+++ b/packages/backend/src/adapters/de/bundesbank.json
@@ -33,14 +33,16 @@
             "description": "End date in YYYY-MM-DD format (e.g. '2024-12-31')"
           }
         },
-        "required": ["currency"]
+        "required": [
+          "currency"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/data/BBEX3/D.${currency}.EUR.BB.AC.000",
+        "path": "/data/BBEX3/D.{currency}.EUR.BB.AC.000",
         "queryParams": {
-          "startPeriod": "${startPeriod}",
-          "endPeriod": "${endPeriod}",
+          "startPeriod": "$startPeriod",
+          "endPeriod": "$endPeriod",
           "detail": "dataonly"
         },
         "headers": {
@@ -68,8 +70,8 @@
         "method": "GET",
         "path": "/data/BBK01/SU0202",
         "queryParams": {
-          "startPeriod": "${startPeriod}",
-          "endPeriod": "${endPeriod}",
+          "startPeriod": "$startPeriod",
+          "endPeriod": "$endPeriod",
           "detail": "dataonly"
         },
         "headers": {
@@ -92,14 +94,16 @@
             "description": "Maximum number of results to return (default: 10, max: 100)"
           }
         },
-        "required": ["query"]
+        "required": [
+          "query"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/metadata/series",
         "queryParams": {
-          "q": "${query}",
-          "limit": "${limit}"
+          "q": "$query",
+          "limit": "$limit"
         },
         "headers": {
           "Accept": "application/json"
@@ -125,14 +129,16 @@
             "description": "End date in YYYY-MM-DD format"
           }
         },
-        "required": ["seriesId"]
+        "required": [
+          "seriesId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/data/${seriesId}",
+        "path": "/data/{seriesId}",
         "queryParams": {
-          "startPeriod": "${startPeriod}",
-          "endPeriod": "${endPeriod}",
+          "startPeriod": "$startPeriod",
+          "endPeriod": "$endPeriod",
           "detail": "dataonly"
         },
         "headers": {

--- a/packages/backend/src/adapters/de/datev.json
+++ b/packages/backend/src/adapters/de/datev.json
@@ -6,7 +6,12 @@
   "category": "accounting",
   "icon": "datev",
   "docsUrl": "https://developer.datev.de/en/products",
-  "requiredEnvVars": ["DATEV_CLIENT_ID", "DATEV_CLIENT_SECRET", "DATEV_TOKEN_URL", "DATEV_AUTH_URL"],
+  "requiredEnvVars": [
+    "DATEV_CLIENT_ID",
+    "DATEV_CLIENT_SECRET",
+    "DATEV_TOKEN_URL",
+    "DATEV_AUTH_URL"
+  ],
   "connector": {
     "name": "DATEV Online APIs",
     "type": "REST",
@@ -51,11 +56,14 @@
             "description": "Unique GUID for the document (RFC4122 format: 8-4-4-4-12)"
           }
         },
-        "required": ["clientId", "documentGuid"]
+        "required": [
+          "clientId",
+          "documentGuid"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/clients/${clientId}/documents/${documentGuid}",
+        "path": "/clients/{clientId}/documents/{documentGuid}",
         "headers": {
           "Content-Type": "application/octet-stream"
         }
@@ -72,11 +80,13 @@
             "description": "The DATEV client ID"
           }
         },
-        "required": ["clientId"]
+        "required": [
+          "clientId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/clients/${clientId}/documents",
+        "path": "/clients/{clientId}/documents",
         "headers": {
           "Accept": "application/json"
         }
@@ -97,11 +107,14 @@
             "description": "The document GUID"
           }
         },
-        "required": ["clientId", "documentGuid"]
+        "required": [
+          "clientId",
+          "documentGuid"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/clients/${clientId}/documents/${documentGuid}",
+        "path": "/clients/{clientId}/documents/{documentGuid}",
         "headers": {
           "Accept": "application/json"
         }

--- a/packages/backend/src/adapters/de/destatis-genesis.json
+++ b/packages/backend/src/adapters/de/destatis-genesis.json
@@ -6,12 +6,19 @@
   "category": "government",
   "icon": "destatis",
   "docsUrl": "https://www-genesis.destatis.de/genesis/misc/GENESIS-Webservices_Einfuehrung.pdf",
-  "requiredEnvVars": ["DESTATIS_USERNAME", "DESTATIS_PASSWORD"],
+  "requiredEnvVars": [
+    "DESTATIS_USERNAME",
+    "DESTATIS_PASSWORD"
+  ],
   "connector": {
     "name": "Destatis GENESIS",
     "type": "REST",
     "baseUrl": "https://www-genesis.destatis.de/genesisWS/rest/2020",
-    "authType": "NONE"
+    "authType": "QUERY_AUTH",
+    "authConfig": {
+      "username": "{{DESTATIS_USERNAME}}",
+      "password": "{{DESTATIS_PASSWORD}}"
+    }
   },
   "tools": [
     {
@@ -29,17 +36,17 @@
             "description": "Language: 'de' for German or 'en' for English. Default: 'de'"
           }
         },
-        "required": ["searchterm"]
+        "required": [
+          "searchterm"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/find/find",
         "queryParams": {
-          "username": "{{DESTATIS_USERNAME}}",
-          "password": "{{DESTATIS_PASSWORD}}",
-          "term": "${searchterm}",
+          "term": "$searchterm",
           "category": "tables",
-          "language": "${language}"
+          "language": "$language"
         }
       }
     },
@@ -66,18 +73,18 @@
             "description": "Language: 'de' or 'en'. Default: 'de'"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/data/table",
         "queryParams": {
-          "username": "{{DESTATIS_USERNAME}}",
-          "password": "{{DESTATIS_PASSWORD}}",
-          "name": "${name}",
-          "startyear": "${startyear}",
-          "endyear": "${endyear}",
-          "language": "${language}"
+          "name": "$name",
+          "startyear": "$startyear",
+          "endyear": "$endyear",
+          "language": "$language"
         }
       }
     },
@@ -96,16 +103,16 @@
             "description": "Language: 'de' or 'en'. Default: 'de'"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/metadata/table",
         "queryParams": {
-          "username": "{{DESTATIS_USERNAME}}",
-          "password": "{{DESTATIS_PASSWORD}}",
-          "name": "${name}",
-          "language": "${language}"
+          "name": "$name",
+          "language": "$language"
         }
       }
     },
@@ -129,10 +136,8 @@
         "method": "GET",
         "path": "/catalogue/statistics",
         "queryParams": {
-          "username": "{{DESTATIS_USERNAME}}",
-          "password": "{{DESTATIS_PASSWORD}}",
-          "selection": "${searchterm}",
-          "language": "${language}"
+          "selection": "$searchterm",
+          "language": "$language"
         }
       }
     }

--- a/packages/backend/src/adapters/de/deutsche-bahn.json
+++ b/packages/backend/src/adapters/de/deutsche-bahn.json
@@ -1,0 +1,189 @@
+{
+  "slug": "deutsche-bahn",
+  "name": "Deutsche Bahn Fahrplan",
+  "description": "Query the Deutsche Bahn (DB) timetable via the community-maintained v6.db.transport.rest proxy over the official HAFAS API. Search stations, look up departures/arrivals in real time, and plan journeys between any two DB stops.",
+  "instructions": "This connector uses https://v6.db.transport.rest — a free, no-auth wrapper around Deutsche Bahn's HAFAS endpoints maintained by the public-transport community.\n\n**No authentication required**, but the service is hosted best-effort — for production use you may want to self-host (see https://github.com/derhuerst/db-rest).\n\n**Typical workflow**:\n1. Resolve a station name to a stop `id` with `db_search_locations`\n2. Call `db_get_departures` or `db_get_arrivals` with that id\n3. For trip planning, use `db_get_journeys` with `from` and `to` stop ids\n\n**Time format**: All times are ISO 8601 with timezone (e.g. `2026-04-21T08:30+02:00`). If omitted, `when` defaults to now.\n\n**Delay tracking**: departure/arrival entries include `delay` in seconds, `cancelled`, and `platform` vs `plannedPlatform` for live monitoring.\n\n**Multi-modal**: results can include S-Bahn, U-Bahn, bus, tram where operated by DB or partner agencies.",
+  "region": "de",
+  "category": "transport",
+  "icon": "db",
+  "docsUrl": "https://v6.db.transport.rest/",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Deutsche Bahn Fahrplan",
+    "type": "REST",
+    "baseUrl": "https://v6.db.transport.rest",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "db_search_locations",
+      "description": "Search for DB stops/stations, addresses, or points of interest by name. Returns a list of matches with id, name, type, and geo coordinates. Use the returned id with other tools.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search term (e.g. 'Freiburg Hbf', 'Berlin Ostbahnhof', 'München Hauptbahnhof')."
+          },
+          "results": {
+            "type": "number",
+            "description": "Max results to return (default: 10)."
+          },
+          "stops": {
+            "type": "boolean",
+            "description": "Include train stops (default: true)."
+          },
+          "addresses": {
+            "type": "boolean",
+            "description": "Include street addresses (default: true)."
+          }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/locations",
+        "queryParams": {
+          "query": "$query",
+          "results": "$results",
+          "stops": "$stops",
+          "addresses": "$addresses"
+        }
+      }
+    },
+    {
+      "name": "db_get_stop",
+      "description": "Retrieve details for a specific stop/station by its DB id, including name, location, station category, and products served (ICE, IC, RE, S, etc.).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The stop id from db_search_locations (e.g. '8000105' for Frankfurt(Main)Hbf)."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/stops/{id}"
+      }
+    },
+    {
+      "name": "db_get_departures",
+      "description": "List upcoming departures from a stop. Returns each departure with line, destination (direction), planned and actual time, platform, delay in seconds, and cancellation status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The stop id."
+          },
+          "when": {
+            "type": "string",
+            "description": "ISO 8601 timestamp for the reference time (default: now). Example: '2026-04-21T08:30+02:00'."
+          },
+          "duration": {
+            "type": "number",
+            "description": "Look-ahead window in minutes (default: 10, max: 120)."
+          },
+          "results": {
+            "type": "number",
+            "description": "Max number of departures (default: 10)."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/stops/{id}/departures",
+        "queryParams": {
+          "when": "$when",
+          "duration": "$duration",
+          "results": "$results"
+        }
+      }
+    },
+    {
+      "name": "db_get_arrivals",
+      "description": "List upcoming arrivals at a stop with origin, planned and actual time, platform, delay, and cancellation status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The stop id."
+          },
+          "when": {
+            "type": "string",
+            "description": "ISO 8601 timestamp (default: now)."
+          },
+          "duration": {
+            "type": "number",
+            "description": "Look-ahead window in minutes (default: 10)."
+          },
+          "results": {
+            "type": "number",
+            "description": "Max number of arrivals (default: 10)."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/stops/{id}/arrivals",
+        "queryParams": {
+          "when": "$when",
+          "duration": "$duration",
+          "results": "$results"
+        }
+      }
+    },
+    {
+      "name": "db_get_journeys",
+      "description": "Plan a journey between two stops. Returns one or more itinerary options with legs (train/bus/S-Bahn), departure and arrival times per leg, transfers, duration, and any delays. Use stop ids from db_search_locations.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "description": "Origin stop id."
+          },
+          "to": {
+            "type": "string",
+            "description": "Destination stop id."
+          },
+          "departure": {
+            "type": "string",
+            "description": "Desired departure time (ISO 8601). Defaults to now. Use either 'departure' or 'arrival', not both."
+          },
+          "arrival": {
+            "type": "string",
+            "description": "Desired latest arrival time (ISO 8601). Use for 'arrive by' queries."
+          },
+          "results": {
+            "type": "number",
+            "description": "Number of itinerary options to return (default: 3)."
+          },
+          "transfers": {
+            "type": "number",
+            "description": "Max number of transfers (-1 = unlimited)."
+          }
+        },
+        "required": ["from", "to"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/journeys",
+        "queryParams": {
+          "from": "$from",
+          "to": "$to",
+          "departure": "$departure",
+          "arrival": "$arrival",
+          "results": "$results",
+          "transfers": "$transfers"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/dhl-tracking.json
+++ b/packages/backend/src/adapters/de/dhl-tracking.json
@@ -6,7 +6,9 @@
   "category": "logistics",
   "icon": "dhl",
   "docsUrl": "https://developer.dhl.com/api-reference/shipment-tracking",
-  "requiredEnvVars": ["DHL_API_KEY"],
+  "requiredEnvVars": [
+    "DHL_API_KEY"
+  ],
   "connector": {
     "name": "DHL Tracking",
     "type": "REST",
@@ -33,14 +35,16 @@
             "description": "ISO 639-1 language code for event descriptions (e.g. 'en', 'de'). Defaults to 'en'."
           }
         },
-        "required": ["trackingNumber"]
+        "required": [
+          "trackingNumber"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/track/shipments",
         "queryParams": {
-          "trackingNumber": "${trackingNumber}",
-          "language": "${language}"
+          "trackingNumber": "$trackingNumber",
+          "language": "$language"
         }
       }
     },
@@ -59,14 +63,16 @@
             "description": "ISO 639-1 language code for event descriptions. Defaults to 'en'."
           }
         },
-        "required": ["trackingNumbers"]
+        "required": [
+          "trackingNumbers"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/track/shipments",
         "queryParams": {
-          "trackingNumber": "${trackingNumbers}",
-          "language": "${language}"
+          "trackingNumber": "$trackingNumbers",
+          "language": "$language"
         }
       }
     }

--- a/packages/backend/src/adapters/de/dpd-germany.json
+++ b/packages/backend/src/adapters/de/dpd-germany.json
@@ -1,0 +1,41 @@
+{
+  "slug": "dpd-germany",
+  "name": "DPD Germany Tracking",
+  "description": "Track DPD (Dynamic Parcel Distribution) shipments in Germany using the public Parcel Life Cycle REST API. Retrieves full event history, current status, sender/recipient, scan-point locations, and predicted delivery time for any DPD parcel.",
+  "instructions": "This connector uses DPD's public Parcel Life Cycle (PLC) REST endpoint — free and without authentication.\n\n**Parcel number format**: 14-digit numeric string (e.g. '01234567890123'). DPD also supports partial matches — the API will return the best match.\n\n**Supported languages**: `de_DE` (German), `en_DE` (English), `fr_FR`, `it_IT`, `es_ES`, `pl_PL`, `cs_CZ`, `nl_NL`. Pass without country code (e.g. 'en') and the API maps to country defaults.\n\n**Events returned**: each event has a timestamp, scan-point (depot/city), status code, and localized description — cover the full parcel journey from pickup through sorting to delivery.\n\n**Limitations**: the public endpoint rate-limits aggressive polling. For large-scale tracking integrations, DPD offers a contract-based SOAP API (WebConnect) — not covered by this adapter.",
+  "region": "de",
+  "category": "logistics",
+  "icon": "dpd",
+  "docsUrl": "https://www.dpd.com/de/de/hilfe-service/entwickler-api/",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "DPD Germany Tracking",
+    "type": "REST",
+    "baseUrl": "https://tracking.dpd.de/rest/plc",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "dpd_track_parcel",
+      "description": "Track a DPD parcel by its parcel label number. Returns the full Parcel Life Cycle: each scan event with timestamp, location (depot/city), status code, and human-readable description, plus current state and estimated delivery.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "parcelNumber": {
+            "type": "string",
+            "description": "The 14-digit DPD parcel number from the shipping label."
+          },
+          "language": {
+            "type": "string",
+            "description": "Locale for event descriptions: 'de_DE', 'en_DE', 'fr_FR', 'it_IT', etc. Defaults to 'en_DE'."
+          }
+        },
+        "required": ["parcelNumber"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{language}/{parcelNumber}"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/fastbill.json
+++ b/packages/backend/src/adapters/de/fastbill.json
@@ -6,12 +6,15 @@
   "category": "finance",
   "icon": "fastbill",
   "docsUrl": "https://apidocs.fastbill.com/fastbill/",
-  "requiredEnvVars": ["FASTBILL_EMAIL", "FASTBILL_API_KEY"],
+  "requiredEnvVars": [
+    "FASTBILL_EMAIL",
+    "FASTBILL_API_KEY"
+  ],
   "connector": {
     "name": "FastBill",
     "type": "REST",
     "baseUrl": "https://my.fastbill.com/api/1.0",
-    "authType": "BASIC",
+    "authType": "BASIC_AUTH",
     "authConfig": {
       "username": "{{FASTBILL_EMAIL}}",
       "password": "{{FASTBILL_API_KEY}}"
@@ -41,12 +44,12 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/api.php",
-        "body": {
+        "bodyMapping": {
           "SERVICE": "customer.get",
-          "LIMIT": "${LIMIT}",
-          "OFFSET": "${OFFSET}",
+          "LIMIT": "$LIMIT",
+          "OFFSET": "$OFFSET",
           "FILTER": {
-            "TERM": "${TERM}"
+            "TERM": "$TERM"
           }
         }
       }
@@ -82,14 +85,14 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/api.php",
-        "body": {
+        "bodyMapping": {
           "SERVICE": "invoice.get",
-          "LIMIT": "${LIMIT}",
-          "OFFSET": "${OFFSET}",
+          "LIMIT": "$LIMIT",
+          "OFFSET": "$OFFSET",
           "FILTER": {
-            "CUSTOMER_ID": "${CUSTOMER_ID}",
-            "MONTH": "${MONTH}",
-            "YEAR": "${YEAR}"
+            "CUSTOMER_ID": "$CUSTOMER_ID",
+            "MONTH": "$MONTH",
+            "YEAR": "$YEAR"
           }
         }
       }
@@ -121,13 +124,13 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/api.php",
-        "body": {
+        "bodyMapping": {
           "SERVICE": "expense.get",
-          "LIMIT": "${LIMIT}",
-          "OFFSET": "${OFFSET}",
+          "LIMIT": "$LIMIT",
+          "OFFSET": "$OFFSET",
           "FILTER": {
-            "MONTH": "${MONTH}",
-            "YEAR": "${YEAR}"
+            "MONTH": "$MONTH",
+            "YEAR": "$YEAR"
           }
         }
       }
@@ -151,10 +154,10 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/api.php",
-        "body": {
+        "bodyMapping": {
           "SERVICE": "revenue.get",
-          "LIMIT": "${LIMIT}",
-          "OFFSET": "${OFFSET}"
+          "LIMIT": "$LIMIT",
+          "OFFSET": "$OFFSET"
         }
       }
     },
@@ -169,15 +172,17 @@
             "description": "The FastBill invoice ID"
           }
         },
-        "required": ["INVOICE_ID"]
+        "required": [
+          "INVOICE_ID"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
         "path": "/api.php",
-        "body": {
+        "bodyMapping": {
           "SERVICE": "invoice.get",
           "FILTER": {
-            "INVOICE_ID": "${INVOICE_ID}"
+            "INVOICE_ID": "$INVOICE_ID"
           }
         }
       }

--- a/packages/backend/src/adapters/de/gls-tracking.json
+++ b/packages/backend/src/adapters/de/gls-tracking.json
@@ -1,0 +1,77 @@
+{
+  "slug": "gls-tracking",
+  "name": "GLS Track & Trace",
+  "description": "Track GLS (General Logistics Systems) parcels across Europe using the free public Track & Trace REST API. Look up parcels by GLS tracking number (TrackID) or customer reference.",
+  "instructions": "This connector uses the GLS public Track & Trace REST endpoint — free, no authentication.\n\n**Tracking number (TrackID)**: 10-12 digit numeric string printed on the parcel label.\n\n**Customer reference**: the reference you (or the shipper) set when creating the parcel. Multiple parcels may share a reference, so results are always an array.\n\n**Language**: `de` (German), `en` (English), `fr`, `it`, `es`, `nl`, `pl`, `cz`. The descriptions in event rows are translated accordingly.\n\n**Country scope**: use `country` (ISO 2-letter like DE, AT, CH, FR) to scope lookup to GLS country organisation. 'EU' covers cross-border.\n\n**Shipping / label generation**: this adapter only covers tracking. Shipment creation requires the GLS ShipIT API with contract-based credentials and is not included here.",
+  "region": "eu",
+  "category": "logistics",
+  "icon": "gls",
+  "docsUrl": "https://www.gls-pakete.de/unternehmen/entwickler",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "GLS Track & Trace",
+    "type": "REST",
+    "baseUrl": "https://gls-group.com/app/service/open/rest",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "gls_track_by_parcel_number",
+      "description": "Track a GLS parcel by its TrackID (parcel number). Returns the parcel status, sender, receiver, service product, weight, and a chronological list of tracking events with location, timestamp and description.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "trackId": {
+            "type": "string",
+            "description": "The GLS TrackID / parcel number (typically 10-12 digits)."
+          },
+          "country": {
+            "type": "string",
+            "description": "Country scope (ISO 2-letter). Defaults to 'EU' for cross-border. Common: 'DE', 'AT', 'CH', 'FR', 'NL', 'BE'."
+          },
+          "language": {
+            "type": "string",
+            "description": "Language for descriptions: 'de', 'en', 'fr', 'it', 'es', 'nl', 'pl', 'cz'. Defaults to 'en'."
+          }
+        },
+        "required": ["trackId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{country}/{language}/rstt001",
+        "queryParams": {
+          "match": "$trackId"
+        }
+      }
+    },
+    {
+      "name": "gls_track_by_reference",
+      "description": "Find GLS parcels by customer reference (the shipper's order/reference number). Returns an array of matching parcels — multiple parcels can share the same reference.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reference": {
+            "type": "string",
+            "description": "The customer/order reference set at shipment creation time."
+          },
+          "country": {
+            "type": "string",
+            "description": "Country scope (ISO 2-letter). Defaults to 'EU'."
+          },
+          "language": {
+            "type": "string",
+            "description": "Language for descriptions. Defaults to 'en'."
+          }
+        },
+        "required": ["reference"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{country}/{language}/rstt001",
+        "queryParams": {
+          "reference": "$reference"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/handelsregister.json
+++ b/packages/backend/src/adapters/de/handelsregister.json
@@ -1,0 +1,103 @@
+{
+  "slug": "handelsregister",
+  "name": "Handelsregister (handelsregister.ai)",
+  "description": "Access the German commercial register (Handelsregister) data via handelsregister.ai — search companies by name, retrieve official entries, current/historical addresses, shareholders, managing directors, and corporate structure.",
+  "instructions": "This connector uses the handelsregister.ai REST API which wraps the official Handelsregister portal and enriches it with structured data.\n\n**Authentication**: API key via Authorization header. Generate a key at https://handelsregister.ai/account.\n\n**Typical workflow**:\n1. `hr_search_companies` — find a company by name or keyword\n2. `hr_get_company` — fetch the full record by `company_id` returned from search\n3. `hr_get_documents` — list SHD/AD/HRA documents attached to a company\n\n**Registernummer format**: Courts + numbers like 'HRB 12345 München'. Search also accepts plain company names.\n\n**Costs**: handelsregister.ai bills per lookup, not per search. Searches are typically free; fetching full company records or documents consumes credits.",
+  "region": "de",
+  "category": "government",
+  "icon": "handelsregister",
+  "docsUrl": "https://handelsregister.ai/docs",
+  "requiredEnvVars": ["HANDELSREGISTER_API_KEY"],
+  "connector": {
+    "name": "Handelsregister",
+    "type": "REST",
+    "baseUrl": "https://handelsregister.ai/api/v1",
+    "authType": "API_KEY",
+    "authConfig": {
+      "headerName": "Authorization",
+      "apiKey": "Bearer {{HANDELSREGISTER_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "hr_search_companies",
+      "description": "Search German companies in the Handelsregister by name or keyword. Returns a list of matches with company_id, legal name, registration court, Registernummer, and location. Use the returned company_id with hr_get_company for full details.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search query — company name, brand, or keyword (e.g. 'SAP SE', 'Koch Freiburg')."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max number of results (default: 10, max: 50)."
+          }
+        },
+        "required": ["q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/search",
+        "queryParams": {
+          "q": "$q",
+          "limit": "$limit"
+        }
+      }
+    },
+    {
+      "name": "hr_get_company",
+      "description": "Retrieve the full Handelsregister record for a company by its company_id. Returns legal name, address, registration data (court + Registernummer), legal form, capital, purpose (Gegenstand), managing directors and Prokuristen, and recent changes.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "company_id": {
+            "type": "string",
+            "description": "The handelsregister.ai company_id returned by hr_search_companies."
+          }
+        },
+        "required": ["company_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/companies/{company_id}"
+      }
+    },
+    {
+      "name": "hr_get_documents",
+      "description": "List the official documents (SHD = Shareholder list, AD = current printout, CD = chronological printout, HD = historical printout) attached to a company in the Handelsregister. Each document has a document_id that can be used for download links.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "company_id": {
+            "type": "string",
+            "description": "The handelsregister.ai company_id."
+          }
+        },
+        "required": ["company_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/companies/{company_id}/documents"
+      }
+    },
+    {
+      "name": "hr_get_shareholders",
+      "description": "Retrieve the shareholder list (Gesellschafterliste) from the most recent SHD filing for a GmbH or UG. Returns each shareholder's name, address, share amount (Geschäftsanteil) and percentage.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "company_id": {
+            "type": "string",
+            "description": "The handelsregister.ai company_id."
+          }
+        },
+        "required": ["company_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/companies/{company_id}/shareholders"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/here-geocoding.json
+++ b/packages/backend/src/adapters/de/here-geocoding.json
@@ -1,0 +1,216 @@
+{
+  "slug": "here-geocoding",
+  "name": "HERE Geocoding & Search",
+  "description": "Geocode addresses, reverse-geocode coordinates, autocomplete addresses as-you-type, and search places via the HERE Location Services API. Useful for address validation, delivery-route planning, and storefront locators. Free tier covers 250k requests/month.",
+  "instructions": "This connector uses the HERE Geocoding & Search v7 REST API.\n\n**Credentials**: generate a REST API key at https://platform.here.com → Projects → API Keys. Paste it into `HERE_API_KEY` when importing. The key is passed as a query parameter (`apiKey`), not as a header.\n\n**Pricing**: HERE's Freemium plan includes 250,000 requests/month free. Bulk batch geocoding requires a paid plan.\n\n**Countries**: worldwide coverage. Use `in=countryCode:DEU` or ISO 3-letter country filter for scope.\n\n**Addressing strategies**:\n- `/geocode` — full forward geocoding (structured or unstructured input)\n- `/autocomplete` — very fast address autocomplete, returns short snippets\n- `/autosuggest` — richer suggestions including POIs, chains, addresses\n- `/revgeocode` — coordinates → address\n- `/discover` — place search with categories, brands, opening hours\n\n**Languages**: add `lang=de` or any BCP-47 tag to localise labels.\n\n**In Germany / Baustoff use-case**: use `in=countryCode:DEU&lang=de` to force German labels on addresses for consistency with ERP records.",
+  "region": "global",
+  "category": "mapping",
+  "icon": "here",
+  "docsUrl": "https://www.here.com/docs/bundle/geocoding-and-search-api-developer-guide/page/README.html",
+  "requiredEnvVars": ["HERE_API_KEY"],
+  "connector": {
+    "name": "HERE Geocoding",
+    "type": "REST",
+    "baseUrl": "https://geocode.search.hereapi.com/v1",
+    "authType": "QUERY_AUTH",
+    "authConfig": {
+      "apiKey": "{{HERE_API_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "here_geocode",
+      "description": "Forward-geocode an address to coordinates. Returns matches with position, label, address components (country, state, city, postalCode, street, houseNumber), result type, and match quality score.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Free-form address query (e.g. 'Kaiser-Joseph-Straße 1, 79098 Freiburg')."
+          },
+          "qq": {
+            "type": "string",
+            "description": "Qualified query — structured address as key=value;… pairs (e.g. 'city=Freiburg;street=Kaiser-Joseph-Straße;houseNumber=1'). Use for disambiguation."
+          },
+          "in": {
+            "type": "string",
+            "description": "Area filter (e.g. 'countryCode:DEU' to scope to Germany, or 'bbox:w,s,e,n')."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default: 20, max: 100)."
+          },
+          "lang": {
+            "type": "string",
+            "description": "Response language BCP-47 tag (e.g. 'de', 'en-US')."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/geocode",
+        "queryParams": {
+          "q": "$q",
+          "qq": "$qq",
+          "in": "$in",
+          "limit": "$limit",
+          "lang": "$lang"
+        }
+      }
+    },
+    {
+      "name": "here_reverse_geocode",
+      "description": "Reverse-geocode coordinates to a human-readable address. Returns the nearest address with full components.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "at": {
+            "type": "string",
+            "description": "Coordinates as 'lat,lng' (e.g. '47.9959,7.8522' for Freiburg Münster)."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default: 1)."
+          },
+          "lang": {
+            "type": "string",
+            "description": "Response language."
+          }
+        },
+        "required": ["at"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/revgeocode",
+        "queryParams": {
+          "at": "$at",
+          "limit": "$limit",
+          "lang": "$lang"
+        }
+      }
+    },
+    {
+      "name": "here_autocomplete",
+      "description": "Fast address-only autocomplete for as-you-type address fields. Returns short labelled snippets. Use when you only need addresses and want the lowest latency.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Partial address query."
+          },
+          "at": {
+            "type": "string",
+            "description": "Optional anchor coordinates 'lat,lng' — biases results near the given point."
+          },
+          "in": {
+            "type": "string",
+            "description": "Area filter like 'countryCode:DEU'."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max suggestions (default: 5, max: 20)."
+          },
+          "lang": {
+            "type": "string",
+            "description": "Response language."
+          }
+        },
+        "required": ["q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/autocomplete",
+        "queryParams": {
+          "q": "$q",
+          "at": "$at",
+          "in": "$in",
+          "limit": "$limit",
+          "lang": "$lang"
+        }
+      }
+    },
+    {
+      "name": "here_autosuggest",
+      "description": "Rich autosuggest — returns addresses AND places/POIs (shops, chains, landmarks). Ideal for search bars where users might type either an address or a business name.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Partial query (address, POI name, category)."
+          },
+          "at": {
+            "type": "string",
+            "description": "Required for place results — anchor coordinates 'lat,lng'."
+          },
+          "in": {
+            "type": "string",
+            "description": "Area filter."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max suggestions."
+          },
+          "lang": {
+            "type": "string",
+            "description": "Response language."
+          }
+        },
+        "required": ["q", "at"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/autosuggest",
+        "queryParams": {
+          "q": "$q",
+          "at": "$at",
+          "in": "$in",
+          "limit": "$limit",
+          "lang": "$lang"
+        }
+      }
+    },
+    {
+      "name": "here_discover",
+      "description": "Discover places, POIs, and businesses near a location or within an area — filterable by category (e.g. 'building-material' Baustoffhandel), chain, or brand. Returns each match with position, contact info, opening hours.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search term (place name, category, brand)."
+          },
+          "at": {
+            "type": "string",
+            "description": "Anchor coordinates 'lat,lng' — required if `in` is not provided."
+          },
+          "in": {
+            "type": "string",
+            "description": "Area filter (bbox or circle) — required if `at` is not provided."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default 20)."
+          },
+          "lang": {
+            "type": "string",
+            "description": "Response language."
+          }
+        },
+        "required": ["q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/discover",
+        "queryParams": {
+          "q": "$q",
+          "at": "$at",
+          "in": "$in",
+          "limit": "$limit",
+          "lang": "$lang"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/immobilienscout24.json
+++ b/packages/backend/src/adapters/de/immobilienscout24.json
@@ -6,7 +6,10 @@
   "category": "real-estate",
   "icon": "immobilienscout24",
   "docsUrl": "https://api.immobilienscout24.de/our-apis.html",
-  "requiredEnvVars": ["IS24_CLIENT_ID", "IS24_CLIENT_SECRET"],
+  "requiredEnvVars": [
+    "IS24_CLIENT_ID",
+    "IS24_CLIENT_SECRET"
+  ],
   "connector": {
     "name": "ImmobilienScout24",
     "type": "REST",
@@ -55,19 +58,22 @@
             "description": "Page number for pagination (default: 1)"
           }
         },
-        "required": ["geocode", "realestatetype"]
+        "required": [
+          "geocode",
+          "realestatetype"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/search/v1.0/search/region",
         "queryParams": {
-          "geocodes": "${geocode}",
-          "realestatetype": "${realestatetype}",
-          "price.min": "${price_min}",
-          "price.max": "${price_max}",
-          "livingspace.min": "${livingspace_min}",
-          "numberofrooms.min": "${numberofrooms_min}",
-          "pagenumber": "${pagenumber}",
+          "geocodes": "$geocode",
+          "realestatetype": "$realestatetype",
+          "price.min": "$price_min",
+          "price.max": "$price_max",
+          "livingspace.min": "$livingspace_min",
+          "numberofrooms.min": "$numberofrooms_min",
+          "pagenumber": "$pagenumber",
           "pagesize": "20"
         },
         "headers": {
@@ -86,13 +92,15 @@
             "description": "Location name to search (e.g. 'Berlin', 'München Schwabing', 'Hamburg Altona')"
           }
         },
-        "required": ["query"]
+        "required": [
+          "query"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/gis/v1.0/geo/autocomplete",
         "queryParams": {
-          "i": "${query}"
+          "i": "$query"
         },
         "headers": {
           "Accept": "application/json"
@@ -110,11 +118,13 @@
             "description": "The ImmobilienScout24 expose ID (listing ID)"
           }
         },
-        "required": ["exposeId"]
+        "required": [
+          "exposeId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/search/v1.0/expose/${exposeId}",
+        "path": "/search/v1.0/expose/{exposeId}",
         "headers": {
           "Accept": "application/json"
         }

--- a/packages/backend/src/adapters/de/kenjo.json
+++ b/packages/backend/src/adapters/de/kenjo.json
@@ -6,7 +6,9 @@
   "category": "hr",
   "icon": "kenjo",
   "docsUrl": "https://kenjo.readme.io/reference",
-  "requiredEnvVars": ["KENJO_API_KEY"],
+  "requiredEnvVars": [
+    "KENJO_API_KEY"
+  ],
   "connector": {
     "name": "Kenjo HR",
     "type": "REST",
@@ -37,8 +39,8 @@
         "method": "GET",
         "path": "/employees",
         "queryParams": {
-          "page": "${page}",
-          "limit": "${limit}"
+          "page": "$page",
+          "limit": "$limit"
         }
       }
     },
@@ -53,11 +55,13 @@
             "description": "The Kenjo employee ID"
           }
         },
-        "required": ["employeeId"]
+        "required": [
+          "employeeId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/employees/${employeeId}"
+        "path": "/employees/{employeeId}"
       }
     },
     {
@@ -104,8 +108,8 @@
         "method": "GET",
         "path": "/recruiting/positions",
         "queryParams": {
-          "page": "${page}",
-          "limit": "${limit}"
+          "page": "$page",
+          "limit": "$limit"
         }
       }
     },

--- a/packages/backend/src/adapters/de/mfr-fieldservice.json
+++ b/packages/backend/src/adapters/de/mfr-fieldservice.json
@@ -7,12 +7,15 @@
   "category": "field-service",
   "icon": "mfr",
   "docsUrl": "https://portal.mobilefieldreport.com/",
-  "requiredEnvVars": ["MFR_USERNAME", "MFR_PASSWORD"],
+  "requiredEnvVars": [
+    "MFR_USERNAME",
+    "MFR_PASSWORD"
+  ],
   "connector": {
     "name": "MFR Field Service",
     "type": "REST",
     "baseUrl": "https://portal.mobilefieldreport.com/odata",
-    "authType": "BASIC",
+    "authType": "BASIC_AUTH",
     "authConfig": {
       "username": "{{MFR_USERNAME}}",
       "password": "{{MFR_PASSWORD}}"
@@ -79,11 +82,13 @@
             "description": "Expand related entities. Options: ServiceObjects, Customer, Reports, Items, Steps, Comments, Appointments, Appointments/Contacts, Tags, Qualifications"
           }
         },
-        "required": ["requestId"]
+        "required": [
+          "requestId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/ServiceRequests(${requestId}L)",
+        "path": "/ServiceRequests({requestId}L)",
         "queryParams": {
           "$expand": "${$expand}"
         }
@@ -104,7 +109,9 @@
             "description": "Expand related entities. Options: ServiceObjects, Customer, Reports, Items, Steps, Comments, Appointments, Appointments/Contacts, Tags, Qualifications"
           }
         },
-        "required": ["externalId"]
+        "required": [
+          "externalId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -170,7 +177,9 @@
             "description": "Create from an existing template by providing the template's ID"
           }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -220,11 +229,13 @@
             "description": "Updated cost center ID"
           }
         },
-        "required": ["requestId"]
+        "required": [
+          "requestId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ServiceRequests(${requestId}L)"
+        "path": "/ServiceRequests({requestId}L)"
       }
     },
     {
@@ -238,11 +249,13 @@
             "description": "The service request numeric ID to delete"
           }
         },
-        "required": ["requestId"]
+        "required": [
+          "requestId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/ServiceRequests(${requestId}L)"
+        "path": "/ServiceRequests({requestId}L)"
       }
     },
     {
@@ -260,14 +273,15 @@
             "description": "The service object numeric ID to link"
           }
         },
-        "required": ["requestId", "serviceObjectId"]
+        "required": [
+          "requestId",
+          "serviceObjectId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
-        "path": "/ServiceRequests(${requestId}L)/$links/ServiceObjects",
-        "body": {
-          "url": "https://portal.mobilefieldreport.com/odata/ServiceObjects(${serviceObjectId}L)"
-        }
+        "path": "/ServiceRequests({requestId}L)/$links/ServiceObjects",
+        "bodyTemplate": "{\"url\":\"https://portal.mobilefieldreport.com/odata/ServiceObjects(${serviceObjectId}L)\"}"
       }
     },
     {
@@ -285,14 +299,15 @@
             "description": "The document numeric ID to link"
           }
         },
-        "required": ["requestId", "documentId"]
+        "required": [
+          "requestId",
+          "documentId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
-        "path": "/ServiceRequests(${requestId}L)/$links/Documents",
-        "body": {
-          "url": "https://portal.mobilefieldreport.com/odata/Documents(${documentId}L)"
-        }
+        "path": "/ServiceRequests({requestId}L)/$links/Documents",
+        "bodyTemplate": "{\"url\":\"https://portal.mobilefieldreport.com/odata/Documents(${documentId}L)\"}"
       }
     },
     {
@@ -310,14 +325,15 @@
             "description": "The tag numeric ID to add"
           }
         },
-        "required": ["requestId", "tagId"]
+        "required": [
+          "requestId",
+          "tagId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ServiceRequests(${requestId}L)/$links/Tags",
-        "body": {
-          "url": "https://portal.mobilefieldreport.com/odata/Tags(${tagId}L)"
-        }
+        "path": "/ServiceRequests({requestId}L)/$links/Tags",
+        "bodyTemplate": "{\"url\":\"https://portal.mobilefieldreport.com/odata/Tags(${tagId}L)\"}"
       }
     },
     {
@@ -335,14 +351,15 @@
             "description": "The tag numeric ID to remove"
           }
         },
-        "required": ["requestId", "tagId"]
+        "required": [
+          "requestId",
+          "tagId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ServiceRequests(${requestId}L)/$links/RemoveTags",
-        "body": {
-          "url": "https://portal.mobilefieldreport.com/odata/Tags(${tagId}L)"
-        }
+        "path": "/ServiceRequests({requestId}L)/$links/RemoveTags",
+        "bodyTemplate": "{\"url\":\"https://portal.mobilefieldreport.com/odata/Tags(${tagId}L)\"}"
       }
     },
     {
@@ -360,14 +377,15 @@
             "description": "The qualification numeric ID to add"
           }
         },
-        "required": ["requestId", "qualificationId"]
+        "required": [
+          "requestId",
+          "qualificationId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ServiceRequests(${requestId}L)/$links/Qualifications",
-        "body": {
-          "url": "https://portal.mobilefieldreport.com/odata/Qualifications(${qualificationId}L)"
-        }
+        "path": "/ServiceRequests({requestId}L)/$links/Qualifications",
+        "bodyTemplate": "{\"url\":\"https://portal.mobilefieldreport.com/odata/Qualifications(${qualificationId}L)\"}"
       }
     },
     {
@@ -385,14 +403,15 @@
             "description": "The qualification numeric ID to remove"
           }
         },
-        "required": ["requestId", "qualificationId"]
+        "required": [
+          "requestId",
+          "qualificationId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ServiceRequests(${requestId}L)/$links/RemoveQualifications",
-        "body": {
-          "url": "https://portal.mobilefieldreport.com/odata/Qualifications(${qualificationId}L)"
-        }
+        "path": "/ServiceRequests({requestId}L)/$links/RemoveQualifications",
+        "bodyTemplate": "{\"url\":\"https://portal.mobilefieldreport.com/odata/Qualifications(${qualificationId}L)\"}"
       }
     },
     {
@@ -479,7 +498,12 @@
             "description": "Additional notes for the appointment"
           }
         },
-        "required": ["Type", "StartDateTime", "EndDateTime", "ContactId"]
+        "required": [
+          "Type",
+          "StartDateTime",
+          "EndDateTime",
+          "ContactId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -521,11 +545,13 @@
             "description": "Updated notes"
           }
         },
-        "required": ["appointmentId"]
+        "required": [
+          "appointmentId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Appointments(${appointmentId}L)"
+        "path": "/Appointments({appointmentId}L)"
       }
     },
     {
@@ -539,11 +565,13 @@
             "description": "The appointment numeric ID to delete"
           }
         },
-        "required": ["appointmentId"]
+        "required": [
+          "appointmentId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/Appointments(${appointmentId}L)"
+        "path": "/Appointments({appointmentId}L)"
       }
     },
     {
@@ -606,11 +634,13 @@
             "description": "Expand related entities. Options: Contacts, Tags, ServiceObjects, MainContact"
           }
         },
-        "required": ["companyId"]
+        "required": [
+          "companyId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/Companies(${companyId}L)",
+        "path": "/Companies({companyId}L)",
         "queryParams": {
           "$expand": "${$expand}"
         }
@@ -663,7 +693,9 @@
             "description": "Address object with fields: AddressString (street), Postal (zip code), City, State, Country (ISO code e.g. 'DE', 'GB')"
           }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -680,20 +712,46 @@
             "type": "string",
             "description": "The company numeric ID"
           },
-          "Name": { "type": "string", "description": "Updated company name" },
-          "ExternalId": { "type": "string", "description": "Updated external ID" },
-          "IsPhysicalPerson": { "type": "boolean", "description": "Is individual person" },
-          "Note": { "type": "string", "description": "Updated notes" },
-          "SupportTelephone": { "type": "string", "description": "Updated phone" },
-          "SupportFax": { "type": "string", "description": "Updated fax" },
-          "SupportMail": { "type": "string", "description": "Updated email" },
-          "Location": { "type": "object", "description": "Updated address: {AddressString, Postal, City, State, Country}" }
+          "Name": {
+            "type": "string",
+            "description": "Updated company name"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Updated external ID"
+          },
+          "IsPhysicalPerson": {
+            "type": "boolean",
+            "description": "Is individual person"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Updated notes"
+          },
+          "SupportTelephone": {
+            "type": "string",
+            "description": "Updated phone"
+          },
+          "SupportFax": {
+            "type": "string",
+            "description": "Updated fax"
+          },
+          "SupportMail": {
+            "type": "string",
+            "description": "Updated email"
+          },
+          "Location": {
+            "type": "object",
+            "description": "Updated address: {AddressString, Postal, City, State, Country}"
+          }
         },
-        "required": ["companyId"]
+        "required": [
+          "companyId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Companies(${companyId}L)"
+        "path": "/Companies({companyId}L)"
       }
     },
     {
@@ -702,13 +760,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "companyId": { "type": "string", "description": "The company numeric ID to delete" }
+          "companyId": {
+            "type": "string",
+            "description": "The company numeric ID to delete"
+          }
         },
-        "required": ["companyId"]
+        "required": [
+          "companyId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/Companies(${companyId}L)"
+        "path": "/Companies({companyId}L)"
       }
     },
     {
@@ -717,15 +780,30 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip for pagination" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip for pagination"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: FirstName, LastName, Email, CompanyId, IsUser (true/false), Gender ('Male', 'Female'), ExternalId, DateModified. Examples: \"CompanyId eq '6026428432'\", \"LastName eq 'Smith'\", \"IsUser eq true\", \"DateModified gt datetime'2025-01-01T00:00:00'\""
           },
-          "$orderby": { "type": "string", "description": "Sort: 'LastName asc', 'DateModified desc'" },
-          "$expand": { "type": "string", "description": "Expand: Company, User" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$orderby": {
+            "type": "string",
+            "description": "Sort: 'LastName asc', 'DateModified desc'"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Company, User"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
@@ -747,15 +825,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "contactId": { "type": "string", "description": "The contact numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: Company, User" }
+          "contactId": {
+            "type": "string",
+            "description": "The contact numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Company, User"
+          }
         },
-        "required": ["contactId"]
+        "required": [
+          "contactId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/Contacts(${contactId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/Contacts({contactId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -764,20 +852,59 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "FirstName": { "type": "string", "description": "First name" },
-          "LastName": { "type": "string", "description": "Last name" },
-          "Email": { "type": "string", "description": "Email address" },
-          "JobTitle": { "type": "string", "description": "Job title/role" },
-          "MobilePhone": { "type": "string", "description": "Mobile phone number" },
-          "Telephone": { "type": "string", "description": "Landline phone number" },
-          "Fax": { "type": "string", "description": "Fax number" },
-          "Note": { "type": "string", "description": "Internal notes" },
-          "Gender": { "type": "string", "description": "Gender: 'Male' or 'Female'" },
-          "CompanyId": { "type": "string", "description": "Company ID to link (use '0' for no company)" },
-          "IsUser": { "type": "boolean", "description": "Whether this contact is also a system user (default: false)" },
-          "ExternalId": { "type": "string", "description": "Your system's reference ID" }
+          "FirstName": {
+            "type": "string",
+            "description": "First name"
+          },
+          "LastName": {
+            "type": "string",
+            "description": "Last name"
+          },
+          "Email": {
+            "type": "string",
+            "description": "Email address"
+          },
+          "JobTitle": {
+            "type": "string",
+            "description": "Job title/role"
+          },
+          "MobilePhone": {
+            "type": "string",
+            "description": "Mobile phone number"
+          },
+          "Telephone": {
+            "type": "string",
+            "description": "Landline phone number"
+          },
+          "Fax": {
+            "type": "string",
+            "description": "Fax number"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Internal notes"
+          },
+          "Gender": {
+            "type": "string",
+            "description": "Gender: 'Male' or 'Female'"
+          },
+          "CompanyId": {
+            "type": "string",
+            "description": "Company ID to link (use '0' for no company)"
+          },
+          "IsUser": {
+            "type": "boolean",
+            "description": "Whether this contact is also a system user (default: false)"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Your system's reference ID"
+          }
         },
-        "required": ["FirstName", "LastName"]
+        "required": [
+          "FirstName",
+          "LastName"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -790,22 +917,54 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "contactId": { "type": "string", "description": "The contact numeric ID" },
-          "FirstName": { "type": "string", "description": "Updated first name" },
-          "LastName": { "type": "string", "description": "Updated last name" },
-          "Email": { "type": "string", "description": "Updated email" },
-          "JobTitle": { "type": "string", "description": "Updated job title" },
-          "MobilePhone": { "type": "string", "description": "Updated mobile phone" },
-          "Telephone": { "type": "string", "description": "Updated phone" },
-          "Note": { "type": "string", "description": "Updated notes" },
-          "Gender": { "type": "string", "description": "'Male' or 'Female'" },
-          "ExternalId": { "type": "string", "description": "Updated external ID" }
+          "contactId": {
+            "type": "string",
+            "description": "The contact numeric ID"
+          },
+          "FirstName": {
+            "type": "string",
+            "description": "Updated first name"
+          },
+          "LastName": {
+            "type": "string",
+            "description": "Updated last name"
+          },
+          "Email": {
+            "type": "string",
+            "description": "Updated email"
+          },
+          "JobTitle": {
+            "type": "string",
+            "description": "Updated job title"
+          },
+          "MobilePhone": {
+            "type": "string",
+            "description": "Updated mobile phone"
+          },
+          "Telephone": {
+            "type": "string",
+            "description": "Updated phone"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Updated notes"
+          },
+          "Gender": {
+            "type": "string",
+            "description": "'Male' or 'Female'"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Updated external ID"
+          }
         },
-        "required": ["contactId"]
+        "required": [
+          "contactId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Contacts(${contactId}L)"
+        "path": "/Contacts({contactId}L)"
       }
     },
     {
@@ -814,23 +973,42 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip for pagination" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip for pagination"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: Name, ExternalId, CompanyId (use Company/Id), IsWarehouse, IsProduct, DateModified. Examples: \"Company/Id eq 10981310465L\", \"Name eq 'Generator A1'\", \"IsWarehouse eq true\", \"DateModified gt datetime'2025-01-01T00:00:00'\""
           },
-          "$orderby": { "type": "string", "description": "Sort: 'Name asc', 'DateModified desc'" },
-          "$expand": { "type": "string", "description": "Expand: Contacts, Company, Product, Tags" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$orderby": {
+            "type": "string",
+            "description": "Sort: 'Name asc', 'DateModified desc'"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Contacts, Company, Product, Tags"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/ServiceObjects",
         "queryParams": {
-          "$top": "${$top}", "$skip": "${$skip}", "$filter": "${$filter}",
-          "$orderby": "${$orderby}", "$expand": "${$expand}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$orderby": "${$orderby}",
+          "$expand": "${$expand}",
+          "$select": "${$select}"
         }
       }
     },
@@ -840,15 +1018,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceObjectId": { "type": "string", "description": "The service object numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: Contacts, Company, Product, Tags" }
+          "serviceObjectId": {
+            "type": "string",
+            "description": "The service object numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Contacts, Company, Product, Tags"
+          }
         },
-        "required": ["serviceObjectId"]
+        "required": [
+          "serviceObjectId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/ServiceObjects(${serviceObjectId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/ServiceObjects({serviceObjectId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -857,15 +1045,38 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Object name" },
-          "ExternalId": { "type": "string", "description": "Your system's reference ID" },
-          "CompanyId": { "type": "string", "description": "Company ID that owns this object" },
-          "Note": { "type": "string", "description": "Internal notes" },
-          "ParentServiceObjectId": { "type": "string", "description": "Parent object ID for hierarchy (use '0' for root)" },
-          "ProductId": { "type": "string", "description": "Product catalog ID to link (use '0' for none)" },
-          "Location": { "type": "object", "description": "Address: {AddressString, Postal, City, State, Country}" }
+          "Name": {
+            "type": "string",
+            "description": "Object name"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Your system's reference ID"
+          },
+          "CompanyId": {
+            "type": "string",
+            "description": "Company ID that owns this object"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Internal notes"
+          },
+          "ParentServiceObjectId": {
+            "type": "string",
+            "description": "Parent object ID for hierarchy (use '0' for root)"
+          },
+          "ProductId": {
+            "type": "string",
+            "description": "Product catalog ID to link (use '0' for none)"
+          },
+          "Location": {
+            "type": "object",
+            "description": "Address: {AddressString, Postal, City, State, Country}"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -878,19 +1089,42 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceObjectId": { "type": "string", "description": "The service object numeric ID" },
-          "Name": { "type": "string", "description": "Updated name" },
-          "ExternalId": { "type": "string", "description": "Updated external ID" },
-          "CompanyId": { "type": "string", "description": "Updated company ID" },
-          "Note": { "type": "string", "description": "Updated notes" },
-          "ParentServiceObjectId": { "type": "string", "description": "Updated parent ID" },
-          "Location": { "type": "object", "description": "Updated address" }
+          "serviceObjectId": {
+            "type": "string",
+            "description": "The service object numeric ID"
+          },
+          "Name": {
+            "type": "string",
+            "description": "Updated name"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Updated external ID"
+          },
+          "CompanyId": {
+            "type": "string",
+            "description": "Updated company ID"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Updated notes"
+          },
+          "ParentServiceObjectId": {
+            "type": "string",
+            "description": "Updated parent ID"
+          },
+          "Location": {
+            "type": "object",
+            "description": "Updated address"
+          }
         },
-        "required": ["serviceObjectId"]
+        "required": [
+          "serviceObjectId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ServiceObjects(${serviceObjectId}L)"
+        "path": "/ServiceObjects({serviceObjectId}L)"
       }
     },
     {
@@ -899,13 +1133,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceObjectId": { "type": "string", "description": "The service object numeric ID to delete" }
+          "serviceObjectId": {
+            "type": "string",
+            "description": "The service object numeric ID to delete"
+          }
         },
-        "required": ["serviceObjectId"]
+        "required": [
+          "serviceObjectId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/ServiceObjects(${serviceObjectId}L)"
+        "path": "/ServiceObjects({serviceObjectId}L)"
       }
     },
     {
@@ -914,21 +1153,32 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: UserName, IsActive (true/false), IsMobile (true/false), IsSystem (true/false), ContactId. Examples: \"IsActive eq true\", \"IsMobile eq true\", \"UserName eq '1demo@simplias.com'\""
           },
-          "$expand": { "type": "string", "description": "Expand: Contact" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Contact"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/Users",
         "queryParams": {
-          "$top": "${$top}", "$filter": "${$filter}",
-          "$expand": "${$expand}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$filter": "${$filter}",
+          "$expand": "${$expand}",
+          "$select": "${$select}"
         }
       }
     },
@@ -938,15 +1188,28 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "userId": { "type": "string", "description": "The user numeric ID" },
-          "IsActive": { "type": "boolean", "description": "Set to true to activate, false to deactivate" },
-          "ContactId": { "type": "string", "description": "The user's contact ID" }
+          "userId": {
+            "type": "string",
+            "description": "The user numeric ID"
+          },
+          "IsActive": {
+            "type": "boolean",
+            "description": "Set to true to activate, false to deactivate"
+          },
+          "ContactId": {
+            "type": "string",
+            "description": "The user's contact ID"
+          }
         },
-        "required": ["userId", "IsActive", "ContactId"]
+        "required": [
+          "userId",
+          "IsActive",
+          "ContactId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Users(${userId}L)"
+        "path": "/Users({userId}L)"
       }
     },
     {
@@ -955,22 +1218,37 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip for pagination" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip for pagination"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: Name, SubKey, DateModified. Examples: \"Name eq 'Heat Pump X200'\", \"DateModified gt datetime'2025-01-01T00:00:00'\""
           },
-          "$expand": { "type": "string", "description": "Expand: CustomValueStepTemplate/Steps" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$expand": {
+            "type": "string",
+            "description": "Expand: CustomValueStepTemplate/Steps"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/Products",
         "queryParams": {
-          "$top": "${$top}", "$skip": "${$skip}", "$filter": "${$filter}",
-          "$expand": "${$expand}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$expand": "${$expand}",
+          "$select": "${$select}"
         }
       }
     },
@@ -980,15 +1258,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "productId": { "type": "string", "description": "The product numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: CustomValueStepTemplate/Steps" }
+          "productId": {
+            "type": "string",
+            "description": "The product numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: CustomValueStepTemplate/Steps"
+          }
         },
-        "required": ["productId"]
+        "required": [
+          "productId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/Products(${productId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/Products({productId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -997,11 +1285,22 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Product name" },
-          "SubKey": { "type": "string", "description": "Sub-key/model number" },
-          "Description": { "type": "string", "description": "Product description" }
+          "Name": {
+            "type": "string",
+            "description": "Product name"
+          },
+          "SubKey": {
+            "type": "string",
+            "description": "Sub-key/model number"
+          },
+          "Description": {
+            "type": "string",
+            "description": "Product description"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1014,22 +1313,37 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: FileName, ContentType, IsGlobal, ExternalId, ServiceRequestId, DateModified. Examples: \"ContentType eq 'application/pdf'\", \"IsGlobal eq true\", \"ServiceRequestId eq '11164418048'\""
           },
-          "$expand": { "type": "string", "description": "Expand: ServiceRequest" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$expand": {
+            "type": "string",
+            "description": "Expand: ServiceRequest"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/Documents",
         "queryParams": {
-          "$top": "${$top}", "$skip": "${$skip}", "$filter": "${$filter}",
-          "$expand": "${$expand}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$expand": "${$expand}",
+          "$select": "${$select}"
         }
       }
     },
@@ -1039,15 +1353,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "documentId": { "type": "string", "description": "The document numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: ServiceRequest" }
+          "documentId": {
+            "type": "string",
+            "description": "The document numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: ServiceRequest"
+          }
         },
-        "required": ["documentId"]
+        "required": [
+          "documentId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/Documents(${documentId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/Documents({documentId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -1056,17 +1380,34 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "documentId": { "type": "string", "description": "The document numeric ID" },
-          "FileName": { "type": "string", "description": "Updated file name" },
-          "ExternalId": { "type": "string", "description": "Updated external ID" },
-          "Note": { "type": "string", "description": "Updated notes" },
-          "IsGlobal": { "type": "boolean", "description": "Set to true to make globally available" }
+          "documentId": {
+            "type": "string",
+            "description": "The document numeric ID"
+          },
+          "FileName": {
+            "type": "string",
+            "description": "Updated file name"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Updated external ID"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Updated notes"
+          },
+          "IsGlobal": {
+            "type": "boolean",
+            "description": "Set to true to make globally available"
+          }
         },
-        "required": ["documentId"]
+        "required": [
+          "documentId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Documents(${documentId}L)"
+        "path": "/Documents({documentId}L)"
       }
     },
     {
@@ -1075,13 +1416,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "documentId": { "type": "string", "description": "The document numeric ID to delete" }
+          "documentId": {
+            "type": "string",
+            "description": "The document numeric ID to delete"
+          }
         },
-        "required": ["documentId"]
+        "required": [
+          "documentId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/Documents(${documentId}L)"
+        "path": "/Documents({documentId}L)"
       }
     },
     {
@@ -1090,23 +1436,42 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: TimeEventType ('eWorking', 'eDriving', 'ePause', 'eVacation', 'eIllness', 'eOther', 'eCustomTimeEvent'), StartDateTime, EndDateTime, ContactId (use Contact/Id), ServiceRequestId, IsApproved, DateModified. Examples: \"StartDateTime gt datetime'2025-01-01T00:00:00'\", \"Contact/Id eq 410583043L\", \"TimeEventType eq 'eWorking'\", \"IsApproved eq true\""
           },
-          "$orderby": { "type": "string", "description": "Sort: 'StartDateTime desc', 'EndDateTime asc'" },
-          "$expand": { "type": "string", "description": "Expand: Contact, ServiceRequest" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$orderby": {
+            "type": "string",
+            "description": "Sort: 'StartDateTime desc', 'EndDateTime asc'"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Contact, ServiceRequest"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/TimeEvents",
         "queryParams": {
-          "$top": "${$top}", "$skip": "${$skip}", "$filter": "${$filter}",
-          "$orderby": "${$orderby}", "$expand": "${$expand}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$orderby": "${$orderby}",
+          "$expand": "${$expand}",
+          "$select": "${$select}"
         }
       }
     },
@@ -1116,13 +1481,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceRequestId": { "type": "string", "description": "The service request numeric ID" }
+          "serviceRequestId": {
+            "type": "string",
+            "description": "The service request numeric ID"
+          }
         },
-        "required": ["serviceRequestId"]
+        "required": [
+          "serviceRequestId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/ServiceRequests(${serviceRequestId}L)",
+        "path": "/ServiceRequests({serviceRequestId}L)",
         "queryParams": {
           "$expand": "TimeEvents",
           "$select": "TimeEvents"
@@ -1139,14 +1509,37 @@
             "type": "string",
             "description": "Type of time event. Values: 'eWorking' (on-site work), 'eDriving' (travel), 'ePause' (break), 'eVacation', 'eIllness', 'eOther', 'eCustomTimeEvent'"
           },
-          "StartDateTime": { "type": "string", "description": "Start time in ISO 8601 (e.g. '2026-06-15T08:00:00Z')" },
-          "EndDateTime": { "type": "string", "description": "End time in ISO 8601" },
-          "ContactId": { "type": "string", "description": "Technician/contact ID" },
-          "ServiceRequestId": { "type": "string", "description": "Linked service request ID (use '0' for standalone events like vacation)" },
-          "Description": { "type": "string", "description": "Description of work done" },
-          "IsApproved": { "type": "boolean", "description": "Whether this time event is pre-approved (default: false)" }
+          "StartDateTime": {
+            "type": "string",
+            "description": "Start time in ISO 8601 (e.g. '2026-06-15T08:00:00Z')"
+          },
+          "EndDateTime": {
+            "type": "string",
+            "description": "End time in ISO 8601"
+          },
+          "ContactId": {
+            "type": "string",
+            "description": "Technician/contact ID"
+          },
+          "ServiceRequestId": {
+            "type": "string",
+            "description": "Linked service request ID (use '0' for standalone events like vacation)"
+          },
+          "Description": {
+            "type": "string",
+            "description": "Description of work done"
+          },
+          "IsApproved": {
+            "type": "boolean",
+            "description": "Whether this time event is pre-approved (default: false)"
+          }
         },
-        "required": ["TimeEventType", "StartDateTime", "EndDateTime", "ContactId"]
+        "required": [
+          "TimeEventType",
+          "StartDateTime",
+          "EndDateTime",
+          "ContactId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1159,13 +1552,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceRequestId": { "type": "string", "description": "The service request numeric ID" }
+          "serviceRequestId": {
+            "type": "string",
+            "description": "The service request numeric ID"
+          }
         },
-        "required": ["serviceRequestId"]
+        "required": [
+          "serviceRequestId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/ServiceRequests(${serviceRequestId}L)",
+        "path": "/ServiceRequests({serviceRequestId}L)",
         "queryParams": {
           "$expand": "Steps",
           "$select": "Steps"
@@ -1178,15 +1576,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "stepId": { "type": "string", "description": "The step numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: Attachments" }
+          "stepId": {
+            "type": "string",
+            "description": "The step numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Attachments"
+          }
         },
-        "required": ["stepId"]
+        "required": [
+          "stepId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/Steps(${stepId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/Steps({stepId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -1195,19 +1603,43 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Step name/title" },
+          "Name": {
+            "type": "string",
+            "description": "Step name/title"
+          },
           "Type": {
             "type": "string",
             "description": "Step type. Values: 'EnterValue' (data entry fields), 'Choice' (selection), 'Picture' (photo capture), 'SignDocument' (signature), 'Material' (material tracking), 'Group' (group container for sub-steps)"
           },
-          "Description": { "type": "string", "description": "Step description (HTML supported)" },
-          "Comment": { "type": "string", "description": "Technician comment" },
-          "ServiceRequestId": { "type": "string", "description": "Service request ID (for request checklist steps)" },
-          "StepListTemplateId": { "type": "string", "description": "Template ID (for template steps)" },
-          "ParentId": { "type": "string", "description": "Parent step ID for nested steps within a Group (use '0' for root level)" },
-          "Data": { "type": "string", "description": "JSON string defining step fields. For EnterValue: {\"fields\": [{\"isRequired\": true, \"name\": \"Field name\", \"type\": \"text|choice|float\", \"enumeration\": \"Opt1;Opt2\", \"unit\": \"kg\"}]}" }
+          "Description": {
+            "type": "string",
+            "description": "Step description (HTML supported)"
+          },
+          "Comment": {
+            "type": "string",
+            "description": "Technician comment"
+          },
+          "ServiceRequestId": {
+            "type": "string",
+            "description": "Service request ID (for request checklist steps)"
+          },
+          "StepListTemplateId": {
+            "type": "string",
+            "description": "Template ID (for template steps)"
+          },
+          "ParentId": {
+            "type": "string",
+            "description": "Parent step ID for nested steps within a Group (use '0' for root level)"
+          },
+          "Data": {
+            "type": "string",
+            "description": "JSON string defining step fields. For EnterValue: {\"fields\": [{\"isRequired\": true, \"name\": \"Field name\", \"type\": \"text|choice|float\", \"enumeration\": \"Opt1;Opt2\", \"unit\": \"kg\"}]}"
+          }
         },
-        "required": ["Name", "Type"]
+        "required": [
+          "Name",
+          "Type"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1220,20 +1652,46 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "stepId": { "type": "string", "description": "The step numeric ID" },
-          "Name": { "type": "string", "description": "Updated step name" },
-          "IsDone": { "type": "boolean", "description": "Mark step as completed (true) or incomplete (false)" },
-          "HasError": { "type": "boolean", "description": "Flag step as having an error" },
-          "Comment": { "type": "string", "description": "Technician comment" },
-          "Description": { "type": "string", "description": "Updated description" },
-          "Data": { "type": "string", "description": "Updated JSON field data" },
-          "ServiceRequestId": { "type": "string", "description": "Service request ID" }
+          "stepId": {
+            "type": "string",
+            "description": "The step numeric ID"
+          },
+          "Name": {
+            "type": "string",
+            "description": "Updated step name"
+          },
+          "IsDone": {
+            "type": "boolean",
+            "description": "Mark step as completed (true) or incomplete (false)"
+          },
+          "HasError": {
+            "type": "boolean",
+            "description": "Flag step as having an error"
+          },
+          "Comment": {
+            "type": "string",
+            "description": "Technician comment"
+          },
+          "Description": {
+            "type": "string",
+            "description": "Updated description"
+          },
+          "Data": {
+            "type": "string",
+            "description": "Updated JSON field data"
+          },
+          "ServiceRequestId": {
+            "type": "string",
+            "description": "Service request ID"
+          }
         },
-        "required": ["stepId"]
+        "required": [
+          "stepId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Steps(${stepId}L)"
+        "path": "/Steps({stepId}L)"
       }
     },
     {
@@ -1242,13 +1700,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "stepId": { "type": "string", "description": "The step numeric ID to delete" }
+          "stepId": {
+            "type": "string",
+            "description": "The step numeric ID to delete"
+          }
         },
-        "required": ["stepId"]
+        "required": [
+          "stepId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/Steps(${stepId}L)"
+        "path": "/Steps({stepId}L)"
       }
     },
     {
@@ -1257,22 +1720,37 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: NameOrNumber, ExternalId, Type ('Material', 'QuickFilter'), IsDiscontinued, DateModified. Examples: \"Type eq 'Material'\", \"substringof('Pump', NameOrNumber)\""
           },
-          "$expand": { "type": "string", "description": "Expand: Unit" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Unit"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/ItemTypes",
         "queryParams": {
-          "$top": "${$top}", "$skip": "${$skip}", "$filter": "${$filter}",
-          "$expand": "${$expand}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$expand": "${$expand}",
+          "$select": "${$select}"
         }
       }
     },
@@ -1282,15 +1760,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "itemTypeId": { "type": "string", "description": "The item type numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: Unit" }
+          "itemTypeId": {
+            "type": "string",
+            "description": "The item type numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Unit"
+          }
         },
-        "required": ["itemTypeId"]
+        "required": [
+          "itemTypeId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/ItemTypes(${itemTypeId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/ItemTypes({itemTypeId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -1299,18 +1787,51 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "NameOrNumber": { "type": "string", "description": "Item name or article number" },
-          "Type": { "type": "string", "description": "Type: 'Material' or 'QuickFilter'" },
-          "ExternalId": { "type": "string", "description": "Your system's article ID" },
-          "Description": { "type": "string", "description": "Item description" },
-          "Manufacture": { "type": "string", "description": "Manufacturer/brand" },
-          "Price": { "type": "string", "description": "Selling price (e.g. '5.99')" },
-          "Costs": { "type": "string", "description": "Cost price (e.g. '3.00')" },
-          "VAT": { "type": "string", "description": "VAT percentage (e.g. '19' for 19%)" },
-          "UnitId": { "type": "string", "description": "Unit ID from ItemUnits (use '0' for default)" },
-          "GlobalTradeItemNr": { "type": "string", "description": "GTIN/EAN barcode number" }
+          "NameOrNumber": {
+            "type": "string",
+            "description": "Item name or article number"
+          },
+          "Type": {
+            "type": "string",
+            "description": "Type: 'Material' or 'QuickFilter'"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "Your system's article ID"
+          },
+          "Description": {
+            "type": "string",
+            "description": "Item description"
+          },
+          "Manufacture": {
+            "type": "string",
+            "description": "Manufacturer/brand"
+          },
+          "Price": {
+            "type": "string",
+            "description": "Selling price (e.g. '5.99')"
+          },
+          "Costs": {
+            "type": "string",
+            "description": "Cost price (e.g. '3.00')"
+          },
+          "VAT": {
+            "type": "string",
+            "description": "VAT percentage (e.g. '19' for 19%)"
+          },
+          "UnitId": {
+            "type": "string",
+            "description": "Unit ID from ItemUnits (use '0' for default)"
+          },
+          "GlobalTradeItemNr": {
+            "type": "string",
+            "description": "GTIN/EAN barcode number"
+          }
         },
-        "required": ["NameOrNumber", "Type"]
+        "required": [
+          "NameOrNumber",
+          "Type"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1323,18 +1844,48 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "itemTypeId": { "type": "string", "description": "The item type numeric ID" },
-          "NameOrNumber": { "type": "string" }, "Type": { "type": "string" },
-          "Description": { "type": "string" }, "Manufacture": { "type": "string" },
-          "Price": { "type": "string" }, "Costs": { "type": "string" },
-          "VAT": { "type": "string" }, "ExternalId": { "type": "string" },
-          "UnitId": { "type": "string" }, "GlobalTradeItemNr": { "type": "string" }
+          "itemTypeId": {
+            "type": "string",
+            "description": "The item type numeric ID"
+          },
+          "NameOrNumber": {
+            "type": "string"
+          },
+          "Type": {
+            "type": "string"
+          },
+          "Description": {
+            "type": "string"
+          },
+          "Manufacture": {
+            "type": "string"
+          },
+          "Price": {
+            "type": "string"
+          },
+          "Costs": {
+            "type": "string"
+          },
+          "VAT": {
+            "type": "string"
+          },
+          "ExternalId": {
+            "type": "string"
+          },
+          "UnitId": {
+            "type": "string"
+          },
+          "GlobalTradeItemNr": {
+            "type": "string"
+          }
         },
-        "required": ["itemTypeId"]
+        "required": [
+          "itemTypeId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/ItemTypes(${itemTypeId}L)"
+        "path": "/ItemTypes({itemTypeId}L)"
       }
     },
     {
@@ -1343,13 +1894,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "itemTypeId": { "type": "string", "description": "The item type numeric ID" }
+          "itemTypeId": {
+            "type": "string",
+            "description": "The item type numeric ID"
+          }
         },
-        "required": ["itemTypeId"]
+        "required": [
+          "itemTypeId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/ItemTypes(${itemTypeId}L)"
+        "path": "/ItemTypes({itemTypeId}L)"
       }
     },
     {
@@ -1358,13 +1914,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceRequestId": { "type": "string", "description": "The service request numeric ID" }
+          "serviceRequestId": {
+            "type": "string",
+            "description": "The service request numeric ID"
+          }
         },
-        "required": ["serviceRequestId"]
+        "required": [
+          "serviceRequestId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/ServiceRequests(${serviceRequestId}L)",
+        "path": "/ServiceRequests({serviceRequestId}L)",
         "queryParams": {
           "$expand": "Items",
           "$select": "Items"
@@ -1377,24 +1938,76 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "ServiceRequestId": { "type": "string", "description": "Service request ID" },
-          "ItemTypeId": { "type": "string", "description": "Item type ID from catalog (use '0' for ad-hoc)" },
-          "NameOrNumber": { "type": "string", "description": "Item name or article number" },
-          "Type": { "type": "string", "description": "Type: 'Material', 'Equipment', 'Service'" },
-          "QuantityHours": { "type": "string", "description": "Quantity or hours used (e.g. '2.50')" },
-          "PlannedQuantityHours": { "type": "string", "description": "Planned quantity/hours" },
-          "Price": { "type": "string", "description": "Unit price" },
-          "Costs": { "type": "string", "description": "Unit cost" },
-          "Discount": { "type": "string", "description": "Discount percentage (e.g. '10.00')" },
-          "VAT": { "type": "string", "description": "VAT rate (e.g. '0.19' for 19%)" },
-          "Manufacture": { "type": "string", "description": "Manufacturer reference" },
-          "Note": { "type": "string", "description": "Notes" },
-          "ExternalId": { "type": "string", "description": "External reference" },
-          "UnitId": { "type": "string", "description": "Unit ID" },
-          "UnitString": { "type": "string", "description": "Unit display string (e.g. 'pcs', 'kg', 'm', 'h')" },
-          "ServiceObjectId": { "type": "string", "description": "Linked service object ID (use '0' for none)" }
+          "ServiceRequestId": {
+            "type": "string",
+            "description": "Service request ID"
+          },
+          "ItemTypeId": {
+            "type": "string",
+            "description": "Item type ID from catalog (use '0' for ad-hoc)"
+          },
+          "NameOrNumber": {
+            "type": "string",
+            "description": "Item name or article number"
+          },
+          "Type": {
+            "type": "string",
+            "description": "Type: 'Material', 'Equipment', 'Service'"
+          },
+          "QuantityHours": {
+            "type": "string",
+            "description": "Quantity or hours used (e.g. '2.50')"
+          },
+          "PlannedQuantityHours": {
+            "type": "string",
+            "description": "Planned quantity/hours"
+          },
+          "Price": {
+            "type": "string",
+            "description": "Unit price"
+          },
+          "Costs": {
+            "type": "string",
+            "description": "Unit cost"
+          },
+          "Discount": {
+            "type": "string",
+            "description": "Discount percentage (e.g. '10.00')"
+          },
+          "VAT": {
+            "type": "string",
+            "description": "VAT rate (e.g. '0.19' for 19%)"
+          },
+          "Manufacture": {
+            "type": "string",
+            "description": "Manufacturer reference"
+          },
+          "Note": {
+            "type": "string",
+            "description": "Notes"
+          },
+          "ExternalId": {
+            "type": "string",
+            "description": "External reference"
+          },
+          "UnitId": {
+            "type": "string",
+            "description": "Unit ID"
+          },
+          "UnitString": {
+            "type": "string",
+            "description": "Unit display string (e.g. 'pcs', 'kg', 'm', 'h')"
+          },
+          "ServiceObjectId": {
+            "type": "string",
+            "description": "Linked service object ID (use '0' for none)"
+          }
         },
-        "required": ["ServiceRequestId", "NameOrNumber", "Type"]
+        "required": [
+          "ServiceRequestId",
+          "NameOrNumber",
+          "Type"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1407,16 +2020,36 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "itemId": { "type": "string", "description": "The item numeric ID" },
-          "QuantityHours": { "type": "string" }, "Price": { "type": "string" },
-          "Discount": { "type": "string" }, "Note": { "type": "string" },
-          "NameOrNumber": { "type": "string" }, "ExternalId": { "type": "string" }
+          "itemId": {
+            "type": "string",
+            "description": "The item numeric ID"
+          },
+          "QuantityHours": {
+            "type": "string"
+          },
+          "Price": {
+            "type": "string"
+          },
+          "Discount": {
+            "type": "string"
+          },
+          "Note": {
+            "type": "string"
+          },
+          "NameOrNumber": {
+            "type": "string"
+          },
+          "ExternalId": {
+            "type": "string"
+          }
         },
-        "required": ["itemId"]
+        "required": [
+          "itemId"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Items(${itemId}L)"
+        "path": "/Items({itemId}L)"
       }
     },
     {
@@ -1425,13 +2058,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "itemId": { "type": "string", "description": "The item numeric ID" }
+          "itemId": {
+            "type": "string",
+            "description": "The item numeric ID"
+          }
         },
-        "required": ["itemId"]
+        "required": [
+          "itemId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/Items(${itemId}L)"
+        "path": "/Items({itemId}L)"
       }
     },
     {
@@ -1452,9 +2090,14 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Unit name (e.g. 'pieces', 'kg', 'meters', 'hours', 'daily')" }
+          "Name": {
+            "type": "string",
+            "description": "Unit name (e.g. 'pieces', 'kg', 'meters', 'hours', 'daily')"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1467,22 +2110,37 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$top": { "type": "number", "description": "Max results to return" },
-          "$skip": { "type": "number", "description": "Results to skip" },
+          "$top": {
+            "type": "number",
+            "description": "Max results to return"
+          },
+          "$skip": {
+            "type": "number",
+            "description": "Results to skip"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Filterable fields: InvoiceState ('eIsDraft', 'eIsPaid', 'eIsSent', 'eIsOverdue'), InvoiceDate, DueDate, DatePayed, InvoiceBalance. Examples: \"InvoiceState eq 'eIsPaid'\", \"InvoiceDate gt datetime'2025-01-01T00:00:00'\", \"InvoiceBalance gt 1000\""
           },
-          "$orderby": { "type": "string", "description": "Sort: 'InvoiceDate desc', 'InvoiceBalance desc'" },
-          "$select": { "type": "string", "description": "Select specific fields" }
+          "$orderby": {
+            "type": "string",
+            "description": "Sort: 'InvoiceDate desc', 'InvoiceBalance desc'"
+          },
+          "$select": {
+            "type": "string",
+            "description": "Select specific fields"
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/Invoices",
         "queryParams": {
-          "$top": "${$top}", "$skip": "${$skip}", "$filter": "${$filter}",
-          "$orderby": "${$orderby}", "$select": "${$select}"
+          "$top": "${$top}",
+          "$skip": "${$skip}",
+          "$filter": "${$filter}",
+          "$orderby": "${$orderby}",
+          "$select": "${$select}"
         }
       }
     },
@@ -1501,7 +2159,9 @@
       "endpointMapping": {
         "method": "GET",
         "path": "/Tags",
-        "queryParams": { "$filter": "${$filter}" }
+        "queryParams": {
+          "$filter": "${$filter}"
+        }
       }
     },
     {
@@ -1510,11 +2170,23 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Tag name" },
-          "ColorDefinition": { "type": "string", "description": "Color hex code (e.g. '#1491ad', '#ff0000')" },
-          "Type": { "type": "string", "description": "Tag type: 'ServiceRequest'" }
+          "Name": {
+            "type": "string",
+            "description": "Tag name"
+          },
+          "ColorDefinition": {
+            "type": "string",
+            "description": "Color hex code (e.g. '#1491ad', '#ff0000')"
+          },
+          "Type": {
+            "type": "string",
+            "description": "Tag type: 'ServiceRequest'"
+          }
         },
-        "required": ["Name", "Type"]
+        "required": [
+          "Name",
+          "Type"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1527,13 +2199,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$filter": { "type": "string", "description": "OData filter. Example: \"Name eq 'Electrician'\"" }
+          "$filter": {
+            "type": "string",
+            "description": "OData filter. Example: \"Name eq 'Electrician'\""
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/Qualifications",
-        "queryParams": { "$filter": "${$filter}" }
+        "queryParams": {
+          "$filter": "${$filter}"
+        }
       }
     },
     {
@@ -1542,9 +2219,14 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Qualification name (e.g. 'Electrician', 'HVAC Certified')" }
+          "Name": {
+            "type": "string",
+            "description": "Qualification name (e.g. 'Electrician', 'HVAC Certified')"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1557,14 +2239,23 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "qualificationId": { "type": "string", "description": "The qualification numeric ID" },
-          "Name": { "type": "string", "description": "Updated name" }
+          "qualificationId": {
+            "type": "string",
+            "description": "The qualification numeric ID"
+          },
+          "Name": {
+            "type": "string",
+            "description": "Updated name"
+          }
         },
-        "required": ["qualificationId", "Name"]
+        "required": [
+          "qualificationId",
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
-        "path": "/Qualifications(${qualificationId}L)"
+        "path": "/Qualifications({qualificationId}L)"
       }
     },
     {
@@ -1573,13 +2264,18 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "qualificationId": { "type": "string", "description": "The qualification numeric ID" }
+          "qualificationId": {
+            "type": "string",
+            "description": "The qualification numeric ID"
+          }
         },
-        "required": ["qualificationId"]
+        "required": [
+          "qualificationId"
+        ]
       },
       "endpointMapping": {
         "method": "DELETE",
-        "path": "/Qualifications(${qualificationId}L)"
+        "path": "/Qualifications({qualificationId}L)"
       }
     },
     {
@@ -1600,9 +2296,14 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Cost center name" }
+          "Name": {
+            "type": "string",
+            "description": "Cost center name"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1615,7 +2316,10 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "$expand": { "type": "string", "description": "Expand: Steps (to include template steps)" },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Steps (to include template steps)"
+          },
           "$filter": {
             "type": "string",
             "description": "OData filter. Examples: \"IsReleased eq true\", \"Name eq 'Safety Check'\""
@@ -1625,7 +2329,10 @@
       "endpointMapping": {
         "method": "GET",
         "path": "/StepListTemplates",
-        "queryParams": { "$expand": "${$expand}", "$filter": "${$filter}" }
+        "queryParams": {
+          "$expand": "${$expand}",
+          "$filter": "${$filter}"
+        }
       }
     },
     {
@@ -1634,15 +2341,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "templateId": { "type": "string", "description": "The template numeric ID" },
-          "$expand": { "type": "string", "description": "Expand: Steps" }
+          "templateId": {
+            "type": "string",
+            "description": "The template numeric ID"
+          },
+          "$expand": {
+            "type": "string",
+            "description": "Expand: Steps"
+          }
         },
-        "required": ["templateId"]
+        "required": [
+          "templateId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/StepListTemplates(${templateId}L)",
-        "queryParams": { "$expand": "${$expand}" }
+        "path": "/StepListTemplates({templateId}L)",
+        "queryParams": {
+          "$expand": "${$expand}"
+        }
       }
     },
     {
@@ -1651,11 +2368,22 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string", "description": "Template name" },
-          "MappingId": { "type": "string", "description": "External mapping/reference ID" },
-          "IsReleased": { "type": "boolean", "description": "Whether the template is released for use (default: false)" }
+          "Name": {
+            "type": "string",
+            "description": "Template name"
+          },
+          "MappingId": {
+            "type": "string",
+            "description": "External mapping/reference ID"
+          },
+          "IsReleased": {
+            "type": "boolean",
+            "description": "Whether the template is released for use (default: false)"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -1668,14 +2396,23 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "serviceRequestId": { "type": "string", "description": "The service request numeric ID" },
-          "reportDefinitionId": { "type": "string", "description": "The report definition ID to use for generation" }
+          "serviceRequestId": {
+            "type": "string",
+            "description": "The service request numeric ID"
+          },
+          "reportDefinitionId": {
+            "type": "string",
+            "description": "The report definition ID to use for generation"
+          }
         },
-        "required": ["serviceRequestId", "reportDefinitionId"]
+        "required": [
+          "serviceRequestId",
+          "reportDefinitionId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
-        "path": "/ServiceRequests(${serviceRequestId}L)/GenerateReportHash"
+        "path": "/ServiceRequests({serviceRequestId}L)/GenerateReportHash"
       }
     }
   ]

--- a/packages/backend/src/adapters/de/n26-openbanking.json
+++ b/packages/backend/src/adapters/de/n26-openbanking.json
@@ -6,7 +6,10 @@
   "category": "banking",
   "icon": "n26",
   "docsUrl": "https://docs.tech26.de/",
-  "requiredEnvVars": ["N26_CLIENT_ID", "N26_CLIENT_SECRET"],
+  "requiredEnvVars": [
+    "N26_CLIENT_ID",
+    "N26_CLIENT_SECRET"
+  ],
   "connector": {
     "name": "N26 Open Banking",
     "type": "REST",
@@ -44,11 +47,13 @@
             "description": "The N26 account ID (obtained from n26_get_accounts)"
           }
         },
-        "required": ["accountId"]
+        "required": [
+          "accountId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/v1/berlin-group/accounts/${accountId}/balances"
+        "path": "/v1/berlin-group/accounts/{accountId}/balances"
       }
     },
     {
@@ -74,15 +79,17 @@
             "description": "Filter by booking status: 'booked', 'pending', or 'both'. Default: 'booked'"
           }
         },
-        "required": ["accountId"]
+        "required": [
+          "accountId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/v1/berlin-group/accounts/${accountId}/transactions",
+        "path": "/v1/berlin-group/accounts/{accountId}/transactions",
         "queryParams": {
-          "dateFrom": "${dateFrom}",
-          "dateTo": "${dateTo}",
-          "bookingStatus": "${bookingStatus}"
+          "dateFrom": "$dateFrom",
+          "dateTo": "$dateTo",
+          "bookingStatus": "$bookingStatus"
         }
       }
     }

--- a/packages/backend/src/adapters/de/nina-warnung.json
+++ b/packages/backend/src/adapters/de/nina-warnung.json
@@ -37,11 +37,13 @@
             "description": "The 12-digit AGS code of the region (e.g. '091620000000' for Munich, '110000000000' for Berlin). Use 5 digits + trailing zeros."
           }
         },
-        "required": ["ags"]
+        "required": [
+          "ags"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/dashboard/${ags}.json"
+        "path": "/dashboard/{ags}.json"
       }
     },
     {
@@ -55,11 +57,13 @@
             "description": "The warning ID (obtained from dashboard or region warnings)"
           }
         },
-        "required": ["warningId"]
+        "required": [
+          "warningId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/warnings/${warningId}.json"
+        "path": "/warnings/{warningId}.json"
       }
     },
     {
@@ -73,11 +77,13 @@
             "description": "The 12-digit AGS code of the region"
           }
         },
-        "required": ["ags"]
+        "required": [
+          "ags"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/appdata/covid/covidrules/DE/${ags}.json"
+        "path": "/appdata/covid/covidrules/DE/{ags}.json"
       }
     }
   ]

--- a/packages/backend/src/adapters/de/openplz.json
+++ b/packages/backend/src/adapters/de/openplz.json
@@ -1,0 +1,147 @@
+{
+  "slug": "openplz",
+  "name": "OpenPLZ Germany",
+  "description": "Look up German postal codes, localities, and streets via the OpenPLZ API. Free, no authentication, based on the official Bundesanstalt für Kartographie und Geodäsie (BKG) datasets.",
+  "instructions": "This connector wraps the free OpenPLZ API for German administrative structure lookups. Useful for address validation, form autocomplete, and regional analytics.\n\n**Hierarchy**: Germany → Federal state (Bundesland) → District (Kreis) → Municipality (Gemeinde) → Locality (Ort) + postal code (PLZ).\n\n**No authentication required**. OpenPLZ is rate-limited (soft limit ~10 req/s) — for bulk work consider self-hosting.\n\n**Common flows**:\n- Postal code → localities: `openplz_lookup_postalcode`\n- City + street autocomplete: `openplz_search_streets`\n- Full town info by AGS (Amtlicher Gemeindeschlüssel): `openplz_get_locality`",
+  "region": "de",
+  "category": "government",
+  "icon": "openplz",
+  "docsUrl": "https://www.openplzapi.org/de/",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "OpenPLZ Germany",
+    "type": "REST",
+    "baseUrl": "https://openplzapi.org/de",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "openplz_lookup_postalcode",
+      "description": "Look up all localities associated with a German postal code (PLZ). Returns each locality's name, federal state, district, and AGS.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postalCode": {
+            "type": "string",
+            "description": "5-digit German postal code (e.g. '79098' for Freiburg im Breisgau)."
+          }
+        },
+        "required": ["postalCode"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Localities",
+        "queryParams": {
+          "postalCode": "$postalCode"
+        }
+      }
+    },
+    {
+      "name": "openplz_search_localities",
+      "description": "Search localities by name, optionally filtered by federal state. Returns name, PLZ, federal state, district.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Locality name or prefix (e.g. 'Freiburg', 'Muench')."
+          },
+          "federalState": {
+            "type": "string",
+            "description": "Federal state name (e.g. 'Baden-Württemberg', 'Bayern'). Optional filter."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)."
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Page size (default: 50, max: 100)."
+          }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Localities",
+        "queryParams": {
+          "name": "$name",
+          "federalState": "$federalState",
+          "page": "$page",
+          "pageSize": "$pageSize"
+        }
+      }
+    },
+    {
+      "name": "openplz_search_streets",
+      "description": "Search streets within a locality. Useful for address autocomplete. Returns street names, borough (Ortsteil), PLZ.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Street name or prefix (e.g. 'Kaiser-Joseph')."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Optional filter — 5-digit PLZ to restrict to one postal area."
+          },
+          "locality": {
+            "type": "string",
+            "description": "Optional filter — locality name."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)."
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Page size (default: 50, max: 100)."
+          }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Streets",
+        "queryParams": {
+          "name": "$name",
+          "postalCode": "$postalCode",
+          "locality": "$locality",
+          "page": "$page",
+          "pageSize": "$pageSize"
+        }
+      }
+    },
+    {
+      "name": "openplz_list_federal_states",
+      "description": "List all 16 German federal states (Bundesländer) with their Regional Key (RS), name, and seat of government.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/FederalStates"
+      }
+    },
+    {
+      "name": "openplz_list_districts",
+      "description": "List all districts (Kreise/kreisfreie Städte) of a federal state. Returns RS, name, type, and administrative seat.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "federalStateKey": {
+            "type": "string",
+            "description": "Federal state Regional Key (e.g. '08' for Baden-Württemberg, '09' for Bayern)."
+          }
+        },
+        "required": ["federalStateKey"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/FederalStates/{federalStateKey}/Districts"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/oxomi.json
+++ b/packages/backend/src/adapters/de/oxomi.json
@@ -1,0 +1,242 @@
+{
+  "slug": "oxomi",
+  "name": "Oxomi Catalog & Media Portal",
+  "description": "Search digital catalogs (Kataloge), product datasheets, technical drawings, safety data sheets, and media assets via Oxomi — the dominant catalog/media portal for the German Baustoff (building materials) trade. Use for product lookup, document download, and cross-selling research across thousands of supplier catalogs.",
+  "instructions": "This connector talks to the Oxomi Portal JSON API.\n\n**Credentials**: every request needs three values, automatically injected from the credentials you enter when creating the connector:\n- `OXOMI_PORTAL_ID` — your portal numeric id (find it in Oxomi → Portal-Einstellungen → ID)\n- `OXOMI_USER` — your portal user name (often an email)\n- `OXOMI_ACCESS_TOKEN` — long-lived API token generated under Portal-Einstellungen → API\n\n**Workflow patterns**:\n- Catalog browse: `oxomi_search_catalogs` → `oxomi_get_catalog_pages` → `oxomi_get_catalog_attachments`\n- Product lookup: `oxomi_search_products` (by SKU or text) → returns supplier, catalog reference, datasheet URLs\n- Document hunting: `oxomi_search_documents` for safety data sheets (Sicherheitsdatenblätter), installation guides (Verarbeitungsanleitungen), CAD drawings\n\n**Suppliers**: results are scoped to the portal — you only see suppliers your Oxomi subscription includes (portals typically include hundreds of Baustoff manufacturers like Knauf, Saint-Gobain, Bosch, Würth, etc.).\n\n**Pagination**: list endpoints accept `page` (1-based) and `pageSize` (default 25, max 100).\n\n**Languages**: most descriptions are German; pass `lang=en` for English where the supplier provides translations.",
+  "region": "de",
+  "category": "wholesale",
+  "icon": "oxomi",
+  "docsUrl": "https://oxomi.com/portal/",
+  "requiredEnvVars": [
+    "OXOMI_PORTAL_ID",
+    "OXOMI_USER",
+    "OXOMI_ACCESS_TOKEN"
+  ],
+  "connector": {
+    "name": "Oxomi",
+    "type": "REST",
+    "baseUrl": "https://oxomi.com/service/json",
+    "authType": "QUERY_AUTH",
+    "authConfig": {
+      "portalId": "{{OXOMI_PORTAL_ID}}",
+      "user": "{{OXOMI_USER}}",
+      "accessToken": "{{OXOMI_ACCESS_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "oxomi_search_catalogs",
+      "description": "Search digital catalogs available in the portal. Returns each catalog with id, title, supplier name, language, page count, and cover image URL. Use the returned catalog id with oxomi_get_catalog_pages or oxomi_get_catalog_attachments.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Free-text search across catalog titles and supplier names (e.g. 'Trockenbau', 'Knauf', 'Dämmstoffe')."
+          },
+          "supplier": {
+            "type": "string",
+            "description": "Optional supplier name filter."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number, 1-based (default: 1)."
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/catalog/search",
+        "queryParams": {
+          "q": "$q",
+          "supplier": "$supplier",
+          "page": "$page",
+          "pageSize": "$pageSize"
+        }
+      }
+    },
+    {
+      "name": "oxomi_get_catalog_pages",
+      "description": "Retrieve the page list (with thumbnails and section/category names) for a specific catalog. Use to browse a catalog's structure or to surface a specific page reference for the user.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "catalogId": {
+            "type": "string",
+            "description": "The numeric catalog id from oxomi_search_catalogs."
+          }
+        },
+        "required": ["catalogId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/catalog/pages",
+        "queryParams": {
+          "catalogId": "$catalogId"
+        }
+      }
+    },
+    {
+      "name": "oxomi_get_catalog_attachments",
+      "description": "List all attachments (datasheets, certificates, CAD files, videos) linked to a catalog or a specific catalog page. Each attachment has a downloadable URL plus type, filename, and language metadata.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "catalogId": {
+            "type": "string",
+            "description": "The catalog id."
+          },
+          "pageNumber": {
+            "type": "number",
+            "description": "Optional — restrict to a specific catalog page."
+          }
+        },
+        "required": ["catalogId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/catalog/attachments",
+        "queryParams": {
+          "catalogId": "$catalogId",
+          "pageNumber": "$pageNumber"
+        }
+      }
+    },
+    {
+      "name": "oxomi_search_products",
+      "description": "Search products across all suppliers in the portal by SKU, EAN, or description. Returns supplier name, supplier SKU, manufacturer SKU, EAN, short description, catalog reference, and image URL. Includes is_diverse flag for custom-priced articles.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search term (description, brand, SKU). Searches across all suppliers."
+          },
+          "sku": {
+            "type": "string",
+            "description": "Exact SKU lookup (manufacturer or supplier SKU)."
+          },
+          "ean": {
+            "type": "string",
+            "description": "EAN/GTIN-13 lookup."
+          },
+          "supplier": {
+            "type": "string",
+            "description": "Optional supplier name filter."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)."
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Results per page (default: 25, max: 100)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/product/search",
+        "queryParams": {
+          "q": "$q",
+          "sku": "$sku",
+          "ean": "$ean",
+          "supplier": "$supplier",
+          "page": "$page",
+          "pageSize": "$pageSize"
+        }
+      }
+    },
+    {
+      "name": "oxomi_get_product_attachments",
+      "description": "Retrieve all documents attached to a single product: safety data sheet (SDB), installation guide (Verarbeitungsanleitung), declaration of performance (DoP), CAD drawings, photos, videos.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "The Oxomi product id from oxomi_search_products."
+          }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/product/attachments",
+        "queryParams": {
+          "productId": "$productId"
+        }
+      }
+    },
+    {
+      "name": "oxomi_search_documents",
+      "description": "Search standalone documents (not bound to a single product) across the portal: catalog supplements, price lists, marketing materials, legal documents, training videos.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Free-text search across document titles and tags."
+          },
+          "documentType": {
+            "type": "string",
+            "description": "Optional filter: 'catalog', 'pricelist', 'datasheet', 'safetydatasheet', 'installation', 'video', 'image', 'cad'."
+          },
+          "supplier": {
+            "type": "string",
+            "description": "Optional supplier filter."
+          },
+          "lang": {
+            "type": "string",
+            "description": "Language filter (e.g. 'de', 'en')."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (default: 1)."
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Page size (default: 25)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/document/search",
+        "queryParams": {
+          "q": "$q",
+          "documentType": "$documentType",
+          "supplier": "$supplier",
+          "lang": "$lang",
+          "page": "$page",
+          "pageSize": "$pageSize"
+        }
+      }
+    },
+    {
+      "name": "oxomi_get_cross_selling",
+      "description": "Find related/cross-sell products for a given product (e.g. accessories, replacements, compatible items). Returns linked products with relation type (alternative, accessory, mounting, complement).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "The base product id."
+          }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/product/cross-selling",
+        "queryParams": {
+          "productId": "$productId"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/payone.json
+++ b/packages/backend/src/adapters/de/payone.json
@@ -6,7 +6,12 @@
   "category": "finance",
   "icon": "payone",
   "docsUrl": "https://docs.payone.com/",
-  "requiredEnvVars": ["PAYONE_MERCHANT_ID", "PAYONE_API_KEY", "PAYONE_PORTAL_ID", "PAYONE_ACCOUNT_ID"],
+  "requiredEnvVars": [
+    "PAYONE_MERCHANT_ID",
+    "PAYONE_API_KEY",
+    "PAYONE_PORTAL_ID",
+    "PAYONE_ACCOUNT_ID"
+  ],
   "connector": {
     "name": "PAYONE Payments",
     "type": "REST",
@@ -38,8 +43,8 @@
         "method": "GET",
         "path": "/transactions",
         "queryParams": {
-          "limit": "${limit}",
-          "offset": "${offset}",
+          "limit": "$limit",
+          "offset": "$offset",
           "merchant_id": "{{PAYONE_MERCHANT_ID}}"
         }
       }
@@ -55,11 +60,13 @@
             "description": "The PAYONE transaction ID"
           }
         },
-        "required": ["transactionId"]
+        "required": [
+          "transactionId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/transactions/${transactionId}"
+        "path": "/transactions/{transactionId}"
       }
     },
     {
@@ -77,13 +84,15 @@
             "description": "Amount to capture in smallest currency unit (cents). Leave empty for full capture."
           }
         },
-        "required": ["transactionId"]
+        "required": [
+          "transactionId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
-        "path": "/transactions/${transactionId}/capture",
+        "path": "/transactions/{transactionId}/capture",
         "bodyMapping": {
-          "amount": "${amount}"
+          "amount": "$amount"
         }
       }
     },
@@ -106,14 +115,16 @@
             "description": "Reason for the refund"
           }
         },
-        "required": ["transactionId"]
+        "required": [
+          "transactionId"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
-        "path": "/transactions/${transactionId}/refund",
+        "path": "/transactions/{transactionId}/refund",
         "bodyMapping": {
-          "amount": "${amount}",
-          "reason": "${reason}"
+          "amount": "$amount",
+          "reason": "$reason"
         }
       }
     }

--- a/packages/backend/src/adapters/de/personio.json
+++ b/packages/backend/src/adapters/de/personio.json
@@ -1,0 +1,176 @@
+{
+  "slug": "personio",
+  "name": "Personio HR",
+  "description": "Access employee records, attendances, absences, and time-offs via the Personio REST API. Personio is the dominant HR platform for DACH SMBs.",
+  "instructions": "This connector uses the Personio v1 REST API.\n\n**Authentication model — IMPORTANT**: Personio's /auth endpoint is not a standard OAuth2 flow. You POST {client_id, client_secret} once and get back a short-lived bearer token, which is then passed as `Authorization: Bearer <token>` on every request. Each successful API response ALSO returns a new token in its Authorization response header that must be used for the next call — effectively a token-rotation scheme. This adapter uses a single long-lived bearer token supplied by you (`PERSONIO_TOKEN`).\n\n**Getting a token**: in Personio admin → Settings → Integrations → API credentials, create a new set, then exchange them for a token via `curl -X POST https://api.personio.de/v1/auth -d 'client_id=...&client_secret=...'`. Paste the returned `token` as `PERSONIO_TOKEN` when importing the connector.\n\n**Token rotation limitation**: because the adapter sends the SAME token on each call, the first call succeeds but subsequent ones may fail once Personio starts rotating. In practice Personio tolerates the same token for a few minutes — good enough for ad-hoc AI workflows but not high-volume integrations. For production, generate a fresh token per session or wrap this adapter in a custom proxy.\n\n**Scopes**: the token inherits the API credential's configured scopes (Employees, Attendances, Absences, Time Offs). Configure these in Personio before generating the token.\n\n**Rate limit**: 10 requests/second per API credential.",
+  "region": "de",
+  "category": "hr",
+  "icon": "personio",
+  "docsUrl": "https://developer.personio.de/reference",
+  "requiredEnvVars": ["PERSONIO_TOKEN"],
+  "connector": {
+    "name": "Personio",
+    "type": "REST",
+    "baseUrl": "https://api.personio.de/v1",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{PERSONIO_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "personio_list_employees",
+      "description": "List all employees. Returns id, first/last name, email, position, department, office, hire date, status (active/inactive/onboarding/leave/offboarded) and supervisor. Supports filtering by email, department, or status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Filter by employee email (exact match)."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default: 200, max: 200)."
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/employees",
+        "queryParams": {
+          "email": "$email",
+          "limit": "$limit",
+          "offset": "$offset"
+        }
+      }
+    },
+    {
+      "name": "personio_get_employee",
+      "description": "Retrieve a single employee by id. Returns all custom attributes, contract details, salary band (if token has permission), and personal data.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Personio employee id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/employees/{id}"
+      }
+    },
+    {
+      "name": "personio_list_absences",
+      "description": "List absences (Abwesenheiten) — vacation, sick leave, parental leave, etc. Returns type, start/end date, half-day flag, certificate URL, and approval status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "description": "Filter: absences overlapping on or after this ISO date (e.g. '2026-01-01')."
+          },
+          "end_date": {
+            "type": "string",
+            "description": "Filter: absences overlapping on or before this date."
+          },
+          "employees": {
+            "type": "string",
+            "description": "Comma-separated employee ids to filter by."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default 200)."
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/time-offs",
+        "queryParams": {
+          "start_date": "$start_date",
+          "end_date": "$end_date",
+          "employees": "$employees",
+          "limit": "$limit",
+          "offset": "$offset"
+        }
+      }
+    },
+    {
+      "name": "personio_list_attendances",
+      "description": "List attendance records (working hours). Returns date, employee, start/end time, break minutes, project (if project tracking enabled), and comment.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "description": "Earliest attendance date (ISO, e.g. '2026-04-01'). Required."
+          },
+          "end_date": {
+            "type": "string",
+            "description": "Latest attendance date (ISO). Required."
+          },
+          "employees": {
+            "type": "string",
+            "description": "Comma-separated employee ids to scope the query."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results."
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination."
+          }
+        },
+        "required": ["start_date", "end_date"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/attendances",
+        "queryParams": {
+          "start_date": "$start_date",
+          "end_date": "$end_date",
+          "employees": "$employees",
+          "limit": "$limit",
+          "offset": "$offset"
+        }
+      }
+    },
+    {
+      "name": "personio_list_absence_types",
+      "description": "List the configured absence types (vacation, sick, parental leave, etc.) with id, name, category, and unit (days vs hours). Use ids when creating new absences.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Max results."
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/time-off-types",
+        "queryParams": {
+          "limit": "$limit",
+          "offset": "$offset"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/planradar.json
+++ b/packages/backend/src/adapters/de/planradar.json
@@ -7,7 +7,10 @@
   "category": "construction",
   "icon": "planradar",
   "docsUrl": "https://help.planradar.com/hc/en-gb/articles/15480453097373-Open-API-Overview",
-  "requiredEnvVars": ["PLANRADAR_API_KEY", "PLANRADAR_CUSTOMER_ID"],
+  "requiredEnvVars": [
+    "PLANRADAR_API_KEY",
+    "PLANRADAR_CUSTOMER_ID"
+  ],
   "connector": {
     "name": "PlanRadar Construction",
     "type": "REST",
@@ -39,8 +42,8 @@
         "method": "GET",
         "path": "/projects",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}"
+          "page": "$page",
+          "per_page": "$per_page"
         }
       }
     },
@@ -55,7 +58,9 @@
             "description": "The project ID"
           }
         },
-        "required": ["project_id"]
+        "required": [
+          "project_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -81,14 +86,16 @@
             "description": "Number of results per page"
           }
         },
-        "required": ["project_id"]
+        "required": [
+          "project_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/projects/{project_id}/tickets",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}"
+          "page": "$page",
+          "per_page": "$per_page"
         }
       }
     },
@@ -107,7 +114,10 @@
             "description": "The ticket ID"
           }
         },
-        "required": ["project_id", "ticket_id"]
+        "required": [
+          "project_id",
+          "ticket_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -135,7 +145,14 @@
           "status": {
             "type": "string",
             "description": "Ticket status. Values: Open, In Progress, Resolved, Feedback, Closed, Rejected",
-            "enum": ["Open", "In Progress", "Resolved", "Feedback", "Closed", "Rejected"]
+            "enum": [
+              "Open",
+              "In Progress",
+              "Resolved",
+              "Feedback",
+              "Closed",
+              "Rejected"
+            ]
           },
           "priority": {
             "type": "string",
@@ -158,21 +175,24 @@
             "description": "Progress percentage (0-100)"
           }
         },
-        "required": ["project_id", "title"]
+        "required": [
+          "project_id",
+          "title"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
         "path": "/projects/{project_id}/tickets",
         "bodyEncoding": "form-urlencoded",
         "bodyMapping": {
-          "title": "${title}",
-          "description": "${description}",
-          "status": "${status}",
-          "priority": "${priority}",
-          "assignee_id": "${assignee_id}",
-          "due_date": "${due_date}",
-          "layer_id": "${layer_id}",
-          "progress": "${progress}"
+          "title": "$title",
+          "description": "$description",
+          "status": "$status",
+          "priority": "$priority",
+          "assignee_id": "$assignee_id",
+          "due_date": "$due_date",
+          "layer_id": "$layer_id",
+          "progress": "$progress"
         }
       }
     },
@@ -201,7 +221,14 @@
           "status": {
             "type": "string",
             "description": "Updated status. Values: Open, In Progress, Resolved, Feedback, Closed, Rejected",
-            "enum": ["Open", "In Progress", "Resolved", "Feedback", "Closed", "Rejected"]
+            "enum": [
+              "Open",
+              "In Progress",
+              "Resolved",
+              "Feedback",
+              "Closed",
+              "Rejected"
+            ]
           },
           "priority": {
             "type": "string",
@@ -220,20 +247,23 @@
             "description": "Progress percentage (0-100)"
           }
         },
-        "required": ["project_id", "ticket_id"]
+        "required": [
+          "project_id",
+          "ticket_id"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
         "path": "/projects/{project_id}/tickets/{ticket_id}",
         "bodyEncoding": "form-urlencoded",
         "bodyMapping": {
-          "title": "${title}",
-          "description": "${description}",
-          "status": "${status}",
-          "priority": "${priority}",
-          "assignee_id": "${assignee_id}",
-          "due_date": "${due_date}",
-          "progress": "${progress}"
+          "title": "$title",
+          "description": "$description",
+          "status": "$status",
+          "priority": "$priority",
+          "assignee_id": "$assignee_id",
+          "due_date": "$due_date",
+          "progress": "$progress"
         }
       }
     },
@@ -257,8 +287,8 @@
         "method": "GET",
         "path": "/users",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}"
+          "page": "$page",
+          "per_page": "$per_page"
         }
       }
     },
@@ -273,7 +303,9 @@
             "description": "The user ID"
           }
         },
-        "required": ["user_id"]
+        "required": [
+          "user_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -299,14 +331,16 @@
             "description": "Number of results per page"
           }
         },
-        "required": ["project_id"]
+        "required": [
+          "project_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/projects/{project_id}/documents",
         "queryParams": {
-          "page": "${page}",
-          "per_page": "${per_page}"
+          "page": "$page",
+          "per_page": "$per_page"
         }
       }
     },
@@ -325,7 +359,10 @@
             "description": "The document ID"
           }
         },
-        "required": ["project_id", "document_id"]
+        "required": [
+          "project_id",
+          "document_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",

--- a/packages/backend/src/adapters/de/scopevisio.json
+++ b/packages/backend/src/adapters/de/scopevisio.json
@@ -6,7 +6,9 @@
   "category": "erp",
   "icon": "scopevisio",
   "docsUrl": "https://appload.scopevisio.com/static/swagger/index.html",
-  "requiredEnvVars": ["SCOPEVISIO_BEARER_TOKEN"],
+  "requiredEnvVars": [
+    "SCOPEVISIO_BEARER_TOKEN"
+  ],
   "connector": {
     "name": "ScopeVisio ERP",
     "type": "REST",
@@ -40,10 +42,10 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/contacts/list",
-        "body": {
-          "pageSize": "${pageSize}",
-          "page": "${page}",
-          "search": "${search}"
+        "bodyMapping": {
+          "pageSize": "$pageSize",
+          "page": "$page",
+          "search": "$search"
         }
       }
     },
@@ -58,11 +60,13 @@
             "description": "The ScopeVisio contact ID"
           }
         },
-        "required": ["contactId"]
+        "required": [
+          "contactId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/contacts/${contactId}"
+        "path": "/contacts/{contactId}"
       }
     },
     {
@@ -84,9 +88,9 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/outgoinginvoice/list",
-        "body": {
-          "pageSize": "${pageSize}",
-          "page": "${page}"
+        "bodyMapping": {
+          "pageSize": "$pageSize",
+          "page": "$page"
         }
       }
     },
@@ -109,9 +113,9 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/incominginvoice/list",
-        "body": {
-          "pageSize": "${pageSize}",
-          "page": "${page}"
+        "bodyMapping": {
+          "pageSize": "$pageSize",
+          "page": "$page"
         }
       }
     },
@@ -134,9 +138,9 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/project/list",
-        "body": {
-          "pageSize": "${pageSize}",
-          "page": "${page}"
+        "bodyMapping": {
+          "pageSize": "$pageSize",
+          "page": "$page"
         }
       }
     },
@@ -159,9 +163,9 @@
       "endpointMapping": {
         "method": "POST",
         "path": "/task/list",
-        "body": {
-          "pageSize": "${pageSize}",
-          "page": "${page}"
+        "bodyMapping": {
+          "pageSize": "$pageSize",
+          "page": "$page"
         }
       }
     }

--- a/packages/backend/src/adapters/de/sendcloud.json
+++ b/packages/backend/src/adapters/de/sendcloud.json
@@ -1,0 +1,155 @@
+{
+  "slug": "sendcloud",
+  "name": "Sendcloud Multi-Carrier Shipping",
+  "description": "Create parcels, print labels, track shipments, and manage returns across major EU carriers (DHL, DPD, UPS, PostNL, Hermes, Colissimo, Bpost and 40+ more) through Sendcloud — the largest multi-carrier shipping platform in EU.",
+  "instructions": "This connector uses the Sendcloud v2 REST API.\n\n**Credentials** (two values, Basic auth): generate an API key pair at https://panel.sendcloud.sc/#/settings/integrations → 'Sendcloud API'. Paste the public key into `SENDCLOUD_PUBLIC_KEY` and the secret into `SENDCLOUD_SECRET_KEY` when importing.\n\n**Carriers covered**: DHL, DPD, UPS, PostNL, Hermes, Colissimo, Bpost, GLS, Chronopost, Mondial Relay, and 40+ more across EU. Use `sendcloud_list_shipping_methods` to get IDs and pricing per carrier.\n\n**Typical flow**:\n1. `sendcloud_list_shipping_methods` → pick a `shipping_method_id`\n2. `sendcloud_create_parcel` with `request_label: true` → returns parcel id + label URL + tracking number\n3. `sendcloud_get_parcel` → check current status (polled from carrier)\n\n**Test mode**: set `request_label: false` on create_parcel to get a price quote without generating a label (no billing).\n\n**Returns portal**: Sendcloud also provides a branded returns portal — configuration is done in the dashboard, not via this adapter.",
+  "region": "eu",
+  "category": "logistics",
+  "icon": "sendcloud",
+  "docsUrl": "https://api.sendcloud.dev/docs/sendcloud-public-api/",
+  "requiredEnvVars": ["SENDCLOUD_PUBLIC_KEY", "SENDCLOUD_SECRET_KEY"],
+  "connector": {
+    "name": "Sendcloud",
+    "type": "REST",
+    "baseUrl": "https://panel.sendcloud.sc/api/v2",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{SENDCLOUD_PUBLIC_KEY}}",
+      "password": "{{SENDCLOUD_SECRET_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "sendcloud_list_shipping_methods",
+      "description": "List all shipping methods available for the account, with carrier, service (e.g. 'DHL Express Domestic'), min/max weight, and price per destination country.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "to_country": {
+            "type": "string",
+            "description": "Destination country ISO 2-letter code (e.g. 'DE', 'FR') — filters methods available for that country."
+          },
+          "from_country": {
+            "type": "string",
+            "description": "Origin country ISO 2-letter code."
+          },
+          "is_return": {
+            "type": "boolean",
+            "description": "If true, return only return-shipment methods."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/shipping_methods",
+        "queryParams": {
+          "to_country": "$to_country",
+          "from_country": "$from_country",
+          "is_return": "$is_return"
+        }
+      }
+    },
+    {
+      "name": "sendcloud_create_parcel",
+      "description": "Create a parcel and optionally generate a shipping label. Returns parcel id, tracking_number, tracking_url, label URL, and price.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "parcel": {
+            "type": "object",
+            "description": "Parcel object: { name, company_name?, address, address_2?, house_number, city, postal_code, country (ISO-2), email?, telephone?, weight (kg), length?, width?, height? (cm), order_number?, shipment: { id: shipping_method_id } }."
+          },
+          "request_label": {
+            "type": "boolean",
+            "description": "If true, generate a real label and bill. If false (default), creates an 'announced' parcel without a label."
+          }
+        },
+        "required": ["parcel"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/parcels",
+        "bodyMapping": {
+          "parcel": "$parcel",
+          "request_label": "$request_label"
+        }
+      }
+    },
+    {
+      "name": "sendcloud_get_parcel",
+      "description": "Retrieve a parcel by its Sendcloud id. Returns full parcel data including tracking number, current status, label URL, and tracking events.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The Sendcloud parcel id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/parcels/{id}"
+      }
+    },
+    {
+      "name": "sendcloud_list_parcels",
+      "description": "List recent parcels, filterable by order number, tracking number, or creation date.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "order_number": {
+            "type": "string",
+            "description": "Filter by your shop order number."
+          },
+          "tracking_number": {
+            "type": "string",
+            "description": "Filter by the carrier's tracking number."
+          },
+          "created_at__gte": {
+            "type": "string",
+            "description": "Created at or after this ISO 8601 datetime (e.g. '2026-04-01T00:00:00Z')."
+          },
+          "created_at__lte": {
+            "type": "string",
+            "description": "Created at or before this ISO 8601 datetime."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number, 1-based."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/parcels",
+        "queryParams": {
+          "order_number": "$order_number",
+          "tracking_number": "$tracking_number",
+          "created_at__gte": "$created_at__gte",
+          "created_at__lte": "$created_at__lte",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "sendcloud_get_parcel_status",
+      "description": "Get the current status and event timeline of a parcel — includes scan-point locations, timestamps, and status codes from the underlying carrier.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The Sendcloud parcel id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/parcels/{id}/status"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/shipcloud.json
+++ b/packages/backend/src/adapters/de/shipcloud.json
@@ -1,0 +1,198 @@
+{
+  "slug": "shipcloud",
+  "name": "Shipcloud Multi-Carrier Shipping",
+  "description": "Create shipments, generate labels, and track parcels across all major German and European carriers (DHL, DPD, GLS, Hermes, UPS, FedEx, TNT) through Shipcloud — the leading multi-carrier shipping aggregator for DE.",
+  "instructions": "This connector uses the Shipcloud v1 REST API.\n\n**Credentials**: a single API key (Basic auth username, empty password). Generate one at https://app.shipcloud.io/account under API-Keys. Paste it into `SHIPCLOUD_API_KEY` when importing.\n\n**Carriers covered**: dhl, dhl_express, dpd, gls, hermes, ups, fedex, tnt, go, deutsche_post, iloxx, parcelone, skynet, liefery. Use `shipcloud_list_carriers` to retrieve IDs and available service products.\n\n**Label creation**: `shipcloud_create_shipment` returns a downloadable label URL plus a carrier_tracking_no and a shipcloud tracking_url. Labels are PDF by default.\n\n**Tracking**: parcels shipped through Shipcloud are auto-tracked — use `shipcloud_get_shipment` with the shipcloud id to read status. For external parcels (not shipped via Shipcloud), create a tracking object with `shipcloud_create_tracker`.\n\n**Webhooks**: Shipcloud also supports webhooks for real-time status updates (configure in the dashboard, not via this adapter).\n\n**Test mode**: set `create_shipping_label: false` when calling create_shipment to get a quote without actually creating a real label (and without being billed).",
+  "region": "de",
+  "category": "logistics",
+  "icon": "shipcloud",
+  "docsUrl": "https://developers.shipcloud.io/",
+  "requiredEnvVars": ["SHIPCLOUD_API_KEY"],
+  "connector": {
+    "name": "Shipcloud",
+    "type": "REST",
+    "baseUrl": "https://api.shipcloud.io/v1",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{SHIPCLOUD_API_KEY}}",
+      "password": ""
+    }
+  },
+  "tools": [
+    {
+      "name": "shipcloud_list_carriers",
+      "description": "List all carriers supported by the Shipcloud account with their names, IDs, service products (e.g. dhl:standard, dpd:classic), and feature flags (label_printer, tracking, etc.).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/carriers"
+      }
+    },
+    {
+      "name": "shipcloud_create_shipment",
+      "description": "Create a shipment and generate a shipping label. Returns the shipcloud shipment id, carrier tracking number, label PDF URL, tracking URL, and price. Set create_shipping_label=false for a quote without billing.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "carrier": {
+            "type": "string",
+            "description": "Carrier id (e.g. 'dhl', 'dpd', 'gls', 'hermes', 'ups')."
+          },
+          "service": {
+            "type": "string",
+            "description": "Service product (e.g. 'standard', 'returns', 'one_day')."
+          },
+          "to": {
+            "type": "object",
+            "description": "Recipient address: { company?, first_name, last_name, street, street_no, zip_code, city, country (ISO 2-letter) }."
+          },
+          "from": {
+            "type": "object",
+            "description": "Sender address — same shape as 'to'. Optional if a default is configured in the Shipcloud account."
+          },
+          "package": {
+            "type": "object",
+            "description": "Package dimensions: { weight (kg), length?, width?, height? (all in cm), type? ('parcel'|'letter'|'bulk') }."
+          },
+          "reference_number": {
+            "type": "string",
+            "description": "Optional customer reference to identify the shipment."
+          },
+          "create_shipping_label": {
+            "type": "boolean",
+            "description": "If true (default), generate a real label and bill. If false, returns a quote only."
+          },
+          "additional_services": {
+            "type": "array",
+            "description": "Optional extras: saturday_delivery, cash_on_delivery, advance_notice, delivery_date etc."
+          }
+        },
+        "required": ["carrier", "to", "package"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/shipments",
+        "bodyMapping": {
+          "carrier": "$carrier",
+          "service": "$service",
+          "to": "$to",
+          "from": "$from",
+          "package": "$package",
+          "reference_number": "$reference_number",
+          "create_shipping_label": "$create_shipping_label",
+          "additional_services": "$additional_services"
+        }
+      }
+    },
+    {
+      "name": "shipcloud_get_shipment",
+      "description": "Retrieve a shipment created via Shipcloud by its id. Returns all fields including tracking events, label URL, and carrier tracking number.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The shipcloud shipment id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/shipments/{id}"
+      }
+    },
+    {
+      "name": "shipcloud_list_shipments",
+      "description": "List recent shipments created via this account, filterable by carrier, date range, or customer reference.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "carrier": {
+            "type": "string",
+            "description": "Filter by carrier id."
+          },
+          "reference_number": {
+            "type": "string",
+            "description": "Filter by customer reference."
+          },
+          "service": {
+            "type": "string",
+            "description": "Filter by service product."
+          },
+          "carrier_tracking_no": {
+            "type": "string",
+            "description": "Filter by the carrier's tracking number."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number, 1-based."
+          },
+          "per_page": {
+            "type": "number",
+            "description": "Results per page (default 20, max 100)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/shipments",
+        "queryParams": {
+          "carrier": "$carrier",
+          "reference_number": "$reference_number",
+          "service": "$service",
+          "carrier_tracking_no": "$carrier_tracking_no",
+          "page": "$page",
+          "per_page": "$per_page"
+        }
+      }
+    },
+    {
+      "name": "shipcloud_create_tracker",
+      "description": "Create a tracking object for an external parcel (not shipped via this Shipcloud account). Provide the carrier and carrier_tracking_no; Shipcloud will poll the carrier for status updates.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "carrier": {
+            "type": "string",
+            "description": "Carrier id (e.g. 'dhl', 'dpd')."
+          },
+          "carrier_tracking_no": {
+            "type": "string",
+            "description": "The tracking number issued by the carrier."
+          }
+        },
+        "required": ["carrier", "carrier_tracking_no"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/tracking_objects",
+        "bodyMapping": {
+          "carrier": "$carrier",
+          "carrier_tracking_no": "$carrier_tracking_no"
+        }
+      }
+    },
+    {
+      "name": "shipcloud_get_tracker",
+      "description": "Retrieve the current state and event history of a tracking object.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The Shipcloud tracking object id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/tracking_objects/{id}"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/shopware-6.json
+++ b/packages/backend/src/adapters/de/shopware-6.json
@@ -1,0 +1,190 @@
+{
+  "slug": "shopware-6",
+  "name": "Shopware 6 Store API",
+  "description": "Query a Shopware 6 storefront programmatically — product catalog, categories, cross-sells, landing pages, and search. Covers the public-facing Store API, which is how the Shopware storefront itself talks to the backend.",
+  "instructions": "This connector uses the Shopware 6 Store API (not the Admin API).\n\n**Instance URL**: every Shopware install has its own URL. Paste it into `SHOPWARE_URL` when importing — e.g. `https://shop.koch-freiburg.de`. Do NOT add `/store-api`; the adapter handles that.\n\n**Access key**: the Store API authenticates with a single header `sw-access-key`. Find it in the Shopware admin under Settings → System → Integrations → 'Access key for sales channels', or per-sales-channel under Sales Channels → 'API access → Access key'. Set it as `SHOPWARE_ACCESS_KEY` at import time.\n\n**Context token (optional)**: for cart/wishlist operations you also need a `sw-context-token` (obtained from POST /context) — not handled by this adapter. For public catalog browsing no context is required.\n\n**Store API vs Admin API**: Store API is optimised for customer-facing reads and is always active. For administrative writes (create products, manage stock, order fulfilment) use the Admin API, which requires OAuth2 client_credentials and is not covered by this adapter.\n\n**Search**: the search endpoint supports Shopware's criteria grammar (associations, filter, sort, pagination) — see https://developer.shopware.com/docs/concepts/search-queries.html",
+  "region": "de",
+  "category": "ecommerce",
+  "icon": "shopware",
+  "docsUrl": "https://developer.shopware.com/docs/guides/integrations-api/store-api-guide",
+  "requiredEnvVars": [
+    "SHOPWARE_URL",
+    "SHOPWARE_ACCESS_KEY"
+  ],
+  "connector": {
+    "name": "Shopware 6",
+    "type": "REST",
+    "baseUrl": "{{SHOPWARE_URL}}/store-api",
+    "authType": "API_KEY",
+    "authConfig": {
+      "headerName": "sw-access-key",
+      "apiKey": "{{SHOPWARE_ACCESS_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "shopware_search_products",
+      "description": "Search products in the sales channel. Returns product id, name, product number, price, stock, manufacturer, and cover image. Supports Shopware criteria.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "search": {
+            "type": "string",
+            "description": "Free-text search term."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default: 24, max: 500)."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number, 1-based."
+          },
+          "filter": {
+            "type": "array",
+            "description": "Array of filter objects per Shopware criteria (e.g. [{\"type\":\"equals\",\"field\":\"active\",\"value\":true}])."
+          },
+          "sort": {
+            "type": "array",
+            "description": "Sort order (e.g. [{\"field\":\"name\",\"order\":\"ASC\"}])."
+          },
+          "associations": {
+            "type": "object",
+            "description": "Associations to load (e.g. {\"manufacturer\":{},\"cover\":{}})."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/product",
+        "bodyMapping": {
+          "search": "$search",
+          "limit": "$limit",
+          "page": "$page",
+          "filter": "$filter",
+          "sort": "$sort",
+          "associations": "$associations"
+        }
+      }
+    },
+    {
+      "name": "shopware_get_product",
+      "description": "Retrieve a single product by id or product number, including description, pricing tiers, cross-sells, properties, media, and associations.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "The Shopware product UUID."
+          },
+          "associations": {
+            "type": "object",
+            "description": "Associations to load (e.g. {\"media\":{},\"properties\":{},\"crossSellings\":{}})."
+          }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/product/{productId}",
+        "bodyMapping": {
+          "associations": "$associations"
+        }
+      }
+    },
+    {
+      "name": "shopware_search_categories",
+      "description": "List or search categories in the storefront category tree.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Max results."
+          },
+          "filter": {
+            "type": "array",
+            "description": "Shopware filter array."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/category",
+        "bodyMapping": {
+          "limit": "$limit",
+          "filter": "$filter"
+        }
+      }
+    },
+    {
+      "name": "shopware_get_category",
+      "description": "Retrieve a category and optionally its products by category id. Used for category listing pages.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "categoryId": {
+            "type": "string",
+            "description": "Category UUID or slug."
+          },
+          "associations": {
+            "type": "object",
+            "description": "Associations to load."
+          }
+        },
+        "required": ["categoryId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/category/{categoryId}",
+        "bodyMapping": {
+          "associations": "$associations"
+        }
+      }
+    },
+    {
+      "name": "shopware_search_suggest",
+      "description": "Shopware search suggest — returns product suggestions for as-you-type autocomplete. Lightweight, optimised for low latency.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "search": {
+            "type": "string",
+            "description": "Query term."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max suggestions (default: 10)."
+          }
+        },
+        "required": ["search"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/search-suggest",
+        "bodyMapping": {
+          "search": "$search",
+          "limit": "$limit"
+        }
+      }
+    },
+    {
+      "name": "shopware_get_cross_sells",
+      "description": "Retrieve the cross-sell product streams configured for a product (e.g. 'Related products', 'Customers also bought').",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "The product UUID."
+          }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/product/{productId}/cross-selling"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/teamviewer.json
+++ b/packages/backend/src/adapters/de/teamviewer.json
@@ -6,7 +6,9 @@
   "category": "remote",
   "icon": "teamviewer",
   "docsUrl": "https://www.teamviewer.com/en/for-developers/",
-  "requiredEnvVars": ["TEAMVIEWER_API_TOKEN"],
+  "requiredEnvVars": [
+    "TEAMVIEWER_API_TOKEN"
+  ],
   "connector": {
     "name": "TeamViewer",
     "type": "REST",
@@ -33,7 +35,7 @@
         "method": "GET",
         "path": "/devices",
         "queryParams": {
-          "online_state": "${online_state}"
+          "online_state": "$online_state"
         }
       }
     },
@@ -48,11 +50,13 @@
             "description": "The TeamViewer device ID"
           }
         },
-        "required": ["deviceId"]
+        "required": [
+          "deviceId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/devices/${deviceId}"
+        "path": "/devices/{deviceId}"
       }
     },
     {

--- a/packages/backend/src/adapters/de/vies-vat.json
+++ b/packages/backend/src/adapters/de/vies-vat.json
@@ -1,0 +1,45 @@
+{
+  "slug": "vies-vat",
+  "name": "VIES VAT Validation",
+  "description": "Validate EU VAT numbers via the European Commission VIES (VAT Information Exchange System) REST API. Confirms that a VAT number is registered for intra-Community trade and returns the trader name and address when the member state exposes them.",
+  "instructions": "Use for B2B invoice compliance: before issuing an intra-EU invoice without VAT, confirm the buyer's VAT number is valid via this adapter.\n\n**Country codes**: ISO 3166-1 alpha-2, plus EL for Greece and XI for Northern Ireland. Common codes: DE, AT, FR, IT, ES, NL, BE, PL, DK, SE, FI, IE, PT, CZ, HU, RO.\n\n**Format**: VAT number must NOT include the country code prefix (e.g. for DE123456789 pass countryCode='DE' and vatNumber='123456789').\n\n**Response**: `valid: true/false`, plus `name` and `address` when provided by the member state. Some countries (DE, ES) do not return name/address for privacy reasons — in that case only `valid` is authoritative.\n\n**Rate limit**: VIES is free but rate-limited per source IP. Batch validations with care; if you see `MS_UNAVAILABLE` or `SERVICE_UNAVAILABLE`, retry after a short delay.",
+  "region": "eu",
+  "category": "government",
+  "icon": "vies",
+  "docsUrl": "https://ec.europa.eu/taxation_customs/vies/",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "VIES VAT Validation",
+    "type": "REST",
+    "baseUrl": "https://ec.europa.eu/taxation_customs/vies/rest-api",
+    "authType": "NONE"
+  },
+  "tools": [
+    {
+      "name": "vies_check_vat",
+      "description": "Check whether an EU VAT number is valid and, when available, return the registered trader name and address.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "countryCode": {
+            "type": "string",
+            "description": "ISO country code of the member state (e.g. 'DE', 'FR', 'IT'). Use 'EL' for Greece and 'XI' for Northern Ireland."
+          },
+          "vatNumber": {
+            "type": "string",
+            "description": "VAT number without the country prefix (e.g. '123456789' for DE123456789)."
+          }
+        },
+        "required": ["countryCode", "vatNumber"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/check-vat-number",
+        "bodyMapping": {
+          "countryCode": "$countryCode",
+          "vatNumber": "$vatNumber"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/weclapp.json
+++ b/packages/backend/src/adapters/de/weclapp.json
@@ -6,7 +6,10 @@
   "category": "erp",
   "icon": "weclapp",
   "docsUrl": "https://www.weclapp.com/api2/",
-  "requiredEnvVars": ["WECLAPP_TENANT", "WECLAPP_API_TOKEN"],
+  "requiredEnvVars": [
+    "WECLAPP_TENANT",
+    "WECLAPP_API_TOKEN"
+  ],
   "connector": {
     "name": "weclapp ERP",
     "type": "REST",
@@ -38,8 +41,8 @@
         "method": "GET",
         "path": "/customer",
         "queryParams": {
-          "page": "${page}",
-          "pageSize": "${pageSize}"
+          "page": "$page",
+          "pageSize": "$pageSize"
         }
       }
     },
@@ -54,11 +57,13 @@
             "description": "The weclapp customer ID"
           }
         },
-        "required": ["customerId"]
+        "required": [
+          "customerId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/customer/id/${customerId}"
+        "path": "/customer/id/{customerId}"
       }
     },
     {
@@ -81,8 +86,8 @@
         "method": "GET",
         "path": "/salesOrder",
         "queryParams": {
-          "page": "${page}",
-          "pageSize": "${pageSize}"
+          "page": "$page",
+          "pageSize": "$pageSize"
         }
       }
     },
@@ -106,8 +111,8 @@
         "method": "GET",
         "path": "/salesInvoice",
         "queryParams": {
-          "page": "${page}",
-          "pageSize": "${pageSize}"
+          "page": "$page",
+          "pageSize": "$pageSize"
         }
       }
     },
@@ -131,8 +136,8 @@
         "method": "GET",
         "path": "/article",
         "queryParams": {
-          "page": "${page}",
-          "pageSize": "${pageSize}"
+          "page": "$page",
+          "pageSize": "$pageSize"
         }
       }
     },
@@ -147,11 +152,13 @@
             "description": "The weclapp article ID"
           }
         },
-        "required": ["articleId"]
+        "required": [
+          "articleId"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/article/id/${articleId}"
+        "path": "/article/id/{articleId}"
       }
     }
   ]

--- a/packages/backend/src/adapters/de/xentral.json
+++ b/packages/backend/src/adapters/de/xentral.json
@@ -1,0 +1,204 @@
+{
+  "slug": "xentral",
+  "name": "Xentral ERP",
+  "description": "Access Xentral Cloud ERP — the SaaS ERP built specifically for German SMBs in e-commerce, wholesale, and manufacturing. Manage articles, customers, sales orders, invoices, and warehouse stock through the Xentral REST API.",
+  "instructions": "This connector uses the Xentral v1 REST API.\n\n**Instance URL**: Xentral is self-hosted per tenant. Paste your instance URL (without trailing slash) into `XENTRAL_URL` when importing — e.g. `https://koch.xentral.biz`. Do NOT append `/api`; the adapter handles that.\n\n**Credentials**: the classic API uses Basic authentication. Generate an API user in your Xentral instance under Einstellungen → Benutzer → API. The username is the API user's login, the password is its password. Set them as `XENTRAL_USER` and `XENTRAL_PASSWORD` at import time.\n\n**Entities covered**: articles (products), customers, sales orders (`/Auftrag`), invoices (`/Rechnung`), vendors, stock levels (`/Lager`), addresses.\n\n**Pagination**: list endpoints accept `page` and `items_per_page`. Default is 50 items per page.\n\n**Filtering**: use `filter` query parameter with Xentral filter DSL — e.g. `?filter=customer_number:eq:10001`.\n\n**Webhooks**: Xentral also supports webhooks for real-time events (configured in-instance, outside this adapter).",
+  "region": "de",
+  "category": "erp",
+  "icon": "xentral",
+  "docsUrl": "https://developer.xentral.com/docs",
+  "requiredEnvVars": [
+    "XENTRAL_URL",
+    "XENTRAL_USER",
+    "XENTRAL_PASSWORD"
+  ],
+  "connector": {
+    "name": "Xentral",
+    "type": "REST",
+    "baseUrl": "{{XENTRAL_URL}}/api/v1",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{XENTRAL_USER}}",
+      "password": "{{XENTRAL_PASSWORD}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "xentral_list_articles",
+      "description": "List articles (products) from Xentral. Returns SKU (Nummer), name, sales price, stock level, tax class, and status. Supports filtering by SKU, EAN, or name prefix.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Xentral filter DSL, e.g. 'nummer:eq:A-1234' or 'bezeichnung:contains:Schraube'."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number, 1-based."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Results per page (default 50, max 500)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/articles",
+        "queryParams": {
+          "filter": "$filter",
+          "page": "$page",
+          "items_per_page": "$items_per_page"
+        }
+      }
+    },
+    {
+      "name": "xentral_get_article",
+      "description": "Retrieve a single article by its Xentral internal id. Returns all fields including description, cost price, barcodes, bulk pricing tiers, and assigned categories.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The Xentral article id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/articles/{id}"
+      }
+    },
+    {
+      "name": "xentral_list_customers",
+      "description": "List customers (Kunden). Returns customer number, name, billing address, email, payment terms, and status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Xentral filter DSL, e.g. 'kundennummer:eq:10001' or 'email:contains:koch'."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Results per page."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customers",
+        "queryParams": {
+          "filter": "$filter",
+          "page": "$page",
+          "items_per_page": "$items_per_page"
+        }
+      }
+    },
+    {
+      "name": "xentral_get_customer",
+      "description": "Retrieve a single customer by id, including contact persons, delivery addresses, bank details, and credit limit.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The Xentral customer id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customers/{id}"
+      }
+    },
+    {
+      "name": "xentral_list_sales_orders",
+      "description": "List sales orders (Auftraege). Returns order number, customer, date, total, status, and line count. Filterable by date range, customer, or status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Xentral filter DSL. Examples: 'status:eq:abgeschlossen', 'datum:gte:2026-01-01'."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Results per page."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sales_orders",
+        "queryParams": {
+          "filter": "$filter",
+          "page": "$page",
+          "items_per_page": "$items_per_page"
+        }
+      }
+    },
+    {
+      "name": "xentral_list_invoices",
+      "description": "List outgoing invoices (Rechnungen). Returns invoice number, customer, date, amount, open amount, paid amount, and status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Xentral filter DSL, e.g. 'status:eq:offen' (open), 'datum:gte:2026-01-01'."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Results per page."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/invoices",
+        "queryParams": {
+          "filter": "$filter",
+          "page": "$page",
+          "items_per_page": "$items_per_page"
+        }
+      }
+    },
+    {
+      "name": "xentral_get_stock",
+      "description": "Retrieve current stock levels across all warehouses for a given article. Returns quantity on hand, reserved, available, and inbound per warehouse.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "string",
+            "description": "The Xentral article id."
+          }
+        },
+        "required": ["article_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/stock",
+        "queryParams": {
+          "article_id": "$article_id"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -139,4 +139,137 @@ describe('RestEngine', () => {
       }),
     );
   });
+
+  it('should recursively resolve $param references in nested bodyMapping', async () => {
+    mockedAxios.mockResolvedValue({ data: {} });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com', authType: 'NONE' },
+      {
+        method: 'POST',
+        path: '/api.php',
+        bodyMapping: {
+          SERVICE: 'customer.get',
+          LIMIT: '$LIMIT',
+          FILTER: { TERM: '$TERM', COUNTRY: 'DE' },
+        },
+      },
+      { LIMIT: 25, TERM: 'acme' },
+    );
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          SERVICE: 'customer.get',
+          LIMIT: 25,
+          FILTER: { TERM: 'acme', COUNTRY: 'DE' },
+        },
+      }),
+    );
+  });
+
+  it('should drop missing params from nested bodyMapping instead of sending "$TERM" literals', async () => {
+    mockedAxios.mockResolvedValue({ data: {} });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com', authType: 'NONE' },
+      {
+        method: 'POST',
+        path: '/api.php',
+        bodyMapping: {
+          SERVICE: 'customer.get',
+          FILTER: { TERM: '$TERM' },
+        },
+      },
+      {},
+    );
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { SERVICE: 'customer.get', FILTER: {} },
+      }),
+    );
+  });
+
+  it('should inject QUERY_AUTH credentials as query parameters and merge with endpoint queryParams', async () => {
+    mockedAxios.mockResolvedValue({ data: {} });
+
+    await engine.execute(
+      {
+        baseUrl: 'https://api.example.com',
+        authType: 'QUERY_AUTH',
+        authConfig: { username: 'alice', password: 'secret' },
+      },
+      {
+        method: 'GET',
+        path: '/find',
+        queryParams: { term: '$searchterm' },
+      },
+      { searchterm: 'hello' },
+    );
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { username: 'alice', password: 'secret', term: 'hello' },
+      }),
+    );
+  });
+
+  it('should interpolate embedded ${param} references inside query param strings', async () => {
+    mockedAxios.mockResolvedValue({ data: [] });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com', authType: 'NONE' },
+      {
+        method: 'GET',
+        path: '/ServiceRequests',
+        queryParams: { $filter: "ExternalId eq '${externalId}'" },
+      },
+      { externalId: 'T-5432' },
+    );
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { $filter: "ExternalId eq 'T-5432'" },
+      }),
+    );
+  });
+
+  it('should drop query param when an embedded placeholder is missing', async () => {
+    mockedAxios.mockResolvedValue({ data: [] });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com', authType: 'NONE' },
+      {
+        method: 'GET',
+        path: '/ServiceRequests',
+        queryParams: { $filter: "ExternalId eq '${externalId}'" },
+      },
+      {},
+    );
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({ params: {} }),
+    );
+  });
+
+  it('should drop optional query params when the value is undefined', async () => {
+    mockedAxios.mockResolvedValue({ data: [] });
+
+    await engine.execute(
+      { baseUrl: 'https://api.example.com', authType: 'NONE' },
+      {
+        method: 'GET',
+        path: '/search',
+        queryParams: { q: '$query', limit: '$limit' },
+      },
+      { query: 'hello' },
+    );
+
+    expect(mockedAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { q: 'hello' },
+      }),
+    );
+  });
 });

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -71,12 +71,12 @@ export class RestEngine {
     // Inject authentication
     await this.injectAuth(axiosConfig, config);
 
-    // Query parameters
+    // Query parameters (merged on top of any params already set by auth injection)
     if (endpointMapping.queryParams) {
-      axiosConfig.params = this.mapParams(
-        endpointMapping.queryParams,
-        params,
-      );
+      axiosConfig.params = {
+        ...(axiosConfig.params as Record<string, unknown> | undefined),
+        ...this.mapParams(endpointMapping.queryParams, params),
+      };
     }
 
     // Request body
@@ -206,6 +206,13 @@ export class RestEngine {
         };
         break;
       }
+      case 'QUERY_AUTH':
+        // Inject authConfig values as query parameters (for APIs that auth via query string)
+        axiosConfig.params = {
+          ...(axiosConfig.params as Record<string, unknown> | undefined),
+          ...config.authConfig,
+        };
+        break;
     }
   }
 
@@ -215,17 +222,62 @@ export class RestEngine {
   ): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(mapping)) {
-      if (typeof value === 'string' && value.startsWith('$')) {
-        // Reference to a param: "$paramName" → params.paramName
-        const paramName = value.substring(1);
-        const paramValue = params[paramName];
-        if (paramValue !== undefined && paramValue !== '') {
-          result[key] = paramValue;
-        }
-      } else {
-        result[key] = value;
+      const resolved = this.resolveValue(value, params);
+      if (resolved !== undefined) {
+        result[key] = resolved;
       }
     }
     return result;
+  }
+
+  /**
+   * Recursively resolve a value against params.
+   * - String "$paramName" (whole string) → params.paramName — returns undefined if missing/empty so the key is dropped
+   * - String "...${paramName}..." (embedded) → interpolated; if any placeholder is missing the whole value is dropped
+   * - Arrays/objects → recurse
+   * - Anything else → returned as-is
+   */
+  private resolveValue(
+    value: unknown,
+    params: Record<string, unknown>,
+  ): unknown {
+    if (typeof value === 'string') {
+      if (value.startsWith('$') && !value.includes('${')) {
+        const paramName = value.substring(1);
+        const paramValue = params[paramName];
+        return paramValue !== undefined && paramValue !== ''
+          ? paramValue
+          : undefined;
+      }
+      if (value.includes('${')) {
+        let missing = false;
+        const interpolated = value.replace(/\$\{([\w$]+)\}/g, (_, name) => {
+          const pv = params[name];
+          if (pv === undefined || pv === '') {
+            missing = true;
+            return '';
+          }
+          return String(pv);
+        });
+        return missing ? undefined : interpolated;
+      }
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value
+        .map((v) => this.resolveValue(v, params))
+        .filter((v) => v !== undefined);
+    }
+    if (value && typeof value === 'object') {
+      const nested: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        const resolved = this.resolveValue(v, params);
+        if (resolved !== undefined) {
+          nested[k] = resolved;
+        }
+      }
+      return nested;
+    }
+    return value;
   }
 }


### PR DESCRIPTION
## Summary

Two-part change: fix systemic bugs that were preventing every JSON adapter in the catalog from working, and add 13 new adapters covering public data, Baustoff/Wholesale, logistics, ERP, e-commerce, mapping, and HR.

## REST engine fixes

- `mapParams` now recurses into nested objects/arrays — FastBill-style nested bodies (`FILTER.TERM`) now interpolate correctly instead of shipping literal `$TERM`.
- New `QUERY_AUTH` auth type: injects `authConfig` values as query parameters, for APIs that pass credentials in the URL (e.g. Destatis, Oxomi, HERE).
- `${param}` interpolation now works embedded inside strings (e.g. `"ExternalId eq '${externalId}'"` for OData filters), not just as whole-string references.
- Endpoint `queryParams` merge with auth-injected params instead of overwriting them.

## Existing adapters (16) — bug fixes

All 16 DE adapters were affected by at least one of:
- `${x}` in `path` (engine expects `{x}`) — widespread
- `${x}` in `queryParams`/`bodyMapping`/`headers` (engine expects `$x`) — widespread
- `"authType": "BASIC"` instead of `"BASIC_AUTH"` — FastBill, MFR
- `"body"` field instead of `"bodyMapping"`/`"bodyTemplate"` — FastBill, Scopevisio, MFR link endpoints
- Destatis credentials wired through `queryParams` with `{{VAR}}` templating that never ran — moved to `QUERY_AUTH` authConfig

All fixes applied via a migration script (`.context/fix-adapters.mjs`, gitignored).

## Tests

- `packages/backend/src/adapters/catalog.spec.ts` (new): parametrized smoke test over every adapter — validates method, path placeholder format, authType whitelist, no legacy `body` field, and that every `$ref`/`${ref}` in `queryParams`/`bodyMapping`/`headers` points to a declared tool parameter (catches typos in future adapters).
- `packages/backend/src/connectors/engines/rest.engine.spec.ts`: added coverage for recursive bodyMapping, missing-param drop, QUERY_AUTH injection + queryParams merge, embedded `${x}` interpolation, empty-result drop.

**275/275 tests passing** across `rest.engine.spec` + `catalog.spec`. TypeScript compiles clean. The 5 test failures in `roles`/`users`/`tool-registry` are pre-existing on `main` (verified by stashing changes) and unrelated to this PR.

## New adapters (13)

All declare `requiredEnvVars` so the frontend import UI auto-generates the credential form with masked inputs for keys/tokens/passwords.

**Public data**
- `vies-vat` — EU VAT number validation (no auth)
- `handelsregister` — German commercial register via handelsregister.ai (API key)
- `deutsche-bahn` — DB timetable & journey planner via v6.db.transport.rest (no auth)
- `openplz` — German postal codes, localities, streets, districts (no auth)

**Baustoff/Wholesale**
- `oxomi` — Catalog, product, document search across Baustoff suppliers (portal id + user + access token)

**Logistics**
- `dpd-germany` — Public DPD parcel tracking (no auth)
- `gls-tracking` — Public GLS Track & Trace (no auth)
- `shipcloud` — Multi-carrier shipping aggregator for DE/EU (API key)
- `sendcloud` — Multi-carrier shipping for EU (public + secret key)

**Other categories**
- `xentral` — Xentral ERP (instance URL + user + password)
- `shopware-6` — Shopware 6 Store API (instance URL + access key)
- `here-geocoding` — HERE geocoding & search (API key)
- `personio` — Personio HR (bearer token — Personio's rotating-token limitation documented in `instructions`)

Catalog is now **29 adapters** total.

## Test plan
- [ ] CI runs clean on the PR
- [ ] Manually import one no-auth adapter (e.g. vies-vat) in the UI — verify connector created and tools registered
- [ ] Manually import one credentialed adapter (e.g. handelsregister) — verify the UI prompts for HANDELSREGISTER_API_KEY and the secret is stored encrypted
- [ ] Run an end-to-end tool call against VIES VAT (public, no secrets) to confirm the engine fixes hold end-to-end