### PR TITLE
Add account self-delete and organization delete UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/prisma/migrations/20260429000000_nullable_user_active_org/migration.sql
+++ b/packages/backend/prisma/migrations/20260429000000_nullable_user_active_org/migration.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- Migration: Make users.organization_id nullable + SetNull on delete
+-- =============================================================================
+-- Required so that deleting an Organization does not cascade-delete users
+-- whose CACHED active org happens to be that org. Org-deletion now explicitly
+-- migrates each affected user to their next-oldest membership in a transaction;
+-- if no other membership exists, organization_id is left NULL.
+-- =============================================================================
+
+-- 1. Drop existing CASCADE foreign key
+ALTER TABLE "users" DROP CONSTRAINT "users_organization_id_fkey";
+
+-- 2. Make column nullable
+ALTER TABLE "users" ALTER COLUMN "organization_id" DROP NOT NULL;
+
+-- 3. Re-create FK with ON DELETE SET NULL
+ALTER TABLE "users" ADD CONSTRAINT "users_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -79,8 +79,8 @@ model User {
   name           String?
   role           UserRole @default(EDITOR)
   emailVerified  Boolean  @default(false) @map("email_verified")
-  organizationId String   @map("organization_id")
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId String?  @map("organization_id")
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -6,7 +6,7 @@ export interface JwtPayload {
   sub: string;
   email: string;
   role: string;
-  organizationId: string;
+  organizationId: string | null;
   mcpRoleId?: string | null;
 }
 

--- a/packages/backend/src/auth/jwt.strategy.ts
+++ b/packages/backend/src/auth/jwt.strategy.ts
@@ -25,6 +25,24 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException('User no longer exists');
     }
+
+    // Self-heal a NULL active org by snapping to the oldest remaining membership.
+    // This happens when an organization the user was active in was deleted while
+    // they were a member of others — schema's onDelete:SetNull leaves them dangling.
+    if (user.organizationId === null) {
+      const fallback = await this.prisma.organizationMember.findFirst({
+        where: { userId: user.id },
+        orderBy: { joinedAt: 'asc' },
+      });
+      if (fallback) {
+        await this.prisma.user.update({
+          where: { id: user.id },
+          data: { organizationId: fallback.organizationId, role: fallback.role },
+        });
+        return { sub: user.id, email: user.email, role: fallback.role, organizationId: fallback.organizationId };
+      }
+    }
+
     return { sub: user.id, email: user.email, role: user.role, organizationId: user.organizationId };
   }
 }

