### PR TITLE
Sprint 1 security hardening: secrets, SSRF, SQLi, IDOR, CORS, deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot keeps dependencies up to date so we don't have to wait for the
+# next CVE to remember which packages we depend on. Grouping related updates
+# means one PR per ecosystem per week instead of dozens.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
+      next:
+        patterns:
+          - "next"
+          - "@next/*"
+          - "react"
+          - "react-dom"
+      eslint-prettier:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "prettier"
+      types:
+        patterns:
+          - "@types/*"
+      jest:
+        patterns:
+          - "jest"
+          - "ts-jest"
+          - "@types/jest"
+    ignore:
+      # Major upgrades require manual review (often include breaking API changes).
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    labels:
+      - dependencies
+      - docker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -373,9 +373,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-      "integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -385,8 +385,8 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
@@ -450,38 +450,37 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.29.0.tgz",
-      "integrity": "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.9.0.tgz",
+      "integrity": "sha512-CzE+4PefDSJWj26zU7G1bKchlGRRHMBFreG4tAlGuzyI8hAPiYGobaJvZBgZBf6L63iphX7VH+ityL8VgEQz9Q==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.15.0"
+        "@azure/msal-common": "16.5.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.15.0.tgz",
-      "integrity": "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.8",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.8.tgz",
-      "integrity": "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.15.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -982,65 +981,14 @@
       "license": "MIT"
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "devOptional": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1078,34 +1026,34 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
-      "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+      "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
-      "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+      "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
       },
       "peerDependencies": {
-        "@electric-sql/pglite": "0.3.15"
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@electric-sql/pglite-tools": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
-      "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+      "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@electric-sql/pglite": "0.3.15"
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1355,9 +1303,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2684,9 +2632,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2945,6 +2893,13 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -3008,20 +2963,6 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "node_modules/@mrleebo/prisma-ast": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
-      "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "^10.5.0",
-        "lilconfig": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3216,13 +3157,13 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.14",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.14.tgz",
-      "integrity": "sha512-IN/tlqd7Nl9gl6f0jsWEuOrQDaCI9vHzxv0fisHysfBQzfQIkqlv5A7w4Qge02BUQyczXT9HHPgHtWHCxhjRng==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.19.tgz",
+      "integrity": "sha512-qeiTt2tv+e5QyDKqG8HlVZb2wx64FEaSGFJouqTSRs+kG44iTfl3xlz1XqVped+rihx4hmjWgL5gkhtdK3E6+Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "file-type": "21.3.0",
+        "file-type": "21.3.4",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -3248,14 +3189,14 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.3.tgz",
-      "integrity": "sha512-FQ3M3Ohqfl+nHAn5tp7++wUQw0f2nAk+SFKe8EpNRnIifPqvfJP6JQxPKtFLMOHbyer4X646prFG4zSRYEssQQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "17.2.3",
+        "dotenv": "17.4.1",
         "dotenv-expand": "12.0.3",
-        "lodash": "4.17.23"
+        "lodash": "4.18.1"
       },
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
@@ -3263,9 +3204,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.14",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.14.tgz",
-      "integrity": "sha512-7OXPPMoDr6z+5NkoQKu4hOhfjz/YYqM3bNilPqv1WVFWrzSmuNXxvhbX69YMmNmRYascPXiwESqf5jJdjKXEww==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.19.tgz",
+      "integrity": "sha512-6nJkWa2efrYi+XlU686J9y5L7OvxpLVjT0T/sxRKE7Jvpffiihelup4WSvLvRhdHDjj/5SuoWEwqReXAaaeHmw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -3273,7 +3214,7 @@
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -3319,14 +3260,14 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
       },
       "peerDependenciesMeta": {
@@ -3350,16 +3291,16 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.14",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.14.tgz",
-      "integrity": "sha512-Fs+/j+mBSBSXErOQJ/YdUn/HqJGSJ4pGfiJyYOyz04l42uNVnqEakvu1kXLbxMabR6vd6/h9d6Bi4tso9p7o4Q==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
+      "integrity": "sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
-        "multer": "2.0.2",
-        "path-to-regexp": "8.3.0",
+        "multer": "2.1.1",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -3372,33 +3313,39 @@
       }
     },
     "node_modules/@nestjs/schematics": {
-      "version": "11.0.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
-      "integrity": "sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
+      "integrity": "sha512-lVxGZ46tcdItFMoXr6vyKWlnOsm1SZm/GUqAEDvy2RL4Q4O+3bkziAhrO7Y8JLssFUUvNFEGqAizI52WAxhjDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.17",
-        "@angular-devkit/schematics": "19.2.17",
-        "comment-json": "4.4.1",
+        "@angular-devkit/core": "19.2.24",
+        "@angular-devkit/schematics": "19.2.24",
+        "comment-json": "5.0.0",
         "jsonc-parser": "3.3.1",
         "pluralize": "8.0.0"
       },
       "peerDependencies": {
+        "prettier": "^3.0.0",
         "typescript": ">=4.8.2"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.17.tgz",
-      "integrity": "sha512-Ah008x2RJkd0F+NLKqIpA34/vUGwjlprRCkvddjDopAWRzYn6xCkz1Tqwuhn0nR1Dy47wTLKYD999TYl5ONOAQ==",
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.24.tgz",
+      "integrity": "sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.17.1",
+        "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.2",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -3417,13 +3364,13 @@
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.17.tgz",
-      "integrity": "sha512-ADfbaBsrG8mBF6Mfs+crKA/2ykB8AJI50Cv9tKmZfwcUcyAdmTr+vVvhsBCfvUAEokigSsgqgpYxfkJVxhJYeg==",
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.24.tgz",
+      "integrity": "sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.17",
+        "@angular-devkit/core": "19.2.24",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -3435,21 +3382,17 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+    "node_modules/@nestjs/schematics/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@nestjs/schematics/node_modules/rxjs": {
@@ -3463,17 +3406,17 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
-      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.2.tgz",
+      "integrity": "sha512-aBihEogDMj/bLEcaqhkvyX/ZVWUw/bmnhKzR0zwUoyGJikvZyaq7rOPYl/H7Lxkkr3c90SJxyuv1AX2UT1WKlw==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "@nestjs/mapped-types": "2.1.0",
+        "@nestjs/mapped-types": "2.1.1",
         "js-yaml": "4.1.1",
-        "lodash": "4.17.23",
-        "path-to-regexp": "8.3.0",
-        "swagger-ui-dist": "5.31.0"
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.4"
       },
       "peerDependencies": {
         "@fastify/static": "^8.0.0 || ^9.0.0",
@@ -3605,9 +3548,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3621,9 +3564,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
       "cpu": [
         "arm64"
       ],
@@ -3637,9 +3580,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
       "cpu": [
         "x64"
       ],
@@ -3653,9 +3596,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
       "cpu": [
         "arm64"
       ],
@@ -3669,9 +3612,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
       ],
@@ -3685,9 +3628,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
       "cpu": [
         "x64"
       ],
@@ -3701,9 +3644,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
       ],
@@ -3717,9 +3660,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -3733,9 +3676,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
       "cpu": [
         "x64"
       ],
@@ -3759,6 +3702,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3900,15 +3855,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.2.tgz",
-      "integrity": "sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
+      "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "c12": "3.1.0",
+        "c12": "3.3.4",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.20.0",
         "empathic": "2.0.0"
       }
     },
@@ -3919,22 +3874,22 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
-      "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+      "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
       "devOptional": true,
       "license": "ISC",
       "dependencies": {
-        "@electric-sql/pglite": "0.3.15",
-        "@electric-sql/pglite-socket": "0.0.20",
-        "@electric-sql/pglite-tools": "0.2.20",
-        "@hono/node-server": "1.19.9",
-        "@mrleebo/prisma-ast": "0.13.1",
+        "@electric-sql/pglite": "0.4.1",
+        "@electric-sql/pglite-socket": "0.1.1",
+        "@electric-sql/pglite-tools": "0.3.1",
+        "@hono/node-server": "1.19.11",
         "@prisma/get-platform": "7.2.0",
         "@prisma/query-plan-executor": "7.2.0",
+        "@prisma/streams-local": "0.1.2",
         "foreground-child": "3.3.1",
         "get-port-please": "3.2.0",
-        "hono": "4.11.4",
+        "hono": "^4.12.8",
         "http-status-codes": "2.3.0",
         "pathe": "2.0.3",
         "proper-lockfile": "4.1.2",
@@ -3944,14 +3899,17 @@
         "zeptomatch": "2.1.0"
       }
     },
-    "node_modules/@prisma/dev/node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+    "node_modules/@prisma/dev/node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@prisma/driver-adapter-utils": {
@@ -3964,56 +3922,70 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.2.tgz",
-      "integrity": "sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
+      "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.2",
-        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
-        "@prisma/fetch-engine": "7.4.2",
-        "@prisma/get-platform": "7.4.2"
+        "@prisma/debug": "7.8.0",
+        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+        "@prisma/fetch-engine": "7.8.0",
+        "@prisma/get-platform": "7.8.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919.tgz",
-      "integrity": "sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==",
+      "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
+      "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+      "integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
-      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.2"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.2.tgz",
-      "integrity": "sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
+      "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.2",
-        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
-        "@prisma/get-platform": "7.4.2"
+        "@prisma/debug": "7.8.0",
+        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+        "@prisma/get-platform": "7.8.0"
       }
     },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+      "integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
-      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.4.2"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -4040,12 +4012,37 @@
       "devOptional": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@prisma/studio-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
-      "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
+    "node_modules/@prisma/streams-local": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+      "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "better-result": "^2.7.0",
+        "env-paths": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
+      },
+      "engines": {
+        "bun": ">=1.3.6",
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+      "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@radix-ui/react-toggle": "1.1.10",
+        "chart.js": "4.5.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0",
+        "pnpm": "8"
+      },
       "peerDependencies": {
         "@types/react": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
@@ -4773,6 +4770,32 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "1.1.1",
         "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -6046,9 +6069,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6602,9 +6625,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6852,9 +6875,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7174,14 +7197,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-ntlm": {
@@ -7377,6 +7400,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/better-result": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.1.tgz",
+      "integrity": "sha512-tPWnUPD8oLESRXMykkuTvi9tJVwaFSVfdhp1/WRd1q04SqengKdYt27avogObRC/BgH+zDqSo713dUEKkXbG5w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/better-sqlite3": {
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
@@ -7476,9 +7506,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7638,27 +7668,27 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
-      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^16.6.1",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.4.2",
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
-        "rc9": "^2.1.2"
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
@@ -7666,17 +7696,34 @@
         }
       }
     },
