### PR TITLE
SEO and discoverability improvements for repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [HelpCode-ai]
+custom: ["https://helpcode.ai", "mailto:info@helpcode.ai"]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+title: "AnythingMCP — Self-Hosted MCP Server & API Gateway"
+message: "If you use AnythingMCP in your research or product, please cite it as below."
+type: software
+authors:
+  - name: "helpcode.ai GmbH"
+    website: "https://helpcode.ai"
+    email: "info@helpcode.ai"
+url: "https://github.com/HelpCode-ai/anythingmcp"
+repository-code: "https://github.com/HelpCode-ai/anythingmcp"
+abstract: >
+  AnythingMCP is a source-available self-hosted Model Context Protocol (MCP)
+  server and API gateway. It converts REST, SOAP, GraphQL endpoints, databases,
+  and other MCP servers into MCP tools consumable by AI clients such as
+  Claude, ChatGPT, Google Gemini, GitHub Copilot, and Cursor. It ships with
+  29 pre-built adapters (DHL, DPD, GLS, DATEV, Weclapp, Personio,
+  Handelsregister, Shopware 6, etc.), OAuth2/RBAC governance, audit logging,
+  and a visual tool editor.
+keywords:
+  - model-context-protocol
+  - mcp
+  - mcp-server
+  - mcp-gateway
+  - api-gateway
+  - llm-tools
+  - ai-agents
+  - claude
+  - chatgpt
+  - rest-to-mcp
+  - soap-to-mcp
+  - graphql-to-mcp
+  - database-to-mcp
+license: BUSL-1.1

--- a/README.md
+++ b/README.md
@@ -6,16 +6,10 @@
   </p>
   <p align="center">
     <a href="https://github.com/HelpCode-ai/anythingmcp/stargazers"><img src="https://img.shields.io/github/stars/HelpCode-ai/anythingmcp?style=social" alt="GitHub Stars"></a>&nbsp;
-    <a href="https://github.com/HelpCode-ai/anythingmcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSL--1.1-blue" alt="License"></a>&nbsp;
     <a href="https://github.com/HelpCode-ai/anythingmcp/releases"><img src="https://img.shields.io/github/v/release/HelpCode-ai/anythingmcp?include_prereleases" alt="Release"></a>&nbsp;
+    <a href="https://github.com/HelpCode-ai/anythingmcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSL--1.1-blue" alt="License"></a>&nbsp;
     <a href="https://hub.docker.com/r/helpcodeai/anythingmcp"><img src="https://img.shields.io/badge/docker-ready-blue?logo=docker" alt="Docker Ready"></a>&nbsp;
-    <img src="https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript&logoColor=white" alt="TypeScript">&nbsp;
-    <img src="https://img.shields.io/badge/NestJS-11-red?logo=nestjs&logoColor=white" alt="NestJS">&nbsp;
-    <img src="https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white" alt="Next.js">&nbsp;
-    <a href="https://github.com/HelpCode-ai/anythingmcp/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs Welcome"></a>&nbsp;
-    <a href="https://github.com/HelpCode-ai/anythingmcp/graphs/contributors"><img src="https://img.shields.io/badge/contributors-welcome-orange" alt="Contributors Welcome"></a>&nbsp;
-    <a href="https://github.com/HelpCode-ai/anythingmcp/commits/main"><img src="https://img.shields.io/github/last-commit/HelpCode-ai/anythingmcp" alt="Last Commit"></a>&nbsp;
-    <a href="https://github.com/HelpCode-ai/anythingmcp/releases"><img src="https://img.shields.io/github/release-date/HelpCode-ai/anythingmcp" alt="Release Date"></a>
+    <a href="https://github.com/HelpCode-ai/anythingmcp/commits/main"><img src="https://img.shields.io/github/last-commit/HelpCode-ai/anythingmcp" alt="Last Commit"></a>
   </p>
 </p>
 
@@ -24,7 +18,7 @@
 </p>
 
 <p align="center">
-  <img src="docs/assets/banner.png" alt="AnythingMCP — open-source self-hosted MCP server and API gateway for Claude, ChatGPT, Gemini, Copilot and Cursor" width="100%" />
+  <img src="docs/assets/banner.png" alt="AnythingMCP — source-available self-hosted MCP server and API gateway for Claude, ChatGPT, Gemini, Copilot and Cursor" width="100%" />
 </p>
 
 ---
