### PR TITLE
Bump version to 0.1.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "BSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -23491,7 +23491,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "BSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -23591,7 +23591,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "BSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BSL-1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BSL-1.1",


### PR DESCRIPTION
Routine version bump.

## What's in 0.1.22 vs 0.1.21
- HR WORKS v2 connector (#138)
- Dependabot auto-merge workflow + branch protection (#139)
- 9 weekly dependency bumps merged (next/react, soap, autoprefixer, graphql, @rekog/mcp-nest, jest, types, eslint-prettier, prisma)
- rxjs duplicate-Observable fix via root override + backend pin (#140 + #142)
- Fix use-before-define in two frontend pages, unpin eslint-plugin-react-hooks (#144)