### PR TITLE
Use SPDX-correct license identifier BUSL-1.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.23",
   "description": "Convert any API into an MCP server — self-hosted, source available",
   "private": true,
-  "license": "BSL-1.1",
+  "license": "BUSL-1.1",
   "workspaces": [
     "packages/backend",
     "packages/frontend"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.23",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
-  "license": "BSL-1.1",
+  "license": "BUSL-1.1",
   "scripts": {
     "build": "prisma generate && nest build",
     "dev": "nest start --watch",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.23",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
-  "license": "BSL-1.1",
+  "license": "BUSL-1.1",
   "scripts": {
     "dev": "next dev --port 3000",
     "build": "next build",


### PR DESCRIPTION
## Summary

Replaces \`\"license\": \"BSL-1.1\"\` with \`\"license\": \"BUSL-1.1\"\` in:
- \`package.json\`
- \`packages/backend/package.json\`
- \`packages/frontend/package.json\`

## Why
\`BSL-1.1\` conflicts with the much older Boost Software License 1.0 in the SPDX registry. The Business Source License 1.1 official SPDX identifier is **BUSL-1.1**. As a result:
- Glama parsed our listing as \"License: not found\" (lowering our maintenance score)
- License scanners and SCA tooling can't classify it correctly
- npm-audit downstreams skip the license check

No actual license change — the LICENSE file, README, and License FAQ continue to use the human-readable name \"Business Source License 1.1\" / \"BSL-1.1\". This patch only fixes the machine-readable identifier so SPDX-aware tools recognise it.

## Test plan
- [x] Three package.json files validated by \`python -m json.tool\`
- [ ] After merge: Glama re-scan should resolve \"License: not found\" once the cached scan refreshes (12-24h)