### PR TITLE
Dedupe MCP-registry tool names across orgs/connectors

### DIFF
--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -87,8 +87,15 @@ export class McpServerService implements OnModuleInit {
           envVars,
         );
 
-        // Register as a native MCP tool so it appears directly in tools/list
-        this.registerMcpTool(tool.name, tool.description, effectiveSchema);
+        // Register as a native MCP tool so it appears directly in tools/list,
+        // but only the first time we see this name. The upstream library's
+        // McpRegistryService is single-tenant (one tool per name); our
+        // ToolRegistry resolves cross-org collisions at handler-dispatch
+        // time via getToolForOrg/getTool, so the second+ registration with
+        // the same name would just overwrite and emit a warning.
+        if (this.toolRegistry.countByName(tool.name) === 1) {
+          this.registerMcpTool(tool.name, tool.description, effectiveSchema);
+        }
       }
     }
   }
@@ -98,10 +105,15 @@ export class McpServerService implements OnModuleInit {
     const oldTools = this.toolRegistry
       .getAllTools()
       .filter((t) => t.connectorId === connectorId);
-    for (const tool of oldTools) {
-      this.mcpRegistry.removeTool(tool.name);
-    }
     this.toolRegistry.unregisterConnectorTools(connectorId);
+    for (const tool of oldTools) {
+      // Only drop from the upstream MCP registry if no other connector
+      // (in any org) still exposes this tool name — otherwise we'd
+      // tear down a name that another tenant still needs.
+      if (this.toolRegistry.countByName(tool.name) === 0) {
+        this.mcpRegistry.removeTool(tool.name);
+      }
+    }
 
     // Load and register new tools
     const connector = await this.prisma.connector.findUnique({
@@ -141,7 +153,12 @@ export class McpServerService implements OnModuleInit {
           tool.parameters as Record<string, unknown>,
           envVars,
         );
-        this.registerMcpTool(tool.name, tool.description, effectiveSchema);
+        // Same dedup rule as loadAllTools — register on the upstream
+        // single-tenant MCP registry only when this is the first tool
+        // with this name across all orgs/connectors.
+        if (this.toolRegistry.countByName(tool.name) === 1) {
+          this.registerMcpTool(tool.name, tool.description, effectiveSchema);
+        }
       }
     }
 

--- a/packages/backend/src/mcp-server/tool-registry.spec.ts
+++ b/packages/backend/src/mcp-server/tool-registry.spec.ts
@@ -128,4 +128,35 @@ describe('ToolRegistry', () => {
       expect(registry.getToolCount()).toBe(2);
     });
   });
+
+  describe('countByName', () => {
+    it('returns 0 for an unknown name', () => {
+      expect(registry.countByName('unknown')).toBe(0);
+    });
+
+    it('counts every tool registered under the same name across orgs/connectors', () => {
+      registry.registerTool(
+        makeTool({ id: 't-a', name: 'shared', connectorId: 'c-a', organizationId: 'org-A' }),
+      );
+      registry.registerTool(
+        makeTool({ id: 't-b', name: 'shared', connectorId: 'c-b', organizationId: 'org-B' }),
+      );
+      registry.registerTool(
+        makeTool({ id: 't-c', name: 'shared', connectorId: 'c-c', organizationId: 'org-A' }),
+      );
+      expect(registry.countByName('shared')).toBe(3);
+    });
+
+    it('decreases when a connector is unregistered', () => {
+      registry.registerTool(
+        makeTool({ id: 't-a', name: 'shared', connectorId: 'c-a' }),
+      );
+      registry.registerTool(
+        makeTool({ id: 't-b', name: 'shared', connectorId: 'c-b' }),
+      );
+      expect(registry.countByName('shared')).toBe(2);
+      registry.unregisterConnectorTools('c-a');
+      expect(registry.countByName('shared')).toBe(1);
+    });
+  });
 });

--- a/packages/backend/src/mcp-server/tool-registry.ts
+++ b/packages/backend/src/mcp-server/tool-registry.ts
@@ -112,6 +112,15 @@ export class ToolRegistry {
   }
 
   /**
+   * Count how many tools share a given name across all orgs/connectors.
+   * Used by McpServerService to decide whether a tool name is already
+   * exposed in the upstream MCP library's (single-tenant) registry.
+   */
+  countByName(name: string): number {
+    return this.toolsByName.get(name)?.length ?? 0;
+  }
+
+  /**
    * Get the count of registered tools.
    */
   getToolCount(): number {


### PR DESCRIPTION
## Summary
Silences the \`Dynamic tool 'X' already registered in module — Overwriting.\` warnings emitted at boot by aligning our registration logic with the upstream library's single-tenant assumption.

## Why
Production logs on \`cloud.anythingmcp.com\` showed 12 such warnings at startup, covering 8 unique tool names. Triage:
- **3 organizations** each imported the Weclapp adapter → 6 cross-tenant duplicates (\`weclapp_*\`).
- **1 organization** has two distinct, legitimate connectors (\"Udyogi - PROD\" and \"Param - Prod\") that share two tool names (\`sales_register_prod\`, \`purchase_register_prod\`) — neither is an accidental import.

Our \`ToolRegistry\` already handles cross-tenant collisions correctly (\`getToolForOrg\`, \`getTool(name, connectorIds)\`). Only the upstream \`@rekog/mcp-nest\` \`McpRegistryService\` (single-tenant) was generating noise.

## Change
- \`ToolRegistry.countByName(name)\` — new O(1) helper.
- \`McpServerService.loadAllTools\` / \`reloadConnectorTools\` — register a name on the upstream MCP registry only when it first appears in our \`ToolRegistry\`, and remove it only when the last entry leaves.

## Test plan
- [x] \`npx jest src/mcp-server/tool-registry.spec.ts\` → 15/15 passed (added 3 new for \`countByName\`).
- [x] \`npm test\` → 601 passed across 24 suites.
- [x] \`tsc --noEmit\` → exit 0.
- [ ] After deploy: re-check \`docker logs amcp-cloud-app | grep 'already registered'\` → expect 0 lines.