### PR TITLE
Fix FUNDING.yml parse errors flagged by Sponsor popup

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-github: [HelpCode-ai]
-custom: ["https://helpcode.ai", "mailto:info@helpcode.ai"]
+custom: ["https://anythingmcp.com/pricing", "https://helpcode.ai"]


### PR DESCRIPTION
## Summary

The Sponsor popup on the repo card shows two parse errors:
- \`github: [HelpCode-ai]\` — the HelpCode-ai org isn't enrolled in GitHub Sponsors, so the field is rejected.
- \`custom: [\"mailto:info@helpcode.ai\"]\` — the \`custom\` field accepts only http(s) URLs. The mailto entry is rejected.

This PR removes both invalid entries and replaces them with two clean HTTPS endpoints:
- \`https://anythingmcp.com/pricing\` — the Cloud plans page (closest thing to \"support the project commercially\" right now)
- \`https://helpcode.ai\` — the company landing page

When the org enrols in GitHub Sponsors we can re-add a \`github:\` line and bump the value list.

## Test plan
- [ ] After merge: visit https://github.com/HelpCode-ai/anythingmcp → Sponsor popup shows the two URLs with no error banner