### PR TITLE
Sprint 2 batch 4: optional pagination on list endpoints

### DIFF
--- a/packages/backend/src/common/pagination.dto.ts
+++ b/packages/backend/src/common/pagination.dto.ts
@@ -1,0 +1,27 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Shared query DTO for offset-based pagination on list endpoints.
+ *
+ *  - limit:  optional, 1..200, default applied by the caller (typically 50)
+ *  - offset: optional, >= 0, default 0
+ *
+ * The route handler decides whether absent params mean "return everything"
+ * (back-compat for callers that never asked for pagination) or "apply the
+ * default page size". This DTO doesn't impose either policy.
+ */
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number;
+}

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -6,13 +6,15 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   Req,
   UseGuards,
   Logger,
   ForbiddenException,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { PaginationQueryDto } from '../common/pagination.dto';
 import { ConfigService } from '@nestjs/config';
 import {
   IsString,
@@ -173,8 +175,13 @@ export class ConnectorsController {
 
   @Get()
   @ApiOperation({ summary: 'List connectors for current organization' })
-  async list(@Req() req: any) {
-    return this.connectorsService.findByOrg(req.user.organizationId);
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: '1..200' })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  async list(@Req() req: any, @Query() pagination: PaginationQueryDto) {
+    return this.connectorsService.findByOrg(req.user.organizationId, {
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
   }
 
   @Post()

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -45,11 +45,16 @@ export class ConnectorsService {
     });
   }
 
-  async findByOrg(organizationId: string): Promise<Connector[]> {
+  async findByOrg(
+    organizationId: string,
+    opts?: { limit?: number; offset?: number },
+  ): Promise<Connector[]> {
     return this.prisma.connector.findMany({
       where: { organizationId },
       include: { tools: true },
       orderBy: { createdAt: 'desc' },
+      ...(opts?.limit !== undefined ? { take: opts.limit } : {}),
+      ...(opts?.offset !== undefined ? { skip: opts.offset } : {}),
     });
   }
 

--- a/packages/backend/src/mcp-servers/mcp-servers.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.controller.ts
@@ -6,12 +6,14 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   Req,
   UseGuards,
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { PaginationQueryDto } from '../common/pagination.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional, IsBoolean, IsArray } from 'class-validator';
 import { McpServersService } from './mcp-servers.service';
@@ -92,8 +94,13 @@ export class McpServersController {
 
   @Get()
   @ApiOperation({ summary: 'List MCP servers for current organization' })
-  async list(@Req() req: any) {
-    return this.mcpServersService.findAllByOrg(req.user.organizationId);
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: '1..200' })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  async list(@Req() req: any, @Query() pagination: PaginationQueryDto) {
+    return this.mcpServersService.findAllByOrg(req.user.organizationId, {
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
   }
 
   @Post()

--- a/packages/backend/src/mcp-servers/mcp-servers.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.service.ts
@@ -17,13 +17,18 @@ export class McpServersService {
     });
   }
 
-  async findAllByOrg(organizationId: string) {
+  async findAllByOrg(
+    organizationId: string,
+    opts?: { limit?: number; offset?: number },
+  ) {
     return this.prisma.mcpServerConfig.findMany({
       where: { organizationId },
       include: {
         _count: { select: { connectors: true, apiKeys: true } },
       },
       orderBy: { createdAt: 'asc' },
+      ...(opts?.limit !== undefined ? { take: opts.limit } : {}),
+      ...(opts?.offset !== undefined ? { skip: opts.offset } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

\`/api/connectors\` and \`/api/mcp-servers\` used to do an unbounded \`findMany\` on every call. Adds a shared \`PaginationQueryDto\` (\`limit\` 1..200, \`offset\` ≥ 0, both validated by class-validator) and an optional \`?limit=&offset=\` on each route.

The absence of either parameter keeps the existing behaviour, so the frontend, smoke test, and any external client keep working without change. We don't return a \`{ items, total, … }\` envelope yet (would be a breaking change for existing callers); when we do, it will go behind a \`?paginated=true\` flag or under a new versioned route.

## Test plan

- [x] backend tsc --noEmit clean
- [x] backend jest: 554 passing, 1 skipped
- [x] smoke test: 12/12 passing (including the full DB write phase)