### PR TITLE
Sprint 3 batch 5: operations docs (backup, DR, SLO, observability)

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,12 @@
+# Operations
+
+Documents that exist for the people running AnythingMCP in production rather than the people building it.
+
+| | |
+|---|---|
+| [`backup-restore.md`](./backup-restore.md) | What to back up, how, and how to restore. |
+| [`disaster-recovery.md`](./disaster-recovery.md) | RPO / RTO, failure modes, runbook drill. |
+| [`slo.md`](./slo.md) | Service level objectives + how we measure them. |
+| [`observability.md`](./observability.md) | Logs (always on), Sentry (opt-in), OpenTelemetry (opt-in). |
+
+If you just installed AnythingMCP, read these in order.

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -1,0 +1,85 @@
+# Backup & restore
+
+AnythingMCP stores all state in PostgreSQL. Encrypted secrets, audit logs, MCP server configs, role assignments — all of it is in one database. Lose the database and you lose the deployment, so this document is the procedure operators are expected to follow.
+
+## What needs to be backed up
+
+| Where | What | How often |
+|---|---|---|
+| PostgreSQL | every table including `Connector.authConfig` (encrypted blob), audit log, OAuth state | continuously / nightly |
+| `ENCRYPTION_KEY` | the AES-256-GCM key that decrypts `authConfig` | once, immutably |
+| `JWT_SECRET` | rotate-able, but losing it logs every user out | once, immutably |
+| `.env` (or your secret manager) | DB connection string, SMTP creds, OAuth IDs | on change |
+
+The encryption key is **the** thing to protect: a database backup without it is unrecoverable for connector credentials. Store it separately from the database backup (different cloud provider, different vault, hardware token, ideally all three).
+
+## Self-hosted (docker-compose)
+
+### Logical backup with `pg_dump`
+
+```bash
+# Full logical dump, gzip'd, into a timestamped file
+docker exec amcp-postgres \
+  pg_dump --format=custom --no-owner --no-acl -U amcp anythingmcp \
+  | gzip > "anythingmcp-$(date -u +%Y%m%dT%H%M%SZ).pgdump.gz"
+```
+
+Schedule it from the host's crontab so the dump file lands outside the container:
+
+```
+0 3 * * *  /usr/local/bin/anythingmcp-backup.sh
+```
+
+`anythingmcp-backup.sh` should:
+
+1. Run the `pg_dump` above.
+2. Encrypt the dump (`gpg --symmetric --cipher-algo AES256` or `age`).
+3. Upload to off-host storage (S3, B2, restic, rsync.net — anything you can verify is in a different failure domain than the docker host).
+4. Prune dumps older than your retention (typically 14 daily + 8 weekly + 6 monthly).
+
+### Restore
+
+```bash
+# Stop the app so it can't write while we restore
+docker compose stop app
+
+# Drop and recreate the database
+docker exec -i amcp-postgres psql -U amcp -d postgres -c "DROP DATABASE anythingmcp;"
+docker exec -i amcp-postgres psql -U amcp -d postgres -c "CREATE DATABASE anythingmcp;"
+
+# Restore the dump (the dump file must already be decompressed + decrypted)
+gunzip -c anythingmcp-…pgdump.gz | docker exec -i amcp-postgres \
+  pg_restore --no-owner --no-acl -U amcp -d anythingmcp
+
+docker compose start app
+```
+
+Verify before declaring success:
+- Login still works → JWT_SECRET unchanged
+- Open a connector that uses encrypted credentials and click "Test connection" → ENCRYPTION_KEY decrypts correctly
+- The dashboard counts of connectors, MCP servers, audit invocations are within the expected window
+
+## Managed Postgres (Railway / Supabase / RDS / Cloud SQL)
+
+Use the platform's native point-in-time recovery (PITR). Don't rely on manual `pg_dump` cron when PITR is one switch away — and configure WAL retention to cover at least 7 days so you can roll back a destructive admin action.
+
+What you still need to back up yourself:
+- `ENCRYPTION_KEY` and `JWT_SECRET` — they're not in the database
+- `.env` (without the database password — that should come from the platform)
+
+## Restoring to a different host
+
+If the new host has a different `ENCRYPTION_KEY`, every encrypted `authConfig` blob in the database becomes unreadable. The connectors will continue to exist as rows, but every API call that needs a credential will fail with a decryption error.
+
+Always migrate the encryption key together with the database. If you've lost the original key, the connectors must be re-created with fresh credentials.
+
+## Testing the backup
+
+A backup that has never been restored is not a backup. Once a quarter:
+
+1. Spin up a throwaway compose stack with the same `ENCRYPTION_KEY`.
+2. Restore the most recent backup into it.
+3. Log in as an admin, run "Test connection" against three different connectors, verify the audit log is intact.
+4. Tear it down.
+
+This is also the cheapest way to discover that retention has silently been broken for two months.

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -1,0 +1,84 @@
+# Disaster recovery
+
+Targets we hold ourselves to for AnythingMCP-the-managed-product. Self-hosters should treat these as a starting point and tighten them where their own SLA requires.
+
+| Metric | Target |
+|---|---|
+| RPO (recovery point objective) | ≤ 1 hour of writes lost in the worst case |
+| RTO (recovery time objective) | ≤ 4 hours from incident declaration to a working instance |
+| Time-to-detect | ≤ 5 minutes for a hard outage (uptime monitor) |
+
+## Failure modes and the response
+
+### 1. Backend container crashes, DB is fine
+
+Symptom: `/health` returns 5xx or times out, Postgres is reachable.
+
+Action:
+- `docker compose restart app`
+- If the crash repeats, pull the most recent logs (`docker compose logs --since=10m app`), look for the structured error line carrying the panic + the request id (`X-Request-Id`).
+- `enableShutdownHooks` should already drain in-flight requests, but check the audit log for `status=ERROR` rows in the crash window so you know which tool invocations need to be re-run by the user.
+
+### 2. Database is unreachable
+
+Symptom: `/health` returns `database: { status: 'down' }`, the app is up.
+
+Action:
+- Verify the Postgres container/managed instance is reachable (`pg_isready`).
+- If managed (Railway/Supabase/RDS): check the provider's status page first.
+- If self-hosted: `docker compose logs postgres` — usually disk full, OOM, or a corrupted WAL.
+- Failover to standby if you have one. Otherwise, the app is unavailable until the DB returns.
+- Backend will reconnect automatically when Postgres comes back; no app restart needed.
+
+### 3. Database is corrupted / data loss
+
+Symptom: query errors on previously-working tables, or admin reports "all my connectors are gone".
+
+Action:
+- Stop the app (`docker compose stop app`) — do not let the broken state get worse.
+- Restore the most recent good backup per `backup-restore.md`.
+- If the corruption window is small and PITR is available (managed instances), prefer point-in-time restore over the latest dump.
+- Bring the app back up. Verify per the checklist in `backup-restore.md`.
+- File an incident note with: time of corruption, last good backup, what was lost between the two, root cause if known.
+
+### 4. ENCRYPTION_KEY is lost
+
+Symptom: app boots, login works, but every connector test returns "decrypt failed".
+
+There is no recovery for the encrypted credentials. Process:
+- Mark every connector as inactive (mass UPDATE if needed).
+- Notify every customer/admin that their stored credentials are unrecoverable and need to be re-entered.
+- Provision a new `ENCRYPTION_KEY` (`openssl rand -base64 48`).
+- Store the new key per `backup-restore.md` immediately.
+
+This is exactly the failure mode we tell operators to design around in advance — so the right time to read this section is *before* the key is lost.
+
+### 5. Compromised secret (JWT_SECRET, OAuth client secret, SMTP creds)
+
+Symptom: external indicator (suspicious login, leaked credential in CI logs).
+
+Action:
+- Rotate the secret first, investigate after.
+- Rotating `JWT_SECRET` invalidates every active session — every user logs out. Communicate before doing it on prod.
+- Rotating an OAuth client secret invalidates pending authorization codes; users mid-flow may need to retry.
+- Update audit log expectations: assume every action since the suspected compromise time was attacker-controlled until proven otherwise.
+
+### 6. Region-wide outage (cloud provider)
+
+Symptom: the host platform is down (Railway / AWS / GCP region issue).
+
+Action:
+- We do not currently maintain a hot standby in a second region. This is on the roadmap.
+- If the outage exceeds RTO, restore the most recent backup into a new instance in a different region and update DNS.
+- This requires that the encryption key, env vars, and DB backup all live somewhere outside the primary region — see `backup-restore.md`.
+
+## Runbook drill
+
+Once a quarter, on a throwaway environment:
+1. Restore yesterday's backup (per `backup-restore.md`).
+2. Verify a known connector decrypts and "Test connection" works.
+3. Rotate `JWT_SECRET` (just on the throwaway).
+4. Confirm every active session was logged out.
+5. Time the whole exercise — that's your real RTO. If it's > 4 h, fix what slowed you down.
+
+If the drill is uncomfortable, run it more often, not less.

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,0 +1,82 @@
+# Observability
+
+Three pipelines. All three are opt-in for self-hosters: the default install ships nothing externally.
+
+## 1. Structured logs (Pino, always on)
+
+Every HTTP request emits one JSON line at completion (or earlier on error), tagged with:
+
+- `req.id` — UUID, present on the response as `X-Request-Id`. Quote it in bug reports.
+- `userId` / `orgId` / `authMethod` — propagated from the authenticated request.
+- `req.method`, `req.url`, `res.statusCode`, `responseTime`.
+
+Sensitive fields are stripped at the pino layer:
+- headers: `authorization`, `cookie`, `x-api-key`, `set-cookie`.
+- bodies: any `password`, `token`, `refreshToken`, `accessToken`, `apiKey`, `secret` field.
+
+Log level: `LOG_LEVEL` env (default `info`). Format: `pino-pretty` in dev, JSON in prod.
+
+`/health` is excluded from autoLogging — it's hit every few seconds by liveness probes.
+
+Forward to:
+- Loki / Promtail (recommended for self-hosted)
+- CloudWatch Logs / Datadog / Logtail (managed)
+- Whatever already eats JSON in your stack
+
+## 2. Errors (Sentry, opt-in)
+
+Set `SENTRY_DSN` (backend) and `NEXT_PUBLIC_SENTRY_DSN` (frontend). Both default to no-op when unset.
+
+Backend (`@sentry/nestjs`) auto-instruments http/express/prisma. `beforeSend` strips the same headers and field names as the log pipeline.
+
+Frontend (`@sentry/nextjs`) wires client / server / edge runtimes. `onRequestError` captures errors thrown in route handlers and RSCs.
+
+Sample rates default to **0** for tracing, profiling and replays — operators must opt in to those explicitly:
+
+| Env | Default | Purpose |
+|---|---|---|
+| `SENTRY_TRACES_SAMPLE_RATE` | 0 | backend transactions |
+| `SENTRY_PROFILES_SAMPLE_RATE` | 0 | backend CPU profiling |
+| `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` | 0 | frontend transactions |
+| `NEXT_PUBLIC_SENTRY_REPLAYS_SAMPLE_RATE` | 0 | session replay (always-on) |
+| `NEXT_PUBLIC_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE` | 0 | session replay (on error only) |
+
+Set them between `0` and `1`. `0.1` = 10 %.
+
+## 3. Distributed tracing (OpenTelemetry, opt-in)
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` (backend only). Auto-instrumentations cover http/express/pg/mysql/redis. `fs` spans are disabled (they'd be 90 % of cold-start noise) and `/health` is excluded.
+
+Service identity:
+
+| Env | Default |
+|---|---|
+| `OTEL_SERVICE_NAME` | `anythingmcp-backend` |
+| `OTEL_SERVICE_VERSION` | `npm_package_version` |
+| `OTEL_DEPLOYMENT_ENVIRONMENT` | `NODE_ENV` |
+
+Auth: standard `OTEL_EXPORTER_OTLP_HEADERS` (e.g. `authorization=Bearer …`).
+
+Suggested collectors:
+- Self-hosted: Tempo + Grafana, or Jaeger.
+- Managed: Honeycomb, Lightstep, Datadog APM (via OTLP receiver).
+
+Sentry's tracing pipeline is independent. Both can run side by side — Sentry for error correlation, OTLP for an in-house collector — and that's intentional.
+
+## Correlating across pipelines
+
+The same `req.id` UUID appears in:
+- the Pino log line (`req.id`)
+- the response header (`X-Request-Id`)
+- Sentry events that include the request scope (added automatically by `@sentry/nestjs`)
+- OTLP traces — pino-otel correlation is on the roadmap; until then, find the trace by matching timestamp + URL + userId
+
+When a customer reports a problem, the **first** thing to ask is "what's the `X-Request-Id` on the failed response?" — it cuts triage time by an order of magnitude.
+
+## What we do not collect
+
+- No usage telemetry. The dashboard does not phone home.
+- No customer payloads in error reports — they're scrubbed before they leave the process.
+- No PII fields beyond `userId` / `orgId` / `email` (and `email` only when the operator hasn't disabled it via Sentry's `sendDefaultPii: false`, which is our default).
+
+If a self-hoster wants any of these enabled, every knob is a documented env var. If we add one that isn't, that's a bug — file it.

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -1,0 +1,50 @@
+# Service level objectives
+
+These are the SLOs we commit to for the managed AnythingMCP cloud. Self-hosters can reuse the structure but should pick their own targets — a single-tenant hobby instance does not need 99.9 % uptime, and it is fine to say so explicitly.
+
+## SLOs
+
+| SLO | Target | Window |
+|---|---|---|
+| API availability (`/api/*` 2xx + 4xx out of total) | ≥ 99.9 % | rolling 30 days |
+| MCP endpoint availability (`/mcp/:serverId` 2xx out of total non-401) | ≥ 99.9 % | rolling 30 days |
+| API p95 latency (excluding `/health`) | ≤ 500 ms | rolling 7 days |
+| Tool invocation p95 end-to-end (server time, excluding upstream) | ≤ 1 500 ms | rolling 7 days |
+| Successful tool invocations (`status=SUCCESS` / total) | ≥ 99 % | rolling 7 days |
+
+5xx counts against availability; 4xx does not (they're contract violations on the caller's side, not faults on ours).
+
+The `/health` endpoint is excluded from latency SLOs because it's a liveness probe pinged every few seconds and would dominate the percentile.
+
+## Error budget
+
+Burning through more than 50 % of the monthly availability budget in any rolling 7-day window triggers an internal review. The budget is just `(1 - SLO) × time`, which for 99.9 %/30d is **~43 minutes/month** of downtime allowed.
+
+Practically: if a single incident burns 20 minutes, that's roughly half the month's budget gone. Two such incidents and we owe ourselves a postmortem and a freeze on shipping non-critical work until the budget recovers.
+
+## How we measure
+
+- Backend access logs (Pino, JSON, request id correlated) feed an aggregator (Loki or the operator's choice).
+- The aggregator computes 5xx rate, latency percentiles, MCP invocation success rate.
+- Audit log table (`ToolInvocation`) is the source of truth for tool success rate.
+- The status page (when present) reads from the same metrics, not a separate pipe.
+
+For self-hosters: the simplest version is `docker logs` piped to whatever you already have. Pino's JSON output keeps grep usable.
+
+## Dependencies that cap our SLOs
+
+- **PostgreSQL** — single point of failure today. Whatever uptime your DB layer offers is the ceiling for the API SLO.
+- **Outbound HTTPS** — every REST/GraphQL/SOAP/MCP-bridge tool depends on the upstream's uptime. The tool-invocation SLO is **server time only** to keep us honest about what we control.
+- **Email delivery (SMTP / Mailgun / Resend)** — verification + password-reset flows. We don't include this in the API SLO; outages there degrade onboarding but not the running deployment.
+
+## Status page
+
+Recommended: a separate, statically-hosted status page (Statuspage / Atlassian / Cachet / a static site that polls `/health`) that does **not** share infrastructure with the main deployment, so a region outage doesn't take both down at once.
+
+A minimal MVP is a JSON file at `https://status.anythingmcp.com/status.json` populated by a cron worker that polls `/health` from a different region; the static page reads it and renders the green/yellow/red badge. Plenty of templates exist; pick one and stick with it.
+
+## When to update this doc
+
+- We agree to a different SLO with a customer (write the customer-specific commitment somewhere they'll see it; this doc is internal).
+- A persistent change in dependency reliability moves the ceiling.
+- The error budget burns down two months in a row — the targets may be wrong, or they may be right and the engineering capacity is the issue. Don't quietly slacken the targets.


### PR DESCRIPTION
Five files under `docs/operations/` covering the gaps the Sprint 1 review flagged:

- `backup-restore.md` — `pg_dump` procedure, the special handling needed for the encrypted-credentials column, managed-Postgres alternative, quarterly restore drill.
- `disaster-recovery.md` — RPO 1h / RTO 4h, six explicit failure modes including the unrecoverable `ENCRYPTION_KEY`-loss case.
- `slo.md` — 99.9% API availability, p95 latency, error-budget policy.
- `observability.md` — Pino (always on), Sentry (opt-in), OpenTelemetry (opt-in), all threaded by the same `X-Request-Id`.
- `README.md` — index.

Pure docs PR — no code changes.