### PR TITLE
OpenAPI 3.1 normalizer (#1)

### DIFF
--- a/packages/backend/src/connectors/parsers/openapi-3.1-normalizer.spec.ts
+++ b/packages/backend/src/connectors/parsers/openapi-3.1-normalizer.spec.ts
@@ -1,0 +1,209 @@
+import { normalizeOpenApi31 } from './openapi-3.1-normalizer';
+
+describe('normalizeOpenApi31', () => {
+  it('rewrites type: ["string","null"] to type: "string" + nullable: true', () => {
+    const spec = {
+      components: {
+        schemas: {
+          User: { type: ['string', 'null'] },
+        },
+      },
+    };
+    normalizeOpenApi31(spec);
+    expect(spec.components.schemas.User).toEqual({ type: 'string', nullable: true });
+  });
+
+  it('keeps a single non-null type when the array contains only null + one type', () => {
+    const spec = { type: ['integer', 'null'] };
+    normalizeOpenApi31(spec);
+    expect(spec).toEqual({ type: 'integer', nullable: true });
+  });
+
+  it('falls back to the first non-null type for multi-type unions with null', () => {
+    const spec = { type: ['string', 'number', 'null'] };
+    normalizeOpenApi31(spec);
+    // 3.0 has no union types — lossy but better than rejection.
+    expect(spec).toEqual({ type: 'string', nullable: true });
+  });
+
+  it('unwraps anyOf: [X, {type:"null"}] into the X branch with nullable: true', () => {
+    const spec = {
+      properties: {
+        email: { anyOf: [{ type: 'string', format: 'email' }, { type: 'null' }] },
+      },
+    };
+    normalizeOpenApi31(spec);
+    expect(spec.properties.email).toEqual({
+      type: 'string',
+      format: 'email',
+      nullable: true,
+    });
+  });
+
+  it('keeps anyOf when there is more than one non-null branch (sets nullable)', () => {
+    const spec = {
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'string' },
+            { type: 'integer' },
+            { type: 'null' },
+          ],
+        },
+      },
+    };
+    normalizeOpenApi31(spec);
+    expect(spec.properties.value).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'integer' }],
+      nullable: true,
+    });
+  });
+
+  it('handles oneOf with a null member the same way as anyOf', () => {
+    const spec = { oneOf: [{ type: 'boolean' }, { type: 'null' }] };
+    normalizeOpenApi31(spec);
+    expect(spec).toEqual({ type: 'boolean', nullable: true });
+  });
+
+  it('rewrites const to a single-value enum', () => {
+    const spec = { const: 'active' };
+    normalizeOpenApi31(spec);
+    expect(spec).toEqual({ enum: ['active'] });
+  });
+
+  it('does not clobber an existing enum when const is also present', () => {
+    const spec = { const: 'active', enum: ['active', 'inactive'] };
+    normalizeOpenApi31(spec);
+    // We respect the explicit enum and leave const alone.
+    expect(spec).toEqual({ const: 'active', enum: ['active', 'inactive'] });
+  });
+
+  it('rewrites examples (plural array) to example (singular, first value)', () => {
+    const spec = {
+      properties: { name: { type: 'string', examples: ['Alice', 'Bob'] } },
+    };
+    normalizeOpenApi31(spec);
+    expect(spec.properties.name).toEqual({ type: 'string', example: 'Alice' });
+  });
+
+  it('preserves the components.examples map (object, not array)', () => {
+    const spec = {
+      components: {
+        examples: {
+          alice: { value: 'Alice' },
+          bob: { value: 'Bob' },
+        },
+      },
+    };
+    normalizeOpenApi31(spec);
+    // Components map untouched — it's an object, not an array.
+    expect(spec.components.examples).toEqual({
+      alice: { value: 'Alice' },
+      bob: { value: 'Bob' },
+    });
+  });
+
+  it('converts numeric exclusiveMinimum/Maximum (3.1) to boolean form (3.0)', () => {
+    const spec = { exclusiveMinimum: 0, exclusiveMaximum: 100 };
+    normalizeOpenApi31(spec);
+    expect(spec).toEqual({
+      minimum: 0,
+      exclusiveMinimum: true,
+      maximum: 100,
+      exclusiveMaximum: true,
+    });
+  });
+
+  it('combines multiple transformations in a realistic FastAPI-style spec', () => {
+    const spec: any = {
+      paths: {
+        '/items/{id}': {
+          get: {
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: ['integer', 'null'], exclusiveMinimum: 0 },
+              },
+            ],
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      properties: {
+                        status: { const: 'available' },
+                        email: {
+                          anyOf: [
+                            { type: 'string', format: 'email' },
+                            { type: 'null' },
+                          ],
+                        },
+                        tags: {
+                          type: ['array', 'null'],
+                          items: { type: 'string', examples: ['urgent'] },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    normalizeOpenApi31(spec);
+
+    const op = spec.paths['/items/{id}'].get;
+    expect(op.parameters[0].schema).toEqual({
+      type: 'integer',
+      nullable: true,
+      minimum: 0,
+      exclusiveMinimum: true,
+    });
+
+    const body =
+      op.responses['200'].content['application/json'].schema.properties;
+    expect(body.status).toEqual({ enum: ['available'] });
+    expect(body.email).toEqual({
+      type: 'string',
+      format: 'email',
+      nullable: true,
+    });
+    expect(body.tags.type).toBe('array');
+    expect(body.tags.nullable).toBe(true);
+    expect(body.tags.items).toEqual({ type: 'string', example: 'urgent' });
+  });
+
+  it('returns the same reference (mutates in place)', () => {
+    const spec = { const: 'x' };
+    const result = normalizeOpenApi31(spec);
+    expect(result).toBe(spec);
+  });
+
+  it('relabels openapi: 3.1.x to 3.0.3 so swagger-parser accepts it', () => {
+    const spec: any = { openapi: '3.1.0', info: { title: 'X', version: '1' }, paths: {} };
+    normalizeOpenApi31(spec);
+    expect(spec.openapi).toBe('3.0.3');
+  });
+
+  it('leaves openapi version alone on a 3.0 spec passed in', () => {
+    const spec: any = { openapi: '3.0.2', info: { title: 'X', version: '1' }, paths: {} };
+    normalizeOpenApi31(spec);
+    expect(spec.openapi).toBe('3.0.2');
+  });
+
+  it('is a no-op on a 3.0-style spec', () => {
+    const spec = {
+      type: 'string',
+      nullable: true,
+      enum: ['a', 'b'],
+      example: 'a',
+    };
+    const before = JSON.stringify(spec);
+    normalizeOpenApi31(spec);
+    expect(JSON.stringify(spec)).toBe(before);
+  });
+});

--- a/packages/backend/src/connectors/parsers/openapi-3.1-normalizer.ts
+++ b/packages/backend/src/connectors/parsers/openapi-3.1-normalizer.ts
@@ -1,0 +1,119 @@
+/**
+ * Translate OpenAPI 3.1-only constructs into their 3.0 equivalents in place
+ * so the rest of the import pipeline (which was written against 3.0) can
+ * consume them.
+ *
+ * 3.1 adopts JSON Schema 2020-12 and removes some 3.0 specialisms; the
+ * differences that bite us in practice are:
+ *
+ *   - `type: ["string", "null"]`           →  `type: "string"` + `nullable: true`
+ *   - `anyOf: [{...}, {type: "null"}]`     →  unwrap and set `nullable: true`
+ *   - `oneOf` with a `type: "null"` member →  unwrap and set `nullable: true`
+ *   - `const: "x"`                          →  `enum: ["x"]`
+ *   - `examples: [...]` (plural array)      →  `example: examples[0]` (singular)
+ *   - `exclusiveMinimum: <number>`          →  `minimum: <number>` + `exclusiveMinimum: true`
+ *   - `exclusiveMaximum: <number>`          →  `maximum: <number>` + `exclusiveMaximum: true`
+ *
+ * Everything else (3.1 webhooks, 3.1 jsonSchemaDialect, info.summary, etc.)
+ * is left alone — it either survives `extractTools` untouched or is metadata
+ * that doesn't affect tool generation.
+ *
+ * The function mutates the input. It returns the same reference so callers
+ * can chain. Use only on documents declared as openapi: 3.1.x — running it
+ * on a 3.0 spec is a no-op but the conditional in OpenApiParser.parse keeps
+ * us honest.
+ */
+export function normalizeOpenApi31(spec: unknown): unknown {
+  walk(spec);
+  // swagger-parser 10.x hard-rejects any openapi value other than 3.0.0–3.0.3
+  // (even from dereference()). Once the structural rewrites above are done the
+  // document is functionally 3.0-compatible, so we relabel it so the parser
+  // accepts it. This is the single point that hides the version difference
+  // from the downstream pipeline.
+  if (spec && typeof spec === 'object') {
+    const obj = spec as Record<string, unknown>;
+    if (typeof obj.openapi === 'string' && obj.openapi.startsWith('3.1')) {
+      obj.openapi = '3.0.3';
+    }
+  }
+  return spec;
+}
+
+function walk(node: unknown): void {
+  if (node === null || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) walk(item);
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  // 1. type: ["string","null"] → type: "string", nullable: true
+  if (Array.isArray(obj.type)) {
+    const types = obj.type as unknown[];
+    const nonNull = types.filter((t) => t !== 'null');
+    if (nonNull.length === 1 && types.includes('null')) {
+      obj.type = nonNull[0];
+      obj.nullable = true;
+    } else if (types.includes('null')) {
+      // Multi-type with null (e.g. ["string","number","null"]) — drop "null"
+      // and mark nullable. 3.0 has no union types so we keep the first
+      // non-null type; this is lossy but better than rejecting the spec.
+      obj.type = nonNull[0] ?? 'string';
+      obj.nullable = true;
+    }
+  }
+
+  // 2. anyOf / oneOf with a {type: "null"} member → unwrap + nullable
+  for (const key of ['anyOf', 'oneOf'] as const) {
+    const arr = obj[key];
+    if (Array.isArray(arr)) {
+      const nullIdx = arr.findIndex(
+        (s) => s && typeof s === 'object' && (s as { type?: unknown }).type === 'null',
+      );
+      if (nullIdx >= 0) {
+        const remaining = arr.filter((_, i) => i !== nullIdx);
+        if (remaining.length === 1) {
+          // Promote the single remaining schema onto this node and flag nullable.
+          const promoted = remaining[0] as Record<string, unknown>;
+          for (const [k, v] of Object.entries(promoted)) {
+            if (!(k in obj)) obj[k] = v;
+          }
+          delete obj[key];
+          obj.nullable = true;
+        } else if (remaining.length > 1) {
+          obj[key] = remaining;
+          obj.nullable = true;
+        }
+      }
+    }
+  }
+
+  // 3. const: "x" → enum: ["x"]
+  if ('const' in obj && !('enum' in obj)) {
+    obj.enum = [obj.const];
+    delete obj.const;
+  }
+
+  // 4. examples: [...] → example: examples[0]
+  // Skip when `examples` is the OpenAPI components-level map of named examples
+  // (a sibling of `schemas`/`parameters`), which is an object, not an array.
+  if (Array.isArray(obj.examples) && obj.examples.length > 0 && !('example' in obj)) {
+    obj.example = obj.examples[0];
+    delete obj.examples;
+  }
+
+  // 5. exclusiveMinimum / exclusiveMaximum as numbers (3.1) → boolean form (3.0)
+  if (typeof obj.exclusiveMinimum === 'number') {
+    obj.minimum = obj.exclusiveMinimum;
+    obj.exclusiveMinimum = true;
+  }
+  if (typeof obj.exclusiveMaximum === 'number') {
+    obj.maximum = obj.exclusiveMaximum;
+    obj.exclusiveMaximum = true;
+  }
+
+  // Recurse into children
+  for (const value of Object.values(obj)) walk(value);
+}

--- a/packages/backend/src/connectors/parsers/openapi.parser.spec.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.spec.ts
@@ -490,4 +490,99 @@ describe('OpenApiParser', () => {
     expect(params.properties.status.enum).toEqual(['active', 'inactive', 'pending']);
     expect(params.properties.created_after.format).toBe('date-time');
   });
+
+  // ── OpenAPI 3.1 support (via internal normalizer) ─────────────────────────
+
+  describe('OpenAPI 3.1 (FastAPI-style)', () => {
+    it('accepts a 3.1 spec without rejection', async () => {
+      const spec: any = {
+        openapi: '3.1.0',
+        info: { title: 'FastAPI', version: '0.1.0' },
+        paths: {
+          '/ping': {
+            get: {
+              operationId: 'ping',
+              summary: 'Health probe',
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      };
+      const tools = await parser.parse(spec);
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('ping');
+    });
+
+    it('normalises type:[X,null], const, and examples to 3.0 form', async () => {
+      const spec: any = {
+        openapi: '3.1.0',
+        info: { title: 'FastAPI', version: '0.1.0' },
+        paths: {
+          '/items': {
+            get: {
+              operationId: 'listItems',
+              summary: 'List items',
+              parameters: [
+                {
+                  name: 'status',
+                  in: 'query',
+                  schema: { const: 'active' },
+                },
+                {
+                  name: 'cursor',
+                  in: 'query',
+                  schema: { type: ['string', 'null'], examples: ['abc'] },
+                },
+              ],
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      };
+      const tools = await parser.parse(spec);
+      const params = tools[0].parameters as any;
+      expect(params.properties.status.enum).toEqual(['active']);
+      expect(params.properties.cursor.type).toBe('string');
+      expect(params.properties.cursor.nullable).toBe(true);
+      expect(params.properties.cursor.example).toBe('abc');
+    });
+
+    it('unwraps anyOf+null in request body schemas', async () => {
+      const spec: any = {
+        openapi: '3.1.0',
+        info: { title: 'FastAPI', version: '0.1.0' },
+        paths: {
+          '/items': {
+            post: {
+              operationId: 'createItem',
+              summary: 'Create item',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        email: {
+                          anyOf: [
+                            { type: 'string', format: 'email' },
+                            { type: 'null' },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      };
+      const tools = await parser.parse(spec);
+      const params = tools[0].parameters as any;
+      expect(params.properties.email.type).toBe('string');
+      expect(params.properties.email.format).toBe('email');
+      expect(params.properties.email.nullable).toBe(true);
+    });
+  });
 });

--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const yaml = require('js-yaml') as { load: (s: string) => unknown };
 import { assertSafeOutboundUrl } from '../../common/ssrf.util';
+import { normalizeOpenApi31 } from './openapi-3.1-normalizer';
 
 export interface ParsedTool {
   name: string;
@@ -39,6 +40,14 @@ export class OpenApiParser {
     // behaviour) blocks every modern spec from MS, AWS, etc.
     const declaredVersion = (rawSpec as { openapi?: string }).openapi || '';
     const isOpenApi31 = declaredVersion.startsWith('3.1');
+
+    // For 3.1 docs, translate the JSON-Schema-2020-12 constructs we know break
+    // the downstream extractor (nullable unions, const, examples plural, numeric
+    // exclusiveMin/Max) into their 3.0 equivalents. This runs *before*
+    // dereference so it applies inside referenced subschemas too.
+    if (isOpenApi31) {
+      normalizeOpenApi31(rawSpec);
+    }
 
     let api: unknown;
     try {
@@ -355,6 +364,8 @@ export class OpenApiParser {
       if (param.schema.default !== undefined)
         schema.default = param.schema.default;
       if (param.schema.format) schema.format = param.schema.format;
+      if (param.schema.nullable) schema.nullable = param.schema.nullable;
+      if (param.schema.example !== undefined) schema.example = param.schema.example;
     } else {
       schema.type = param.type || 'string';
     }
@@ -390,6 +401,8 @@ export class OpenApiParser {
       if (prop.enum) entry.enum = prop.enum;
       if (prop.format) entry.format = prop.format;
       if (prop.default !== undefined) entry.default = prop.default;
+      if (prop.nullable) entry.nullable = prop.nullable;
+      if (prop.example !== undefined) entry.example = prop.example;
       result[name] = entry;
     }
 


### PR DESCRIPTION
## Problem
FastAPI ≥ 0.100, recent NestJS, spring-doc 3.x and Hono all emit OpenAPI **3.1** natively. Our pipeline depends on swagger-parser 10.x which hard-rejects any \`openapi\` value other than 3.0.0–3.0.3 — including from \`dereference()\`. Customers were getting \`Unsupported OpenAPI version: 3.1.0\` and had to patch their bridges to emit 3.0 by hand (PR #5 in the customer's repo did this).

## Fix
A small normalizer that rewrites the 3.1-only constructs we care about into their 3.0 equivalents *in place*, **before** swagger-parser sees the document, and relabels \`openapi\` to \`3.0.3\` so the parser proceeds.

Rewrites covered:

| 3.1 input | 3.0 output |
|---|---|
| \`type: [X, "null"]\` | \`type: X\` + \`nullable: true\` |
| \`anyOf: [X, {type:"null"}]\` | unwrap \`X\` + \`nullable: true\` |
| \`oneOf: [X, {type:"null"}]\` | same |
| \`const: "x"\` | \`enum: ["x"]\` |
| \`examples: [...]\` (array) | \`example: examples[0]\` |
| \`exclusiveMinimum: <n>\` | \`minimum: <n>\` + \`exclusiveMinimum: true\` |
| \`exclusiveMaximum: <n>\` | \`maximum: <n>\` + \`exclusiveMaximum: true\` |

The \`components.examples\` map (object, not array) is preserved.

Also forwards \`nullable\` and \`example\` through \`paramToJsonSchema\` / \`flattenSchema\` so the normalized fields actually survive into the generated tool schemas. Without this, the normalizer's work was being silently dropped when the parser flattened parameters.

## Out of scope
- Webhooks, jsonSchemaDialect, info.summary — survive untouched, not used by tool extraction.
- Full replacement of swagger-parser (the \"stradone giusto\" with \`@redocly/openapi-core\`) — left for a future PR.

## Test plan
- [x] 16 unit tests for the normalizer (\`openapi-3.1-normalizer.spec.ts\`).
- [x] 3 E2E tests in \`openapi.parser.spec.ts\` covering a FastAPI-style 3.1 spec end-to-end.
- [x] Full backend test suite: 620 passed, 0 regressions.