### PR TITLE
DTO @ApiProperty + MCP arguments alias (#5 + #4)

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -15,7 +15,7 @@ import {
   ForbiddenException,
   Logger,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { Throttle } from '@nestjs/throttler';
 import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsBoolean, Equals, Matches } from 'class-validator';
@@ -33,9 +33,11 @@ import { OrganizationsService } from '../organizations/organizations.service';
 import { Roles, RolesGuard } from './roles.guard';
 
 class LoginDto {
+  @ApiProperty({ description: 'Email address.', example: 'user@example.com' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ description: 'Password (min 8 characters).', format: 'password' })
   @IsString()
   @MinLength(8)
   password: string;
@@ -46,36 +48,50 @@ const PASSWORD_MESSAGE =
   'Password must be at least 8 characters and include uppercase, lowercase, number, and special character';
 
 class RegisterDto {
+  @ApiProperty({ description: 'Email address.', example: 'user@example.com' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    description: 'Password: 8+ chars, mixed case, digit, special.',
+    format: 'password',
+  })
   @IsString()
   @MinLength(8)
   @Matches(PASSWORD_REGEX, { message: PASSWORD_MESSAGE })
   password: string;
 
+  @ApiProperty({ description: 'Display name.', example: 'Jane Doe' })
   @IsString()
   name: string;
 
+  @ApiProperty({
+    description: 'Must be true: caller has accepted the Terms of Use.',
+    example: true,
+  })
   @IsBoolean()
   @Equals(true, { message: 'You must accept the Terms of Use' })
   acceptTerms: boolean;
 }
 
 class VerifyEmailDto {
+  @ApiProperty({ description: 'Email verification code sent to the user.' })
   @IsString()
   code: string;
 }
 
 class ForgotPasswordDto {
+  @ApiProperty({ description: 'Email to send the reset link to.' })
   @IsEmail()
   email: string;
 }
 
 class ResetPasswordDto {
+  @ApiProperty({ description: 'Reset token from the reset email.' })
   @IsString()
   token: string;
 
+  @ApiProperty({ description: 'New password (same rules as register).', format: 'password' })
   @IsString()
   @MinLength(8)
   @Matches(PASSWORD_REGEX, { message: PASSWORD_MESSAGE })
@@ -83,26 +99,34 @@ class ResetPasswordDto {
 }
 
 class InviteUserDto {
+  @ApiProperty({ description: 'Email of the user being invited.' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ enum: UserRole, description: 'Organization role to grant.' })
   @IsEnum(UserRole)
   role: UserRole;
 
+  @ApiPropertyOptional({
+    description: 'Optional MCP role id to attach (controls which tools the invitee can call).',
+  })
   @IsOptional()
   @IsString()
   mcpRoleId?: string;
 }
 
 class AcceptInviteDto {
+  @ApiProperty({ description: 'Invite token from the invitation email.' })
   @IsString()
   token: string;
 
+  @ApiProperty({ description: 'Account password.', format: 'password' })
   @IsString()
   @MinLength(8)
   @Matches(PASSWORD_REGEX, { message: PASSWORD_MESSAGE })
   password: string;
 
+  @ApiProperty({ description: 'Display name for the new account.' })
   @IsString()
   name: string;
 }

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -12,7 +12,7 @@ import {
   Logger,
   ForbiddenException,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { PaginationQueryDto } from '../common/pagination.dto';
 import { ConfigService } from '@nestjs/config';
@@ -43,90 +43,181 @@ import { getRequiredSecret } from '../common/secrets.util';
 import { decrypt } from '../common/crypto/encryption.util';
 
 class CreateConnectorDto {
+  @ApiProperty({
+    description: 'Human-readable connector name shown in the UI and surfaced via MCP.',
+    example: 'Acme CRM',
+  })
   @IsString()
   name: string;
 
+  @ApiProperty({
+    enum: ConnectorType,
+    description: 'Transport family for this connector.',
+    example: 'REST',
+  })
   @IsEnum(ConnectorType)
   type: ConnectorType;
 
+  @ApiProperty({
+    description: 'Root URL the engine will call. Path interpolation is applied per-tool.',
+    example: 'https://api.acme.example/v1',
+  })
   @IsString()
   baseUrl: string;
 
+  @ApiPropertyOptional({
+    enum: AuthType,
+    description: 'Auth scheme. Omit to send no auth.',
+    example: 'BEARER_TOKEN',
+  })
   @IsOptional()
   @IsEnum(AuthType)
   authType?: AuthType;
 
+  @ApiPropertyOptional({
+    description:
+      'Credential payload keyed by authType (e.g. { token: "..." } for BEARER_TOKEN, { username, password } for BASIC_AUTH).',
+    example: { token: 'sk_live_…' },
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   authConfig?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Public URL of an OpenAPI/WSDL/GraphQL spec to associate with this connector.',
+    example: 'https://api.acme.example/v1/openapi.json',
+  })
   @IsOptional()
   @IsString()
   specUrl?: string;
 
+  @ApiPropertyOptional({
+    description: 'Extra HTTP headers sent on every request.',
+    example: { 'X-Tenant': 'acme' },
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
   @IsOptional()
   @IsObject()
   headers?: Record<string, string>;
 
+  @ApiPropertyOptional({
+    description: 'Engine-specific options (e.g. { readOnly: true } for DATABASE connectors).',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   config?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description:
+      'Per-connector runtime values. Referenced from tool params with `$envVarName` so the AI never has to provide them.',
+    example: { ACME_TENANT_ID: '42' },
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
   @IsOptional()
   @IsObject()
   envVars?: Record<string, string>;
 
+  @ApiPropertyOptional({
+    description:
+      'Markdown notes appended to the MCP server instructions for any server that exposes this connector. Use it to tell clients about token lifetime, scopes, or quirks.',
+  })
   @IsOptional()
   @IsString()
   instructions?: string;
 }
 
 class UpdateConnectorDto {
+  @ApiPropertyOptional({ description: 'Human-readable connector name.' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Root URL the engine will call.' })
   @IsOptional()
   @IsString()
   baseUrl?: string;
 
+  @ApiPropertyOptional({ enum: AuthType, description: 'Auth scheme.' })
   @IsOptional()
   @IsEnum(AuthType)
   authType?: AuthType;
 
+  @ApiPropertyOptional({
+    description: 'Credential payload (see CreateConnectorDto.authConfig).',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   authConfig?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Set to false to disable the connector without deleting it.',
+    example: false,
+  })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Extra HTTP headers sent on every request.',
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
   @IsOptional()
   @IsObject()
   headers?: Record<string, string>;
 
+  @ApiPropertyOptional({
+    description: 'Engine-specific options.',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   config?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Per-connector runtime values referenced by tool params with `$name`.',
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
   @IsOptional()
   @IsObject()
   envVars?: Record<string, string>;
 
+  @ApiPropertyOptional({ description: 'Markdown notes surfaced to MCP clients.' })
   @IsOptional()
   @IsString()
   instructions?: string;
 }
 
 class ImportToolsDto {
+  @ApiProperty({
+    enum: ['openapi', 'wsdl', 'graphql', 'postman', 'curl', 'json', 'mcp'],
+    description: 'Which parser to run on the supplied content/url.',
+    example: 'openapi',
+  })
   @IsString()
   source: 'openapi' | 'wsdl' | 'graphql' | 'postman' | 'curl' | 'json' | 'mcp';
 
+  @ApiPropertyOptional({
+    description: 'Inline spec content (JSON or YAML). Mutually exclusive with `url`.',
+  })
   @IsOptional()
   @IsString()
   content?: string;
 
+  @ApiPropertyOptional({
+    description: 'Public URL to fetch the spec from. Mutually exclusive with `content`.',
+    example: 'https://api.acme.example/v1/openapi.json',
+  })
   @IsOptional()
   @IsString()
   url?: string;
@@ -135,61 +226,92 @@ class ImportToolsDto {
 // ── DTOs for importAll / updateEnvVars ─────────────────────────────────────
 
 class ImportToolDto {
+  @ApiProperty({ description: 'Tool name exposed via MCP (must be unique per connector).' })
   @IsString()
   name: string;
 
+  @ApiProperty({ description: 'One-line description shown in MCP tools/list.' })
   @IsString()
   description: string;
 
+  @ApiPropertyOptional({ description: 'If false, the tool is registered but hidden.' })
   @IsOptional()
   @IsBoolean()
   isEnabled?: boolean;
 
+  @ApiProperty({
+    description: 'JSON Schema describing the tool input parameters.',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsObject()
   parameters: Record<string, unknown>;
 
+  @ApiProperty({
+    description: 'Engine-specific routing: method, path, queryParams, bodyMapping, etc.',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsObject()
   endpointMapping: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Optional response shaping (field selection, key rename).',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   responseMapping?: Record<string, unknown>;
 }
 
 class ImportConnectorDto {
+  @ApiProperty({ description: 'Connector name.' })
   @IsString()
   name: string;
 
+  @ApiProperty({ enum: ConnectorType })
   @IsEnum(ConnectorType)
   type: ConnectorType;
 
+  @ApiProperty({ description: 'Root URL.' })
   @IsString()
   baseUrl: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
 
+  @ApiPropertyOptional({ enum: AuthType })
   @IsOptional()
   @IsEnum(AuthType)
   authType?: AuthType;
 
+  @ApiPropertyOptional({ description: 'Spec URL associated with this connector.' })
   @IsOptional()
   @IsString()
   specUrl?: string;
 
+  @ApiPropertyOptional({ type: 'object', additionalProperties: { type: 'string' } })
   @IsOptional()
   @IsObject()
   headers?: Record<string, string>;
 
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
   @IsOptional()
   @IsObject()
   config?: Record<string, unknown>;
 
+  @ApiPropertyOptional({ type: 'object', additionalProperties: { type: 'string' } })
   @IsOptional()
   @IsObject()
   envVars?: Record<string, string>;
 
+  @ApiPropertyOptional({
+    description: 'Tools to seed under this connector. Skipped if the connector already has tools with the same names.',
+    type: [ImportToolDto],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
@@ -198,6 +320,10 @@ class ImportConnectorDto {
 }
 
 class ImportAllDto {
+  @ApiProperty({
+    description: 'Bulk-import payload: an array of connectors with their tools.',
+    type: [ImportConnectorDto],
+  })
   @IsArray()
   @ArrayMinSize(1)
   @ValidateNested({ each: true })
@@ -206,6 +332,12 @@ class ImportAllDto {
 }
 
 class UpdateEnvVarsDto {
+  @ApiProperty({
+    description: 'New env-var map. Replaces the existing map entirely.',
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    example: { ACME_TENANT_ID: '42', ACME_API_KEY: 'sk_…' },
+  })
   @IsObject()
   envVars: Record<string, string>;
 }

--- a/packages/backend/src/connectors/tools.controller.ts
+++ b/packages/backend/src/connectors/tools.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
   ForbiddenException,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import {
   IsString,
@@ -26,50 +26,104 @@ import { McpServerService } from '../mcp-server/mcp-server.service';
 import { ConnectorsService } from './connectors.service';
 
 class CreateToolDto {
+  @ApiProperty({
+    description: 'Tool name exposed via MCP (unique per connector).',
+    example: 'list_invoices',
+  })
   @IsString()
   name: string;
 
+  @ApiProperty({
+    description: 'One-line description shown in MCP tools/list.',
+    example: 'List all invoices for the given customer.',
+  })
   @IsString()
   description: string;
 
+  @ApiProperty({
+    description: 'JSON Schema describing the tool input parameters.',
+    type: 'object',
+    additionalProperties: true,
+    example: {
+      type: 'object',
+      properties: { customerId: { type: 'string' } },
+      required: ['customerId'],
+    },
+  })
   @IsObject()
   parameters: Record<string, unknown>;
 
+  @ApiProperty({
+    description:
+      'Engine-specific routing. For REST: { method, path, queryParams?, bodyMapping?, headers? }.',
+    type: 'object',
+    additionalProperties: true,
+    example: { method: 'GET', path: '/customers/{customerId}/invoices' },
+  })
   @IsObject()
   endpointMapping: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Optional response shaping (field selection, rename).',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   responseMapping?: Record<string, unknown>;
 }
 
 class UpdateToolDto {
+  @ApiPropertyOptional({ description: 'Tool name.' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'One-line description.' })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'JSON Schema for input parameters.',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   parameters?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Engine-specific routing.',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   endpointMapping?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Response shaping.',
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   responseMapping?: Record<string, unknown>;
 
+  @ApiPropertyOptional({
+    description: 'Set to false to hide the tool from MCP without deleting it.',
+  })
   @IsOptional()
   @IsBoolean()
   isEnabled?: boolean;
 }
 
 class BulkCreateToolsDto {
+  @ApiProperty({
+    description: 'Tools to create in a single call. Duplicates (same name) on the connector are skipped.',
+    type: [CreateToolDto],
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => CreateToolDto)
@@ -77,6 +131,24 @@ class BulkCreateToolsDto {
 }
 
 class TestToolDto {
+  @ApiPropertyOptional({
+    description:
+      'MCP-standard input map for the tool. Equivalent to the `arguments` field MCP clients send.',
+    type: 'object',
+    additionalProperties: true,
+    example: { customerId: 'cus_123' },
+  })
+  @IsOptional()
+  @IsObject()
+  arguments?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description:
+      'Legacy alias for `arguments`. Accepted for backward compatibility; new clients should use `arguments`.',
+    deprecated: true,
+    type: 'object',
+    additionalProperties: true,
+  })
   @IsOptional()
   @IsObject()
   params?: Record<string, unknown>;
@@ -226,7 +298,8 @@ export class ToolsController {
     summary: 'Test an MCP tool with sample parameters',
     description:
       'Execute a tool against its connector with provided parameters. ' +
-      'Returns the API response or error details. Useful for testing tools before exposing via MCP.',
+      'Accepts MCP-standard `{ arguments: {...} }` or legacy `{ params: {...} }` ' +
+      '(deprecated). Returns the API response or error details.',
   })
   async testTool(
     @Param('connectorId') connectorId: string,
@@ -245,12 +318,16 @@ export class ToolsController {
       return { ok: false, error: 'Tool not found' };
     }
 
+    // MCP standard uses `arguments`; we historically accepted `params`. Take
+    // `arguments` first, fall back to `params` so old clients keep working.
+    const inputs = body.arguments ?? body.params ?? {};
+
     const startTime = Date.now();
     try {
       const result = await this.connectorsService.executeConnectorCall(
         tool.connector,
         tool.endpointMapping as any,
-        body.params || {},
+        inputs,
       );
       const durationMs = Date.now() - startTime;
       return {

--- a/packages/backend/src/mcp-servers/mcp-servers.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.controller.ts
@@ -12,7 +12,7 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationQueryDto } from '../common/pagination.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional, IsBoolean, IsArray } from 'class-validator';
@@ -21,45 +21,67 @@ import { LicenseGuardService } from '../license/license-guard.service';
 import { PrismaService } from '../common/prisma.service';
 
 class CreateMcpServerDto {
+  @ApiProperty({ description: 'Human-readable name.', example: 'Sales Workspace' })
   @IsString()
   name: string;
 
+  @ApiPropertyOptional({
+    description:
+      'URL-safe slug for the per-server MCP endpoint (e.g. /mcp/<slug>). Auto-generated if omitted.',
+    example: 'sales-workspace',
+  })
   @IsOptional()
   @IsString()
   slug?: string;
 
+  @ApiPropertyOptional({ description: 'Free-text description (UI only).' })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Markdown instructions surfaced to MCP clients on initialize(). Concatenated with each assigned connector\'s instructions.',
+  })
   @IsOptional()
   @IsString()
   instructions?: string;
 }
 
 class UpdateMcpServerDto {
+  @ApiPropertyOptional({ description: 'Human-readable name.' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'URL-safe slug.' })
   @IsOptional()
   @IsString()
   slug?: string;
 
+  @ApiPropertyOptional({ description: 'Free-text description.' })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiPropertyOptional({ description: 'Markdown instructions for MCP clients.' })
   @IsOptional()
   @IsString()
   instructions?: string;
 
+  @ApiPropertyOptional({ description: 'Set to false to disable the endpoint without deleting it.' })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
 }
 
 class AssignConnectorsDto {
+  @ApiProperty({
+    description:
+      'Connector IDs to expose under this MCP server. Replaces the existing assignment.',
+    type: [String],
+    example: ['cmob60dvv00c01zrpeujwmnep'],
+  })
   @IsArray()
   @IsString({ each: true })
   connectorIds: string[];

--- a/packages/backend/src/organizations/organizations.controller.ts
+++ b/packages/backend/src/organizations/organizations.controller.ts
@@ -11,7 +11,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional } from 'class-validator';
 import { OrganizationsService } from './organizations.service';
@@ -19,22 +19,29 @@ import { AuthService } from '../auth/auth.service';
 import { ConfigService } from '@nestjs/config';
 
 class UpdateOrganizationDto {
+  @ApiPropertyOptional({ description: 'New organization name.' })
   @IsOptional()
   @IsString()
   name?: string;
 }
 
 class SwitchOrgDto {
+  @ApiProperty({ description: 'Organization id to switch the caller\'s session to.' })
   @IsString()
   organizationId: string;
 }
 
 class CreateOrgDto {
+  @ApiProperty({ description: 'Display name for the new organization.', example: 'Acme Inc.' })
   @IsString()
   name: string;
 }
 
 class DeleteOrgDto {
+  @ApiProperty({
+    description:
+      'Type the organization name exactly to confirm deletion — protection against accidental calls.',
+  })
   @IsString()
   confirmName: string;
 }

--- a/packages/backend/src/roles/mcp-api-keys.controller.ts
+++ b/packages/backend/src/roles/mcp-api-keys.controller.ts
@@ -8,15 +8,23 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional } from 'class-validator';
 import { McpApiKeysService } from './mcp-api-keys.service';
 
 class CreateKeyDto {
+  @ApiProperty({
+    description: 'Label for the key (visible only to its owner).',
+    example: 'claude-desktop',
+  })
   @IsString()
   name: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Scope the key to a specific MCP server. Omit for an account-wide key (access to all assigned servers).',
+  })
   @IsOptional()
   @IsString()
   mcpServerId?: string;

--- a/packages/backend/src/roles/roles.controller.ts
+++ b/packages/backend/src/roles/roles.controller.ts
@@ -11,38 +11,51 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional, IsArray } from 'class-validator';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 import { RolesService } from './roles.service';
 
 class CreateRoleDto {
+  @ApiProperty({ description: 'Role display name.', example: 'sales-read-only' })
   @IsString()
   name: string;
 
+  @ApiPropertyOptional({ description: 'Free-text description shown in the admin UI.' })
   @IsOptional()
   @IsString()
   description?: string;
 }
 
 class UpdateRoleDto {
+  @ApiPropertyOptional({ description: 'Role display name.' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Free-text description.' })
   @IsOptional()
   @IsString()
   description?: string;
 }
 
 class SetToolAccessDto {
+  @ApiProperty({
+    description:
+      'Tool IDs this role can invoke. Replaces the existing assignment. Members without an MCP role keep unrestricted access.',
+    type: [String],
+  })
   @IsArray()
   @IsString({ each: true })
   toolIds: string[];
 }
 
 class AssignRoleDto {
+  @ApiPropertyOptional({
+    description: 'MCP role id to attach. Pass null or omit to clear the assignment.',
+    nullable: true,
+  })
   @IsOptional()
   @IsString()
   roleId?: string | null;

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -7,7 +7,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsNumber, IsOptional, IsBoolean, IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -17,36 +17,53 @@ import { OrgSettingsService } from './org-settings.service';
 import { EmailService } from './email.service';
 
 class SmtpConfigDto {
+  @ApiProperty({ description: 'SMTP server hostname.', example: 'smtp.sendgrid.net' })
   @IsString()
   host: string;
 
+  @ApiProperty({ description: 'SMTP port.', example: 587 })
   @IsNumber()
   port: number;
 
+  @ApiProperty({ description: 'SMTP username.' })
   @IsString()
   user: string;
 
+  @ApiProperty({ description: 'SMTP password / API key.' })
   @IsString()
   pass: string;
 
+  @ApiPropertyOptional({
+    description: '"From" address used by outbound mail. Defaults to the SMTP user.',
+    example: 'noreply@example.com',
+  })
   @IsOptional()
   @IsString()
   from?: string;
 
+  @ApiPropertyOptional({
+    description: 'Use implicit TLS (port 465). Default false (STARTTLS).',
+  })
   @IsOptional()
   @IsBoolean()
   secure?: boolean;
 }
 
 class FooterLinkDto {
+  @ApiProperty({ description: 'Link label shown in the footer.', example: 'Privacy' })
   @IsString()
   label: string;
 
+  @ApiProperty({ description: 'Target URL.', example: 'https://example.com/privacy' })
   @IsString()
   url: string;
 }
 
 class FooterLinksDto {
+  @ApiProperty({
+    description: 'Footer links. Replaces the existing array.',
+    type: [FooterLinkDto],
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => FooterLinkDto)

--- a/packages/backend/src/users/users.controller.ts
+++ b/packages/backend/src/users/users.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { IsString, IsOptional, IsEmail, IsEnum, MinLength, Matches, Equals } from 'class-validator';
 import { UserRole } from '../generated/prisma/client';
@@ -18,10 +18,12 @@ import { AuthService } from '../auth/auth.service';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 
 class UpdateProfileDto {
+  @ApiPropertyOptional({ description: 'Display name.' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Email. Triggers re-verification on change.' })
   @IsOptional()
   @IsEmail()
   email?: string;
@@ -32,10 +34,12 @@ const PASSWORD_MESSAGE =
   'Password must be at least 8 characters and include uppercase, lowercase, number, and special character';
 
 class ChangePasswordDto {
+  @ApiProperty({ description: 'Current password (verified before applying the change).', format: 'password' })
   @IsString()
   @MinLength(8)
   currentPassword: string;
 
+  @ApiProperty({ description: 'New password (8+ chars, mixed case, digit, special).', format: 'password' })
   @IsString()
   @MinLength(8)
   @Matches(PASSWORD_REGEX, { message: PASSWORD_MESSAGE })
@@ -43,15 +47,21 @@ class ChangePasswordDto {
 }
 
 class UpdateUserRoleDto {
+  @ApiProperty({ enum: UserRole, description: 'New organization role for the target user.' })
   @IsEnum(UserRole)
   role: UserRole;
 }
 
 class DeleteSelfDto {
+  @ApiProperty({ description: 'Account password (re-confirmation).', format: 'password' })
   @IsString()
   @MinLength(1)
   password: string;
 
+  @ApiProperty({
+    description: 'Must equal the literal string "DELETE" — protection against accidental calls.',
+    example: 'DELETE',
+  })
   @IsString()
   @Equals('DELETE')
   confirm: string;


### PR DESCRIPTION
## Summary
Two related fixes bundled (both are mechanical, low-risk).

### #5 — DTO @ApiProperty decorators
\`/api/docs-json\` returned \`properties: {}\` for every DTO because \`nestjs-swagger\` needs explicit metadata when no CLI plugin is configured. Anyone automating against the API had to clone the repo and read the controllers. Decorated all DTOs in:
- \`auth.controller.ts\` (LoginDto, RegisterDto, VerifyEmailDto, ForgotPasswordDto, ResetPasswordDto, InviteUserDto, AcceptInviteDto)
- \`connectors.controller.ts\` (CreateConnectorDto, UpdateConnectorDto, ImportToolsDto, ImportToolDto, ImportConnectorDto, ImportAllDto, UpdateEnvVarsDto)
- \`tools.controller.ts\` (CreateToolDto, UpdateToolDto, BulkCreateToolsDto, TestToolDto)
- \`mcp-servers.controller.ts\` (CreateMcpServerDto, UpdateMcpServerDto, AssignConnectorsDto)
- \`site-settings.controller.ts\` (SmtpConfigDto, FooterLinkDto, FooterLinksDto)
- \`roles.controller.ts\` (CreateRoleDto, UpdateRoleDto, SetToolAccessDto, AssignRoleDto)
- \`mcp-api-keys.controller.ts\` (CreateKeyDto)
- \`users.controller.ts\` (UpdateProfileDto, ChangePasswordDto, UpdateUserRoleDto, DeleteSelfDto)
- \`organizations.controller.ts\` (UpdateOrganizationDto, SwitchOrgDto, CreateOrgDto, DeleteOrgDto)

### #4 — MCP \`arguments\` alias on tool test
\`POST /api/connectors/:id/tools/:toolId/test\` historically accepted \`{ params: {...} }\`. MCP-standard is \`{ arguments: {...} }\`. The DTO now exposes both; the handler prefers \`arguments\` and falls back to \`params\` for legacy callers. \`params\` is marked \`deprecated: true\` in the \`@ApiProperty\` so OpenAPI consumers can see it's a legacy alias.

## Test plan
- [x] \`tsc --noEmit\` exit 0
- [x] \`npm test\` → 601 passed, no behavioural regression
- [ ] After deploy: \`curl /api/docs-json | jq '.components.schemas.CreateConnectorDto.properties'\` should show descriptions/examples instead of \`{}\`.
- [ ] After deploy: POST /api/connectors/:id/tools/:toolId/test with \`{arguments: {...}}\` should work identically to \`{params: {...}}\`.