### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,84 @@
+name: Dependabot auto-merge
+
+# Auto-merge low-risk Dependabot PRs (npm patch/minor and github-actions
+# patch/minor) once required CI checks pass. Higher-risk bumps — major
+# updates, Docker base-image bumps (e.g. node 22 → 25), or any major bump
+# of a GitHub Action (deploy, scp, etc.) — are labelled `needs-review` and
+# left for a human.
+#
+# Safety model:
+#   - Uses `gh pr merge --auto`, which only fires once GitHub's required
+#     status checks are green. This relies on branch protection being
+#     configured on `main` with the CI jobs marked as required.
+#   - Without branch protection, --auto still works but merges immediately
+#     after CI without waiting for review. Still safer than today (nothing
+#     gets merged at all) but less defensive.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  triage:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to auto-merge
+        id: decide
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+          echo "update-type=$UPDATE_TYPE"
+          echo "ecosystem=$ECOSYSTEM"
+          echo "deps=$DEP_NAMES"
+
+          # Default: do not auto-merge.
+          AUTO=false
+          REASON="default-deny"
+
+          # Allow patch+minor for npm and github-actions.
+          if [[ "$UPDATE_TYPE" == "version-update:semver-patch" \
+             || "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
+            if [[ "$ECOSYSTEM" == "npm_and_yarn" || "$ECOSYSTEM" == "github_actions" ]]; then
+              AUTO=true
+              REASON="patch-or-minor-on-low-risk-ecosystem"
+            else
+              REASON="ecosystem-not-allowlisted ($ECOSYSTEM)"
+            fi
+          else
+            REASON="not-patch-or-minor ($UPDATE_TYPE)"
+          fi
+
+          echo "auto=$AUTO" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+
+      - name: Approve and enable auto-merge
+        if: steps.decide.outputs.auto == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL" --body "Auto-approved: ${{ steps.decide.outputs.reason }}"
+          gh pr merge --auto --squash "$PR_URL"
+
+      - name: Label as needs-review
+        if: steps.decide.outputs.auto != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "needs-review" || true
+          gh pr comment "$PR_URL" --body "Skipping auto-merge: ${{ steps.decide.outputs.reason }}. A human should review this bump."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` that auto-approves and enables `--auto` merge on Dependabot PRs that are **patch or minor** in the **npm** or **github-actions** ecosystems.
- Higher-risk bumps (majors, Docker base images like node 22→25, deploy-action majors) are labelled `needs-review` with an explanatory comment and left for a human.
- Repo-level settings already updated separately: `allow_auto_merge=true`, `delete_branch_on_merge=true`.

## Safety model
- Uses `gh pr merge --auto`, so the merge fires only after required CI checks pass.
- Recommended follow-up: enable branch protection on `main` with the existing CI jobs (Backend, Frontend) marked as required. Without it, `--auto` still waits for CI but does not enforce reviews.
- The 16 currently-open Dependabot PRs are not touched until a new event fires; they can be triggered manually via `gh pr update-branch` or by closing/reopening.

## Test plan
- [ ] Merge this PR.
- [ ] Pick one open Dependabot PR (e.g. #114 jest group), close-and-reopen to retrigger the workflow, and verify it gets auto-approved + auto-merged once CI is green.
- [ ] Pick one excluded PR (e.g. #104 node 22→25) and verify it gets the `needs-review` label and the explanatory comment instead.