### PR TITLE
Sprint 2 batch 3: frontend error/not-found + a11y on auth forms

### DIFF
--- a/packages/frontend/next-env.d.ts
+++ b/packages/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/frontend/src/app/error.tsx
+++ b/packages/frontend/src/app/error.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Global error boundary. Renders for any uncaught exception inside an App
+ * Router segment that hasn't installed its own error.tsx.
+ *
+ * Without this, Next.js falls back to its built-in dev / "Application
+ * error" screen — fine in development but a poor first impression in
+ * production. We surface a calm message + a retry button + the digest
+ * Next assigns to the error so a user can quote it when reporting a bug.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Avoid leaking stack traces; just record that something tripped.
+    if (typeof window !== 'undefined' && error?.digest) {
+      console.error(`[error.tsx] uncaught error (digest=${error.digest})`);
+    } else {
+      console.error('[error.tsx] uncaught error', error);
+    }
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px',
+      }}
+    >
+      <div
+        role="alert"
+        style={{
+          maxWidth: 480,
+          width: '100%',
+          background: 'var(--card, #fff)',
+          color: 'var(--foreground, #111827)',
+          border: '1px solid var(--border, #e5e7eb)',
+          borderRadius: 12,
+          padding: 24,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.06)',
+        }}
+      >
+        <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 8 }}>
+          Something went wrong
+        </h1>
+        <p style={{ color: 'var(--muted-foreground, #6b7280)', marginBottom: 16 }}>
+          The page hit an unexpected error. You can retry, or go back to the
+          dashboard.
+        </p>
+
+        {error?.digest ? (
+          <p
+            style={{
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 12,
+              color: 'var(--muted-foreground, #6b7280)',
+              marginBottom: 16,
+            }}
+          >
+            Error reference: <strong>{error.digest}</strong>
+          </p>
+        ) : null}
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{
+              padding: '8px 14px',
+              borderRadius: 8,
+              border: 'none',
+              background: 'var(--brand, #2563eb)',
+              color: '#fff',
+              cursor: 'pointer',
+              fontWeight: 500,
+            }}
+          >
+            Try again
+          </button>
+          <a
+            href="/"
+            style={{
+              padding: '8px 14px',
+              borderRadius: 8,
+              border: '1px solid var(--border, #e5e7eb)',
+              color: 'inherit',
+              textDecoration: 'none',
+              fontWeight: 500,
+            }}
+          >
+            Go to dashboard
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/forgot-password/page.tsx
+++ b/packages/frontend/src/app/forgot-password/page.tsx
@@ -70,9 +70,12 @@ export default function ForgotPasswordPage() {
 
               <form className="space-y-4" onSubmit={handleSubmit}>
                 <div>
-                  <label className="block text-sm font-medium mb-1">Email</label>
+                  <label htmlFor="forgot-email" className="block text-sm font-medium mb-1">Email</label>
                   <input
+                    id="forgot-email"
+                    name="email"
                     type="email"
+                    autoComplete="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="admin@example.com"

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -584,9 +584,12 @@ function LoginForm() {
         <form className="space-y-4" onSubmit={handleSubmit}>
           {isRegister && (
             <div>
-              <label className="block text-sm font-medium mb-1">Name</label>
+              <label htmlFor="auth-name" className="block text-sm font-medium mb-1">Name</label>
               <input
+                id="auth-name"
+                name="name"
                 type="text"
+                autoComplete="name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Your name"
@@ -597,9 +600,12 @@ function LoginForm() {
           )}
 
           <div>
-            <label className="block text-sm font-medium mb-1">Email</label>
+            <label htmlFor="auth-email" className="block text-sm font-medium mb-1">Email</label>
             <input
+              id="auth-email"
+              name="email"
               type="email"
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="admin@example.com"
@@ -609,9 +615,12 @@ function LoginForm() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1">Password</label>
+            <label htmlFor="auth-password" className="block text-sm font-medium mb-1">Password</label>
             <input
+              id="auth-password"
+              name="password"
               type="password"
+              autoComplete={isRegister ? 'new-password' : 'current-password'}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Min. 8 characters"
@@ -639,9 +648,12 @@ function LoginForm() {
           {isRegister && (
             <>
               <div>
-                <label className="block text-sm font-medium mb-1">Confirm Password</label>
+                <label htmlFor="auth-confirm-password" className="block text-sm font-medium mb-1">Confirm Password</label>
                 <input
+                  id="auth-confirm-password"
+                  name="confirm-password"
                   type="password"
+                  autoComplete="new-password"
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   placeholder="Repeat your password"

--- a/packages/frontend/src/app/not-found.tsx
+++ b/packages/frontend/src/app/not-found.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 480,
+          width: '100%',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            fontSize: 12,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--muted-foreground, #6b7280)',
+            marginBottom: 8,
+          }}
+        >
+          404
+        </p>
+        <h1 style={{ fontSize: 24, fontWeight: 600, marginBottom: 8 }}>
+          Page not found
+        </h1>
+        <p
+          style={{
+            color: 'var(--muted-foreground, #6b7280)',
+            marginBottom: 24,
+          }}
+        >
+          The page you were looking for doesn&apos;t exist or has moved.
+        </p>
+        <Link
+          href="/"
+          style={{
+            display: 'inline-block',
+            padding: '8px 14px',
+            borderRadius: 8,
+            background: 'var(--brand, #2563eb)',
+            color: '#fff',
+            fontWeight: 500,
+            textDecoration: 'none',
+          }}
+        >
+          Go to dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/reset-password/page.tsx
+++ b/packages/frontend/src/app/reset-password/page.tsx
@@ -87,9 +87,12 @@ function ResetPasswordForm() {
 
       <form className="space-y-4" onSubmit={handleSubmit}>
         <div>
-          <label className="block text-sm font-medium mb-1">New Password</label>
+          <label htmlFor="reset-new-password" className="block text-sm font-medium mb-1">New Password</label>
           <input
+            id="reset-new-password"
+            name="new-password"
             type="password"
+            autoComplete="new-password"
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}
             placeholder="Min. 8 characters"
@@ -99,9 +102,12 @@ function ResetPasswordForm() {
           />
         </div>
         <div>
-          <label className="block text-sm font-medium mb-1">Confirm Password</label>
+          <label htmlFor="reset-confirm-password" className="block text-sm font-medium mb-1">Confirm Password</label>
           <input
+            id="reset-confirm-password"
+            name="confirm-password"
             type="password"
+            autoComplete="new-password"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             placeholder="Repeat password"


### PR DESCRIPTION
## Summary

App Router was missing the two error fallbacks; the auth forms had broken label/input pairing.

### error.tsx
Renders for any uncaught exception inside an App Router segment that hasn't installed its own. Surfaces the digest Next attaches in production so a user can quote it when reporting a bug, plus a retry button and a link back to the dashboard.

### not-found.tsx
Branded 404 instead of the framework default.

### Auth a11y
Login, register, forgot-password, reset-password forms had \`<label className="…">Email</label>\` with no \`htmlFor\` and \`<input>\` with no \`id\` — so screen readers and password managers couldn't associate them. Fixed: every input now has \`id\` + \`name\` + \`autoComplete\`, every label points to it via \`htmlFor\`. Settings, connectors editor and other deeper forms intentionally left for the dedicated UI sprint.

## Test plan

- [x] frontend tsc --noEmit clean
- [x] frontend build succeeds, error.tsx + not-found.tsx in the build manifest
- [x] frontend lint pass