### PR TITLE
Connector healthcheckPath + classified test errors (#3)

### DIFF
--- a/packages/backend/prisma/migrations/20260511000000_add_healthcheck_path/migration.sql
+++ b/packages/backend/prisma/migrations/20260511000000_add_healthcheck_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "connectors" ADD COLUMN "healthcheck_path" TEXT;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -268,6 +268,11 @@ model Connector {
   baseUrl  String        @map("base_url")
   isActive Boolean       @default(true) @map("is_active")
 
+  // Path appended to baseUrl when "Test connection" runs. Defaults to "/"
+  // when null but can be set explicitly (auto-deduced from imported OpenAPI
+  // specs when one of /health, /healthz, /_health, /ping, /status is present).
+  healthcheckPath String? @map("healthcheck_path")
+
   // Authentication
   authType   AuthType @default(NONE) @map("auth_type")
   authConfig String?  @map("auth_config") // encrypted JSON

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -94,6 +94,15 @@ class CreateConnectorDto {
   specUrl?: string;
 
   @ApiPropertyOptional({
+    description:
+      'Path appended to baseUrl when "Test connection" runs. Defaults to "/" when not set. Auto-detected from imported OpenAPI specs if /health, /healthz, /_health, /ping or /status exist.',
+    example: '/health',
+  })
+  @IsOptional()
+  @IsString()
+  healthcheckPath?: string;
+
+  @ApiPropertyOptional({
     description: 'Extra HTTP headers sent on every request.',
     example: { 'X-Tenant': 'acme' },
     type: 'object',
@@ -142,6 +151,13 @@ class UpdateConnectorDto {
   @IsOptional()
   @IsString()
   baseUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'Path appended to baseUrl when "Test connection" runs. See CreateConnectorDto.',
+  })
+  @IsOptional()
+  @IsString()
+  healthcheckPath?: string;
 
   @ApiPropertyOptional({ enum: AuthType, description: 'Auth scheme.' })
   @IsOptional()
@@ -779,16 +795,20 @@ export class ConnectorsController {
     this.assertCanWrite(connector, req);
 
     let parsedTools: any[] = [];
+    let detectedHealthcheckPath: string | undefined;
 
     switch (connector.type) {
       case 'REST': {
+        let parsed;
         if (connector.specUrl) {
-          parsedTools = await this.openApiParser.parseFromUrl(connector.specUrl);
+          parsed = await this.openApiParser.parseSpecFromUrl(connector.specUrl);
         } else if (connector.specData) {
-          parsedTools = await this.openApiParser.parse(connector.specData as any);
+          parsed = await this.openApiParser.parseSpec(connector.specData as any);
         } else {
           return { error: 'No spec URL or spec data provided for this connector' };
         }
+        parsedTools = parsed.tools;
+        detectedHealthcheckPath = parsed.healthcheckPath;
         break;
       }
       case 'SOAP': {
@@ -805,6 +825,15 @@ export class ConnectorsController {
       }
       default:
         return { error: `Spec import not supported for ${connector.type} connectors` };
+    }
+
+    // Auto-populate healthcheckPath the first time it's detected (only if the
+    // user hasn't set one explicitly — preserves customisations on re-import).
+    if (detectedHealthcheckPath && !connector.healthcheckPath) {
+      await this.prisma.connector.update({
+        where: { id: connector.id },
+        data: { healthcheckPath: detectedHealthcheckPath },
+      });
     }
 
     return this.createToolsFromParsed(connector.id, parsedTools);
@@ -824,16 +853,21 @@ export class ConnectorsController {
 
     let parsedTools: any[] = [];
 
+    let detectedHealthcheckPath: string | undefined;
+
     try {
       switch (dto.source) {
         case 'openapi': {
+          let parsed;
           if (dto.url) {
-            parsedTools = await this.openApiParser.parseFromUrl(dto.url);
+            parsed = await this.openApiParser.parseSpecFromUrl(dto.url);
           } else if (dto.content) {
-            parsedTools = await this.openApiParser.parse(dto.content);
+            parsed = await this.openApiParser.parseSpec(dto.content);
           } else {
             return { error: 'Provide either content or url for OpenAPI import' };
           }
+          parsedTools = parsed.tools;
+          detectedHealthcheckPath = parsed.healthcheckPath;
           break;
         }
         case 'wsdl': {
@@ -925,6 +959,15 @@ export class ConnectorsController {
     } catch (err: any) {
       this.logger.warn(`Import failed for connector ${id}: ${err.message}`);
       return { error: `Import failed: ${err.message}` };
+    }
+
+    // Auto-populate healthcheckPath when first detected from an OpenAPI import,
+    // preserving any explicit value the user may have set.
+    if (detectedHealthcheckPath && !connector.healthcheckPath) {
+      await this.prisma.connector.update({
+        where: { id: connector.id },
+        data: { healthcheckPath: detectedHealthcheckPath },
+      });
     }
 
     return this.createToolsFromParsed(connector.id, parsedTools);

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -155,7 +155,30 @@ export class ConnectorsService {
 
   async testConnection(
     id: string,
-  ): Promise<{ ok: boolean; message: string }> {
+  ): Promise<{
+    ok: boolean;
+    message: string;
+    /**
+     * Coarse classification of the result so the UI can show useful state
+     * (icon, hint, suggested fix) instead of treating every non-2xx as a
+     * blanket failure.
+     *
+     *   ok           — 2xx response
+     *   auth_failed  — 401 / 403: handshake reached the API, credentials rejected
+     *   not_found    — 404: URL reachable but the healthcheck path doesn't exist
+     *   unreachable  — DNS/network/SSRF/timeout
+     *   unsupported  — connector type with no test implementation yet
+     *   error        — anything else (5xx, parse error, etc.)
+     */
+    kind?:
+      | 'ok'
+      | 'auth_failed'
+      | 'not_found'
+      | 'unreachable'
+      | 'unsupported'
+      | 'error';
+    httpStatus?: number;
+  }> {
     const connector = await this.findById(id);
 
     try {
@@ -164,7 +187,12 @@ export class ConnectorsService {
         : undefined;
 
       switch (connector.type) {
-        case 'REST':
+        case 'REST': {
+          // Use the configured healthcheckPath if set (auto-detected on
+          // OpenAPI import, or set by the user). Falls back to "/" — many
+          // APIs without a root handler return 404 there, which we surface
+          // as kind: 'not_found' with a hint to set the path.
+          const path = connector.healthcheckPath || '/';
           await this.restEngine.execute(
             {
               baseUrl: connector.baseUrl,
@@ -172,10 +200,11 @@ export class ConnectorsService {
               authConfig,
               headers: connector.headers as Record<string, string>,
             },
-            { method: 'GET', path: '/' },
+            { method: 'GET', path },
             {},
           );
           break;
+        }
         case 'GRAPHQL':
           await this.graphqlEngine.execute(
             {
@@ -204,19 +233,71 @@ export class ConnectorsService {
           });
           return {
             ok: true,
+            kind: 'ok',
             message: `Connection successful — found ${tools.length} tools on remote MCP server`,
           };
         }
         default:
           return {
             ok: true,
+            kind: 'unsupported',
             message: `Connection type ${connector.type} — test not yet implemented`,
           };
       }
-      return { ok: true, message: 'Connection successful' };
+      return { ok: true, kind: 'ok', message: 'Connection successful' };
     } catch (error: any) {
-      return { ok: false, message: error.message || 'Connection failed' };
+      return this.classifyTestError(error, connector.healthcheckPath || '/');
     }
+  }
+
+  private classifyTestError(
+    error: any,
+    healthcheckPath: string,
+  ): { ok: false; message: string; kind: NonNullable<Awaited<ReturnType<typeof this.testConnection>>['kind']>; httpStatus?: number } {
+    // HTTP responses (axios)
+    const status: number | undefined = error?.response?.status;
+    if (status === 401 || status === 403) {
+      return {
+        ok: false,
+        kind: 'auth_failed',
+        httpStatus: status,
+        message:
+          'Auth handshake reached the API, but the credentials were rejected. Update authConfig and retry.',
+      };
+    }
+    if (status === 404) {
+      return {
+        ok: false,
+        kind: 'not_found',
+        httpStatus: status,
+        message:
+          `Healthcheck path "${healthcheckPath}" returned 404. ` +
+          'If the API has no root handler, set Connector.healthcheckPath to an existing endpoint (e.g. /health).',
+      };
+    }
+    if (typeof status === 'number') {
+      return {
+        ok: false,
+        kind: 'error',
+        httpStatus: status,
+        message: `Healthcheck returned HTTP ${status}.`,
+      };
+    }
+
+    // Network-layer errors (DNS, ECONNREFUSED, SSRF guard, timeout)
+    const msg = String(error?.message || '');
+    if (
+      /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ETIMEDOUT|timeout|SSRF guard/i.test(
+        msg,
+      )
+    ) {
+      return {
+        ok: false,
+        kind: 'unreachable',
+        message: msg || 'Network error',
+      };
+    }
+    return { ok: false, kind: 'error', message: msg || 'Connection failed' };
   }
 
   async executeConnectorCall(

--- a/packages/backend/src/connectors/parsers/openapi.parser.spec.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.spec.ts
@@ -547,6 +547,68 @@ describe('OpenApiParser', () => {
       expect(params.properties.cursor.example).toBe('abc');
     });
 
+    it('detects /health as the healthcheck path when present', async () => {
+      const spec: any = {
+        openapi: '3.1.0',
+        info: { title: 'X', version: '1' },
+        paths: {
+          '/health': { get: { operationId: 'health', responses: { '200': { description: 'OK' } } } },
+          '/users': { get: { operationId: 'list', responses: { '200': { description: 'OK' } } } },
+        },
+      };
+      const result = await parser.parseSpec(spec);
+      expect(result.healthcheckPath).toBe('/health');
+    });
+
+    it('falls back through /healthz, /_health, /ping, /status', async () => {
+      const spec: any = {
+        openapi: '3.0.0',
+        info: { title: 'X', version: '1' },
+        paths: {
+          '/_health': { get: { operationId: 'x', responses: { '200': { description: 'OK' } } } },
+        },
+      };
+      const result = await parser.parseSpec(spec);
+      expect(result.healthcheckPath).toBe('/_health');
+    });
+
+    it('uses the first GET with no required params as fallback', async () => {
+      const spec: any = {
+        openapi: '3.0.0',
+        info: { title: 'X', version: '1' },
+        paths: {
+          '/users/{id}': {
+            get: {
+              operationId: 'getUser',
+              parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+          '/users': { get: { operationId: 'list', responses: { '200': { description: 'OK' } } } },
+        },
+      };
+      const result = await parser.parseSpec(spec);
+      expect(result.healthcheckPath).toBe('/users');
+    });
+
+    it('returns undefined when no eligible GET exists', async () => {
+      const spec: any = {
+        openapi: '3.0.0',
+        info: { title: 'X', version: '1' },
+        paths: {
+          '/users/{id}': {
+            get: {
+              operationId: 'getUser',
+              parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      };
+      const result = await parser.parseSpec(spec);
+      expect(result.healthcheckPath).toBeUndefined();
+    });
+
     it('unwraps anyOf+null in request body schemas', async () => {
       const spec: any = {
         openapi: '3.1.0',

--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -24,11 +24,36 @@ export interface ParsedTool {
   };
 }
 
+export interface ParsedSpec {
+  tools: ParsedTool[];
+  /**
+   * Best-effort healthcheck path inferred from the spec. Used to populate
+   * Connector.healthcheckPath on import so the "Test connection" UI hits a
+   * meaningful endpoint instead of "/" (which 404s for most APIs that don't
+   * have a root handler).
+   */
+  healthcheckPath?: string;
+}
+
 @Injectable()
 export class OpenApiParser {
   private readonly logger = new Logger(OpenApiParser.name);
 
+  /**
+   * Backward-compatible: returns just the tools. New callers should prefer
+   * parseSpec() which also surfaces the inferred healthcheckPath.
+   */
   async parse(spec: string | Record<string, unknown>): Promise<ParsedTool[]> {
+    const result = await this.parseSpec(spec);
+    return result.tools;
+  }
+
+  /**
+   * Like parse() but also reports the auto-detected healthcheckPath.
+   */
+  async parseSpec(
+    spec: string | Record<string, unknown>,
+  ): Promise<ParsedSpec> {
     this.logger.debug('Parsing OpenAPI specification...');
 
     const rawSpec = typeof spec === 'string' ? this.decodeSpecString(spec) : spec;
@@ -67,7 +92,41 @@ export class OpenApiParser {
       throw err;
     }
 
-    return this.extractTools(api);
+    const tools = this.extractTools(api);
+    const healthcheckPath = this.detectHealthcheckPath(api);
+    return { tools, healthcheckPath };
+  }
+
+  /**
+   * Pick a sensible default healthcheck path for the connector. Priorities:
+   *   1. A path matching one of /health, /healthz, /_health, /ping, /status
+   *      that has a GET operation with no required parameters.
+   *   2. The first GET operation in the spec with no required parameters.
+   *   3. Undefined — caller falls back to "/".
+   */
+  private detectHealthcheckPath(api: unknown): string | undefined {
+    const paths = (api as { paths?: Record<string, any> })?.paths;
+    if (!paths) return undefined;
+
+    const preferred = ['/health', '/healthz', '/_health', '/ping', '/status'];
+    const isParamFreeGet = (op: any): boolean => {
+      if (!op || typeof op !== 'object') return false;
+      const requiredParams = (op.parameters || []).filter((p: any) => p?.required);
+      return requiredParams.length === 0;
+    };
+
+    for (const candidate of preferred) {
+      const op = paths[candidate]?.get;
+      if (isParamFreeGet(op)) return candidate;
+    }
+
+    for (const [path, methods] of Object.entries(paths)) {
+      if (path.includes('{')) continue; // skip parametric paths
+      const get = (methods as any)?.get;
+      if (isParamFreeGet(get)) return path;
+    }
+
+    return undefined;
   }
 
   /**
@@ -96,6 +155,10 @@ export class OpenApiParser {
   }
 
   async parseFromUrl(url: string): Promise<ParsedTool[]> {
+    return (await this.parseSpecFromUrl(url)).tools;
+  }
+
+  async parseSpecFromUrl(url: string): Promise<ParsedSpec> {
     this.logger.debug(`Fetching OpenAPI spec from: ${url}`);
 
     await assertSafeOutboundUrl(url);
@@ -103,7 +166,7 @@ export class OpenApiParser {
 
     // If the response is already a valid spec object, parse directly
     if (typeof response.data === 'object' && response.data !== null) {
-      return this.parse(response.data);
+      return this.parseSpec(response.data);
     }
 
     const text = typeof response.data === 'string' ? response.data : '';
@@ -111,7 +174,7 @@ export class OpenApiParser {
     // If it looks like JSON or YAML, try parsing directly
     const trimmed = text.trimStart();
     if (trimmed.startsWith('{') || trimmed.startsWith('openapi') || trimmed.startsWith('swagger')) {
-      return this.parse(text);
+      return this.parseSpec(text);
     }
 
     // Response is likely HTML (Swagger UI page) — try to resolve the actual spec
@@ -119,12 +182,12 @@ export class OpenApiParser {
       this.logger.debug('Detected Swagger UI HTML page, attempting to resolve spec URL...');
       const spec = await this.resolveSpecFromSwaggerUi(url, text);
       if (spec) {
-        return this.parse(spec);
+        return this.parseSpec(spec);
       }
     }
 
     // Fallback: try parsing as-is (will throw a descriptive error)
-    return this.parse(response.data);
+    return this.parseSpec(response.data);
   }
 
   /**

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -36,6 +36,7 @@ export default function ConnectorDetailPage() {
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState('');
   const [editBaseUrl, setEditBaseUrl] = useState('');
+  const [editHealthcheckPath, setEditHealthcheckPath] = useState('');
   const [editActive, setEditActive] = useState(true);
   const [editAuthType, setEditAuthType] = useState('NONE');
   const [editAuthKey, setEditAuthKey] = useState('');
@@ -43,7 +44,12 @@ export default function ConnectorDetailPage() {
   const [editDbReadOnly, setEditDbReadOnly] = useState(true);
   const [editInstructions, setEditInstructions] = useState('');
   const [msg, setMsg] = useState('');
-  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const [testResult, setTestResult] = useState<{
+    ok: boolean;
+    message: string;
+    kind?: 'ok' | 'auth_failed' | 'not_found' | 'unreachable' | 'unsupported' | 'error';
+    httpStatus?: number;
+  } | null>(null);
 
   // Tool editor state
   const [showNewTool, setShowNewTool] = useState(false);
@@ -78,6 +84,7 @@ export default function ConnectorDetailPage() {
       setConnector(c);
       setEditName(c.name);
       setEditBaseUrl(c.baseUrl);
+      setEditHealthcheckPath(c.healthcheckPath || '');
       setEditActive(c.isActive);
       setEditAuthType(c.authType || 'NONE');
       setEditInstructions(c.instructions || '');
@@ -143,6 +150,7 @@ export default function ConnectorDetailPage() {
       const data: Record<string, unknown> = {
         name: editName,
         baseUrl: editBaseUrl,
+        healthcheckPath: editHealthcheckPath.trim() || null,
         isActive: editActive,
         authType: editAuthType,
         instructions: editInstructions.trim() || null,
@@ -433,8 +441,22 @@ export default function ConnectorDetailPage() {
         )}
         {testResult && (
           <div
-            className={`p-3 rounded-md text-sm border ${testResult.ok ? 'bg-[var(--success-bg)] text-[var(--success-text)] border-[var(--success-border)]' : 'bg-[var(--destructive-bg)] text-[var(--destructive-text)] border-[var(--destructive-border)]'}`}
+            className={`p-3 rounded-md text-sm border ${
+              testResult.ok
+                ? 'bg-[var(--success-bg)] text-[var(--success-text)] border-[var(--success-border)]'
+                : testResult.kind === 'auth_failed'
+                  ? 'bg-[var(--warning-bg)] text-[var(--warning-text)] border-[var(--warning-border)]'
+                  : 'bg-[var(--destructive-bg)] text-[var(--destructive-text)] border-[var(--destructive-border)]'
+            }`}
           >
+            {testResult.kind && testResult.kind !== 'ok' && (
+              <span className="font-semibold mr-1">
+                {testResult.kind === 'auth_failed' && 'Auth rejected: '}
+                {testResult.kind === 'not_found' && 'Not found: '}
+                {testResult.kind === 'unreachable' && 'Unreachable: '}
+                {testResult.kind === 'error' && 'Error: '}
+              </span>
+            )}
             {testResult.message}
           </div>
         )}
@@ -462,6 +484,28 @@ export default function ConnectorDetailPage() {
                   className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)]"
                 />
               </div>
+              {connector.type === 'REST' && (
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    Healthcheck path
+                    <span className="ml-2 text-xs text-[var(--muted-foreground)] font-normal">
+                      optional — defaults to /
+                    </span>
+                  </label>
+                  <input
+                    type="text"
+                    value={editHealthcheckPath}
+                    onChange={(e) => setEditHealthcheckPath(e.target.value)}
+                    placeholder="/health"
+                    className="w-full border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
+                  />
+                  <p className="text-xs text-[var(--muted-foreground)] mt-1">
+                    Path used by "Test connection". Set to an endpoint that
+                    returns 2xx without auth (e.g. <code>/health</code>) if the
+                    API has no root handler.
+                  </p>
+                </div>
+              )}
               <div className="flex items-center gap-2">
                 <input
                   type="checkbox"

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -167,7 +167,18 @@ export const connectors = {
   delete: (id: string, token: string) =>
     request(`/api/connectors/${id}`, { method: 'DELETE', token }),
   test: (id: string, token: string) =>
-    request<{ ok: boolean; message: string }>(`/api/connectors/${id}/test`, { method: 'POST', token }),
+    request<{
+      ok: boolean;
+      message: string;
+      kind?:
+        | 'ok'
+        | 'auth_failed'
+        | 'not_found'
+        | 'unreachable'
+        | 'unsupported'
+        | 'error';
+      httpStatus?: number;
+    }>(`/api/connectors/${id}/test`, { method: 'POST', token }),
   importSpec: (id: string, token: string) =>
     request<{ message: string; tools: any[] }>(`/api/connectors/${id}/import-spec`, { method: 'POST', token }),
   importTools: (id: string, data: { source: string; content?: string; url?: string }, token: string) =>


### PR DESCRIPTION
## Problem
\`POST /api/connectors/:id/test\` always hit \`baseUrl + '/'\`. APIs without a root handler returned 404 and the UI flashed red even when the connector was fine. We also couldn't distinguish:
- *wrong path* (404)
- *wrong credentials* (401/403)
- *network unreachable* (DNS/SSRF/timeout)

They all surfaced as the same generic failure.

## Changes

### Schema (additive migration)
- \`Connector.healthcheckPath String?\` — the path used by Test Connection. Defaults to \`/\` when null.

### Parser
- New \`OpenApiParser.parseSpec\` / \`parseSpecFromUrl\` return \`{ tools, healthcheckPath? }\`. The legacy \`parse()\` / \`parseFromUrl()\` are now thin wrappers preserving their old shape for any external callers.
- \`detectHealthcheckPath\` priority: \`/health\`, \`/healthz\`, \`/_health\`, \`/ping\`, \`/status\` → first non-parametric GET with no required params → \`undefined\`.

### Service
- \`testConnection()\` uses \`connector.healthcheckPath\` when set and returns a \`kind\` classification:
  - \`ok\` — 2xx
  - \`auth_failed\` — 401/403 (handshake reached the API)
  - \`not_found\` — 404 (path doesn't exist; hint to set healthcheckPath)
  - \`unreachable\` — DNS, ECONNREFUSED, SSRF guard, timeout
  - \`unsupported\` — connector type with no test impl
  - \`error\` — anything else (5xx, parse error)

### Controller
- Both import flows (\`POST /import-spec\` and \`POST /import\` with \`source: 'openapi'\`) write the auto-detected \`healthcheckPath\` when the user hasn't already set one. Re-import preserves a user's explicit setting.
- \`CreateConnectorDto\` / \`UpdateConnectorDto\` expose the field.

### Frontend
- Connector detail page: edit form gets a "Healthcheck path" input with explanatory hint (REST connectors only).
- Test result banner colours/labels by kind: yellow \`Auth rejected:\` for 401/403; red \`Not found:\`/\`Unreachable:\`/\`Error:\` otherwise. Successful tests stay green.
- \`api.ts\` client typed for the new response shape.

## Test plan
- [x] 4 new unit tests for \`detectHealthcheckPath\` (preferred path, fallback chain, first GET, no eligible GET).
- [x] \`tsc --noEmit\` exit 0 (backend + frontend).
- [x] \`npm test\` → 624 passed across 25 suites.
- [ ] After deploy: import a spec with \`/health\` → check Connector.healthcheckPath populated. Hit Test → expect \`kind: 'ok'\`.
- [ ] After deploy: change healthcheckPath to \`/does-not-exist\` → Test should return \`kind: 'not_found'\` with the hint.