### PR TITLE
SEO round 3: engagement workflows (stale, welcome, release-announce)

### DIFF
--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,0 +1,66 @@
+name: Announce release in Discussions
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  discussions: write
+  contents: read
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    steps:
+      - name: Post comment on the Roadmap discussion
+        uses: actions/github-script@v7
+        env:
+          # The pinned Roadmap discussion. Update DISCUSSION_NUMBER if it changes.
+          DISCUSSION_NUMBER: "147"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const release = context.payload.release;
+            const discussionNumber = parseInt(process.env.DISCUSSION_NUMBER, 10);
+            const { owner, repo } = context.repo;
+
+            // Resolve discussion ID
+            const q = `
+              query($owner:String!,$name:String!,$number:Int!){
+                repository(owner:$owner,name:$name){
+                  discussion(number:$number){ id title }
+                }
+              }`;
+            const r = await github.graphql(q, {
+              owner,
+              name: repo,
+              number: discussionNumber,
+            });
+            const discussionId = r.repository.discussion.id;
+
+            const truncatedBody = (release.body || "")
+              .split("\n")
+              .slice(0, 25)
+              .join("\n");
+
+            const body = [
+              `### 🚀 ${release.name || release.tag_name} is out`,
+              ``,
+              `Published ${new Date(release.published_at).toISOString().slice(0, 10)} — see the [full release notes](${release.html_url}).`,
+              ``,
+              truncatedBody,
+              ``,
+              `---`,
+              `Update with \`docker compose pull && docker compose up -d\` (self-hosted) or wait for the Cloud rollout (~24h after this comment).`,
+              `⭐ Star &middot; 👀 Watch → Releases &middot; 💡 [Vote on the next adapter](https://github.com/${owner}/${repo}/discussions/148)`,
+            ].join("\n");
+
+            const m = `
+              mutation($id:ID!,$body:String!){
+                addDiscussionComment(input:{discussionId:$id, body:$body}){
+                  comment{ id url }
+                }
+              }`;
+            const res = await github.graphql(m, { id: discussionId, body });
+            core.info(`Posted: ${res.addDiscussionComment.comment.url}`);

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          exempt-issue-labels: "pinned,security,roadmap,help wanted,good first issue"
+          stale-issue-message: >
+            This issue has been quiet for 60 days. We're marking it `stale`
+            so it stays visible. If it's still relevant, drop a comment and
+            we'll keep it open — otherwise it will close in 14 days.
+          close-issue-message: >
+            Closing as stale. If this is still relevant, please reopen
+            with an updated description — we'd rather have a focused
+            issue than a long-running one. Thanks!
+
+          # Pull requests
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: "stale"
+          exempt-pr-labels: "pinned,security,blocked,wip"
+          stale-pr-message: >
+            This PR has been quiet for 30 days. If you're still working
+            on it, leave a comment so we don't auto-close it in 14 days.
+          close-pr-message: >
+            Closing as stale to keep the queue clean. Re-open any time
+            once the work resumes.
+
+          operations-per-run: 100
+          ascending: true
+          remove-stale-when-updated: true

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,75 @@
+name: Welcome new contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Greet first-time contributors
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const isPR = !!context.payload.pull_request;
+            const number = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+            const author = isPR
+              ? context.payload.pull_request.user.login
+              : context.payload.issue.user.login;
+
+            // Skip bots
+            if (/\[bot\]$/.test(author) || ["dependabot", "renovate"].includes(author)) {
+              return;
+            }
+
+            // Count this author's prior contributions
+            const { data: priorIssues } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} author:${author}`,
+              per_page: 2,
+            });
+            if (priorIssues.total_count > 1) {
+              core.info(`${author} has ${priorIssues.total_count} prior items — not first-timer.`);
+              return;
+            }
+
+            const body = isPR
+              ? [
+                  `👋 Welcome, @${author}, and thanks for opening your first PR on AnythingMCP!`,
+                  ``,
+                  `A few quick pointers:`,
+                  `- Make sure CI is green before requesting review (\`Backend\`, \`Frontend\`, \`Playwright\`, \`CodeQL\`, \`Trivy\`).`,
+                  `- If this is a new adapter, the parametrised \`catalog.spec.ts\` test will validate it automatically.`,
+                  `- Sign off your commits if you can — it's not blocking, just nice to have.`,
+                  ``,
+                  `Someone from the core team will look at this within ~48h. If you don't hear back, please ping us in [Discussions / Q&A](https://github.com/${owner}/${repo}/discussions/categories/q-a).`,
+                  ``,
+                  `⭐ While you wait — if you find AnythingMCP useful, a star helps others discover it.`,
+                ].join("\n")
+              : [
+                  `👋 Hi @${author}, thanks for opening your first issue on AnythingMCP!`,
+                  ``,
+                  `A maintainer will triage this within ~48h. To help us help you faster:`,
+                  `- For "how do I…" questions, [Discussions / Q&A](https://github.com/${owner}/${repo}/discussions/categories/q-a) usually gets faster answers.`,
+                  `- For feature requests, vote on [Which integrations should we build next?](https://github.com/${owner}/${repo}/discussions/148) so we can prioritise based on demand.`,
+                  `- Bug? Please confirm the version and deployment mode (Docker / Railway / DO / Cloud) if you haven't already.`,
+                  ``,
+                  `⭐ If AnythingMCP has been useful to you, a star helps others find it.`,
+                ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: number,
+              body,
+            });


### PR DESCRIPTION
## Summary

Three GitHub Actions workflows that automate community-engagement signals so we don't have to remember to do them by hand.

- **stale.yml** — issues go stale after 60d and close at 74d; PRs after 30d and 44d. Exempts pinned/security/roadmap/help-wanted/good-first-issue/wip.
- **welcome.yml** — comments on first-time contributors' issues and PRs with a context-aware welcome that points them at CI, Discussions, and the next-adapter wishlist. Skips bots and prior contributors.
- **release-announce.yml** — when a non-prerelease, non-draft release is published, posts a summary comment on the pinned Roadmap discussion (#147) so the Announcements channel doesn't go stale.

## Why
Audit found Discussions abandoned (1 auto-generated welcome, 0 comments) and 0 visible engagement triggers. These three workflows close the loop: every release pings the discussion, every new contributor gets greeted, and old issues don't pile up.

## Test plan
- [x] YAML syntax validates locally
- [x] `actions/stale@v9` and `actions/github-script@v7` are pinned majors
- [ ] After merge: stale workflow runs on schedule (next morning 06:00 UTC) and exits cleanly with 0 stales
- [ ] After merge: open a test PR from a new account, verify welcome comment posts
- [ ] After next release: verify auto-comment lands on discussion #147

If discussion #147 changes number, update `DISCUSSION_NUMBER` env var in `release-announce.yml`.