-    "node_modules/c12/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "devOptional": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">= 20.19.0"
       },
       "funding": {
-        "url": "https://dotenvx.com"
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/call-bind": {
@@ -7858,6 +7905,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/check-disk-space": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
@@ -7867,33 +7927,11 @@
         "node": ">=16"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
-      }
-    },
-    "node_modules/chevrotain/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7936,16 +7974,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -8186,14 +8214,13 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.4.1.tgz",
-      "integrity": "sha512-r1To31BQD5060QdkC+Iheai7gHwoSZobzunqkf2/kQ6xIAfJyrKNAFUwdKvkK7Qgu7pVTKQEa7ok7Ed3ycAJgg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-5.0.0.tgz",
+      "integrity": "sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
         "esprima": "^4.0.1"
       },
       "engines": {
@@ -8334,13 +8361,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -8661,9 +8681,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -8798,9 +8818,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -8873,9 +8893,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+      "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8949,6 +8969,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -9847,12 +9880,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -9999,21 +10032,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -10022,8 +10043,25 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -10081,9 +10119,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -10170,16 +10208,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10593,19 +10631,11 @@
       }
     },
     "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
+      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
       "devOptional": true,
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
       "bin": {
         "giget": "dist/cli.mjs"
       }
@@ -10665,9 +10695,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10778,9 +10808,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10968,6 +10998,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -10995,9 +11034,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11247,9 +11286,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -12158,9 +12197,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12537,9 +12576,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13245,16 +13284,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13312,9 +13341,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -14486,9 +14515,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14581,18 +14610,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -14695,21 +14712,22 @@
       }
     },
     "node_modules/multer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -14867,14 +14885,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -14886,15 +14904,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -15016,13 +15034,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -15049,9 +15060,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
-      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -15079,31 +15090,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.2.0",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/oauth": {
       "version": "0.9.15",
@@ -15621,6 +15607,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -15675,9 +15676,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -15707,9 +15708,9 @@
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -15920,14 +15921,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -15952,9 +15953,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",
@@ -16083,6 +16084,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16122,18 +16124,18 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.2.tgz",
-      "integrity": "sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
+      "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@prisma/config": "7.4.2",
-        "@prisma/dev": "0.20.0",
-        "@prisma/engines": "7.4.2",
-        "@prisma/studio-core": "0.13.1",
+        "@prisma/config": "7.8.0",
+        "@prisma/dev": "0.24.3",
+        "@prisma/engines": "7.8.0",
+        "@prisma/studio-core": "0.27.3",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
       },
@@ -16227,10 +16229,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -16304,16 +16309,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16363,14 +16358,14 @@
       }
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/react": {
@@ -16517,7 +16512,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -16577,13 +16572,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -17075,16 +17063,6 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
@@ -17822,9 +17800,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -17834,9 +17812,9 @@
       "license": "MIT"
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
@@ -17928,9 +17906,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
-      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -18127,16 +18105,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -18274,16 +18251,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -18302,9 +18269,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19128,15 +19095,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -19841,7 +19799,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -19865,6 +19823,7 @@
         "fast-xml-parser": "^5.3.3",
         "graphql": "^16.10.0",
         "graphql-request": "^7.1.2",
+        "helmet": "^8.1.0",
         "ioredis": "^5.6.0",
         "mongodb": "^7.1.0",
         "mssql": "^12.2.0",
@@ -19925,7 +19884,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,6 +43,7 @@
     "fast-xml-parser": "^5.3.3",
     "graphql": "^16.10.0",
     "graphql-request": "^7.1.2",
+    "helmet": "^8.1.0",
     "ioredis": "^5.6.0",
     "mongodb": "^7.1.0",
     "mssql": "^12.2.0",

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -4,6 +4,7 @@ import { McpServerService } from '../mcp-server/mcp-server.service';
 import { encrypt } from '../common/crypto/encryption.util';
 import { ConfigService } from '@nestjs/config';
 import { listAdapters, getAdapter, AdapterMeta, AdapterDefinition } from './catalog';
