### PR TITLE
SEO round 2: TOC, watch CTA, star-history, support docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Normalize line endings to LF on checkin, native on checkout.
+* text=auto eol=lf
+
+# Shell scripts and Dockerfiles must always be LF.
+*.sh           text eol=lf
+Dockerfile*    text eol=lf
+*.yml          text eol=lf
+*.yaml         text eol=lf
+
+# Tell GitHub Linguist to classify documentation, generated files, and assets
+# correctly so the language stats reflect actual product code.
+docs/**             linguist-documentation
+content/**          linguist-documentation
+*.md                linguist-documentation
+*.mdx               linguist-documentation
+ROADMAP.md          linguist-documentation
+CHANGELOG.md        linguist-documentation
+SUPPORT.md          linguist-documentation
+CONTRIBUTING.md     linguist-documentation
+SECURITY.md         linguist-documentation
+CODE_OF_CONDUCT.md  linguist-documentation
+
+# Lockfiles and large generated artefacts shouldn't pollute language stats.
+package-lock.json   linguist-generated
+*.svg               linguist-generated
+*.png binary
+*.jpg binary
+*.gif binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS — review routing for AnythingMCP
+#
+# Defaults: any change requires review from a core maintainer.
+*                       @keysersoft
+
+# Adapter catalog — community PRs welcome, but a maintainer must validate
+# the JSON schema and the catalog test before merge.
+/packages/backend/src/adapters/   @keysersoft @D3nisty
+/packages/backend/src/catalog.ts  @keysersoft @D3nisty
+
+# Frontend
+/packages/frontend/     @keysersoft @mirkopoloni
+
+# Infra & deployment
+/Dockerfile             @keysersoft
+/docker-compose*.yml    @keysersoft
+/deploy/                @keysersoft
+/railway.*              @keysersoft
+/setup.sh               @keysersoft
+
+# Documentation
+/docs/                  @keysersoft
+/README.md              @keysersoft
+/CONTRIBUTING.md        @keysersoft
+/SECURITY.md            @keysersoft
+/ROADMAP.md             @keysersoft

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions, ideas, show & tell
+    url: https://github.com/HelpCode-ai/anythingmcp/discussions
+    about: For anything that isn't a clear bug or feature request — please use Discussions so the answer helps everyone else too.
+  - name: 📚 Documentation & Guides
+    url: https://anythingmcp.com
+    about: 150+ adapter and AI-client setup guides in English, German, and Italian.
+  - name: 🔐 Security vulnerabilities
+    url: https://github.com/HelpCode-ai/anythingmcp/blob/main/SECURITY.md
+    about: Please do NOT open a public issue. Follow the security disclosure policy.
+  - name: 💼 Commercial licensing & support
+    url: mailto:info@helpcode.ai
+    about: For commercial use, custom adapters, SLA, or on-prem support contracts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to AnythingMCP are tracked on the [GitHub Releases page](https://github.com/HelpCode-ai/anythingmcp/releases).
+
+Each release ships with a structured changelog covering fixes, new features, breaking changes (if any), and verification notes. Subscribe to releases by clicking **Watch → Custom → Releases** on the repository page.
+
+## Quick links
+
+- [Latest release](https://github.com/HelpCode-ai/anythingmcp/releases/latest)
+- [All releases](https://github.com/HelpCode-ai/anythingmcp/releases)
+- [Roadmap](ROADMAP.md)
+
+## Versioning
+
+AnythingMCP follows [Semantic Versioning](https://semver.org). While the project is on `0.x` we may introduce breaking changes between minor versions; each one is called out explicitly in the corresponding release notes.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,44 @@
 </p>
 
 <p align="center">
-  <strong>⭐ Star this repo if you find it useful — it helps others discover AnythingMCP!</strong>
+  <strong>⭐ Star this repo</strong> if you find it useful &middot; <strong>👀 Watch</strong> to get notified about new adapters and releases &middot; <strong>🔱 Fork</strong> to add your own connector
 </p>
 
 <p align="center">
   <img src="docs/assets/banner.png" alt="AnythingMCP — source-available self-hosted MCP server and API gateway for Claude, ChatGPT, Gemini, Copilot and Cursor" width="100%" />
 </p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/docs/assets/demo.gif" alt="AnythingMCP demo — turning a REST API into an MCP server with no code" />
+  <br/>
+  <a href="https://anythingmcp.com/en/video-promo"><strong>Watch the 90-second demo video</strong></a>
+</p>
+
+<details>
+<summary><strong>📖 Table of Contents</strong></summary>
+
+- [Cloud & Deploy](#cloud--deploy)
+- [What is AnythingMCP?](#what-is-anythingmcp)
+- [Get Started in 60 Seconds](#get-started-in-60-seconds)
+- [Use Cases](#use-cases)
+- [Why AnythingMCP?](#why-anythingmcp)
+- [How AnythingMCP Compares](#how-anythingmcp-compares)
+- [Key Features](#key-features)
+- [Pre-configured MCP Connectors](#pre-configured-mcp-connectors)
+- [Quick Start](#quick-start)
+- [Connect Your AI Client to the MCP Server](#connect-your-ai-client-to-the-mcp-server)
+- [Connector Guides](#connector-guides)
+- [Architecture](#architecture)
+- [FAQ](#faq)
+- [Documentation](#documentation)
+- [Tech Stack](#tech-stack)
+- [Development](#development)
+- [Community & Support](#community--support)
+- [Star History](#star-history)
+- [Contributing](#contributing)
+- [License](#license)
+
+</details>
 
 ---
 
@@ -44,12 +76,6 @@ No SDK. No code changes. Just point, configure, and connect.
 **Built-in adapters** ship with the catalog so you get an instant MCP server for popular SaaS and public APIs — DHL, DPD, GLS, Shipcloud, Sendcloud, Deutsche Bahn, DATEV, Weclapp, Xentral, Shopware 6, Personio, Handelsregister, VIES VAT, OpenPLZ, HERE Geocoding, Oxomi and more (full list [below](#pre-configured-mcp-connectors)).
 
 > **Looking for an MCP gateway?** AnythingMCP acts as a universal MCP proxy and API-to-MCP bridge — the missing middleware between your APIs and AI agents.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/docs/assets/demo.gif" alt="AnythingMCP demo — turning a REST API into an MCP server with no code" />
-  <br/>
-  <a href="https://anythingmcp.com/en/video-promo"><strong>Watch the demo video</strong></a>
-</p>
 
 ---
 
@@ -200,6 +226,8 @@ AnythingMCP ships with **29 ready-to-use MCP server adapters** — provide your 
 </details>
 
 **Want to add your own?** Create a JSON adapter file in `packages/backend/src/adapters/` (organized by region, e.g. `de/`), register it in `catalog.ts`, and it becomes available to all users. The new `catalog.spec.ts` parametrized test validates every adapter at build time. See the existing adapters and the [Tool Definition Format](docs/tool-definition.md) for the expected schema.
+
+> 👀 **Don't see your favourite SaaS?** [**Open a discussion**](https://github.com/HelpCode-ai/anythingmcp/discussions/categories/ideas) and we'll prioritise the next adapter based on community demand. ⭐ Star and 👀 Watch the repo to be notified when it ships.
 
 ---
 
@@ -372,10 +400,25 @@ Or see the [Deployment Guide](docs/deployment.md#local-development) for manual s
 
 ## Community & Support
 
-- **Questions & Discussions** — [GitHub Discussions](https://github.com/HelpCode-ai/anythingmcp/discussions)
+- **Questions & Discussions** — [GitHub Discussions](https://github.com/HelpCode-ai/anythingmcp/discussions) — vote on the next adapter, share what you've built, ask for help
 - **Bug Reports** — [Open an issue](https://github.com/HelpCode-ai/anythingmcp/issues)
 - **Feature Requests** — [Request a feature](https://github.com/HelpCode-ai/anythingmcp/issues/new?labels=enhancement&template=feature_request.md)
+- **Need help?** — see [SUPPORT.md](SUPPORT.md) for the full list of channels
 - **Built by** [helpcode.ai](https://helpcode.ai) — AI-powered software development from Germany
+
+---
+
+## Star History
+
+<a href="https://www.star-history.com/#HelpCode-ai/anythingmcp&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=HelpCode-ai/anythingmcp&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=HelpCode-ai/anythingmcp&type=Date" />
+    <img alt="AnythingMCP star history chart" src="https://api.star-history.com/svg?repos=HelpCode-ai/anythingmcp&type=Date" />
+  </picture>
+</a>
+
+> ⭐ **Like what you see?** [**Star this repo**](https://github.com/HelpCode-ai/anythingmcp/stargazers) — every star helps another developer discover AnythingMCP.
 
 ---
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,47 @@
+# Getting help with AnythingMCP
+
+Different questions go to different places — please use the right channel so we can answer faster.
+
+## Ask the community first
+
+The fastest answers usually come from other users. Before opening an issue, check:
+
+- **[GitHub Discussions](https://github.com/HelpCode-ai/anythingmcp/discussions)** — Q&A, ideas, show & tell
+  - **Q&A** for "how do I…" questions
+  - **Ideas** for feature requests and "please add adapter X"
+  - **Show and tell** for sharing what you built
+  - **Announcements** for release notes and roadmap updates
+
+## Documentation
+
+- **[README](README.md)** — overview and quick start
+- **[anythingmcp.com](https://anythingmcp.com)** — website with 150+ guides for individual adapters and AI clients (English / German / Italian)
+- **[Deployment Guide](docs/deployment.md)** — production self-hosting
+- **[API Reference](docs/api-reference.md)** — full REST API
+- **[Tool Definition Format](docs/tool-definition.md)** — how adapter JSON files are structured
+- **[License FAQ](docs/license-faq.md)** — what BSL-1.1 means in practice
+
+## Bug reports
+
+Found a reproducible bug? [Open an issue](https://github.com/HelpCode-ai/anythingmcp/issues/new/choose) using the **Bug report** template. Please include:
+
+- Version (`docker compose exec backend npm version`, or `git rev-parse HEAD` for source builds)
+- Deployment mode (Docker / Railway / DigitalOcean / Cloud)
+- The smallest possible reproduction steps
+- Logs (sanitise any credentials first)
+
+## Security issues
+
+**Do not** open a public issue for security vulnerabilities. Follow the [SECURITY.md](SECURITY.md) policy and email **info@helpcode.ai** instead.
+
+## Commercial support
+
+For commercial licensing, custom adapter development, on-prem support contracts, or SLA-backed Cloud plans:
+
+📧 **info@helpcode.ai** &nbsp; · &nbsp; 🌐 **[helpcode.ai](https://helpcode.ai)**
+
+## Stay in the loop
+
+- ⭐ **Star** the repo
+- 👀 **Watch → Custom → Releases** to be notified about new versions and adapters
+- 📣 Follow [@helpcode_ai](https://twitter.com/helpcode_ai) for release announcements


### PR DESCRIPTION
## Summary

Follow-up to #141. Tackles the next SEO/discoverability issues identified in the audit:

**README**
- Collapsible **Table of Contents** at the top of the file
- Demo GIF moved immediately under the banner (was buried mid-page)
- **star-history.com** chart at the end, with light/dark variants
- Two extra Star/Watch CTAs: one mid-document near the adapter catalog ("Don't see your favourite SaaS?"), one after the star-history chart
- Top CTA line now mentions Watch + Fork, not just Star, so the watcher count starts moving from zero

**Meta files**
- `CHANGELOG.md` — thin pointer to the Releases page (some scanners expect this file)
- `SUPPORT.md` — surfaces the "Get help" sidebar with proper routing across Discussions, docs, security, commercial
- `.gitattributes` — normalise line endings; tell Linguist that `/docs`, `/content`, MDX, and lockfiles are documentation/generated, so the language bar reflects actual product code (currently TypeScript 89.2 / MDX 7.7 / Shell 2.2 → expected TypeScript ~95 / Shell ~5)
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, routes non-bug questions to Discussions, security to SECURITY.md
- `.github/CODEOWNERS` — review routing for adapter catalog, frontend, infra, docs

## Out of scope (separate work)
- Pinned discussions, pinned issues, repo description update, release-note backfill — applied directly via API after merge.
- Dual-license / GitHub Sponsors enrolment / dedicated OG image — require external decisions.

## Test plan
- [x] README renders on github.com (TOC `<details>` works, star-history img loads)
- [x] `.gitattributes` syntax validated locally
- [ ] After merge: language bar collapses MDX into "documentation"
- [ ] After merge: "Get help" entry appears in repo's About sidebar (from SUPPORT.md)
- [ ] After merge: `New issue` button no longer shows "Open a blank issue" — only the two YAML templates + 4 contact links