### PR TITLE
Add HR WORKS v2 connector

### DIFF
--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -27,6 +27,7 @@ import * as xentral from './de/xentral.json';
 import * as shopware6 from './de/shopware-6.json';
 import * as hereGeocoding from './de/here-geocoding.json';
 import * as personio from './de/personio.json';
+import * as hrworks from './de/hrworks.json';
 
 export interface AdapterMeta {
   slug: string;
@@ -93,6 +94,7 @@ const ALL_ADAPTERS: AdapterDefinition[] = [
   shopware6 as unknown as AdapterDefinition,
   hereGeocoding as unknown as AdapterDefinition,
   personio as unknown as AdapterDefinition,
+  hrworks as unknown as AdapterDefinition,
 ];
 
 export function listAdapters(): AdapterMeta[] {

--- a/packages/backend/src/adapters/de/hrworks.json
+++ b/packages/backend/src/adapters/de/hrworks.json
@@ -1,0 +1,835 @@
+{
+  "slug": "hrworks",
+  "name": "HR WORKS",
+  "description": "Access HR WORKS, the German HR/payroll platform: employees, absences, sick leaves, remote work (home office), working times, projects, applicants, organization units, holidays and cost centers via the v2 REST API.",
+  "instructions": "This connector uses the HR WORKS v2 REST API (https://developers.hrworks.de).\n\n**Authentication model — IMPORTANT**: HR WORKS does not use a long-lived API key. Instead, you POST `{accessKey, secretAccessKey}` to `/v2/authentication` and receive a short-lived JWT (valid 15 minutes) which is then sent as `Authorization: Bearer <token>` on every subsequent call. This adapter stores a single bearer token (`HRWORKS_TOKEN`) supplied by you.\n\n**Getting a token** (run before importing the connector, then again whenever the token expires):\n\n```bash\ncurl -X POST https://api.hrworks.de/v2/authentication \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"accessKey\":\"YOUR_ACCESS_KEY\",\"secretAccessKey\":\"YOUR_SECRET_ACCESS_KEY\"}'\n```\n\nThe response contains `{\"token\": \"eyJ...\"}` — paste that JWT as `HRWORKS_TOKEN` when importing.\n\n**Token lifetime**: ~15 minutes. After expiration the API will reject calls with 401; you must mint a new token and re-import or update the connector. For long-running workflows, consider wrapping this adapter in a custom proxy that refreshes tokens automatically.\n\n**Sandbox**: HR WORKS provides a demo environment at `https://api.demo-hrworks.de`. Set `HRWORKS_BASE_URL=https://api.demo-hrworks.de` to test against demo data; otherwise the production endpoint `https://api.hrworks.de` is used.\n\n**Identifiers**: most person-related endpoints accept either the HR WORKS personnel number or the HR WORKS username. Use the optional `personIdentifierType` / `usePersonnelNumbers` parameters when the identifier you have on hand is not the default.\n\n**Date intervals**: most listing endpoints (absences, sick leaves, working times, remote work) require ISO `YYYY-MM-DD` `beginDate`/`endDate` — maximum span is one year (or 31 days if `interval=days`).\n\n**Pagination**: page size is 50; the API returns a `Link` header with next/prev URLs. Pass `page` to step through results.\n\n**Rate limit**: HR WORKS imposes per-tenant rate limits — see their developer portal for details.",
+  "region": "de",
+  "category": "hr",
+  "icon": "hrworks",
+  "docsUrl": "https://developers.hrworks.de",
+  "requiredEnvVars": ["HRWORKS_TOKEN"],
+  "connector": {
+    "name": "HR WORKS",
+    "type": "REST",
+    "baseUrl": "https://api.hrworks.de",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{HRWORKS_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "hrworks_health_check",
+      "description": "Check whether the HR WORKS API is reachable. Returns 200 OK with no body. Useful for connector validation; does not require authentication.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/health-check"
+      }
+    },
+    {
+      "name": "hrworks_list_organization_units",
+      "description": "List all active organization units (Organisationseinheiten) of the company with their uuid, number and name.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/organization-units"
+      }
+    },
+    {
+      "name": "hrworks_get_organization_unit",
+      "description": "Return the data of a specific organization unit. Pass the unit's uuid (preferred) or its number (deprecated).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "The uuid (preferred) or number of the organization unit."
+          }
+        },
+        "required": ["uuid"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/organization-units/{uuid}"
+      }
+    },
+    {
+      "name": "hrworks_list_present_persons",
+      "description": "List all persons currently 'in the office' for a given organization unit. Accounts for vacations, trips, sicknesses and other absences (forenoon/afternoon).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "string",
+            "description": "Number/ID of the organization unit to inspect."
+          }
+        },
+        "required": ["number"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/organization-units/{number}/present-persons"
+      }
+    },
+    {
+      "name": "hrworks_list_permanent_establishments",
+      "description": "List all permanent establishments (Betriebsstätten) of the company with id and name.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/permanent-establishments"
+      }
+    },
+    {
+      "name": "hrworks_list_holidays",
+      "description": "List company holidays for a given year and (optionally) country. Country codes are ISO 3166-1 alpha-3 (e.g. DEU, AUT, CHE).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "year": {
+            "type": "number",
+            "description": "Year to fetch holidays for (e.g. 2026)."
+          },
+          "countryCodes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional ISO 3166-1 alpha-3 country codes to filter by (e.g. ['DEU'])."
+          },
+          "permanentEstablishments": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of permanent establishment IDs."
+          }
+        },
+        "required": ["year"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/holidays",
+        "queryParams": {
+          "year": "$year",
+          "countryCodes": "$countryCodes",
+          "permanentEstablishments": "$permanentEstablishments"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_persons",
+      "description": "List all persons (employees) in the company. By default only active employees are returned. Optionally filter by organization unit.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "organizationUnits": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Filter by one or more organization unit identifiers."
+          },
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, also returns persons that have left the company (default: true)."
+          },
+          "onlyActiveOrganizationUnits": {
+            "type": "boolean",
+            "description": "If false, also returns persons assigned to deactivated org units (default: true)."
+          },
+          "identifierType": {
+            "type": "string",
+            "description": "Type of identifier in organizationUnits ('number' or 'uuid'). Default 'number'."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/persons",
+        "queryParams": {
+          "organizationUnits": "$organizationUnits",
+          "onlyActive": "$onlyActive",
+          "onlyActiveOrganizationUnits": "$onlyActiveOrganizationUnits",
+          "identifierType": "$identifierType"
+        }
+      }
+    },
+    {
+      "name": "hrworks_get_person",
+      "description": "Return the base data of a specific person (employee). The personIdentifier defaults to the personnel number; pass personIdentifierType='username' or 'personId' to use a different identifier.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "personIdentifier": {
+            "type": "string",
+            "description": "Personnel number (default), HR WORKS username or personId of the person."
+          },
+          "personIdentifierType": {
+            "type": "string",
+            "description": "Type of identifier: 'personnelNumber' (default), 'username' or 'personId'."
+          }
+        },
+        "required": ["personIdentifier"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/persons/{personIdentifier}",
+        "queryParams": {
+          "personIdentifierType": "$personIdentifierType"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_persons_master_data",
+      "description": "Return the current master data (full personal data, contract details, addresses, bank info, etc.) for one or more persons. Page size is 50.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of person identifiers to fetch. If omitted, returns master data for all active persons."
+          },
+          "personIdentifierType": {
+            "type": "string",
+            "description": "Identifier type: 'personId' (default), 'personnelNumber' or 'username'."
+          },
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, also returns persons that have left the company (default: true)."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/persons/master-data",
+        "queryParams": {
+          "persons": "$persons",
+          "personIdentifierType": "$personIdentifierType",
+          "onlyActive": "$onlyActive",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_get_persons_today",
+      "description": "Return day-related objects (working hours, attendance, absences) for the current day for one or more persons.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of person identifiers. If omitted, returns data for all active persons."
+          },
+          "personIdentifierType": {
+            "type": "string",
+            "description": "Identifier type: 'personId' (default), 'personnelNumber' or 'username'."
+          },
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, also returns persons that have left the company (default: true)."
+          },
+          "includeData": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of data sources to include (e.g. workingTimes, absences). Target working hours and holidays are always included."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/persons/today",
+        "queryParams": {
+          "persons": "$persons",
+          "personIdentifierType": "$personIdentifierType",
+          "onlyActive": "$onlyActive",
+          "includeData": "$includeData",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_get_leave_account",
+      "description": "Return the leave account (vacation balance) of a single person up to a reference date. The interval starts at January 1st of the reference year.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "personnelNumber": {
+            "type": "string",
+            "description": "HR WORKS personnel number of the person."
+          },
+          "referenceDate": {
+            "type": "string",
+            "description": "Reference date (YYYY-MM-DD). If omitted, defaults to today."
+          }
+        },
+        "required": ["personnelNumber"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/persons/{personnelNumber}/leave-account",
+        "queryParams": {
+          "referenceDate": "$referenceDate"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_absences",
+      "description": "List absences (vacation, parental leave, etc.) for one or more persons over a date interval. Required: beginDate and endDate (YYYY-MM-DD, max 1-year span).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "beginDate": {
+            "type": "string",
+            "description": "Start of the date interval (YYYY-MM-DD)."
+          },
+          "endDate": {
+            "type": "string",
+            "description": "End of the date interval (YYYY-MM-DD)."
+          },
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of HR WORKS usernames (or personnel numbers if usePersonnelNumbers=true)."
+          },
+          "types": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional absence type keys to filter by (see hrworks_list_absence_types)."
+          },
+          "count": {
+            "type": "boolean",
+            "description": "If true, return cumulated working-day counts per absence type instead of details."
+          },
+          "usePersonnelNumbers": {
+            "type": "boolean",
+            "description": "If true, treat 'persons' values as personnel numbers (default: false → usernames)."
+          },
+          "interval": {
+            "type": "string",
+            "description": "Optional interval split: 'days' (≤31d), 'weeks' or 'months'."
+          },
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, includes persons who have left the company."
+          },
+          "statusFilter": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of absence statuses to filter by (e.g. APPROVED, PENDING)."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        },
+        "required": ["beginDate", "endDate"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/absences",
+        "queryParams": {
+          "beginDate": "$beginDate",
+          "endDate": "$endDate",
+          "persons": "$persons",
+          "types": "$types",
+          "count": "$count",
+          "usePersonnelNumbers": "$usePersonnelNumbers",
+          "interval": "$interval",
+          "onlyActive": "$onlyActive",
+          "statusFilter": "$statusFilter",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_absence_types",
+      "description": "List all absence types (vacation, parental leave, special leave, etc.) configured for the customer account, with their keys for use as filter values.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If true, only currently active absence types are returned."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/absences/absence-types",
+        "queryParams": {
+          "onlyActive": "$onlyActive"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_vacation_types",
+      "description": "List vacation types defined for the customer account (subset of absence types focused on vacation/leave).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/absences/vacation-types"
+      }
+    },
+    {
+      "name": "hrworks_list_sick_leaves",
+      "description": "List sick leaves (Krankheitstage) for one or more persons over a date interval. Required: beginDate and endDate (YYYY-MM-DD, max 1-year span).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "beginDate": {
+            "type": "string",
+            "description": "Start of the date interval (YYYY-MM-DD)."
+          },
+          "endDate": {
+            "type": "string",
+            "description": "End of the date interval (YYYY-MM-DD)."
+          },
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of HR WORKS usernames (or personnel numbers if usePersonnelNumbers=true)."
+          },
+          "types": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional sick leave type keys to filter by."
+          },
+          "count": {
+            "type": "boolean",
+            "description": "If true, return cumulated working-day counts per type instead of details."
+          },
+          "usePersonnelNumbers": {
+            "type": "boolean",
+            "description": "If true, treat 'persons' values as personnel numbers."
+          },
+          "interval": {
+            "type": "string",
+            "description": "Optional interval split: 'days', 'weeks' or 'months'."
+          },
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, includes persons who have left the company."
+          },
+          "statusFilter": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of sick leave statuses to filter by."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        },
+        "required": ["beginDate", "endDate"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/sick-leaves",
+        "queryParams": {
+          "beginDate": "$beginDate",
+          "endDate": "$endDate",
+          "persons": "$persons",
+          "types": "$types",
+          "count": "$count",
+          "usePersonnelNumbers": "$usePersonnelNumbers",
+          "interval": "$interval",
+          "onlyActive": "$onlyActive",
+          "statusFilter": "$statusFilter",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_sick_leave_types",
+      "description": "List all sick leave types configured for the customer account with their keys (used as filter values for hrworks_list_sick_leaves).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/sick-leaves/sick-leave-types"
+      }
+    },
+    {
+      "name": "hrworks_list_remote_work",
+      "description": "List remote work / home office records for one or more persons over a date interval. Required: beginDate and endDate (YYYY-MM-DD, max 1-year span).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "beginDate": {
+            "type": "string",
+            "description": "Start of the date interval (YYYY-MM-DD)."
+          },
+          "endDate": {
+            "type": "string",
+            "description": "End of the date interval (YYYY-MM-DD)."
+          },
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of HR WORKS usernames (or personnel numbers if usePersonnelNumbers=true)."
+          },
+          "usePersonnelNumbers": {
+            "type": "boolean",
+            "description": "If true, treat 'persons' values as personnel numbers."
+          },
+          "interval": {
+            "type": "string",
+            "description": "Optional interval split: 'days', 'weeks' or 'months'."
+          },
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, includes persons who have left the company."
+          },
+          "statusFilter": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of statuses to filter by."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        },
+        "required": ["beginDate", "endDate"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/remote-work",
+        "queryParams": {
+          "beginDate": "$beginDate",
+          "endDate": "$endDate",
+          "persons": "$persons",
+          "usePersonnelNumbers": "$usePersonnelNumbers",
+          "interval": "$interval",
+          "onlyActive": "$onlyActive",
+          "statusFilter": "$statusFilter",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_working_times",
+      "description": "List logged working times (project time tracking) for one or more persons over a date interval. Only persons with a configured time tracking regulation in the requested interval are returned.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "beginDate": {
+            "type": "string",
+            "description": "Start of the date interval (YYYY-MM-DD)."
+          },
+          "endDate": {
+            "type": "string",
+            "description": "End of the date interval (YYYY-MM-DD)."
+          },
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of HR WORKS usernames (or personnel numbers if usePersonnelNumbers=true)."
+          },
+          "types": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional working time types to filter by (see hrworks_list_time_recording_regulations)."
+          },
+          "usePersonnelNumbers": {
+            "type": "boolean",
+            "description": "If true, treat 'persons' values as personnel numbers."
+          },
+          "interval": {
+            "type": "string",
+            "description": "Optional interval split: 'days', 'weeks' or 'months'."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        },
+        "required": ["beginDate", "endDate"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/working-times",
+        "queryParams": {
+          "beginDate": "$beginDate",
+          "endDate": "$endDate",
+          "persons": "$persons",
+          "types": "$types",
+          "usePersonnelNumbers": "$usePersonnelNumbers",
+          "interval": "$interval",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_time_recording_regulations",
+      "description": "List all time-recording regulations configured for the customer (defines which working time types are allowed per regulation).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/working-times/time-recording-regulations"
+      }
+    },
+    {
+      "name": "hrworks_list_projects",
+      "description": "List time-tracking projects of the company.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/working-times/projects"
+      }
+    },
+    {
+      "name": "hrworks_get_project",
+      "description": "Return the data of a specific time-tracking project by id.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Project id."
+          }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/working-times/projects/{id}"
+      }
+    },
+    {
+      "name": "hrworks_list_project_customers",
+      "description": "List the customers used for project time tracking.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/working-times/projects/customers"
+      }
+    },
+    {
+      "name": "hrworks_list_job_applications",
+      "description": "List job applications. Optionally filter by post id and/or status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          },
+          "posts": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of post ids to filter by."
+          },
+          "statusFilter": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of application status identifiers to filter by."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/applicant-management/job-applications",
+        "queryParams": {
+          "page": "$page",
+          "posts": "$posts",
+          "statusFilter": "$statusFilter"
+        }
+      }
+    },
+    {
+      "name": "hrworks_list_posts",
+      "description": "List all recruiting posts (job postings) of the company.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "onlyActive": {
+            "type": "boolean",
+            "description": "If false, also returns inactive posts (default: true)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/applicant-management/posts",
+        "queryParams": {
+          "onlyActive": "$onlyActive"
+        }
+      }
+    },
+    {
+      "name": "hrworks_get_post",
+      "description": "Return the data of a single recruiting post by uuid.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "The uuid (preferred) or id of the post."
+          }
+        },
+        "required": ["uuid"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/applicant-management/posts/{uuid}"
+      }
+    },
+    {
+      "name": "hrworks_list_applicants",
+      "description": "List applicants (only those with at least one job application). Optionally filter by status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "applicants": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of applicant uuids."
+          },
+          "statusFilter": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of application statuses to filter by."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/applicant-management/applicants",
+        "queryParams": {
+          "applicants": "$applicants",
+          "statusFilter": "$statusFilter",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "hrworks_get_applicant",
+      "description": "Return data of a specific applicant by uuid. The uuid does not change when the applicant is converted to an employee.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "Applicant uuid."
+          }
+        },
+        "required": ["uuid"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/applicant-management/applicants/{uuid}"
+      }
+    },
+    {
+      "name": "hrworks_list_cost_centers",
+      "description": "List all cost centers (Kostenstellen) of the company with their number/id and name.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/cost-objects/cost-centers"
+      }
+    },
+    {
+      "name": "hrworks_list_cost_objectives",
+      "description": "List all cost objectives (Kostenträger) of the company.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/cost-objects/cost-objectives"
+      }
+    },
+    {
+      "name": "hrworks_list_wage_salary_types",
+      "description": "List all wage/salary types defined for the customer account (used in payroll exports).",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/wage-and-salary/types"
+      }
+    },
+    {
+      "name": "hrworks_list_travel_expense_reports",
+      "description": "List travel expense reports (Reisekostenabrechnungen). Pass optional date and person filters.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "beginDate": {
+            "type": "string",
+            "description": "Start of the date interval (YYYY-MM-DD)."
+          },
+          "endDate": {
+            "type": "string",
+            "description": "End of the date interval (YYYY-MM-DD)."
+          },
+          "persons": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of person identifiers."
+          },
+          "usePersonnelNumbers": {
+            "type": "boolean",
+            "description": "If true, treat 'persons' values as personnel numbers."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for paginated results (page size 50)."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/travel-expenses/expense-reports",
+        "queryParams": {
+          "beginDate": "$beginDate",
+          "endDate": "$endDate",
+          "persons": "$persons",
+          "usePersonnelNumbers": "$usePersonnelNumbers",
+          "page": "$page"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/de/hrworks.live.spec.ts
+++ b/packages/backend/src/adapters/de/hrworks.live.spec.ts
@@ -1,0 +1,78 @@
+import * as adapter from './hrworks.json';
+import { RestEngine } from '../../connectors/engines/rest.engine';
+import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+
+/**
+ * Smoke test against the real HR WORKS sandbox endpoint to verify that:
+ *  - the adapter's baseUrl resolves
+ *  - the RestEngine builds a request that HR WORKS accepts as syntactically valid
+ *  - Bearer token injection actually puts the token in the Authorization header
+ *    (we can tell because the API rejects a bogus token with 401 InvalidBearerTokenError
+ *    instead of 403 MissingAuthorizationHeaderError)
+ *
+ * Skipped automatically in CI (no network); run locally with:
+ *   RUN_HRWORKS_LIVE=1 npx jest src/adapters/de/hrworks.live.spec.ts
+ */
+const maybe = process.env.RUN_HRWORKS_LIVE ? describe : describe.skip;
+
+maybe('hrworks adapter — live smoke test', () => {
+  // Minimal stub — we don't exercise OAuth2 paths in this test
+  const oauth = {} as unknown as OAuth2TokenService;
+  const engine = new RestEngine(oauth);
+
+  it('reaches HR WORKS auth endpoint and gets InvalidCredentials with bogus creds', async () => {
+    const cfg = adapter as unknown as {
+      connector: { baseUrl: string; authType: string };
+    };
+
+    let err: any;
+    try {
+      // POST /v2/authentication with bogus credentials — the adapter's auth
+      // endpoint returns 403 InvalidCredentialsError for unknown keys.
+      await engine.execute(
+        { baseUrl: cfg.connector.baseUrl, authType: 'NONE' },
+        {
+          method: 'POST',
+          path: '/v2/authentication',
+          bodyMapping: { accessKey: '$accessKey', secretAccessKey: '$secretAccessKey' },
+        },
+        { accessKey: 'bogus-key-for-test', secretAccessKey: 'bogus-secret-for-test' },
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.response?.status).toBe(403);
+    expect(err.response?.data?.type).toBe('InvalidCredentialsError');
+  }, 30000);
+
+  it('Bearer token header is actually injected (bogus token → InvalidBearerTokenError, not MissingAuthorizationHeader)', async () => {
+    const cfg = adapter as unknown as {
+      connector: { baseUrl: string; authType: string };
+      tools: Array<{ name: string; endpointMapping: any }>;
+    };
+    const orgUnits = cfg.tools.find((t) => t.name === 'hrworks_list_organization_units');
+    expect(orgUnits).toBeDefined();
+
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl: cfg.connector.baseUrl,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'eyJobviously.not.a.valid.jwt' },
+        },
+        orgUnits!.endpointMapping,
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    // HR WORKS returns 403 InvalidBearerTokenError when the header was present but
+    // the token is bogus; 403 MissingAuthorizationHeaderError would mean the engine
+    // forgot to send the Authorization header at all.
+    expect(err.response?.status).toBe(403);
+    expect(err.response?.data?.type).toBe('InvalidBearerTokenError');
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- Adds a new adapter (`slug: hrworks`) for the HR WORKS v2 REST API with 30 read-only tools across persons, absences, sick leaves, remote work, working times, projects, applicants, org units, holidays and cost centers.
- Uses `BEARER_TOKEN` auth with `HRWORKS_TOKEN` (same pattern as Personio). The connector's `instructions` explain the JWT 15-minute lifetime so MCP clients are aware they must refresh when the token expires.
- Includes an opt-in live smoke test (`RUN_HRWORKS_LIVE=1`) that hits `api.hrworks.de` to verify the engine wires Bearer auth correctly.

## Test plan
- [x] `npx jest src/adapters/catalog.spec.ts` — 296/296 passed (all 30 hrworks tools validated)
- [x] `RUN_HRWORKS_LIVE=1 npx jest src/adapters/de/hrworks.live.spec.ts` — 2/2 passed against the real API (bogus credentials → `InvalidCredentialsError`; bogus bearer → `InvalidBearerTokenError`, confirming `Authorization` header is sent)
- [ ] Manual end-to-end: import the connector with a real `HRWORKS_TOKEN` and call `hrworks_list_organization_units` from an MCP client