+import { getRequiredSecret } from '../common/secrets.util';
 
 @Injectable()
 export class AdaptersService {
@@ -15,9 +16,10 @@ export class AdaptersService {
     private readonly mcpServer: McpServerService,
     private readonly configService: ConfigService,
   ) {
-    this.encryptionKey =
-      this.configService.get<string>('ENCRYPTION_KEY') ||
-      'default-dev-key-change-in-prod!!';
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      this.configService.get<string>('ENCRYPTION_KEY'),
+    );
   }
 
   listAll(): AdapterMeta[] {

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { OAuthUrlRewriteInterceptor } from './auth/oauth-url-rewrite.interceptor
 import { AdaptersModule } from './adapters/adapters.module';
 import { OrganizationsModule } from './organizations/organizations.module';
 import { CloudModule } from './cloud/cloud.module';
+import { getRequiredSecret } from './common/secrets.util';
 
 // Determine deployment and auth mode from env
 const useCloud = process.env.DEPLOYMENT_MODE === 'cloud';
@@ -46,8 +47,7 @@ const conditionalImports: any[] = [];
 
 if (useOAuth) {
   const serverUrl = process.env.SERVER_URL || 'http://localhost:4000';
-  const jwtSecret =
-    process.env.JWT_SECRET || 'dev-secret-change-me-at-least-32chars!!';
+  const jwtSecret = getRequiredSecret('JWT_SECRET', process.env.JWT_SECRET);
 
   conditionalImports.push(
     McpAuthModule.forRoot({
@@ -90,8 +90,14 @@ if (useOAuth) {
     // Cache
     RedisModule,
 
-    // Rate limiting
-    ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+    // Rate limiting — named buckets so callers can pick a stricter policy
+    // for sensitive endpoints (login, password reset) without affecting
+    // general API throughput.
+    ThrottlerModule.forRoot([
+      { name: 'default', ttl: 60_000, limit: 100 },
+      { name: 'auth', ttl: 60_000, limit: 10 },
+      { name: 'auth-strict', ttl: 60_000, limit: 5 },
+    ]),
 
     // MCP Server (dynamic tools registered by McpServerModule)
     McpModule.forRoot({

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -17,6 +17,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { Throttle } from '@nestjs/throttler';
 import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsBoolean, Equals, Matches } from 'class-validator';
 import { UserRole } from '../generated/prisma/client';
 import { ConfigService } from '@nestjs/config';
@@ -177,6 +178,7 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Login with email and password' })
   async login(@Req() req: any, @Body() dto: LoginDto) {
     const user = await this.usersService.findByEmail(dto.email);
@@ -229,6 +231,7 @@ export class AuthController {
   }
 
   @Post('register')
+  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Register a new user account' })
   async register(@Req() req: any, @Body() dto: RegisterDto) {
     const existing = await this.usersService.findByEmail(dto.email);
@@ -365,6 +368,7 @@ export class AuthController {
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
+  @Throttle({ 'auth': { limit: 10, ttl: 60_000 } })
   @ApiOperation({ summary: 'Resend email verification code' })
   async resendVerification(@Req() req: any) {
     const userId = req.user.sub;
@@ -576,6 +580,7 @@ export class AuthController {
 
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Request password reset email' })
   async forgotPassword(@Req() req: any, @Body() dto: ForgotPasswordDto) {
     // Always return success to prevent email enumeration
@@ -617,6 +622,7 @@ export class AuthController {
 
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Reset password using token' })
   async resetPassword(@Body() dto: ResetPasswordDto) {
     const resetRecord = await this.prisma.passwordResetToken.findUnique({

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -16,6 +16,7 @@ import { UsersModule } from '../users/users.module';
 import { SettingsModule } from '../settings/settings.module';
 import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 import { OrganizationsModule } from '../organizations/organizations.module';
+import { getRequiredSecret } from '../common/secrets.util';
 
 @Global()
 @Module({
@@ -28,7 +29,10 @@ import { OrganizationsModule } from '../organizations/organizations.module';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
+        secret: getRequiredSecret(
+          'JWT_SECRET',
+          configService.get<string>('JWT_SECRET'),
+        ),
         signOptions: { expiresIn: '24h' },
       }),
       inject: [ConfigService],

--- a/packages/backend/src/auth/jwt.strategy.ts
+++ b/packages/backend/src/auth/jwt.strategy.ts
@@ -4,6 +4,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtPayload } from './auth.service';
 import { PrismaService } from '../common/prisma.service';
+import { getRequiredSecret } from '../common/secrets.util';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -14,7 +15,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get<string>('JWT_SECRET') || 'default-dev-secret-change-me',
+      secretOrKey: getRequiredSecret(
+        'JWT_SECRET',
+        configService.get<string>('JWT_SECRET'),
+      ),
     });
   }
 

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -9,6 +9,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../common/prisma.service';
@@ -37,6 +38,7 @@ export class LoginController {
   }
 
   @Post('login')
+  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
   async handleLogin(
     @Req() req: Request,
     @Body() body: { email: string; password: string; session: string },

--- a/packages/backend/src/common/secrets.util.ts
+++ b/packages/backend/src/common/secrets.util.ts
@@ -1,0 +1,67 @@
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('Secrets');
+
+const MIN_SECRET_LENGTH = 32;
+
+/**
+ * Returns a required secret from the environment.
+ * Throws on startup if the value is missing or shorter than the minimum length.
+ *
+ * Never falls back to a hardcoded default: a known default key on a
+ * source-available product is equivalent to having no encryption at all.
+ */
+export function getRequiredSecret(
+  name: string,
+  value: string | undefined,
+  minLength: number = MIN_SECRET_LENGTH,
+): string {
+  if (!value || value.length === 0) {
+    throw new Error(
+      `[secrets] ${name} is not set. Generate one with: openssl rand -base64 48`,
+    );
+  }
+  if (value.length < minLength) {
+    throw new Error(
+      `[secrets] ${name} is too short (${value.length} chars, minimum ${minLength}). Regenerate with: openssl rand -base64 48`,
+    );
+  }
+  if (looksLikeDefaultSecret(value)) {
+    throw new Error(
+      `[secrets] ${name} appears to be a placeholder/default value. Generate a real secret with: openssl rand -base64 48`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate all required secrets eagerly at boot. Call from main.ts before
+ * any code that uses them runs.
+ */
+export function validateRequiredSecretsAtStartup(env: NodeJS.ProcessEnv): void {
+  // These are required for any deployment — no graceful degradation.
+  getRequiredSecret('JWT_SECRET', env.JWT_SECRET);
+  getRequiredSecret('ENCRYPTION_KEY', env.ENCRYPTION_KEY);
+  logger.log('Secrets validated (JWT_SECRET, ENCRYPTION_KEY).');
+}
+
+const KNOWN_PLACEHOLDERS = [
+  'default-dev-secret-change-me',
+  'default-dev-key-change-in-prod!!',
+  'dev-secret-change-me-at-least-32chars!!',
+  'change-me-in-production-min-32-chars',
+  'change-me-in-production-exactly-32',
+];
+
+function looksLikeDefaultSecret(value: string): boolean {
+  if (KNOWN_PLACEHOLDERS.includes(value)) return true;
+  const lower = value.toLowerCase();
+  return (
+    lower.includes('change-me') ||
+    lower.includes('changeme') ||
+    lower.includes('default-dev') ||
+    lower.includes('placeholder') ||
+    lower.includes('your-secret') ||
+    lower.includes('your-encryption-key')
+  );
+}

--- a/packages/backend/src/common/ssrf.util.ts
+++ b/packages/backend/src/common/ssrf.util.ts
@@ -1,0 +1,192 @@
+import { promises as dns } from 'dns';
+import { isIP } from 'net';
+
+/**
+ * SSRF guard for outbound HTTP/S calls performed on behalf of users.
+ *
+ * Users can configure connectors with arbitrary baseUrls and tokenUrls,
+ * which means our backend will resolve and call any host they want. Without
+ * a guard this becomes a confused deputy: an attacker uses our backend to
+ * read AWS/GCP/Azure metadata, scan internal services, or reach databases
+ * exposed only on the internal network.
+ *
+ * Behavior: resolve the hostname to all A/AAAA records and reject the
+ * request if ANY resolved IP falls into a blocked range. Public DNS that
+ * happens to point at a private IP (DNS rebinding / pinning trick) is also
+ * caught because we check the resolved IPs, not the hostname.
+ *
+ * Configuration via env:
+ *   - SSRF_GUARD=disabled            disable the check entirely (NOT recommended)
+ *   - SSRF_ALLOW_LOCALHOST=true      allow loopback (only useful in dev / e2e)
+ *   - SSRF_ALLOW_PRIVATE=true        allow RFC1918 ranges (NOT recommended; use
+ *                                    SSRF_ALLOWED_HOSTS for specific hosts)
+ *   - SSRF_ALLOWED_HOSTS=a,b,c       comma-separated hostname allowlist
+ *                                    (exact match or *.suffix)
+ */
+
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfBlockedError';
+  }
+}
+
+interface SsrfPolicy {
+  enabled: boolean;
+  allowLoopback: boolean;
+  allowPrivate: boolean;
+  allowedHosts: string[];
+}
+
+function readPolicy(env: NodeJS.ProcessEnv = process.env): SsrfPolicy {
+  // The guard performs real DNS resolution and would make most unit tests
+  // depend on the network. Disable it under jest unless the test explicitly
+  // opts in by setting SSRF_GUARD=enabled.
+  const isTest = env.NODE_ENV === 'test' || !!env.JEST_WORKER_ID;
+  const disabled =
+    env.SSRF_GUARD === 'disabled' ||
+    (isTest && env.SSRF_GUARD !== 'enabled');
+  return {
+    enabled: !disabled,
+    allowLoopback: env.SSRF_ALLOW_LOCALHOST === 'true',
+    allowPrivate: env.SSRF_ALLOW_PRIVATE === 'true',
+    allowedHosts: (env.SSRF_ALLOWED_HOSTS || '')
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  };
+}
+
+function hostMatchesAllowlist(hostname: string, allowed: string[]): boolean {
+  const lower = hostname.toLowerCase();
+  for (const entry of allowed) {
+    if (entry.startsWith('*.')) {
+      const suffix = entry.slice(1);
+      if (lower.endsWith(suffix)) return true;
+    } else if (entry === lower) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if `ip` is a routable public address — i.e. NOT loopback,
+ * link-local, RFC1918 private, CGNAT, multicast, broadcast, or
+ * IPv6-mapped private equivalents.
+ */
+function isPublicIp(ip: string, policy: SsrfPolicy): boolean {
+  const family = isIP(ip);
+  if (family === 0) return false;
+
+  if (family === 4) {
+    const parts = ip.split('.').map((p) => parseInt(p, 10));
+    if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return false;
+    const [a, b] = parts;
+
+    // Loopback 127.0.0.0/8
+    if (a === 127) return policy.allowLoopback;
+    // RFC1918 private
+    if (a === 10) return policy.allowPrivate;
+    if (a === 172 && b >= 16 && b <= 31) return policy.allowPrivate;
+    if (a === 192 && b === 168) return policy.allowPrivate;
+    // Link-local 169.254.0.0/16 (incl. cloud metadata 169.254.169.254)
+    if (a === 169 && b === 254) return false;
+    // CGNAT 100.64.0.0/10
+    if (a === 100 && b >= 64 && b <= 127) return policy.allowPrivate;
+    // 0.0.0.0/8
+    if (a === 0) return false;
+    // Multicast 224.0.0.0/4
+    if (a >= 224 && a <= 239) return false;
+    // Reserved 240.0.0.0/4 + broadcast
+    if (a >= 240) return false;
+    return true;
+  }
+
+  // IPv6
+  const lower = ip.toLowerCase();
+  if (lower === '::' || lower === '::1') return policy.allowLoopback;
+  if (lower.startsWith('fe80:') || lower.startsWith('fe80::')) return false; // link-local
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return policy.allowPrivate; // ULA
+  if (lower.startsWith('ff')) return false; // multicast
+  // IPv4-mapped (::ffff:a.b.c.d)
+  const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPublicIp(mapped[1], policy);
+  return true;
+}
+
+/**
+ * Throws SsrfBlockedError if the URL's hostname resolves to a blocked
+ * address. Resolves DNS so that public hostnames pointing at private IPs
+ * (rebinding) are also caught.
+ *
+ * Returns silently when the request is permitted.
+ */
+export async function assertSafeOutboundUrl(
+  url: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const policy = readPolicy(env);
+  if (!policy.enabled) return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new SsrfBlockedError(`SSRF guard: invalid URL '${url}'`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new SsrfBlockedError(
+      `SSRF guard: protocol '${parsed.protocol}' is not allowed`,
+    );
+  }
+
+  const hostname = parsed.hostname;
+
+  if (hostMatchesAllowlist(hostname, policy.allowedHosts)) return;
+
+  // If the host is already a literal IP, check it directly.
+  if (isIP(hostname)) {
+    if (!isPublicIp(hostname, policy)) {
+      throw new SsrfBlockedError(
+        `SSRF guard: address '${hostname}' is not a public IP`,
+      );
+    }
+    return;
+  }
+
+  // Block 'localhost' and friends explicitly — DNS may not resolve them
+  // consistently across environments.
+  const lowerHost = hostname.toLowerCase();
+  if (
+    !policy.allowLoopback &&
+    (lowerHost === 'localhost' ||
+      lowerHost.endsWith('.localhost') ||
+      lowerHost.endsWith('.local'))
+  ) {
+    throw new SsrfBlockedError(
+      `SSRF guard: hostname '${hostname}' is loopback / local`,
+    );
+  }
+
+  let resolved: { address: string; family: number }[];
+  try {
+    resolved = await dns.lookup(hostname, { all: true });
+  } catch (e: any) {
+    throw new SsrfBlockedError(
+      `SSRF guard: cannot resolve '${hostname}': ${e?.message || e}`,
+    );
+  }
+
+  for (const { address } of resolved) {
+    if (!isPublicIp(address, policy)) {
+      throw new SsrfBlockedError(
+        `SSRF guard: hostname '${hostname}' resolves to non-public address '${address}'`,
+      );
+    }
+  }
+}
+
+// Exposed for unit tests.
+export const __test = { isPublicIp, hostMatchesAllowlist, readPolicy };

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -33,6 +33,7 @@ import { McpOAuthService } from './mcp-oauth.service';
 import { PrismaService } from '../common/prisma.service';
 import { McpServerService } from '../mcp-server/mcp-server.service';
 import { LicenseGuardService } from '../license/license-guard.service';
+import { getRequiredSecret } from '../common/secrets.util';
 import { decrypt } from '../common/crypto/encryption.util';
 
 class CreateConnectorDto {
@@ -146,9 +147,10 @@ export class ConnectorsController {
     private readonly configService: ConfigService,
     private readonly licenseGuard: LicenseGuardService,
   ) {
-    this.encryptionKey =
-      this.configService.get<string>('ENCRYPTION_KEY') ||
-      'default-dev-key-change-in-prod!!';
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      this.configService.get<string>('ENCRYPTION_KEY'),
+    );
   }
 
   private readonly encryptionKey: string;

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -8,6 +8,7 @@ import { GraphqlEngine } from './engines/graphql.engine';
 import { DatabaseEngine } from './engines/database.engine';
 import { McpClientEngine } from './engines/mcp-client.engine';
 import { encrypt, decrypt } from '../common/crypto/encryption.util';
+import { getRequiredSecret } from '../common/secrets.util';
 
 @Injectable()
 export class ConnectorsService {
@@ -23,9 +24,10 @@ export class ConnectorsService {
     private readonly databaseEngine: DatabaseEngine,
     private readonly mcpClientEngine: McpClientEngine,
   ) {
-    this.encryptionKey =
-      this.configService.get<string>('ENCRYPTION_KEY') ||
-      'default-dev-key-change-in-prod!!';
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      this.configService.get<string>('ENCRYPTION_KEY'),
+    );
   }
 
   async findAll(): Promise<Connector[]> {

--- a/packages/backend/src/connectors/engines/database.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/database.engine.spec.ts
@@ -114,8 +114,8 @@ describe('DatabaseEngine', () => {
     });
   });
 
-  describe('SQL parameter interpolation (escapeValue)', () => {
-    it('should escape string values with single quotes', async () => {
+  describe('SQL parameter binding (prepared statements)', () => {
+    it('binds string values as positional parameters', async () => {
       mockQuery.mockResolvedValue({ rows: [] });
       await engine.execute(
         { baseUrl: 'postgres://host/db', authType: 'NONE' },
@@ -123,11 +123,12 @@ describe('DatabaseEngine', () => {
         { name: 'John' },
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        "SELECT * FROM users WHERE name = 'John'",
+        'SELECT * FROM users WHERE name = $1',
+        ['John'],
       );
     });
 
-    it('should escape single quotes by doubling them', async () => {
+    it('passes single quotes through as a parameter (no escaping)', async () => {
       mockQuery.mockResolvedValue({ rows: [] });
       await engine.execute(
         { baseUrl: 'postgres://host/db', authType: 'NONE' },
@@ -135,11 +136,25 @@ describe('DatabaseEngine', () => {
         { name: "O'Brien" },
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        "SELECT * FROM users WHERE name = 'O''Brien'",
+        'SELECT * FROM users WHERE name = $1',
+        ["O'Brien"],
       );
     });
 
-    it('should return NULL for null/undefined', async () => {
+    it('rejects classic SQL-injection payloads as a literal value, not as SQL', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        { method: 'query', path: 'SELECT * FROM users WHERE name = $name' },
+        { name: "x'; DROP TABLE users; --" },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM users WHERE name = $1',
+        ["x'; DROP TABLE users; --"],
+      );
+    });
+
+    it('binds null values', async () => {
       mockQuery.mockResolvedValue({ rows: [] });
       await engine.execute(
         { baseUrl: 'postgres://host/db', authType: 'NONE' },
@@ -147,11 +162,12 @@ describe('DatabaseEngine', () => {
         { name: null },
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        'SELECT * FROM users WHERE name = NULL',
+        'SELECT * FROM users WHERE name = $1',
+        [null],
       );
     });
 
-    it('should return numeric values unquoted', async () => {
+    it('binds numeric values', async () => {
       mockQuery.mockResolvedValue({ rows: [] });
       await engine.execute(
         { baseUrl: 'postgres://host/db', authType: 'NONE' },
@@ -159,11 +175,12 @@ describe('DatabaseEngine', () => {
         { age: 25 },
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        'SELECT * FROM users WHERE age = 25',
+        'SELECT * FROM users WHERE age = $1',
+        [25],
       );
     });
 
-    it('should return TRUE/FALSE for booleans', async () => {
+    it('binds boolean values', async () => {
       mockQuery.mockResolvedValue({ rows: [] });
       await engine.execute(
         { baseUrl: 'postgres://host/db', authType: 'NONE' },
@@ -171,7 +188,24 @@ describe('DatabaseEngine', () => {
         { active: true },
       );
       expect(mockQuery).toHaveBeenCalledWith(
-        'SELECT * FROM users WHERE active = TRUE',
+        'SELECT * FROM users WHERE active = $1',
+        [true],
+      );
+    });
+
+    it('binds repeated occurrences of the same param twice', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await engine.execute(
+        { baseUrl: 'postgres://host/db', authType: 'NONE' },
+        {
+          method: 'query',
+          path: 'SELECT * FROM users WHERE first = $name OR last = $name',
+        },
+        { name: 'Alice' },
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM users WHERE first = $1 OR last = $2',
+        ['Alice', 'Alice'],
       );
     });
   });

--- a/packages/backend/src/connectors/engines/database.engine.ts
+++ b/packages/backend/src/connectors/engines/database.engine.ts
@@ -41,29 +41,64 @@ export class DatabaseEngine {
       return this.executeMongodb(config, endpointMapping, params);
     }
 
-    // If the path is a single param reference like ${query}, use the raw value as SQL
-    // (don't escape it as a string literal — it IS the SQL)
+    // If the path is a single param reference like ${query}, use the raw value as SQL.
+    // The query value is fully untrusted; rely on validateQuery() (in readOnly mode)
+    // and on the database role's grants. Prepared statements cannot help here because
+    // the entire statement comes from the caller.
     const rawParamMatch = endpointMapping.path.match(/^\$\{(\w+)\}$/);
-    const sql = rawParamMatch
-      ? String(params[rawParamMatch[1]] || '')
-      : this.interpolateParams(endpointMapping.path, params);
+    const isRawSql = !!rawParamMatch;
+
+    if (isRawSql) {
+      const sql = String(params[rawParamMatch![1]] || '');
+      if (readOnly) {
+        this.validateQuery(sql);
+      }
+      return this.dispatch(config, sql, [], readOnly);
+    }
+
+    // Templated SQL: compile ${name} / $name placeholders to driver-specific
+    // parameterised queries. Values are bound, never inlined.
+    const driver = this.detectDriver(config.baseUrl);
+    const { sql, values } = compileParameterized(
+      endpointMapping.path,
+      params,
+      driver,
+    );
     if (readOnly) {
       this.validateQuery(sql);
     }
+    return this.dispatch(config, sql, values, readOnly);
+  }
 
+  private detectDriver(baseUrl: string): SqlDriver {
+    if (this.isMssql(baseUrl)) return 'mssql';
+    if (this.isMysql(baseUrl)) return 'mysql';
+    if (this.isOracle(baseUrl)) return 'oracle';
+    if (this.isSqlite(baseUrl)) return 'sqlite';
+    return 'postgres';
+  }
+
+  private dispatch(
+    config: { baseUrl: string; authType: string; authConfig?: Record<string, unknown> },
+    sql: string,
+    values: unknown[],
+    readOnly: boolean,
+  ): Promise<unknown> {
     if (this.isMssql(config.baseUrl)) {
-      return this.executeMssql(config, sql);
+      return this.executeMssql(config, sql, values);
     }
     if (this.isMysql(config.baseUrl)) {
-      return this.executeMysql(config, sql);
+      return this.executeMysql(config, sql, values);
     }
     if (this.isOracle(config.baseUrl)) {
-      return this.executeOracle(config, sql);
+      return this.executeOracle(config, sql, values);
     }
     if (this.isSqlite(config.baseUrl)) {
-      return this.executeSqlite(config.baseUrl, sql, readOnly);
+      return Promise.resolve(
+        this.executeSqlite(config.baseUrl, sql, values, readOnly),
+      );
     }
-    return this.executePostgres(config.baseUrl, sql);
+    return this.executePostgres(config.baseUrl, sql, values);
   }
 
   /** Test connectivity — runs SELECT 1 (SQL) or ping (MongoDB) */
@@ -130,13 +165,15 @@ export class DatabaseEngine {
   private async executePostgres(
     connectionString: string,
     sql: string,
+    values: unknown[] = [],
   ): Promise<unknown> {
     const safeHost = connectionString.split('@')[1] ?? 'unknown';
     this.logger.debug(`PostgreSQL query → ${safeHost}`);
 
     const pool = new Pool({ connectionString });
     try {
-      const result = await pool.query(sql);
+      const result =
+        values.length > 0 ? await pool.query(sql, values) : await pool.query(sql);
       if (result.rows && result.rows.length > 0) {
         const rows = Array.isArray(result.rows) ? result.rows : [result.rows];
         return this.truncateRows(rows);
@@ -159,13 +196,18 @@ export class DatabaseEngine {
       authConfig?: Record<string, unknown>;
     },
     sql: string,
+    values: unknown[] = [],
   ): Promise<unknown> {
     const mssqlConfig = this.buildMssqlConfig(config);
     this.logger.debug(`MSSQL query → ${mssqlConfig.server}/${mssqlConfig.database}`);
 
     const pool = await mssql.connect(mssqlConfig);
     try {
-      const result = await pool.request().query(sql);
+      const request = pool.request();
+      values.forEach((value, idx) => {
+        request.input(`p${idx}`, value as any);
+      });
+      const result = await request.query(sql);
       if (result.recordset && result.recordset.length > 0) {
         return this.truncateRows(result.recordset);
       }
@@ -405,13 +447,17 @@ export class DatabaseEngine {
       authConfig?: Record<string, unknown>;
     },
     sql: string,
+    values: unknown[] = [],
   ): Promise<unknown> {
     const uri = this.mysqlUri(config.baseUrl);
     this.logger.debug(`MySQL query → ${new URL(uri).hostname}`);
 
     const conn = await mysql.createConnection(uri);
     try {
-      const [result] = await conn.query(sql);
+      const [result] =
+        values.length > 0
+          ? await conn.execute(sql, values as any[])
+          : await conn.query(sql);
       if (Array.isArray(result)) {
         return this.truncateRows(result as Record<string, unknown>[]);
       }
@@ -442,13 +488,14 @@ export class DatabaseEngine {
       authConfig?: Record<string, unknown>;
     },
     sql: string,
+    values: unknown[] = [],
   ): Promise<unknown> {
     const oraConfig = this.buildOracleConfig(config);
     this.logger.debug(`Oracle query → ${oraConfig.connectString}`);
 
     const conn = await oracledb.getConnection(oraConfig);
     try {
-      const result = await conn.execute(sql, [], {
+      const result = await conn.execute(sql, values as any[], {
         outFormat: oracledb.OUT_FORMAT_OBJECT,
         autoCommit: true,
       });
@@ -489,7 +536,12 @@ export class DatabaseEngine {
   /*  SQLite                                                             */
   /* ------------------------------------------------------------------ */
 
-  private executeSqlite(baseUrl: string, sql: string, readOnly = true): unknown {
+  private executeSqlite(
+    baseUrl: string,
+    sql: string,
+    values: unknown[] = [],
+    readOnly = true,
+  ): unknown {
     const filePath = this.sqlitePath(baseUrl);
     this.logger.debug(`SQLite query → ${filePath}`);
 
@@ -497,11 +549,11 @@ export class DatabaseEngine {
     try {
       const stmt = db.prepare(sql);
       if (stmt.reader) {
-        const rows = stmt.all() as Record<string, unknown>[];
+        const rows = stmt.all(...(values as any[])) as Record<string, unknown>[];
         return this.truncateRows(rows);
       }
       // Write statement (INSERT, UPDATE, DELETE, etc.)
-      const info = stmt.run();
+      const info = stmt.run(...(values as any[]));
       return { changes: info.changes, lastInsertRowid: info.lastInsertRowid };
     } finally {
       db.close();
@@ -584,24 +636,58 @@ export class DatabaseEngine {
     }
   }
 
-  private interpolateParams(
-    template: string,
-    params: Record<string, unknown>,
-  ): string {
-    let sql = template;
-    for (const [key, value] of Object.entries(params)) {
-      const escapedValue = this.escapeValue(value);
-      sql = sql.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), escapedValue);
-      sql = sql.replace(new RegExp(`\\$${key}\\b`, 'g'), escapedValue);
-    }
-    return sql;
-  }
+}
 
-  private escapeValue(value: unknown): string {
-    if (value === null || value === undefined) return 'NULL';
-    if (typeof value === 'number') return String(value);
-    if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
-    const str = String(value).replace(/'/g, "''");
-    return `'${str}'`;
+export type SqlDriver = 'postgres' | 'mysql' | 'mssql' | 'oracle' | 'sqlite';
+
+/**
+ * Compile a SQL template with `${name}` or `$name` placeholders into a
+ * parameterised query for the given driver. Each placeholder becomes a
+ * positional or named bind variable; values are returned in the order the
+ * driver expects them.
+ *
+ * - postgres   →  `$1, $2, ...`
+ * - mysql      →  `?, ?, ...` (bound via `connection.execute()`)
+ * - mssql      →  `@p0, @p1, ...` (bound via `request.input('p0', value)`)
+ * - oracle     →  `:b0, :b1, ...` (positional array)
+ * - sqlite     →  `?, ?, ...`
+ *
+ * The same param name appearing twice in the template is bound twice (once
+ * per occurrence) to keep the indices simple. A reference to a parameter
+ * that is not present in `params` is left unresolved (yielding a SQL error
+ * at execution time, not a SQL injection).
+ */
+export function compileParameterized(
+  template: string,
+  params: Record<string, unknown>,
+  driver: SqlDriver,
+): { sql: string; values: unknown[] } {
+  const values: unknown[] = [];
+  const sql = template.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)\b/g,
+    (match, brace: string | undefined, bare: string | undefined) => {
+      const name = brace || bare;
+      if (!name || !Object.prototype.hasOwnProperty.call(params, name)) {
+        return match;
+      }
+      values.push(params[name]);
+      return placeholderFor(driver, values.length);
+    },
+  );
+  return { sql, values };
+}
+
+function placeholderFor(driver: SqlDriver, oneBasedIndex: number): string {
+  switch (driver) {
+    case 'postgres':
+      return `$${oneBasedIndex}`;
+    case 'mssql':
+      return `@p${oneBasedIndex - 1}`;
+    case 'oracle':
+      return `:b${oneBasedIndex - 1}`;
+    case 'mysql':
+    case 'sqlite':
+    default:
+      return '?';
   }
 }

--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosError } from 'axios';
 import { OAuth2TokenService } from './oauth2-token.service';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /**
  * GraphqlEngine — executes GraphQL queries/mutations.
@@ -30,6 +31,7 @@ export class GraphqlEngine {
     params: Record<string, unknown>,
   ): Promise<unknown> {
     this.logger.debug(`GraphQL ${endpointMapping.method} → ${config.baseUrl}`);
+    await assertSafeOutboundUrl(config.baseUrl);
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/packages/backend/src/connectors/engines/mcp-client.engine.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { OAuth2TokenService } from './oauth2-token.service';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 @Injectable()
 export class McpClientEngine {
@@ -31,6 +32,7 @@ export class McpClientEngine {
       endpointMapping.path || '/mcp',
       config.baseUrl,
     );
+    await assertSafeOutboundUrl(mcpUrl.toString());
 
     const headers: Record<string, string> = { ...config.headers };
     await this.injectAuth(headers, config.authType, config.authConfig, config.connectorId);

--- a/packages/backend/src/connectors/engines/oauth2-token.service.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { PrismaService } from '../../common/prisma.service';
 import { encrypt, decrypt } from '../../common/crypto/encryption.util';
+import { getRequiredSecret } from '../../common/secrets.util';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /** Refresh tokens that expire within this window (5 minutes). */
 const PROACTIVE_REFRESH_BUFFER_MS = 5 * 60 * 1000;
@@ -32,9 +34,10 @@ export class OAuth2TokenService {
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
   ) {
-    this.encryptionKey =
-      this.configService.get<string>('ENCRYPTION_KEY') ||
-      'default-dev-key-change-in-prod!!';
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      this.configService.get<string>('ENCRYPTION_KEY'),
+    );
   }
 
   /**
@@ -114,6 +117,7 @@ export class OAuth2TokenService {
       if (clientId) body.client_id = clientId;
       if (clientSecret) body.client_secret = clientSecret;
 
+      await assertSafeOutboundUrl(tokenUrl);
       const response = await axios.post(
         tokenUrl,
         new URLSearchParams(body).toString(),

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
 import FormData from 'form-data';
 import { OAuth2TokenService } from './oauth2-token.service';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /**
  * RestEngine — executes HTTP calls to REST APIs.
@@ -41,6 +42,7 @@ export class RestEngine {
     }
 
     const url = `${config.baseUrl}${path}`;
+    await assertSafeOutboundUrl(url);
 
     // Resolve dynamic headers from endpoint mapping ($param references)
     const resolvedEndpointHeaders: Record<string, string> = {};
@@ -82,20 +84,18 @@ export class RestEngine {
     // Request body
     if (['POST', 'PUT', 'PATCH'].includes(endpointMapping.method.toUpperCase())) {
       if (endpointMapping.bodyTemplate) {
-        // Template mode: interpolate ${paramName} placeholders, then parse as JSON
-        let rendered = endpointMapping.bodyTemplate;
-        for (const [key, value] of Object.entries(params)) {
-          const placeholder = '${' + key + '}';
-          if (rendered.includes(placeholder)) {
-            const replacement = typeof value === 'string' ? value : JSON.stringify(value);
-            rendered = rendered.split(placeholder).join(replacement);
-          }
-        }
+        const rendered = renderBodyTemplate(
+          endpointMapping.bodyTemplate,
+          params,
+        );
+        let parsed: unknown;
         try {
-          axiosConfig.data = JSON.parse(rendered);
+          parsed = JSON.parse(rendered);
         } catch (e: any) {
           throw new Error(`bodyTemplate produced invalid JSON after interpolation: ${e.message}`);
         }
+        assertNoPrototypePollution(parsed);
+        axiosConfig.data = parsed;
       } else if (endpointMapping.bodyMapping) {
         // Handle __raw body mapping (non-JSON body, e.g. XML/SOAP)
         if ('__raw' in endpointMapping.bodyMapping) {
@@ -279,5 +279,77 @@ export class RestEngine {
       return nested;
     }
     return value;
+  }
+}
+
+/**
+ * Param names that, if interpolated into a JSON body, can poison the
+ * Object.prototype chain after JSON.parse and let an attacker forge
+ * application-level booleans (isAdmin, role, etc.).
+ */
+const FORBIDDEN_PARAM_KEYS: ReadonlySet<string> = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+/**
+ * Render a JSON body template by substituting ${name} placeholders with
+ * properly-encoded values:
+ *   - Inside a JSON string ("...${name}..."): the value is coerced to a
+ *     string and JSON-string-escaped so it cannot terminate the surrounding
+ *     quotes or inject syntax.
+ *   - In a free position ({"x": ${name}}): the value is JSON-encoded as a
+ *     full JSON value (number/object/array/null/string).
+ *
+ * Forbidden param names that can pollute Object.prototype are rejected.
+ */
+function renderBodyTemplate(
+  template: string,
+  params: Record<string, unknown>,
+): string {
+  for (const key of Object.keys(params)) {
+    if (FORBIDDEN_PARAM_KEYS.has(key)) {
+      throw new Error(
+        `bodyTemplate param '${key}' is not allowed (prototype pollution)`,
+      );
+    }
+  }
+
+  return template.replace(
+    /(")?\$\{([A-Za-z_][A-Za-z0-9_]*)\}(")?/g,
+    (_match, leftQuote: string | undefined, name: string, rightQuote: string | undefined) => {
+      const value = params[name];
+      const insideString = leftQuote && rightQuote;
+      if (insideString) {
+        const asString =
+          value === undefined || value === null ? '' : String(value);
+        const escaped = JSON.stringify(asString).slice(1, -1);
+        return `${leftQuote}${escaped}${rightQuote}`;
+      }
+      if (value === undefined) return 'null';
+      return JSON.stringify(value);
+    },
+  );
+}
+
+/**
+ * Walk a parsed JSON value and reject any explicit __proto__ / constructor /
+ * prototype keys. Catches injections that survived interpolation (e.g. a
+ * pre-baked malicious template).
+ */
+function assertNoPrototypePollution(value: unknown): void {
+  if (value === null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (const item of value) assertNoPrototypePollution(item);
+    return;
+  }
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_PARAM_KEYS.has(key)) {
+      throw new Error(
+        `bodyTemplate produced forbidden key '${key}' (prototype pollution)`,
+      );
+    }
+    assertNoPrototypePollution((value as Record<string, unknown>)[key]);
   }
 }

--- a/packages/backend/src/connectors/engines/soap.engine.ts
+++ b/packages/backend/src/connectors/engines/soap.engine.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
 import * as soap from 'soap';
 import { XMLParser } from 'fast-xml-parser';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /**
  * SoapEngine — executes SOAP calls using raw HTTP via axios.
@@ -107,6 +108,7 @@ export class SoapEngine {
     }
 
     try {
+      await assertSafeOutboundUrl(endpoint);
       const response = await axios.post(endpoint, envelope, {
         headers,
         timeout: 30000,
@@ -243,6 +245,7 @@ ${paramXml}
     paramOrder: string[];
   }> {
     try {
+      await assertSafeOutboundUrl(wsdlUrl);
       const client = await soap.createClientAsync(wsdlUrl);
       const wsdl = client.wsdl;
 

--- a/packages/backend/src/connectors/mcp-oauth.service.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { createHash, randomBytes } from 'crypto';
 import axios from 'axios';
+import { assertSafeOutboundUrl } from '../common/ssrf.util';
 
 interface OAuthMetadata {
   issuer: string;
@@ -48,6 +49,7 @@ export class McpOAuthService {
 
     this.logger.debug(`Discovering OAuth metadata from ${metadataUrl}`);
 
+    await assertSafeOutboundUrl(metadataUrl);
     const response = await axios.get(metadataUrl, { timeout: 10000 });
     const metadata: OAuthMetadata = response.data;
 
@@ -89,6 +91,7 @@ export class McpOAuthService {
       `Registering OAuth client at ${registrationEndpoint}`,
     );
 
+    await assertSafeOutboundUrl(registrationEndpoint);
     const response = await axios.post(
       registrationEndpoint,
       {
@@ -166,6 +169,7 @@ export class McpOAuthService {
 
     this.logger.debug(`Exchanging auth code at ${params.tokenUrl}`);
 
+    await assertSafeOutboundUrl(params.tokenUrl);
     const response = await axios.post(
       params.tokenUrl,
       new URLSearchParams(body).toString(),

--- a/packages/backend/src/connectors/parsers/graphql.parser.ts
+++ b/packages/backend/src/connectors/parsers/graphql.parser.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ParsedTool } from './openapi.parser';
 import { buildSchema, introspectionFromSchema } from 'graphql';
 import axios from 'axios';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 const INTROSPECTION_QUERY = `
   query IntrospectionQuery {
@@ -48,6 +49,7 @@ export class GraphqlParser {
     // 1. Try standard introspection query
     try {
       this.logger.debug(`Introspecting GraphQL schema from: ${endpoint}`);
+      await assertSafeOutboundUrl(endpoint);
       const response = await axios.post(
         endpoint,
         { query: INTROSPECTION_QUERY },
@@ -73,6 +75,7 @@ export class GraphqlParser {
     this.logger.debug(`Falling back to SDL schema from: ${sdlUrl}`);
 
     try {
+      await assertSafeOutboundUrl(sdlUrl);
       const sdlResponse = await axios.get(sdlUrl, {
         headers,
         timeout: 30000,

--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const SwaggerParser = require('swagger-parser');
 import axios from 'axios';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 export interface ParsedTool {
   name: string;
@@ -36,6 +37,7 @@ export class OpenApiParser {
   async parseFromUrl(url: string): Promise<ParsedTool[]> {
     this.logger.debug(`Fetching OpenAPI spec from: ${url}`);
 
+    await assertSafeOutboundUrl(url);
     const response = await axios.get(url, { timeout: 15000 });
 
     // If the response is already a valid spec object, parse directly
@@ -85,6 +87,7 @@ export class OpenApiParser {
       const specUrl = new URL(urlMatch[1], pageUrl).href;
       this.logger.debug(`Found spec URL in HTML: ${specUrl}`);
       try {
+        await assertSafeOutboundUrl(specUrl);
         const specResp = await axios.get(specUrl, { timeout: 15000 });
         return specResp.data;
       } catch {
@@ -95,6 +98,7 @@ export class OpenApiParser {
     // 2. Try swagger-ui-init.js (swagger-ui-express embeds the spec inline)
     const initJsUrl = new URL('swagger-ui-init.js', pageUrl.endsWith('/') ? pageUrl : pageUrl + '/').href;
     try {
+      await assertSafeOutboundUrl(initJsUrl);
       const initResp = await axios.get(initJsUrl, { timeout: 15000 });
       const initJs = typeof initResp.data === 'string' ? initResp.data : '';
       // The spec is embedded as: let defined = { ... "swaggerDoc": { <the spec> }, ... }
@@ -131,7 +135,9 @@ export class OpenApiParser {
     ];
     for (const path of commonPaths) {
       try {
-        const resp = await axios.get(`${origin}${path}`, { timeout: 5000 });
+        const candidate = `${origin}${path}`;
+        await assertSafeOutboundUrl(candidate);
+        const resp = await axios.get(candidate, { timeout: 5000 });
         if (
           typeof resp.data === 'object' &&
           resp.data !== null &&

--- a/packages/backend/src/connectors/parsers/postman.parser.ts
+++ b/packages/backend/src/connectors/parsers/postman.parser.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 import { ParsedTool } from './openapi.parser';
 
 /**
@@ -55,6 +56,7 @@ export class PostmanParser {
       const apiUrl = `https://documenter.getpostman.com/api/collections/download?version=latest&document_id=${slug}&owner=${ownerId}`;
       this.logger.debug(`Detected Postman Documenter URL. Trying API: ${apiUrl}`);
       try {
+        await assertSafeOutboundUrl(apiUrl);
         const apiResp = await axios.get(apiUrl, { timeout: 15000 });
         if (apiResp.data && typeof apiResp.data === 'object') {
           return this.parse(apiResp.data);
@@ -68,6 +70,7 @@ export class PostmanParser {
       );
     }
 
+    await assertSafeOutboundUrl(url);
     const response = await axios.get(url, { timeout: 15000 });
 
     // Validate response is JSON, not HTML

--- a/packages/backend/src/connectors/tools.controller.ts
+++ b/packages/backend/src/connectors/tools.controller.ts
@@ -193,13 +193,19 @@ export class ToolsController {
     @Body() dto: UpdateToolDto,
   ) {
     await this.assertCanWriteConnector(connectorId, req);
-    const tool = await this.prisma.mcpTool.update({
-      where: { id: toolId },
+    // Bind the toolId to the connectorId in the WHERE clause so that
+    // a request like /connectors/<my>/tools/<other-org's-tool> cannot
+    // update a tool that doesn't belong to the requested connector.
+    const result = await this.prisma.mcpTool.updateMany({
+      where: { id: toolId, connectorId },
       data: dto as any,
     });
+    if (result.count === 0) {
+      throw new ForbiddenException('Tool not found');
+    }
 
     await this.mcpServer.reloadConnectorTools(connectorId);
-    return tool;
+    return this.prisma.mcpTool.findUnique({ where: { id: toolId } });
   }
 
   @Post(':toolId/test')
@@ -272,7 +278,12 @@ export class ToolsController {
     @Param('connectorId') connectorId: string,
   ) {
     await this.assertCanWriteConnector(connectorId, req);
-    await this.prisma.mcpTool.delete({ where: { id: toolId } });
+    const result = await this.prisma.mcpTool.deleteMany({
+      where: { id: toolId, connectorId },
+    });
+    if (result.count === 0) {
+      throw new ForbiddenException('Tool not found');
+    }
     await this.mcpServer.reloadConnectorTools(connectorId);
     return { message: 'Tool deleted' };
   }

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -12,11 +12,18 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import cookieParser from 'cookie-parser';
 import { json, urlencoded } from 'express';
+import helmet from 'helmet';
 import { AppModule } from './app.module';
 import { McpAuthExceptionFilter } from './auth/mcp-auth-exception.filter';
+import { validateRequiredSecretsAtStartup } from './common/secrets.util';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
+
+  // Fail fast if required secrets are missing or use known placeholder values.
+  // Done before NestFactory.create to surface config errors before module init.
+  validateRequiredSecretsAtStartup(process.env);
+
   const app = await NestFactory.create(AppModule);
 
   // Trust proxy headers (ngrok, reverse proxies) for correct protocol/host detection
@@ -32,7 +39,19 @@ async function bootstrap() {
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT') || 4000;
-  const corsOrigin = configService.get<string>('CORS_ORIGIN') || '*';
+  const isProduction = configService.get<string>('NODE_ENV') === 'production';
+
+  // Security headers (CSP relaxed because Swagger UI ships inline scripts/styles)
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+      crossOriginEmbedderPolicy: false,
+      crossOriginResourcePolicy: { policy: 'cross-origin' },
+      strictTransportSecurity: isProduction
+        ? { maxAge: 31536000, includeSubDomains: true, preload: false }
+        : false,
+    }),
+  );
 
   // Add WWW-Authenticate header to MCP 401 responses for OAuth discovery
   app.useGlobalFilters(new McpAuthExceptionFilter());
@@ -46,7 +65,10 @@ async function bootstrap() {
     }),
   );
 
-  // CORS
+  // CORS — never use wildcard with credentials. In production an explicit
+  // CORS_ORIGIN list is required. In development a sensible localhost default
+  // is used when CORS_ORIGIN is not set.
+  const corsOrigin = resolveCorsOrigin(configService, isProduction);
   app.enableCors({
     origin: corsOrigin,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
@@ -84,6 +106,33 @@ async function bootstrap() {
   logger.log(`Swagger docs: http://localhost:${port}/api/docs`);
   logger.log(`MCP endpoint (global): http://localhost:${port}/mcp`);
   logger.log(`MCP endpoint (per-server): http://localhost:${port}/mcp/:serverId`);
+}
+
+function resolveCorsOrigin(
+  configService: ConfigService,
+  isProduction: boolean,
+): string | string[] | RegExp[] | boolean {
+  const raw = configService.get<string>('CORS_ORIGIN');
+
+  if (!raw || raw.trim() === '') {
+    if (isProduction) {
+      throw new Error(
+        '[cors] CORS_ORIGIN must be set explicitly in production (comma-separated allowlist of origins).',
+      );
+    }
+    return ['http://localhost:3000', 'http://127.0.0.1:3000'];
+  }
+
+  if (raw.trim() === '*') {
+    if (isProduction) {
+      throw new Error(
+        "[cors] CORS_ORIGIN='*' is not allowed in production with credentials enabled.",
+      );
+    }
+    return true;
+  }
+
+  return raw.split(',').map((s) => s.trim()).filter(Boolean);
 }
 
 bootstrap();

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { McpRegistryService } from '@rekog/mcp-nest';
 import { PrismaService } from '../common/prisma.service';
 import { decrypt } from '../common/crypto/encryption.util';
+import { getRequiredSecret } from '../common/secrets.util';
 import { ToolRegistry } from './tool-registry';
 import { DynamicMcpTools } from './dynamic-mcp-tools';
 import { RolesService } from '../roles/roles.service';
@@ -25,9 +26,10 @@ export class McpServerService implements OnModuleInit {
     private readonly rolesService: RolesService,
     private readonly mcpServersService: McpServersService,
   ) {
-    this.encryptionKey =
-      this.configService.get<string>('ENCRYPTION_KEY') ||
-      'default-dev-key-change-in-prod!!';
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      this.configService.get<string>('ENCRYPTION_KEY'),
+    );
   }
 
   async onModuleInit() {

--- a/packages/backend/src/roles/roles.controller.ts
+++ b/packages/backend/src/roles/roles.controller.ts
@@ -70,28 +70,35 @@ export class RolesController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get role details with tool access (ADMIN)' })
-  async getRole(@Param('id') id: string) {
-    const role = await this.rolesService.findById(id);
+  async getRole(@Req() req: any, @Param('id') id: string) {
+    const role = await this.rolesService.findByIdForOrg(id, req.user.organizationId);
     if (!role) throw new NotFoundException('Role not found');
     return role;
   }
 
   @Put(':id')
   @ApiOperation({ summary: 'Update a role (ADMIN)' })
-  async updateRole(@Param('id') id: string, @Body() dto: UpdateRoleDto) {
-    const role = await this.rolesService.findById(id);
+  async updateRole(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: UpdateRoleDto,
+  ) {
+    const role = await this.rolesService.findByIdForOrg(id, req.user.organizationId);
     if (!role) throw new NotFoundException('Role not found');
     if (role.isSystem) throw new ForbiddenException('Cannot modify system roles');
-    return this.rolesService.update(id, dto);
+    const updated = await this.rolesService.update(id, req.user.organizationId, dto);
+    if (!updated) throw new NotFoundException('Role not found');
+    return updated;
   }
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a role (ADMIN)' })
-  async deleteRole(@Param('id') id: string) {
-    const role = await this.rolesService.findById(id);
+  async deleteRole(@Req() req: any, @Param('id') id: string) {
+    const role = await this.rolesService.findByIdForOrg(id, req.user.organizationId);
     if (!role) throw new NotFoundException('Role not found');
     if (role.isSystem) throw new ForbiddenException('Cannot delete system roles');
-    await this.rolesService.delete(id);
+    const deleted = await this.rolesService.delete(id, req.user.organizationId);
+    if (!deleted) throw new NotFoundException('Role not found');
     return { message: 'Role deleted' };
   }
 
@@ -99,14 +106,22 @@ export class RolesController {
 
   @Get(':id/tools')
   @ApiOperation({ summary: 'Get tools assigned to a role (ADMIN)' })
-  async getToolAccess(@Param('id') id: string) {
+  async getToolAccess(@Req() req: any, @Param('id') id: string) {
+    const role = await this.rolesService.findByIdForOrg(id, req.user.organizationId);
+    if (!role) throw new NotFoundException('Role not found');
     return this.rolesService.getToolAccess(id);
   }
 
   @Put(':id/tools')
   @ApiOperation({ summary: 'Set tool access for a role (ADMIN)' })
-  async setToolAccess(@Param('id') id: string, @Body() dto: SetToolAccessDto) {
-    await this.rolesService.setToolAccess(id, dto.toolIds);
+  async setToolAccess(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: SetToolAccessDto,
+  ) {
+    const role = await this.rolesService.findByIdForOrg(id, req.user.organizationId);
+    if (!role) throw new NotFoundException('Role not found');
+    await this.rolesService.setToolAccess(id, dto.toolIds, req.user.organizationId);
     return { message: 'Tool access updated' };
   }
 
@@ -114,8 +129,17 @@ export class RolesController {
 
   @Put('assign/:userId')
   @ApiOperation({ summary: 'Assign MCP role to a user (ADMIN)' })
-  async assignRole(@Param('userId') userId: string, @Body() dto: AssignRoleDto) {
-    await this.rolesService.assignRoleToUser(userId, dto.roleId ?? null);
+  async assignRole(
+    @Req() req: any,
+    @Param('userId') userId: string,
+    @Body() dto: AssignRoleDto,
+  ) {
+    const result = await this.rolesService.assignRoleToUser(
+      userId,
+      dto.roleId ?? null,
+      req.user.organizationId,
+    );
+    if (!result) throw new NotFoundException('User or role not found');
     return { message: 'Role assigned' };
   }
 }

--- a/packages/backend/src/roles/roles.service.spec.ts
+++ b/packages/backend/src/roles/roles.service.spec.ts
@@ -9,13 +9,16 @@ describe('RolesService', () => {
       role: {
         findMany: jest.fn(),
         findUnique: jest.fn(),
+        findFirst: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
         delete: jest.fn(),
         upsert: jest.fn(),
       },
       user: {
         findUnique: jest.fn(),
+        findFirst: jest.fn(),
         updateMany: jest.fn(),
         update: jest.fn(),
       },
@@ -24,6 +27,9 @@ describe('RolesService', () => {
         create: jest.fn(),
         deleteMany: jest.fn(),
         upsert: jest.fn(),
+      },
+      mcpTool: {
+        count: jest.fn(),
       },
       $transaction: jest.fn(),
     };
@@ -68,28 +74,48 @@ describe('RolesService', () => {
   });
 
   describe('update', () => {
-    it('should update role fields', async () => {
+    it('should update role fields scoped to organization', async () => {
+      mockPrisma.role.updateMany = jest.fn().mockResolvedValue({ count: 1 });
       const updated = { id: 'r1', name: 'New Name' };
-      mockPrisma.role.update.mockResolvedValue(updated);
-      const result = await service.update('r1', { name: 'New Name' });
+      mockPrisma.role.findUnique.mockResolvedValue(updated);
+      const result = await service.update('r1', 'org-1', { name: 'New Name' });
       expect(result).toBe(updated);
-      expect(mockPrisma.role.update).toHaveBeenCalledWith({
-        where: { id: 'r1' },
+      expect(mockPrisma.role.updateMany).toHaveBeenCalledWith({
+        where: { id: 'r1', organizationId: 'org-1' },
         data: { name: 'New Name' },
       });
+    });
+
+    it('returns null when role does not belong to organization', async () => {
+      mockPrisma.role.updateMany = jest.fn().mockResolvedValue({ count: 0 });
+      const result = await service.update('r1', 'org-2', { name: 'X' });
+      expect(result).toBeNull();
     });
   });
 
   describe('delete', () => {
-    it('should unassign users then delete role', async () => {
+    it('should unassign users then delete role when org matches', async () => {
+      mockPrisma.role.findFirst.mockResolvedValue({ id: 'r1' });
       mockPrisma.user.updateMany.mockResolvedValue({ count: 2 });
       mockPrisma.role.delete.mockResolvedValue({});
-      await service.delete('r1');
+      const ok = await service.delete('r1', 'org-1');
+      expect(ok).toBe(true);
+      expect(mockPrisma.role.findFirst).toHaveBeenCalledWith({
+        where: { id: 'r1', organizationId: 'org-1' },
+        select: { id: true },
+      });
       expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
         where: { mcpRoleId: 'r1' },
         data: { mcpRoleId: null },
       });
       expect(mockPrisma.role.delete).toHaveBeenCalledWith({ where: { id: 'r1' } });
+    });
+
+    it('returns false when role is not in the organization', async () => {
+      mockPrisma.role.findFirst.mockResolvedValue(null);
+      const ok = await service.delete('r1', 'org-2');
+      expect(ok).toBe(false);
+      expect(mockPrisma.role.delete).not.toHaveBeenCalled();
     });
   });
 
@@ -103,20 +129,34 @@ describe('RolesService', () => {
   });
 
   describe('setToolAccess', () => {
-    it('should call $transaction with delete + create operations', async () => {
+    it('should call $transaction with delete + create operations after validating org-ownership of tools', async () => {
+      mockPrisma.mcpTool = { count: jest.fn().mockResolvedValue(2) } as any;
       mockPrisma.toolRoleAccess.deleteMany.mockReturnValue('delete-op');
       mockPrisma.toolRoleAccess.create
         .mockReturnValueOnce('create-op-1')
         .mockReturnValueOnce('create-op-2');
       mockPrisma.$transaction.mockResolvedValue([]);
 
-      await service.setToolAccess('r1', ['t1', 't2']);
+      await service.setToolAccess('r1', ['t1', 't2'], 'org-1');
 
+      expect(mockPrisma.mcpTool.count).toHaveBeenCalledWith({
+        where: {
+          id: { in: ['t1', 't2'] },
+          connector: { organizationId: 'org-1' },
+        },
+      });
       expect(mockPrisma.$transaction).toHaveBeenCalledWith([
         'delete-op',
         'create-op-1',
         'create-op-2',
       ]);
+    });
+
+    it('rejects when toolIds contain ids from another organization', async () => {
+      mockPrisma.mcpTool = { count: jest.fn().mockResolvedValue(1) } as any;
+      await expect(
+        service.setToolAccess('r1', ['t1', 't2'], 'org-1'),
+      ).rejects.toThrow('not in this organization');
     });
   });
 
@@ -190,10 +230,12 @@ describe('RolesService', () => {
   });
 
   describe('assignRoleToUser', () => {
-    it('should update user mcpRoleId', async () => {
+    it('should update user mcpRoleId when both user and role belong to the org', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
+      mockPrisma.role.findFirst.mockResolvedValue({ id: 'r1' });
       const updated = { id: 'user-1', mcpRoleId: 'r1' };
       mockPrisma.user.update.mockResolvedValue(updated);
-      const result = await service.assignRoleToUser('user-1', 'r1');
+      const result = await service.assignRoleToUser('user-1', 'r1', 'org-1');
       expect(result).toBe(updated);
       expect(mockPrisma.user.update).toHaveBeenCalledWith({
         where: { id: 'user-1' },
@@ -201,13 +243,29 @@ describe('RolesService', () => {
       });
     });
 
-    it('should allow setting roleId to null', async () => {
+    it('should allow setting roleId to null without role lookup', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
       mockPrisma.user.update.mockResolvedValue({ id: 'user-1', mcpRoleId: null });
-      await service.assignRoleToUser('user-1', null);
+      await service.assignRoleToUser('user-1', null, 'org-1');
       expect(mockPrisma.user.update).toHaveBeenCalledWith({
         where: { id: 'user-1' },
         data: { mcpRoleId: null },
       });
+    });
+
+    it('returns null when user belongs to a different org', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue(null);
+      const result = await service.assignRoleToUser('user-1', 'r1', 'org-2');
+      expect(result).toBeNull();
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('returns null when role belongs to a different org', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
+      mockPrisma.role.findFirst.mockResolvedValue(null);
+      const result = await service.assignRoleToUser('user-1', 'r1', 'org-1');
+      expect(result).toBeNull();
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/roles/roles.service.ts
+++ b/packages/backend/src/roles/roles.service.ts
@@ -31,26 +31,55 @@ export class RolesService {
     });
   }
 
+  /**
+   * Like findById, but only returns the role if it belongs to the given
+   * organization (or is a system role visible to all). Use this from any
+   * controller that resolves a role from a user-supplied id.
+   */
+  async findByIdForOrg(id: string, organizationId: string) {
+    return this.prisma.role.findFirst({
+      where: {
+        id,
+        OR: [{ organizationId }, { isSystem: true }],
+      },
+      include: {
+        toolAccess: {
+          include: { tool: { select: { id: true, name: true, connector: { select: { name: true } } } } },
+        },
+        _count: { select: { users: true } },
+      },
+    });
+  }
+
   async create(data: { name: string; description?: string; organizationId?: string }) {
     return this.prisma.role.create({
       data: { name: data.name, description: data.description, organizationId: data.organizationId },
     });
   }
 
-  async update(id: string, data: { name?: string; description?: string }) {
-    return this.prisma.role.update({
-      where: { id },
+  async update(id: string, organizationId: string, data: { name?: string; description?: string }) {
+    const result = await this.prisma.role.updateMany({
+      where: { id, organizationId },
       data,
     });
+    if (result.count === 0) return null;
+    return this.prisma.role.findUnique({ where: { id } });
   }
 
-  async delete(id: string) {
+  async delete(id: string, organizationId: string) {
+    // Only delete the role if it belongs to the given organization
+    const role = await this.prisma.role.findFirst({
+      where: { id, organizationId },
+      select: { id: true },
+    });
+    if (!role) return false;
     // Unassign users first
     await this.prisma.user.updateMany({
       where: { mcpRoleId: id },
       data: { mcpRoleId: null },
     });
     await this.prisma.role.delete({ where: { id } });
+    return true;
   }
 
   // ── Tool access management ────────────────────────────────────────────────
@@ -62,7 +91,21 @@ export class RolesService {
     });
   }
 
-  async setToolAccess(roleId: string, toolIds: string[]) {
+  async setToolAccess(roleId: string, toolIds: string[], organizationId: string) {
+    // Validate that every tool ID belongs to the given organization. This
+    // prevents an admin from assigning tools owned by another org to a role
+    // they control.
+    if (toolIds.length > 0) {
+      const validCount = await this.prisma.mcpTool.count({
+        where: {
+          id: { in: toolIds },
+          connector: { organizationId },
+        },
+      });
+      if (validCount !== toolIds.length) {
+        throw new Error('One or more toolIds are not in this organization');
+      }
+    }
     // Replace all tool access for this role
     await this.prisma.$transaction([
       this.prisma.toolRoleAccess.deleteMany({ where: { roleId } }),
@@ -128,7 +171,31 @@ export class RolesService {
 
   // ── User role assignment ──────────────────────────────────────────────────
 
-  async assignRoleToUser(userId: string, roleId: string | null) {
+  async assignRoleToUser(
+    userId: string,
+    roleId: string | null,
+    organizationId: string,
+  ) {
+    // The user must belong to the requesting org, and the role must be
+    // visible to that org (system roles or org-owned). Otherwise an admin
+    // could assign someone else's user a role from their own org.
+    const user = await this.prisma.user.findFirst({
+      where: { id: userId, organizationId },
+      select: { id: true },
+    });
+    if (!user) return null;
+
+    if (roleId !== null) {
+      const role = await this.prisma.role.findFirst({
+        where: {
+          id: roleId,
+          OR: [{ organizationId }, { isSystem: true }],
+        },
+        select: { id: true },
+      });
+      if (!role) return null;
+    }
+
     return this.prisma.user.update({
       where: { id: userId },
       data: { mcpRoleId: roleId },

--- a/packages/backend/src/users/users.controller.ts
+++ b/packages/backend/src/users/users.controller.ts
@@ -142,8 +142,9 @@ export class UsersController {
   @UseGuards(RolesGuard)
   @Roles('ADMIN')
   @ApiOperation({ summary: 'Revoke an invitation (ADMIN only)' })
-  async deleteInvitation(@Param('id') id: string) {
-    await this.usersService.deleteInvitation(id);
+  async deleteInvitation(@Req() req: any, @Param('id') id: string) {
+    const ok = await this.usersService.deleteInvitationInOrg(id, req.user.organizationId);
+    if (!ok) return { error: 'Invitation not found' };
     return { message: 'Invitation revoked' };
   }
 
@@ -160,10 +161,12 @@ export class UsersController {
       return { error: 'Cannot change your own role' };
     }
 
-    const user = await this.usersService.findById(id);
-    if (!user) return { error: 'User not found' };
-
-    await this.usersService.update(id, { role: dto.role });
+    const updated = await this.usersService.updateInOrg(
+      id,
+      req.user.organizationId,
+      { role: dto.role },
+    );
+    if (!updated) return { error: 'User not found' };
     return { message: `User role updated to ${dto.role}` };
   }
 
@@ -176,7 +179,8 @@ export class UsersController {
       return { error: 'Cannot delete your own account' };
     }
 
-    await this.usersService.delete(id);
+    const ok = await this.usersService.deleteInOrg(id, req.user.organizationId);
+    if (!ok) return { error: 'User not found' };
     return { message: 'User deleted' };
   }
 }

--- a/packages/backend/src/users/users.service.ts
+++ b/packages/backend/src/users/users.service.ts
@@ -54,8 +54,36 @@ export class UsersService {
     });
   }
 
+  /**
+   * Update a user only if they belong to the given organization.
+   * Returns null if no row matched. Use this from any admin endpoint
+   * that takes a user id from the request URL.
+   */
+  async updateInOrg(
+    userId: string,
+    organizationId: string,
+    data: Partial<User>,
+  ): Promise<User | null> {
+    const result = await this.prisma.user.updateMany({
+      where: { id: userId, organizationId },
+      data,
+    });
+    if (result.count === 0) return null;
+    return this.prisma.user.findUnique({ where: { id: userId } });
+  }
+
   async delete(userId: string): Promise<void> {
     await this.prisma.user.delete({ where: { id: userId } });
+  }
+
+  async deleteInOrg(userId: string, organizationId: string): Promise<boolean> {
+    const target = await this.prisma.user.findFirst({
+      where: { id: userId, organizationId },
+      select: { id: true },
+    });
+    if (!target) return false;
+    await this.prisma.user.delete({ where: { id: userId } });
+    return true;
   }
 
   async deleteSelf(userId: string): Promise<void> {
@@ -117,5 +145,12 @@ export class UsersService {
 
   async deleteInvitation(id: string): Promise<void> {
     await this.prisma.invitationToken.delete({ where: { id } });
+  }
+
+  async deleteInvitationInOrg(id: string, organizationId: string): Promise<boolean> {
+    const result = await this.prisma.invitationToken.deleteMany({
+      where: { id, organizationId },
+    });
+    return result.count > 0;
   }
 }


### PR DESCRIPTION
## Summary

First batch of security blockers from the full project review. All seven Sprint 1 tasks completed.

- **Secrets**: removed hardcoded `JWT_SECRET` / `ENCRYPTION_KEY` fallbacks; new `secrets.util.ts` validates required secrets at boot (length ≥ 32, rejects known placeholders) — app refuses to start otherwise.
- **SSRF**: new `ssrf.util.ts` with DNS-aware host check (resolves the hostname before allowing the request, so DNS rebinding to private IPs is also blocked). Covers loopback / 169.254 metadata / RFC1918 / link-local / IPv4-mapped IPv6. Integrated into REST, GraphQL, SOAP, MCP-client, OAuth2 token, mcp-oauth, and the OpenAPI / Postman / GraphQL spec fetchers. Auto-disabled in jest.
- **SQL injection**: `DatabaseEngine` now compiles templates to driver-specific prepared statements (`$1` pg, `?` mysql/sqlite, `@p0` mssql, `:b0` oracle); values are bound, never inlined. The legacy `${query}` raw-mode is kept for admin SELECT-only introspection.
- **Template injection**: REST `bodyTemplate` rejects `__proto__` / `constructor` / `prototype` param keys, escapes string values JSON-safely, and re-validates the parsed result.
- **IDOR**: tools `update`/`delete` are pinned to `connectorId` via `updateMany`/`deleteMany`; roles service has new `findByIdForOrg`, `update`, `delete`, `setToolAccess`, `assignRoleToUser` overloads that take `organizationId` and refuse cross-tenant operations; users admin endpoints (role change, delete, invitation revoke) confined to the requesting org.
- **HTTP**: Helmet middleware, HSTS in prod, CORS rejects `'*' + credentials` in production, per-endpoint throttle (`auth-strict` 5/min on login / register / password-reset, `auth` 10/min on resend-verification).
- **Dependencies**: `npm audit fix` brings vulnerabilities from 43 (1 critical, 22 high, 20 moderate) down to 11 (1 high, 10 moderate, all transitive dev tooling). Dependabot config added.

## Test plan

- [x] `tsc --noEmit -p packages/backend/tsconfig.json` clean
- [x] `nest build` produces dist
- [x] `npm test` baseline 5 failures (pre-existing, unrelated to this PR) — same 5 after; 7 new tests added pass
- [ ] manual smoke: start backend with missing secrets → fails fast
- [ ] manual smoke: connector pointing at `http://169.254.169.254/...` → blocked by SSRF guard
- [ ] manual smoke: tool with template `WHERE name = \$name` and param `"x'; DROP TABLE users; --"` → bound as parameter, no SQL executed