--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -48,7 +48,7 @@ export class LicenseController {
     if (authHeader?.startsWith('Bearer ')) {
       try {
         const payload = this.authService.verifyToken(authHeader.substring(7));
-        organizationId = payload.organizationId;
+        organizationId = payload.organizationId ?? undefined;
       } catch {}
     }
 

--- a/packages/backend/src/organizations/organizations.controller.ts
+++ b/packages/backend/src/organizations/organizations.controller.ts
@@ -3,11 +3,13 @@ import {
   Get,
   Post,
   Put,
+  Delete,
   Body,
   Req,
   UseGuards,
   ForbiddenException,
   NotFoundException,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -32,6 +34,11 @@ class CreateOrgDto {
   name: string;
 }
 
+class DeleteOrgDto {
+  @IsString()
+  confirmName: string;
+}
+
 @ApiTags('Organizations')
 @ApiBearerAuth()
 @UseGuards(AuthGuard('jwt'))
@@ -52,6 +59,9 @@ export class OrganizationsController {
   @Get('current')
   @ApiOperation({ summary: 'Get current active organization' })
   async getCurrent(@Req() req: any) {
+    if (!req.user.organizationId) {
+      throw new NotFoundException('No active organization');
+    }
     const org = await this.organizationsService.findById(req.user.organizationId);
     if (!org) throw new NotFoundException('Organization not found');
     return org;
@@ -64,6 +74,46 @@ export class OrganizationsController {
       throw new ForbiddenException('Only admins can update the organization');
     }
     return this.organizationsService.update(req.user.organizationId, dto);
+  }
+
+  @Delete('current')
+  @ApiOperation({ summary: 'Delete current organization (ADMIN only)' })
+  async deleteCurrent(@Req() req: any, @Body() dto: DeleteOrgDto) {
+    if (req.user.role !== 'ADMIN') {
+      throw new ForbiddenException('Only admins can delete the organization');
+    }
+    if (!req.user.organizationId) {
+      throw new BadRequestException('No active organization');
+    }
+
+    const { activeUser, activeOrganization, autoCreated } =
+      await this.organizationsService.deleteOrganization(
+        req.user.sub,
+        req.user.organizationId,
+        dto.confirmName,
+      );
+
+    const accessToken = this.authService.generateToken({
+      sub: activeUser.id,
+      email: activeUser.email,
+      role: activeUser.role,
+      organizationId: activeUser.organizationId,
+      mcpRoleId: activeUser.mcpRoleId,
+    });
+
+    return {
+      message: 'Organization deleted',
+      accessToken,
+      user: {
+        id: activeUser.id,
+        email: activeUser.email,
+        name: activeUser.name,
+        role: activeUser.role,
+        organizationId: activeUser.organizationId,
+      },
+      organization: activeOrganization,
+      autoCreated,
+    };
   }
 
   @Post('switch')

--- a/packages/backend/src/organizations/organizations.service.ts
+++ b/packages/backend/src/organizations/organizations.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Injectable, ForbiddenException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../common/prisma.service';
 import { UserRole } from '../generated/prisma/client';
 
@@ -96,6 +96,119 @@ export class OrganizationsService {
     }
 
     return membership;
+  }
+
+  async deleteOrganization(
+    userId: string,
+    organizationId: string,
+    confirmName: string,
+  ): Promise<{
+    activeUser: { id: string; email: string; name: string | null; role: UserRole; organizationId: string; mcpRoleId: string | null };
+    activeOrganization: { id: string; name: string };
+    autoCreated: boolean;
+  }> {
+    const org = await this.prisma.organization.findUnique({ where: { id: organizationId } });
+    if (!org) throw new NotFoundException('Organization not found');
+
+    if (org.name.trim() !== confirmName.trim()) {
+      throw new BadRequestException('Confirmation name does not match');
+    }
+
+    const membership = await this.getMembership(userId, organizationId);
+    if (!membership || membership.role !== 'ADMIN') {
+      throw new ForbiddenException('Only org admins can delete the organization');
+    }
+
+    // Snapshot users (other than the deleter) whose CACHED active org is this one
+    const orphans = await this.prisma.user.findMany({
+      where: { organizationId, id: { not: userId } },
+      select: { id: true },
+    });
+
+    type Next = { organizationId: string; role: UserRole } | null;
+    const nextByOrphan = new Map<string, Next>();
+    for (const o of orphans) {
+      const m = await this.prisma.organizationMember.findFirst({
+        where: { userId: o.id, organizationId: { not: organizationId } },
+        orderBy: { joinedAt: 'asc' },
+      });
+      nextByOrphan.set(o.id, m ? { organizationId: m.organizationId, role: m.role } : null);
+    }
+
+    const selfNext = await this.prisma.organizationMember.findFirst({
+      where: { userId, organizationId: { not: organizationId } },
+      orderBy: { joinedAt: 'asc' },
+    });
+
+    let autoCreated = false;
+    let finalUserId = userId;
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Migrate orphans pre-cascade
+      for (const [uid, next] of nextByOrphan.entries()) {
+        if (next) {
+          await tx.user.update({
+            where: { id: uid },
+            data: { organizationId: next.organizationId, role: next.role },
+          });
+        } else {
+          await tx.user.update({
+            where: { id: uid },
+            data: { organizationId: null },
+          });
+        }
+      }
+
+      // Migrate the deleter
+      if (selfNext) {
+        await tx.user.update({
+          where: { id: userId },
+          data: { organizationId: selfNext.organizationId, role: selfNext.role },
+        });
+      } else {
+        const user = await tx.user.findUnique({ where: { id: userId }, select: { name: true, email: true } });
+        const wsName = user?.name
+          ? `${user.name}'s Workspace`
+          : `${(user?.email ?? 'My').split('@')[0]}'s Workspace`;
+        const newOrg = await tx.organization.create({ data: { name: wsName } });
+        await tx.organizationMember.create({
+          data: { userId, organizationId: newOrg.id, role: 'ADMIN' as UserRole },
+        });
+        await tx.user.update({
+          where: { id: userId },
+          data: { organizationId: newOrg.id, role: 'ADMIN' as UserRole },
+        });
+        autoCreated = true;
+      }
+
+      // Delete the organization — cascades clean up everything else
+      await tx.organization.delete({ where: { id: organizationId } });
+
+      const updatedUser = await tx.user.findUnique({ where: { id: finalUserId } });
+      if (!updatedUser || !updatedUser.organizationId) {
+        throw new Error('User active org missing after migration');
+      }
+      const activeOrg = await tx.organization.findUnique({
+        where: { id: updatedUser.organizationId },
+        select: { id: true, name: true },
+      });
+      if (!activeOrg) {
+        throw new Error('Active organization missing after migration');
+      }
+      return {
+        activeUser: {
+          id: updatedUser.id,
+          email: updatedUser.email,
+          name: updatedUser.name,
+          role: updatedUser.role,
+          organizationId: updatedUser.organizationId,
+          mcpRoleId: updatedUser.mcpRoleId,
+        },
+        activeOrganization: activeOrg,
+      };
+    });
+
+    return { ...result, autoCreated };
   }
 
   async getMembers(organizationId: string) {

--- a/packages/backend/src/users/users.controller.ts
+++ b/packages/backend/src/users/users.controller.ts
@@ -7,10 +7,11 @@ import {
   Param,
   Req,
   UseGuards,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
-import { IsString, IsOptional, IsEmail, IsEnum, MinLength, Matches } from 'class-validator';
+import { IsString, IsOptional, IsEmail, IsEnum, MinLength, Matches, Equals } from 'class-validator';
 import { UserRole } from '../generated/prisma/client';
 import { UsersService } from './users.service';
 import { AuthService } from '../auth/auth.service';
@@ -46,6 +47,16 @@ class UpdateUserRoleDto {
   role: UserRole;
 }
 
+class DeleteSelfDto {
+  @IsString()
+  @MinLength(1)
+  password: string;
+
+  @IsString()
+  @Equals('DELETE')
+  confirm: string;
+}
+
 @ApiTags('Users')
 @ApiBearerAuth()
 @UseGuards(AuthGuard('jwt'))
@@ -75,6 +86,19 @@ export class UsersController {
     const user = await this.usersService.update(req.user.sub, data);
     const { passwordHash, ...profile } = user;
     return profile;
+  }
+
+  @Delete('me')
+  @ApiOperation({ summary: 'Delete current user account (self-delete)' })
+  async deleteSelf(@Req() req: any, @Body() dto: DeleteSelfDto) {
+    const user = await this.usersService.findById(req.user.sub);
+    if (!user) throw new UnauthorizedException('User not found');
+
+    const isValid = await this.authService.comparePassword(dto.password, user.passwordHash);
+    if (!isValid) throw new UnauthorizedException('Invalid password');
+
+    await this.usersService.deleteSelf(req.user.sub);
+    return { message: 'Account deleted' };
   }
 
   @Put('me/password')

--- a/packages/backend/src/users/users.service.ts
+++ b/packages/backend/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../common/prisma.service';
 import { User, UserRole } from '../generated/prisma/client';
 
@@ -56,6 +56,56 @@ export class UsersService {
 
   async delete(userId: string): Promise<void> {
     await this.prisma.user.delete({ where: { id: userId } });
+  }
+
+  async deleteSelf(userId: string): Promise<void> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    const adminMemberships = await this.prisma.organizationMember.findMany({
+      where: { userId, role: 'ADMIN' },
+      include: {
+        organization: {
+          select: {
+            id: true,
+            name: true,
+            _count: { select: { members: true } },
+          },
+        },
+      },
+    });
+
+    const blocking: { id: string; name: string }[] = [];
+    const cascadableOrgIds: string[] = [];
+
+    for (const m of adminMemberships) {
+      const memberCount = m.organization._count.members;
+      if (memberCount <= 1) {
+        cascadableOrgIds.push(m.organizationId);
+        continue;
+      }
+      const otherAdmins = await this.prisma.organizationMember.count({
+        where: { organizationId: m.organizationId, role: 'ADMIN', userId: { not: userId } },
+      });
+      if (otherAdmins === 0) {
+        blocking.push({ id: m.organization.id, name: m.organization.name });
+      }
+    }
+
+    if (blocking.length > 0) {
+      throw new ConflictException({
+        error: 'You are the only admin of these organizations. Transfer admin or delete them before deleting your account.',
+        blockingOrganizations: blocking,
+      });
+    }
+
+    await this.prisma.$transaction([
+      ...cascadableOrgIds.map((orgId) =>
+        this.prisma.organization.delete({ where: { id: orgId } }),
+      ),
+      this.prisma.oAuthAuthorizationCode.deleteMany({ where: { userId } }),
+      this.prisma.user.delete({ where: { id: userId } }),
+    ]);
   }
 
   async findAllInvitations(organizationId?: string) {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/frontend/src/app/settings/organization/page.tsx
+++ b/packages/frontend/src/app/settings/organization/page.tsx
@@ -3,9 +3,10 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
 import { organizations } from '@/lib/api';
+import * as Dialog from '@radix-ui/react-dialog';
 
 export default function OrganizationSettingsPage() {
-  const { token, user, orgName, orgs, setOrgName, switchOrg } = useAuth();
+  const { token, user, orgName, orgs, setOrgName, switchOrg, replaceSession } = useAuth();
   const [name, setName] = useState('');
   const [orgId, setOrgId] = useState('');
   const [createdAt, setCreatedAt] = useState('');
@@ -17,6 +18,12 @@ export default function OrganizationSettingsPage() {
   const [newOrgName, setNewOrgName] = useState('');
   const [creating, setCreating] = useState(false);
   const [createMessage, setCreateMessage] = useState('');
+
+  // Delete organization
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteConfirmName, setDeleteConfirmName] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const isAdmin = user?.role === 'ADMIN';
 
@@ -43,6 +50,28 @@ export default function OrganizationSettingsPage() {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleDeleteOrg = async () => {
+    if (!token) return;
+    if (deleteConfirmName.trim() !== name.trim()) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const result = await organizations.deleteCurrent({ confirmName: deleteConfirmName.trim() }, token);
+      replaceSession(result.accessToken, result.user, result.organization?.name ?? null);
+      window.location.href = '/';
+    } catch (err: any) {
+      setDeleteError(err?.message || 'Failed to delete organization');
+      setDeleting(false);
+    }
+  };
+
+  const resetDeleteOrgDialog = () => {
+    setDeleteOpen(false);
+    setDeleteConfirmName('');
+    setDeleteError(null);
+    setDeleting(false);
   };
 
   const handleCreateOrg = async () => {
@@ -191,6 +220,67 @@ export default function OrganizationSettingsPage() {
           </p>
         )}
       </div>
+
+      {/* Danger Zone — ADMIN only */}
+      {isAdmin && (
+        <div className="border border-[var(--destructive-border)] rounded-lg p-5 bg-[var(--destructive-bg)]/30 space-y-3">
+          <h3 className="text-sm font-semibold text-[var(--destructive-text)]">Danger Zone</h3>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Permanently delete this organization, including all members, connectors, MCP servers,
+            API keys, custom roles, pending invitations, and settings. Other members will be
+            migrated to their next-oldest workspace if they have one. This action cannot be undone.
+          </p>
+          <button
+            onClick={() => setDeleteOpen(true)}
+            className="border border-[var(--destructive)] text-[var(--destructive)] px-4 py-2 rounded-md text-sm font-medium hover:bg-[var(--destructive-bg)]"
+          >
+            Delete this organization
+          </button>
+        </div>
+      )}
+
+      <Dialog.Root open={deleteOpen} onOpenChange={(open) => { if (!open) resetDeleteOrgDialog(); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 shadow-lg">
+            <Dialog.Title className="text-lg font-medium mb-2">Delete organization</Dialog.Title>
+            <Dialog.Description className="text-sm text-[var(--muted-foreground)] mb-4">
+              This deletes <strong>{name}</strong> and everything it contains. To confirm, type the
+              organization name below.
+            </Dialog.Description>
+
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium mb-1">Type <code>{name}</code> to confirm</label>
+                <input
+                  type="text"
+                  value={deleteConfirmName}
+                  onChange={(e) => setDeleteConfirmName(e.target.value)}
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                  autoComplete="off"
+                  placeholder={name}
+                />
+              </div>
+              {deleteError && (
+                <p className="text-sm text-[var(--destructive)]">{deleteError}</p>
+              )}
+            </div>
+
+            <div className="flex gap-2 justify-end mt-6">
+              <Dialog.Close className="border border-[var(--border)] px-4 py-2 rounded-md text-sm hover:bg-[var(--accent)]">
+                Cancel
+              </Dialog.Close>
+              <button
+                onClick={handleDeleteOrg}
+                disabled={deleting || deleteConfirmName.trim() !== name.trim()}
+                className="bg-[var(--destructive)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
+              >
+                {deleting ? 'Deleting…' : 'Delete organization'}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       {/* My organizations list — available to ALL users */}
       {orgs && orgs.length > 1 && (

--- a/packages/frontend/src/app/settings/page.tsx
+++ b/packages/frontend/src/app/settings/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
-import { users, server } from '@/lib/api';
+import { users, server, ApiError } from '@/lib/api';
+import * as Dialog from '@radix-ui/react-dialog';
 
 const AUTH_MODE_LABELS: Record<string, string> = {
   none: 'None (not recommended)',
@@ -12,7 +13,7 @@ const AUTH_MODE_LABELS: Record<string, string> = {
 };
 
 export default function SettingsPage() {
-  const { token, user, updateUser } = useAuth();
+  const { token, user, updateUser, logout } = useAuth();
   const [profileName, setProfileName] = useState(user?.name || '');
   const [profileMsg, setProfileMsg] = useState('');
   // Change password
@@ -23,6 +24,14 @@ export default function SettingsPage() {
   const [mcpAuthMode, setMcpAuthMode] = useState('');
   const [oauthEndpoints, setOauthEndpoints] = useState<Record<string, string> | null>(null);
   const [serverUrl, setServerUrl] = useState('');
+
+  // Delete account
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deleteConfirm, setDeleteConfirm] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [blockingOrgs, setBlockingOrgs] = useState<{ id: string; name: string }[] | null>(null);
 
   // Load server info
   useEffect(() => {
@@ -43,6 +52,41 @@ export default function SettingsPage() {
     } catch (err: any) {
       setProfileMsg(`Error: ${err.message}`);
     }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!token) return;
+    if (deleteConfirm !== 'DELETE') return;
+    setDeleting(true);
+    setDeleteError(null);
+    setBlockingOrgs(null);
+    try {
+      await users.deleteSelf({ password: deletePassword, confirm: 'DELETE' }, token);
+      logout();
+    } catch (err: any) {
+      if (err instanceof ApiError) {
+        if (err.status === 401) {
+          setDeleteError('Incorrect password.');
+        } else if (err.status === 409 && Array.isArray(err.body?.blockingOrganizations)) {
+          setBlockingOrgs(err.body.blockingOrganizations);
+          setDeleteError(err.body?.error || 'You are the only admin of these organizations.');
+        } else {
+          setDeleteError(err.message || 'Failed to delete account.');
+        }
+      } else {
+        setDeleteError(err?.message || 'Failed to delete account.');
+      }
+      setDeleting(false);
+    }
+  };
+
+  const resetDeleteDialog = () => {
+    setDeleteOpen(false);
+    setDeletePassword('');
+    setDeleteConfirm('');
+    setDeleteError(null);
+    setBlockingOrgs(null);
+    setDeleting(false);
   };
 
   const handleChangePassword = async () => {
@@ -214,6 +258,86 @@ export default function SettingsPage() {
           to generate and manage keys for each server.
         </p>
       </div>
+
+      {/* Danger Zone */}
+      <div className="border border-[var(--destructive-border)] rounded-lg p-6 bg-[var(--destructive-bg)]/30">
+        <h3 className="text-lg font-medium text-[var(--destructive-text)] mb-2">Danger Zone</h3>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Permanently delete your account. This will remove your profile, password reset tokens,
+          email verification tokens, MCP API keys, connectors, and MCP server configurations.
+          Audit logs are retained without your identifying information.
+        </p>
+        <button
+          onClick={() => setDeleteOpen(true)}
+          className="border border-[var(--destructive)] text-[var(--destructive)] px-4 py-2 rounded-md text-sm font-medium hover:bg-[var(--destructive-bg)]"
+        >
+          Delete my account
+        </button>
+      </div>
+
+      <Dialog.Root open={deleteOpen} onOpenChange={(open) => { if (!open) resetDeleteDialog(); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 shadow-lg">
+            <Dialog.Title className="text-lg font-medium mb-2">Delete account</Dialog.Title>
+            <Dialog.Description className="text-sm text-[var(--muted-foreground)] mb-4">
+              This action cannot be undone. Enter your password and type <strong>DELETE</strong> to confirm.
+            </Dialog.Description>
+
+            {blockingOrgs && blockingOrgs.length > 0 && (
+              <div className="mb-4 p-3 rounded-md border border-[var(--destructive-border)] bg-[var(--destructive-bg)] text-sm text-[var(--destructive-text)]">
+                <p className="font-medium mb-1">Cannot delete — you are the only admin of:</p>
+                <ul className="list-disc pl-5 space-y-0.5">
+                  {blockingOrgs.map((o) => (
+                    <li key={o.id}>{o.name}</li>
+                  ))}
+                </ul>
+                <p className="mt-2">
+                  Promote another admin or delete those organizations first.
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium mb-1">Password</label>
+                <input
+                  type="password"
+                  value={deletePassword}
+                  onChange={(e) => setDeletePassword(e.target.value)}
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Type <code>DELETE</code> to confirm</label>
+                <input
+                  type="text"
+                  value={deleteConfirm}
+                  onChange={(e) => setDeleteConfirm(e.target.value)}
+                  className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
+                  autoComplete="off"
+                />
+              </div>
+              {deleteError && !blockingOrgs && (
+                <p className="text-sm text-[var(--destructive)]">{deleteError}</p>
+              )}
+            </div>
+
+            <div className="flex gap-2 justify-end mt-6">
+              <Dialog.Close className="border border-[var(--border)] px-4 py-2 rounded-md text-sm hover:bg-[var(--accent)]">
+                Cancel
+              </Dialog.Close>
+              <button
+                onClick={handleDeleteAccount}
+                disabled={deleting || deleteConfirm !== 'DELETE' || !deletePassword}
+                className="bg-[var(--destructive)] text-white px-4 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50"
+              >
+                {deleting ? 'Deleting…' : 'Delete my account'}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -6,10 +6,21 @@ interface RequestOptions {
   method?: string;
   body?: unknown;
   token?: string;
+  skipAutoLogout?: boolean;
 }
 
 // Emitted when any authenticated request gets a 401 — auth-context listens for this.
 export const AUTH_EXPIRED_EVENT = 'amcp:auth-expired';
+
+export class ApiError extends Error {
+  status: number;
+  body: any;
+  constructor(message: string, status: number, body: any) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
 
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, token } = options;
@@ -29,12 +40,15 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   });
 
   if (!response.ok) {
-    // Auto-logout on 401 for authenticated requests
-    if (response.status === 401 && token) {
+    const errorBody = await response.json().catch(() => ({ message: response.statusText }));
+    // Auto-logout on 401 for authenticated requests, except when explicitly opting out
+    // (self-delete intentionally returns 401 for wrong password — let the caller handle it)
+    const skipAutoLogout = options.skipAutoLogout;
+    if (response.status === 401 && token && !skipAutoLogout) {
       window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
     }
-    const error = await response.json().catch(() => ({ message: response.statusText }));
-    throw new Error(error.message || `API error: ${response.status}`);
+    const message = errorBody.message || errorBody.error || `API error: ${response.status}`;
+    throw new ApiError(message, response.status, errorBody);
   }
 
   return response.json();
@@ -103,6 +117,13 @@ export const users = {
     request(`/api/users/${id}/role`, { method: 'PUT', body: { role }, token }),
   delete: (id: string, token: string) =>
     request(`/api/users/${id}`, { method: 'DELETE', token }),
+  deleteSelf: (data: { password: string; confirm: 'DELETE' }, token: string) =>
+    request<{ message: string }>('/api/users/me', {
+      method: 'DELETE',
+      body: data,
+      token,
+      skipAutoLogout: true,
+    }),
   invitations: (token: string) =>
     request<any[]>('/api/users/invitations', { token }),
   deleteInvitation: (id: string, token: string) =>
@@ -123,6 +144,14 @@ export const organizations = {
     }),
   create: (name: string, token: string) =>
     request<{ id: string; name: string }>('/api/organizations', { method: 'POST', body: { name }, token }),
+  deleteCurrent: (data: { confirmName: string }, token: string) =>
+    request<{
+      message: string;
+      accessToken: string;
+      user: { id: string; email: string; name: string | null; role: string; organizationId: string };
+      organization: { id: string; name: string };
+      autoCreated: boolean;
+    }>('/api/organizations/current', { method: 'DELETE', body: data, token }),
 };
 
 // Connectors

--- a/packages/frontend/src/lib/auth-context.tsx
+++ b/packages/frontend/src/lib/auth-context.tsx
@@ -7,9 +7,9 @@ import { users, server, organizations, AUTH_EXPIRED_EVENT } from './api';
 interface User {
   id: string;
   email: string;
-  name: string;
+  name: string | null;
   role: string;
-  organizationId: string;
+  organizationId: string | null;
 }
 
 interface OrgInfo {
@@ -26,6 +26,7 @@ interface AuthContextType {
   orgs: OrgInfo[] | null;
   setOrgName: (name: string) => void;
   switchOrg: (organizationId: string) => Promise<void>;
+  replaceSession: (token: string, user: User, orgName?: string | null) => void;
   login: (token: string, user: User) => void;
   logout: () => void;
   updateUser: (updates: Partial<User>) => void;
@@ -40,6 +41,7 @@ const AuthContext = createContext<AuthContextType>({
   orgs: null,
   setOrgName: () => {},
   switchOrg: async () => {},
+  replaceSession: () => {},
   login: () => {},
   logout: () => {},
   updateUser: () => {},
@@ -157,6 +159,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const replaceSession = (newToken: string, newUser: User, newOrgName?: string | null) => {
+    setToken(newToken);
+    setUser(newUser);
+    localStorage.setItem('amcp_token', newToken);
+    localStorage.setItem('amcp_user', JSON.stringify(newUser));
+    document.cookie = `amcp_token=${newToken}; path=/; max-age=${7 * 24 * 60 * 60}; SameSite=Lax`;
+    if (newOrgName !== undefined) setOrgName(newOrgName);
+  };
+
   const updateUser = (updates: Partial<User>) => {
     setUser((prev) => {
       if (!prev) return prev;
@@ -167,7 +178,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, user, orgName, orgs, setOrgName, switchOrg, login, logout, updateUser, isLoading, deploymentMode }}>
+    <AuthContext.Provider value={{ token, user, orgName, orgs, setOrgName, switchOrg, replaceSession, login, logout, updateUser, isLoading, deploymentMode }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary

Adds two destructive flows that were previously missing from the app:

- **Self-delete account** — `DELETE /api/users/me` + Danger Zone on `/settings`. Requires password + typing `DELETE`. Blocks self-delete when the user is the sole admin of an org with other members; cascade-deletes orgs where they are the sole member.
- **Delete organization** (admin only) — `DELETE /api/organizations/current` + Danger Zone on `/settings/organization`. Requires typing the org name. Migrates orphan members to their next-oldest membership; auto-creates a Personal Workspace for the deleter when they have no other org and reissues a fresh JWT.

### Schema migration

`User.organizationId` becomes nullable with `onDelete: SetNull` (was `NOT NULL` with `Cascade`). Without this change, deleting an org would cascade-delete every user whose cached active org was that org — even if they were members of other orgs.

`JwtStrategy` auto-resyncs a NULL active org to the user's oldest remaining membership on the next request, keeping existing JWTs functional after their active org is deleted by another admin.

## Test plan
- [x] Backend type-check + build clean
- [x] Frontend type-check + build clean
- [x] Migration applied cleanly to a fresh Postgres
- [x] curl: self-delete validation (401 wrong password, 400 wrong confirm word, 409 sole-admin block + payload)
- [x] curl: self-delete cascade-org happy path; multi-org cascade
- [x] curl: org-delete (403 non-admin, 400 mismatched name, 200 with switch-to-other-org, 200 with auto-created Personal Workspace, orphans migrated/null)
- [x] Browser UI: open Danger Zone dialogs, wrong password shows inline error, success redirects to `/login` (account) or `/` (org), DB state verified