@@ -158,6 +152,9 @@ AnythingMCP ships with **29 ready-to-use MCP server adapters** — provide your 
 | **Billomat** | Online invoicing & bookkeeping for DE SMBs | [Billomat MCP Server](https://anythingmcp.com/guides/billomat-to-mcp) |
 | **FastBill** | Invoicing tool for German freelancers and SMBs | [FastBill MCP Server](https://anythingmcp.com/guides/fastbill-to-mcp) |
 
+<details>
+<summary><strong>E-commerce, HR, Government, Banking & Construction MCP servers — click to expand</strong> (Shopware 6, Oxomi, ImmobilienScout24, Personio, Kenjo, MFR, VIES VAT, Handelsregister, OpenPLZ, Bundesbank, DESTATIS, NINA, N26, PAYONE, TeamViewer, PlanRadar, HERE Geocoding)</summary>
+
 ### E-commerce & Catalog
 
 | Connector | Description | Guide |
@@ -199,6 +196,8 @@ AnythingMCP ships with **29 ready-to-use MCP server adapters** — provide your 
 |-----------|-------------|-------|
 | **PlanRadar** | Construction & real-estate project management — tickets, layers | [PlanRadar MCP Server](https://anythingmcp.com/guides/planradar-to-mcp) |
 | **HERE Geocoding** | Worldwide geocoding, autocomplete, place discovery (free tier) | [HERE MCP Server](https://anythingmcp.com/guides/here-geocoding-to-mcp) |
+
+</details>
 
 **Want to add your own?** Create a JSON adapter file in `packages/backend/src/adapters/` (organized by region, e.g. `de/`), register it in `catalog.ts`, and it becomes available to all users. The new `catalog.spec.ts` parametrized test validates every adapter at build time. See the existing adapters and the [Tool Definition Format](docs/tool-definition.md) for the expected schema.
 
@@ -302,9 +301,13 @@ You don't write code. AnythingMCP imports your OpenAPI/Postman/WSDL spec (or you
 
 Yes. Any client that speaks MCP works. See the [Connect Your AI Client](#connect-your-ai-client-to-the-mcp-server) table for direct setup guides.
 
+### Why source-available and not "open source"?
+
+We use the [Business Source License 1.1](LICENSE) (BSL-1.1), the same model as Sentry, MariaDB, CockroachDB and HashiCorp Terraform. The source is fully public, you can read, fork, modify and self-host — but you can't resell it as a managed SaaS without a commercial license. On **2030-03-04** the license **automatically converts to Apache 2.0**, so the code is guaranteed to become OSI-approved open-source. We chose this over MIT/Apache up-front to keep building AnythingMCP sustainably while avoiding the AWS-strip-mining trap. See the [License FAQ](docs/license-faq.md) for plain-language details.
+
 ### Is AnythingMCP free?
 
-It's source-available under [BSL-1.1](LICENSE) — free for internal use, personal use, development, testing, and academic use. The license converts to Apache 2.0 on 2030-03-04. The only thing not allowed is reselling it as a hosted SaaS to third parties without a commercial license.
+Yes, for everyone except SaaS resellers. Free for internal company use, personal use, development, testing, evaluation and academic use. The only restriction is offering it as a hosted commercial service to third parties without a commercial license — and even that restriction lifts on 2030-03-04 when BSL converts to Apache 2.0.
 
 ### Can I self-host AnythingMCP?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,44 @@
+# AnythingMCP Roadmap
+
+This is a **living document**. We publish it so users and contributors can see where AnythingMCP is going and propose changes. Pull requests welcome.
+
+For the current shipped state, see the [latest release](https://github.com/HelpCode-ai/anythingmcp/releases).
+
+---
+
+## Now (in active development)
+
+- More pre-built adapters — community-requested SaaS connectors prioritised in [GitHub Discussions](https://github.com/HelpCode-ai/anythingmcp/discussions)
+- Improved adapter authoring DX — better validation errors, scaffolding CLI
+- Tool-level rate limiting per role
+- Sharper observability: per-tool latency histograms, error-rate dashboards
+
+## Next (planned, not yet started)
+
+- **Streaming tool responses** — for long-running tool calls (DB queries, file generation)
+- **Tool composition** — declaratively chain tools without leaving the gateway
+- **Multi-tenant Cloud parity** — feature parity between self-hosted and [cloud.anythingmcp.com](https://cloud.anythingmcp.com)
+- **Adapter marketplace** — install community adapters from a curated index, similar to a plugin registry
+- **gRPC connector type** — first-class support for gRPC services alongside REST/SOAP/GraphQL
+- **Webhook ingestion** — register webhooks as MCP "events" consumable by clients
+- **Fine-grained tool versioning** — pin AI agents to specific tool versions
+- **Native MCP elicitation & resources** — beyond tools, full MCP spec coverage
+
+## Later (under consideration)
+
+- **Tool A/B testing** — version-flag tool definitions and route per-user
+- **Self-tuning rate limits** based on AI client behavior
+- **OpenTelemetry exporter** for traces and metrics
+- **Plugin SDK in TypeScript and Python** for custom auth/transformations
+
+## Out of scope (for now)
+
+- Building our own LLM client
+- Code-execution sandbox (use [E2B](https://e2b.dev) or similar instead)
+- Replacing Postman/Insomnia as a general API client
+
+---
+
+## Suggest a feature
+
+Open a [feature request](https://github.com/HelpCode-ai/anythingmcp/issues/new?labels=enhancement&template=feature_request.md) or start a thread in [Discussions → Ideas](https://github.com/HelpCode-ai/anythingmcp/discussions/categories/ideas).


### PR DESCRIPTION
## Summary
- README: collapse less-prominent connector tables, trim badge row, fix banner alt-text wording, add a FAQ entry explaining the BSL-1.1 choice (preempts the recurring HN/Reddit question).
- Add `.github/FUNDING.yml` so the Sponsor button surfaces on the repo card.
- Add `ROADMAP.md` to signal active development to potential contributors and curators of awesome-lists.
- Add `CITATION.cff` for academic and tool-driven citations.

Companion change applied directly via `gh repo edit` (no diff): repo topics updated — removed `typescript`, `nestjs`, `nextjs` (high-competition, low-intent), added `anthropic`, `mcp-proxy`, `gemini` (high-intent, low-competition).

## Test plan
- [x] README renders correctly on github.com (collapsible section opens, tables intact)
- [x] FUNDING.yml validates (Sponsor button appears)
- [x] CITATION.cff validates against schema 1.2.0
- [x] Topics list updated to 20/20 with target keywords