### PR TITLE
Fix use-before-define, unpin eslint-plugin-react-hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12466,6 +12466,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13608,22 +13609,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/generate-function": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "class-validator": "^0.15.1"
   },
   "overrides": {
-    "rxjs": "7.8.1",
-    "eslint-plugin-react-hooks": "7.0.1"
+    "rxjs": "7.8.1"
   }
 }

--- a/packages/frontend/src/app/connectors/store/page.tsx
+++ b/packages/frontend/src/app/connectors/store/page.tsx
@@ -98,16 +98,23 @@ function AdapterStoreContent() {
       .finally(() => setLoading(false));
   }, [token]);
 
-  // Auto-import when ?install=<slug> is present (e.g. from website marketplace)
-  useEffect(() => {
-    if (autoInstallTriggered.current || loading || !token || list.length === 0) return;
-    const installSlug = searchParams.get('install');
-    if (!installSlug) return;
-    const adapter = list.find((a) => a.slug === installSlug);
-    if (!adapter) return;
-    autoInstallTriggered.current = true;
-    handleImportClick(adapter);
-  }, [loading, list, token, searchParams]);
+  const doImport = async (slug: string, credentials?: Record<string, string>) => {
+    if (!token) return;
+    setImporting(slug);
+    setMsg('');
+    setConfigAdapter(null);
+    try {
+      const adapter = list.find((a) => a.slug === slug);
+      const result = await adapters.import(slug, token, credentials);
+      setMsg(result.message);
+      setImporting(null);
+      // Show MCP assignment modal
+      setImportedConnector({ id: result.connectorId, name: adapter?.name || slug });
+    } catch (err: any) {
+      setMsg(`Import failed: ${err.message}`);
+      setImporting(null);
+    }
+  };
 
   const handleImportClick = async (adapter: AdapterItem) => {
     if (!token) return;
@@ -136,23 +143,16 @@ function AdapterStoreContent() {
     }
   };
 
-  const doImport = async (slug: string, credentials?: Record<string, string>) => {
-    if (!token) return;
-    setImporting(slug);
-    setMsg('');
-    setConfigAdapter(null);
-    try {
-      const adapter = list.find((a) => a.slug === slug);
-      const result = await adapters.import(slug, token, credentials);
-      setMsg(result.message);
-      setImporting(null);
-      // Show MCP assignment modal
-      setImportedConnector({ id: result.connectorId, name: adapter?.name || slug });
-    } catch (err: any) {
-      setMsg(`Import failed: ${err.message}`);
-      setImporting(null);
-    }
-  };
+  // Auto-import when ?install=<slug> is present (e.g. from website marketplace)
+  useEffect(() => {
+    if (autoInstallTriggered.current || loading || !token || list.length === 0) return;
+    const installSlug = searchParams.get('install');
+    if (!installSlug) return;
+    const adapter = list.find((a) => a.slug === installSlug);
+    if (!adapter) return;
+    autoInstallTriggered.current = true;
+    handleImportClick(adapter);
+  }, [loading, list, token, searchParams]);
 
   const handleConfigSubmit = () => {
     if (!configAdapter) return;

--- a/packages/frontend/src/app/settings/license/page.tsx
+++ b/packages/frontend/src/app/settings/license/page.tsx
@@ -25,10 +25,6 @@ export default function LicenseSettingsPage() {
 
   const isCloud = deploymentMode === 'cloud';
 
-  useEffect(() => {
-    loadStatus();
-  }, [token]);
-
   const loadStatus = async () => {
     try {
       const data = await license.getStatus(token || undefined);
@@ -37,6 +33,10 @@ export default function LicenseSettingsPage() {
       // ignore
     }
   };
+
+  useEffect(() => {
+    loadStatus();
+  }, [token]);
 
   const handleActivate = async () => {
     if (!token || !licenseKey) return;


### PR DESCRIPTION
## Summary
Closes the technical debt left by PR #142 (the temporary `eslint-plugin-react-hooks: 7.0.1` pin in root overrides).

## What changed
- **`packages/frontend/src/app/connectors/store/page.tsx`**: moved \`handleImportClick\` and \`doImport\` declarations above the \`useEffect\` that references \`handleImportClick\`.
- **`packages/frontend/src/app/settings/license/page.tsx`**: moved \`loadStatus\` declaration above the \`useEffect\` that references it.
- **`package.json`**: removed the \`eslint-plugin-react-hooks: 7.0.1\` override. The plugin now follows upstream (resolved to 7.1.x via eslint-config-next).

## Why
\`eslint-plugin-react-hooks\` 7.1.x added a \`react-hooks/use-before-define\` rule. Both patterns were temporally safe at runtime (effects run after the function exists in scope), but the rule is correct that the order is hostile to readers and prevents React Compiler from analyzing the dependency graph cleanly.

## Test plan
- [x] \`npm run lint\` in \`packages/frontend\` → 24 warnings, 0 errors (matches main's pre-bump baseline).
- [x] \`npx tsc --noEmit -p tsconfig.json\` in \`packages/backend\` → exit 0.
- [x] \`npm test\` in \`packages/backend\` → 594 passed, 3 skipped.
- [ ] Manual smoke: hit \`/connectors/store?install=hrworks\` and verify auto-import still triggers correctly (functional behaviour of moved code is unchanged).