### PR TITLE
Sprint 2 batch 6: type contracts for engine inputs (no runtime change)

### DIFF
--- a/packages/backend/src/connectors/engines/engine-types.ts
+++ b/packages/backend/src/connectors/engines/engine-types.ts
@@ -1,0 +1,83 @@
+/**
+ * Type contracts for connector engines.
+ *
+ * `endpointMapping` is stored as a `Json` column in Prisma so the wire shape
+ * is `Record<string, unknown>` — this file describes what each engine
+ * actually accepts, so the engines can drop their internal `as any` casts
+ * and the surrounding code is type-checked.
+ *
+ * Runtime behaviour is unchanged: the engine code already validates each
+ * field at use time. These types document the contract.
+ */
+
+export interface RestEndpointMapping {
+  method: string; // GET / POST / PUT / PATCH / DELETE
+  path: string;
+  queryParams?: Record<string, unknown>;
+  bodyMapping?: Record<string, unknown>;
+  bodyTemplate?: string;
+  bodyEncoding?: 'json' | 'form-urlencoded' | 'form-data' | string;
+  headers?: Record<string, string>;
+}
+
+export interface GraphqlEndpointMapping {
+  method: 'query' | 'mutation' | string;
+  path: string; // the GraphQL document
+  queryParams?: Record<string, unknown>;
+  bodyMapping?: Record<string, unknown>;
+  headers?: Record<string, string>;
+}
+
+export interface SoapEndpointMapping {
+  method: string; // SOAP operation name
+  path: string; // port name
+  queryParams?: Record<string, unknown>;
+  bodyMapping?: Record<string, unknown>;
+  paramOrder?: string[];
+  headers?: Record<string, string>;
+  soapAction?: string;
+  endpoint?: string;
+  targetNamespace?: string;
+}
+
+export interface DatabaseEndpointMapping {
+  method:
+    | 'query'
+    | 'static'
+    | 'mongo_schema'
+    | string;
+  path: string;
+  staticResponse?: string;
+}
+
+export interface McpEndpointMapping {
+  method: string; // remote tool name
+  path: string; // remote MCP path (e.g. /mcp)
+}
+
+export type AnyEndpointMapping =
+  | RestEndpointMapping
+  | GraphqlEndpointMapping
+  | SoapEndpointMapping
+  | DatabaseEndpointMapping
+  | McpEndpointMapping;
+
+/**
+ * Common metadata that may appear on responseMapping. We only use cacheTtl
+ * for the moment (used by dynamic-mcp-tools to short-circuit re-execution).
+ */
+export interface ResponseMapping {
+  cacheTtl?: number;
+  type?: string;
+  fields?: string[];
+  [k: string]: unknown;
+}
+
+export interface ConnectorEngineConfig {
+  baseUrl: string;
+  authType: string;
+  authConfig?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  connectorId?: string;
+  specUrl?: string;
+}

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -84,7 +84,10 @@ export class DynamicMcpTools {
     }
 
     // Check response cache
-    const cacheTtl = (tool.responseMapping as any)?.cacheTtl;
+    const responseMapping = tool.responseMapping as
+      | import('../connectors/engines/engine-types').ResponseMapping
+      | undefined;
+    const cacheTtl = responseMapping?.cacheTtl;
     if (cacheTtl && cacheTtl > 0) {
       const cacheKey = this.buildCacheKey(toolName, params);
       const cached = await this.redisService.get(cacheKey);


### PR DESCRIPTION
Adds connectors/engines/engine-types.ts with discriminated unions for REST/GraphQL/SOAP/Database/MCP endpointMapping plus a ResponseMapping interface. First consumer: dynamic-mcp-tools cacheTtl access is now typed instead of `(x as any)?.cacheTtl`.

Prisma write paths still cast to any because the underlying Json columns require it; tightening the write side to AnyEndpointMapping is left as a follow-up to keep this PR small and the smoke test signal clean.