### PR TITLE
Add connectors+MCP smoke test, fix global throttler bucketing

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -90,14 +90,13 @@ if (useOAuth) {
     // Cache
     RedisModule,
 
-    // Rate limiting — named buckets so callers can pick a stricter policy
-    // for sensitive endpoints (login, password reset) without affecting
-    // general API throughput.
-    ThrottlerModule.forRoot([
-      { name: 'default', ttl: 60_000, limit: 100 },
-      { name: 'auth', ttl: 60_000, limit: 10 },
-      { name: 'auth-strict', ttl: 60_000, limit: 5 },
-    ]),
+    // Rate limiting — single default bucket (100 req/min). Sensitive routes
+    // (login, register, password reset) override this with @Throttle() so
+    // they can have a much stricter cap without throttling general traffic.
+    // Note: do NOT add additional named buckets here. With nestjs/throttler
+    // v6, ALL configured buckets apply to every request, which means a
+    // strict bucket would also throttle the MCP endpoints.
+    ThrottlerModule.forRoot([{ ttl: 60_000, limit: 100 }]),
 
     // MCP Server (dynamic tools registered by McpServerModule)
     McpModule.forRoot({

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -178,7 +178,7 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Login with email and password' })
   async login(@Req() req: any, @Body() dto: LoginDto) {
     const user = await this.usersService.findByEmail(dto.email);
@@ -231,7 +231,7 @@ export class AuthController {
   }
 
   @Post('register')
-  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Register a new user account' })
   async register(@Req() req: any, @Body() dto: RegisterDto) {
     const existing = await this.usersService.findByEmail(dto.email);
@@ -368,7 +368,7 @@ export class AuthController {
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
-  @Throttle({ 'auth': { limit: 10, ttl: 60_000 } })
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @ApiOperation({ summary: 'Resend email verification code' })
   async resendVerification(@Req() req: any) {
     const userId = req.user.sub;
@@ -580,7 +580,7 @@ export class AuthController {
 
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
-  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Request password reset email' })
   async forgotPassword(@Req() req: any, @Body() dto: ForgotPasswordDto) {
     // Always return success to prevent email enumeration
@@ -622,7 +622,7 @@ export class AuthController {
 
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
-  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Reset password using token' })
   async resetPassword(@Body() dto: ResetPasswordDto) {
     const resetRecord = await this.prisma.passwordResetToken.findUnique({

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -38,7 +38,7 @@ export class LoginController {
   }
 
   @Post('login')
-  @Throttle({ 'auth-strict': { limit: 5, ttl: 60_000 } })
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   async handleLogin(
     @Req() req: Request,
     @Body() body: { email: string; password: string; session: string },

--- a/scripts/smoke-test/docker-compose.smoke.yml
+++ b/scripts/smoke-test/docker-compose.smoke.yml
@@ -1,0 +1,96 @@
+# =============================================================================
+# Smoke-test stack
+# =============================================================================
+# Brings up everything the smoke-test script needs:
+#   - postgres: app database
+#   - mysql:    target for the DATABASE-connector test (with sample data)
+#   - app:      backend + frontend (the Sprint-1-hardened build)
+#
+# Usage:
+#   ./scripts/smoke-test/run.sh
+#
+# Secrets are generated on the fly inside run.sh so they pass our boot-time
+# validation (JWT_SECRET / ENCRYPTION_KEY ≥ 32 chars, no known placeholders).
+# =============================================================================
+
+name: amcp-smoke
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: amcp-smoke-postgres
+    environment:
+      POSTGRES_USER: amcp
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: anythingmcp
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U amcp -d anythingmcp"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    tmpfs:
+      - /var/lib/postgresql/data
+    networks: [smoke]
+
+  mysql:
+    image: mysql:8.4
+    container_name: amcp-smoke-mysql
+    environment:
+      MYSQL_DATABASE: smoketest
+      MYSQL_USER: smoke
+      MYSQL_PASSWORD: smokepass
+      MYSQL_ROOT_PASSWORD: smokerootpass
+    volumes:
+      - ./mysql-init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      test:
+        ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-usmoke", "-psmokepass"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+    tmpfs:
+      - /var/lib/mysql
+    networks: [smoke]
+
+  app:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    image: anythingmcp-smoke:local
+    container_name: amcp-smoke-app
+    environment:
+      NODE_ENV: production
+      PORT: "4000"
+      DATABASE_URL: "postgresql://amcp:${POSTGRES_PASSWORD}@postgres:5432/anythingmcp"
+      JWT_SECRET: ${JWT_SECRET}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      CORS_ORIGIN: http://localhost:3000
+      SERVER_URL: http://localhost:4000
+      FRONTEND_URL: http://localhost:3000
+      MCP_AUTH_MODE: legacy
+      ALLOW_OPEN_REGISTRATION: "true"
+      DEPLOYMENT_MODE: self-hosted
+      # Allow the smoke test to reach the local mysql container (private IP)
+      # without disabling the SSRF guard globally.
+      SSRF_ALLOW_PRIVATE: "true"
+      SSRF_ALLOW_LOCALHOST: "true"
+    ports:
+      - "${SMOKE_BACKEND_PORT:-4100}:4000"
+      - "${SMOKE_FRONTEND_PORT:-3100}:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test:
+        ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+    networks: [smoke]
+
+networks:
+  smoke:
+    name: amcp-smoke

--- a/scripts/smoke-test/main.ts
+++ b/scripts/smoke-test/main.ts
@@ -1,0 +1,391 @@
+/* eslint-disable no-console */
+/**
+ * AnythingMCP smoke test
+ * ----------------------
+ * End-to-end check that exercises every connector type we ship and verifies
+ * the per-server MCP endpoint actually returns useful data over the MCP
+ * protocol after the Sprint 1 hardening (prepared statements, SSRF guard,
+ * tightened CORS, body-template sanitisation, secret enforcement, IDOR fixes).
+ *
+ * Flow:
+ *   1. Wait for /health on the running stack.
+ *   2. Register an admin (open registration is on for the smoke profile).
+ *   3. List MCP servers — the default one is created on register.
+ *   4. Create connectors:
+ *        - REST   → https://jsonplaceholder.typicode.com
+ *        - SOAP   → http://www.dataaccess.com/.../NumberConversion.wso
+ *        - GRAPHQL→ https://countries.trevorblades.com/
+ *        - DATABASE/MySQL → in-stack mysql container with sample data
+ *   5. Define one or two tools per connector (manual definitions to avoid
+ *      depending on remote SDL/Swagger fetchers, which we already SSRF-guard).
+ *   6. Assign all four connectors to the default MCP server.
+ *   7. Mint an MCP API key bound to that server.
+ *   8. Connect via @modelcontextprotocol/sdk to /mcp/<serverId> using the key.
+ *   9. List tools, then invoke one tool per connector and assert the response
+ *      contains the expected substring.
+ *  10. Print a summary; exit non-zero on any failure.
+ */
+
+import axios, { AxiosInstance } from 'axios';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const API_BASE = process.env.SMOKE_API_BASE || 'http://localhost:4000';
+const ADMIN_EMAIL =
+  process.env.SMOKE_ADMIN_EMAIL || `smoke-${Date.now()}@anythingmcp.local`;
+const ADMIN_PASSWORD = process.env.SMOKE_ADMIN_PASSWORD || 'Smoke!Pass#2026';
+const ADMIN_NAME = 'Smoke Tester';
+
+interface CallResult {
+  label: string;
+  ok: boolean;
+  detail: string;
+}
+
+const results: CallResult[] = [];
+
+function record(label: string, ok: boolean, detail: string) {
+  results.push({ label, ok, detail });
+  const tag = ok ? 'PASS' : 'FAIL';
+  console.log(`  [${tag}] ${label} — ${detail}`);
+}
+
+async function waitForHealth(api: AxiosInstance, attempts = 60): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await api.get('/health');
+      if (res.status === 200) return;
+    } catch {
+      /* retry */
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`/health never became reachable at ${API_BASE}`);
+}
+
+async function registerAdmin(api: AxiosInstance): Promise<string> {
+  const res = await api.post('/api/auth/register', {
+    email: ADMIN_EMAIL,
+    password: ADMIN_PASSWORD,
+    name: ADMIN_NAME,
+    acceptTerms: true,
+  });
+  if (!res.data?.accessToken) {
+    throw new Error(`register did not return accessToken: ${JSON.stringify(res.data)}`);
+  }
+  return res.data.accessToken as string;
+}
+
+async function getDefaultMcpServer(api: AxiosInstance): Promise<{
+  id: string;
+  slug: string;
+}> {
+  const res = await api.get('/api/mcp-servers');
+  const servers = res.data;
+  if (!Array.isArray(servers) || servers.length === 0) {
+    throw new Error('expected at least one MCP server (default) after register');
+  }
+  return { id: servers[0].id, slug: servers[0].slug };
+}
+
+async function createConnector(
+  api: AxiosInstance,
+  body: Record<string, unknown>,
+): Promise<string> {
+  const res = await api.post('/api/connectors', body);
+  if (!res.data?.id) {
+    throw new Error(
+      `create connector failed for ${body.name}: ${JSON.stringify(res.data)}`,
+    );
+  }
+  return res.data.id as string;
+}
+
+async function createTool(
+  api: AxiosInstance,
+  connectorId: string,
+  tool: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    endpointMapping: Record<string, unknown>;
+  },
+): Promise<void> {
+  await api.post(`/api/connectors/${connectorId}/tools`, tool);
+}
+
+async function assignConnectors(
+  api: AxiosInstance,
+  serverId: string,
+  connectorIds: string[],
+): Promise<void> {
+  await api.put(`/api/mcp-servers/${serverId}/connectors`, { connectorIds });
+}
+
+async function mintApiKey(
+  api: AxiosInstance,
+  serverId: string,
+): Promise<string> {
+  const res = await api.post('/api/mcp-keys', {
+    name: 'smoke-test-key',
+    mcpServerId: serverId,
+  });
+  if (!res.data?.key) {
+    throw new Error(`mint key failed: ${JSON.stringify(res.data)}`);
+  }
+  return res.data.key as string;
+}
+
+async function callMcpTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const out = await client.callTool({ name, arguments: args });
+  if ((out as { isError?: boolean }).isError) {
+    throw new Error(
+      `tool ${name} returned isError: ${JSON.stringify(out.content)}`,
+    );
+  }
+  return out;
+}
+
+function extractText(out: unknown): string {
+  const r = out as { content?: Array<{ type?: string; text?: string }> };
+  if (!r?.content) return '';
+  return r.content
+    .filter((c) => c.type === 'text' && typeof c.text === 'string')
+    .map((c) => c.text!)
+    .join('\n');
+}
+
+async function main() {
+  const adminApi = axios.create({
+    baseURL: API_BASE,
+    validateStatus: () => true,
+  });
+
+  console.log(`[smoke] API at ${API_BASE}`);
+  console.log('[smoke] Waiting for /health...');
+  await waitForHealth(adminApi);
+
+  console.log('[smoke] Registering admin...');
+  const token = await registerAdmin(adminApi);
+  adminApi.defaults.headers.common.Authorization = `Bearer ${token}`;
+
+  console.log('[smoke] Resolving default MCP server...');
+  const server = await getDefaultMcpServer(adminApi);
+  console.log(`[smoke] Default MCP server id=${server.id} slug=${server.slug}`);
+
+  // ---- REST ----------------------------------------------------------------
+  console.log('[smoke] Creating REST connector (jsonplaceholder)...');
+  const restId = await createConnector(adminApi, {
+    name: 'jsonplaceholder',
+    type: 'REST',
+    baseUrl: 'https://jsonplaceholder.typicode.com',
+    authType: 'NONE',
+  });
+  await createTool(adminApi, restId, {
+    name: 'jph_get_post',
+    description: 'Fetch a single post from JSONPlaceholder by id.',
+    parameters: {
+      type: 'object',
+      properties: {
+        id: { type: 'integer', description: 'Post id (1-100)' },
+      },
+      required: ['id'],
+    },
+    endpointMapping: { method: 'GET', path: '/posts/{id}' },
+  });
+
+  // ---- SOAP ----------------------------------------------------------------
+  console.log('[smoke] Creating SOAP connector (NumberConversion)...');
+  const soapId = await createConnector(adminApi, {
+    name: 'numberconversion',
+    type: 'SOAP',
+    baseUrl: 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
+    specUrl:
+      'https://www.dataaccess.com/webservicesserver/NumberConversion.wso?WSDL',
+    authType: 'NONE',
+  });
+  await createTool(adminApi, soapId, {
+    name: 'number_to_words',
+    description: 'Convert an unsigned integer to its English word form.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ubiNum: { type: 'integer', description: 'A non-negative integer' },
+      },
+      required: ['ubiNum'],
+    },
+    endpointMapping: {
+      method: 'NumberToWords',
+      path: 'NumberConversionSoap',
+      paramOrder: ['ubiNum'],
+    },
+  });
+
+  // ---- GRAPHQL -------------------------------------------------------------
+  console.log('[smoke] Creating GRAPHQL connector (countries)...');
+  const gqlId = await createConnector(adminApi, {
+    name: 'countries-graphql',
+    type: 'GRAPHQL',
+    baseUrl: 'https://countries.trevorblades.com/',
+    authType: 'NONE',
+  });
+  await createTool(adminApi, gqlId, {
+    name: 'country_by_code',
+    description: 'Look up a country by ISO 3166-1 alpha-2 code.',
+    parameters: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'ISO alpha-2 code, e.g. IT' },
+      },
+      required: ['code'],
+    },
+    endpointMapping: {
+      method: 'query',
+      path: 'query CountryByCode($code: ID!) { country(code: $code) { name capital currency emoji } }',
+      queryParams: { code: '$code' },
+    },
+  });
+
+  // ---- DATABASE (MySQL) ----------------------------------------------------
+  console.log('[smoke] Creating DATABASE/MySQL connector...');
+  const dbId = await createConnector(adminApi, {
+    name: 'mysql-smoke',
+    type: 'DATABASE',
+    baseUrl: 'mysql://smoke:smokepass@mysql:3306/smoketest',
+    authType: 'NONE',
+    config: { readOnly: true },
+  });
+  // The default tools auto-created for DATABASE connectors include
+  // exec_sql / list_tables / describe_table. We add one bound-parameter
+  // SELECT to specifically exercise the prepared-statement path.
+  await createTool(adminApi, dbId, {
+    name: 'find_user_by_name',
+    description:
+      'Find a user row by exact name match. Bound via prepared statement.',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Exact user name to look up' },
+      },
+      required: ['name'],
+    },
+    endpointMapping: {
+      method: 'query',
+      path: 'SELECT id, name, email, active FROM users WHERE name = $name',
+    },
+  });
+
+  // ---- Wire connectors to MCP server --------------------------------------
+  console.log('[smoke] Assigning connectors to MCP server...');
+  await assignConnectors(adminApi, server.id, [restId, soapId, gqlId, dbId]);
+
+  console.log('[smoke] Minting MCP API key...');
+  const apiKey = await mintApiKey(adminApi, server.id);
+
+  // ---- MCP client ----------------------------------------------------------
+  const mcpUrl = new URL(`/mcp/${server.id}`, API_BASE);
+  console.log(`[smoke] Connecting MCP client to ${mcpUrl.toString()}`);
+  const transport = new StreamableHTTPClientTransport(mcpUrl, {
+    requestInit: { headers: { 'X-API-Key': apiKey } },
+  });
+  const client = new Client({ name: 'smoke-test-client', version: '1.0.0' });
+  await client.connect(transport);
+
+  const toolsResp = await client.listTools();
+  const toolNames = toolsResp.tools.map((t) => t.name);
+  console.log(`[smoke] MCP server exposes ${toolNames.length} tools: ${toolNames.join(', ')}`);
+
+  // ---- Invoke one tool per connector --------------------------------------
+  try {
+    const out = await callMcpTool(client, 'jph_get_post', { id: 1 });
+    const text = extractText(out);
+    record(
+      'REST jph_get_post',
+      text.includes('"id"') && text.includes('"title"'),
+      text.slice(0, 120).replace(/\s+/g, ' '),
+    );
+  } catch (e: any) {
+    record('REST jph_get_post', false, e.message);
+  }
+
+  try {
+    const out = await callMcpTool(client, 'number_to_words', { ubiNum: 42 });
+    const text = extractText(out).toLowerCase();
+    record(
+      'SOAP number_to_words',
+      text.includes('forty') && text.includes('two'),
+      text.slice(0, 120).replace(/\s+/g, ' '),
+    );
+  } catch (e: any) {
+    record('SOAP number_to_words', false, e.message);
+  }
+
+  try {
+    const out = await callMcpTool(client, 'country_by_code', { code: 'IT' });
+    const text = extractText(out);
+    record(
+      'GraphQL country_by_code',
+      text.includes('Italy') || text.includes('"name"'),
+      text.slice(0, 120).replace(/\s+/g, ' '),
+    );
+  } catch (e: any) {
+    record('GraphQL country_by_code', false, e.message);
+  }
+
+  try {
+    const out = await callMcpTool(client, 'find_user_by_name', {
+      name: 'Alice',
+    });
+    const text = extractText(out);
+    record(
+      'MySQL prepared SELECT (alice)',
+      text.includes('alice@example.com'),
+      text.slice(0, 120).replace(/\s+/g, ' '),
+    );
+  } catch (e: any) {
+    record('MySQL prepared SELECT (alice)', false, e.message);
+  }
+
+  // The injection-shaped row exists; binding the literal must return that row,
+  // never execute a DROP TABLE.
+  try {
+    const sqliName = "x'; DROP TABLE users;--";
+    const out = await callMcpTool(client, 'find_user_by_name', {
+      name: sqliName,
+    });
+    const text = extractText(out);
+    record(
+      'MySQL prepared SELECT (sqli payload bound as literal)',
+      text.includes('sqli@example.com'),
+      text.slice(0, 120).replace(/\s+/g, ' '),
+    );
+  } catch (e: any) {
+    record('MySQL prepared SELECT (sqli payload bound as literal)', false, e.message);
+  }
+
+  await client.close();
+
+  console.log('\n[smoke] Summary');
+  console.log('---------------');
+  let failed = 0;
+  for (const r of results) {
+    const tag = r.ok ? '✓' : '✗';
+    console.log(`  ${tag}  ${r.label}`);
+    if (!r.ok) failed += 1;
+  }
+  console.log('---------------');
+  console.log(`[smoke] ${results.length - failed}/${results.length} passed`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('[smoke] Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/smoke-test/mysql-init.sql
+++ b/scripts/smoke-test/mysql-init.sql
@@ -1,0 +1,21 @@
+-- Sample data for the DATABASE-connector smoke test.
+-- Designed to exercise the prepared-statement code path: a row is fetched by
+-- bound parameter, and a deliberately injection-shaped string is also stored
+-- so the test can assert that it round-trips as a literal value.
+
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(120) NOT NULL,
+  email VARCHAR(190) NOT NULL UNIQUE,
+  active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users (name, email, active) VALUES
+  ('Alice',                 'alice@example.com',         1),
+  ('Bob',                   'bob@example.com',           1),
+  ('Carol',                 'carol@example.com',         0),
+  ('x''; DROP TABLE users;--', 'sqli@example.com', 1);
+
+GRANT SELECT ON smoketest.* TO 'smoke'@'%';
+FLUSH PRIVILEGES;

--- a/scripts/smoke-test/run.sh
+++ b/scripts/smoke-test/run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# =============================================================================
+# AnythingMCP smoke test runner
+# =============================================================================
+# Builds the Docker image from the current working tree, brings up postgres +
+# mysql + app, runs the TypeScript smoke test on the host, then tears
+# everything down.
+#
+# Usage:
+#   ./scripts/smoke-test/run.sh             # build, run, tear down
+#   KEEP_STACK=1 ./scripts/smoke-test/run.sh # leave stack up after the test
+#   SKIP_BUILD=1 ./scripts/smoke-test/run.sh # reuse existing image
+# =============================================================================
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+SMOKE_DIR="$(pwd)"
+ROOT_DIR="$(cd ../.. && pwd)"
+
+export POSTGRES_PASSWORD="$(openssl rand -hex 16)"
+export JWT_SECRET="$(openssl rand -base64 48 | tr -d '=' | tr -d '\n')"
+export ENCRYPTION_KEY="$(openssl rand -base64 48 | tr -d '=' | tr -d '\n')"
+
+trap_handler() {
+  local code=$?
+  if [[ "${KEEP_STACK:-0}" == "1" ]]; then
+    echo "[smoke] KEEP_STACK=1 set — leaving stack running."
+    echo "[smoke] App: http://localhost:4000  |  MySQL: localhost:3306"
+  else
+    echo "[smoke] Tearing down stack..."
+    docker compose -f "$SMOKE_DIR/docker-compose.smoke.yml" down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+  exit "$code"
+}
+trap trap_handler EXIT INT TERM
+
+echo "[smoke] Working dir: $SMOKE_DIR"
+echo "[smoke] Repo root  : $ROOT_DIR"
+
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+  echo "[smoke] Building app image..."
+  docker compose -f "$SMOKE_DIR/docker-compose.smoke.yml" build app
+fi
+
+echo "[smoke] Starting stack..."
+docker compose -f "$SMOKE_DIR/docker-compose.smoke.yml" up -d
+
+echo "[smoke] Waiting for app to be healthy..."
+for i in $(seq 1 60); do
+  status=$(docker inspect -f '{{.State.Health.Status}}' amcp-smoke-app 2>/dev/null || echo "starting")
+  if [[ "$status" == "healthy" ]]; then
+    echo "[smoke] App is healthy."
+    break
+  fi
+  if [[ $i -eq 60 ]]; then
+    echo "[smoke] App did not become healthy within 5 minutes."
+    docker compose -f "$SMOKE_DIR/docker-compose.smoke.yml" logs app | tail -100
+    exit 1
+  fi
+  sleep 5
+done
+
+echo "[smoke] Running smoke test..."
+cd "$ROOT_DIR"
+export SMOKE_API_BASE="${SMOKE_API_BASE:-http://localhost:${SMOKE_BACKEND_PORT:-4100}}"
+npx -y --package=typescript --package=ts-node --package=axios --package=@modelcontextprotocol/sdk \
+  ts-node --transpile-only \
+  --compiler-options '{"module":"commonjs","target":"es2020","esModuleInterop":true,"resolveJsonModule":true,"strict":false}' \
+  scripts/smoke-test/main.ts
+
+echo "[smoke] OK."


### PR DESCRIPTION
## Summary

End-to-end verification for the Sprint 1 hardening, plus a fix for a regression the smoke test surfaced.

### The fix
Sprint 1 added three named throttler buckets (\`default\` 100/min, \`auth\` 10/min, \`auth-strict\` 5/min) in \`app.module.ts\`. With \`@nestjs/throttler\` v6, every configured bucket is checked on every request — so the 5/min \`auth-strict\` cap was throttling \`/mcp/:serverId\` too. Reverted to one default bucket and switched the per-route \`@Throttle\` overrides to that bucket. \`@SkipThrottle()\` on \`McpEndpointController\` already exempts MCP traffic from the default bucket.

### The smoke test
\`scripts/smoke-test/\` brings up postgres + mysql + a freshly-built app image, then runs a TypeScript script that:

- registers an admin (open registration in the smoke profile)
- creates four connectors:
  - **REST** → \`https://jsonplaceholder.typicode.com\`
  - **SOAP** → DataAccess \`NumberConversion.wso\`
  - **GraphQL** → \`https://countries.trevorblades.com/\`
  - **DATABASE/MySQL** → the in-stack \`mysql\` container with seed data including an SQL-injection-shaped name
- assigns all four to the default MCP server
- mints an MCP API key
- opens an MCP client over Streamable HTTP and invokes one tool per connector
- asserts an \`x'; DROP TABLE users;--\` parameter is bound as a literal value, not executed (verifying the prepared-statement fix)

Local run after this PR: **5/5 passed**.

\`\`\`
[smoke] MCP server exposes 7 tools: jph_get_post, number_to_words, country_by_code, get_database_schema, get_example_queries, execute_query, find_user_by_name
  [PASS] REST jph_get_post
  [PASS] SOAP number_to_words
  [PASS] GraphQL country_by_code
  [PASS] MySQL prepared SELECT (alice)
  [PASS] MySQL prepared SELECT (sqli payload bound as literal)
\`\`\`

## Test plan

- [x] \`./scripts/smoke-test/run.sh\` (with \`SMOKE_BACKEND_PORT=44000 SMOKE_FRONTEND_PORT=43000\` if dev ports are taken)
- [x] \`tsc --noEmit -p packages/backend/tsconfig.json\`
- [x] backend jest suite: same 5 pre-existing failures, no new ones