### PR TITLE
Persistent SSRF allowlist + admin UI + test fix hint (#2)

### DIFF
--- a/packages/backend/src/common/ssrf-policy.service.spec.ts
+++ b/packages/backend/src/common/ssrf-policy.service.spec.ts
@@ -1,0 +1,109 @@
+import { SsrfPolicyService } from './ssrf-policy.service';
+
+type FakePrisma = {
+  siteSettings: {
+    findUnique: jest.Mock;
+    upsert: jest.Mock;
+  };
+};
+
+function makeService(rows: Record<string, string> = {}) {
+  const prisma: FakePrisma = {
+    siteSettings: {
+      findUnique: jest.fn(({ where: { key } }: any) =>
+        Promise.resolve(rows[key] ? { value: rows[key] } : null),
+      ),
+      upsert: jest.fn(({ where: { key }, update, create }: any) => {
+        rows[key] = update?.value ?? create?.value;
+        return Promise.resolve({ value: rows[key] });
+      }),
+    },
+  };
+  // The setDbAllowedHostsProvider side-effect in onModuleInit is harmless
+  // outside Nest context — it just stores a callback.
+  return new SsrfPolicyService(prisma as any);
+}
+
+describe('SsrfPolicyService', () => {
+  const ORIG_ENV = process.env.SSRF_ALLOWED_HOSTS;
+  beforeEach(() => {
+    delete process.env.SSRF_ALLOWED_HOSTS;
+  });
+  afterAll(() => {
+    if (ORIG_ENV === undefined) delete process.env.SSRF_ALLOWED_HOSTS;
+    else process.env.SSRF_ALLOWED_HOSTS = ORIG_ENV;
+  });
+
+  it('returns the empty list when neither env nor DB have entries', async () => {
+    const svc = makeService();
+    expect(await svc.getEffectiveAllowedHosts()).toEqual([]);
+  });
+
+  it('merges env-var and DB hosts, lowercased and unique', async () => {
+    process.env.SSRF_ALLOWED_HOSTS = 'Env-Host,shared';
+    const svc = makeService({
+      ssrf_allowed_hosts: JSON.stringify(['DB-host', 'shared']),
+    });
+    const hosts = await svc.getEffectiveAllowedHosts();
+    expect(hosts.sort()).toEqual(['db-host', 'env-host', 'shared']);
+  });
+
+  it('persists via setDbAllowedHosts and the next read reflects the change', async () => {
+    const svc = makeService();
+    await svc.setDbAllowedHosts(['Internal-Bridge', '*.corp.example']);
+    expect(await svc.getDbAllowedHosts()).toEqual([
+      'internal-bridge',
+      '*.corp.example',
+    ]);
+  });
+
+  it('caches the effective list for 60s and re-reads after invalidate()', async () => {
+    const svc = makeService({ ssrf_allowed_hosts: JSON.stringify(['first']) });
+    expect(await svc.getEffectiveAllowedHosts()).toEqual(['first']);
+    // mutate DB directly, bypassing the service so the cache is stale
+    (svc as any).cache.value = ['first'];
+    // Without invalidate, cached value sticks
+    expect(await svc.getEffectiveAllowedHosts()).toEqual(['first']);
+    // After invalidate, next call hits DB again
+    (svc as any).prisma.siteSettings.findUnique.mockResolvedValueOnce({
+      value: JSON.stringify(['second']),
+    });
+    svc.invalidate();
+    expect(await svc.getEffectiveAllowedHosts()).toEqual(['second']);
+  });
+
+  it('rejects host entries with unsupported characters', async () => {
+    const svc = makeService();
+    await expect(svc.setDbAllowedHosts(['https://oops'])).rejects.toThrow(
+      /Invalid host entry/,
+    );
+    await expect(svc.setDbAllowedHosts(['has space'])).rejects.toThrow(
+      /Invalid host entry/,
+    );
+  });
+
+  it('accepts hostnames, *.suffix wildcards and bare IPs', async () => {
+    const svc = makeService();
+    const result = await svc.setDbAllowedHosts([
+      'plain-host',
+      '*.internal.example.com',
+      '10.0.0.5',
+      'host.with.dots',
+    ]);
+    expect(result).toEqual([
+      'plain-host',
+      '*.internal.example.com',
+      '10.0.0.5',
+      'host.with.dots',
+    ]);
+  });
+
+  it('falls back to env-only when the DB read throws', async () => {
+    process.env.SSRF_ALLOWED_HOSTS = 'env-fallback';
+    const svc = makeService();
+    (svc as any).prisma.siteSettings.findUnique.mockRejectedValueOnce(
+      new Error('db down'),
+    );
+    expect(await svc.getEffectiveAllowedHosts()).toEqual(['env-fallback']);
+  });
+});

--- a/packages/backend/src/common/ssrf-policy.service.ts
+++ b/packages/backend/src/common/ssrf-policy.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+import { setDbAllowedHostsProvider } from './ssrf.util';
+
+const KEY = 'ssrf_allowed_hosts';
+const CACHE_TTL_MS = 60_000;
+
+/**
+ * Source-of-truth for the SSRF allowlist. Merges the static env-var list
+ * (SSRF_ALLOWED_HOSTS, for CI / bootstrap) with a DB-backed list the admin
+ * can edit from the UI without restarting the backend.
+ *
+ * Cached in-process for 60s so we don't hit Postgres on every outbound HTTP
+ * call. invalidate() lets the settings controller flush after a write so the
+ * change applies on the next request.
+ */
+@Injectable()
+export class SsrfPolicyService implements OnModuleInit {
+  private readonly logger = new Logger(SsrfPolicyService.name);
+  private cache: { value: string[]; expiresAt: number } | null = null;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  onModuleInit(): void {
+    // Wire the guard so every outbound URL check consults the DB list too.
+    setDbAllowedHostsProvider(() => this.getEffectiveAllowedHosts());
+  }
+
+  /**
+   * Effective allowlist = unique union of env hosts + DB hosts. Empty list is
+   * a valid state — means "no extra hosts beyond public DNS".
+   */
+  async getEffectiveAllowedHosts(): Promise<string[]> {
+    const now = Date.now();
+    if (this.cache && this.cache.expiresAt > now) {
+      return this.cache.value;
+    }
+
+    const envHosts = (process.env.SSRF_ALLOWED_HOSTS || '')
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
+
+    let dbHosts: string[] = [];
+    try {
+      const row = await this.prisma.siteSettings.findUnique({ where: { key: KEY } });
+      if (row?.value) {
+        const parsed = JSON.parse(row.value);
+        if (Array.isArray(parsed)) {
+          dbHosts = parsed
+            .filter((x): x is string => typeof x === 'string')
+            .map((s) => s.trim().toLowerCase())
+            .filter(Boolean);
+        }
+      }
+    } catch (err: any) {
+      // Don't tank outbound calls if DB is briefly unreachable — env-only is
+      // a safe fallback.
+      this.logger.warn(
+        `SsrfPolicyService: DB lookup failed, falling back to env: ${err.message}`,
+      );
+    }
+
+    const merged = Array.from(new Set([...envHosts, ...dbHosts]));
+    this.cache = { value: merged, expiresAt: now + CACHE_TTL_MS };
+    return merged;
+  }
+
+  /** Read just the DB layer (UI shows the admin-editable list, not env). */
+  async getDbAllowedHosts(): Promise<string[]> {
+    const row = await this.prisma.siteSettings.findUnique({ where: { key: KEY } });
+    if (!row?.value) return [];
+    try {
+      const parsed = JSON.parse(row.value);
+      return Array.isArray(parsed)
+        ? parsed.filter((x): x is string => typeof x === 'string')
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Replace the DB-backed list. Validates basic hostname shape. */
+  async setDbAllowedHosts(hosts: string[]): Promise<string[]> {
+    const cleaned: string[] = [];
+    for (const raw of hosts) {
+      if (typeof raw !== 'string') continue;
+      const h = raw.trim().toLowerCase();
+      if (!h) continue;
+      // Accept: hostnames, *.suffix wildcards, plain IPs. Reject anything
+      // that looks like a URL or contains whitespace/control chars.
+      if (!/^(?:\*\.)?[a-z0-9._:-]+$/i.test(h)) {
+        throw new Error(`Invalid host entry: '${raw}'`);
+      }
+      cleaned.push(h);
+    }
+    const unique = Array.from(new Set(cleaned));
+    await this.prisma.siteSettings.upsert({
+      where: { key: KEY },
+      update: { value: JSON.stringify(unique) },
+      create: { key: KEY, value: JSON.stringify(unique) },
+    });
+    this.invalidate();
+    return unique;
+  }
+
+  /** Force the next call to re-read DB. Used by the admin API after writes. */
+  invalidate(): void {
+    this.cache = null;
+  }
+}

--- a/packages/backend/src/common/ssrf.util.ts
+++ b/packages/backend/src/common/ssrf.util.ts
@@ -57,6 +57,24 @@ function readPolicy(env: NodeJS.ProcessEnv = process.env): SsrfPolicy {
   };
 }
 
+/**
+ * Hook point that lets the DB-backed admin allowlist contribute extra hosts
+ * to the policy. Set by SsrfPolicyService at module init; falls back to a
+ * no-op when the service isn't wired (unit tests, scripts).
+ */
+let dbAllowedHostsProvider: (() => Promise<string[]>) | null = null;
+
+/**
+ * Wire a DB-backed list provider into the guard. Called once by
+ * SsrfPolicyService.onModuleInit. The provider may return a cached list so it
+ * is cheap to call on every outbound URL.
+ */
+export function setDbAllowedHostsProvider(
+  provider: () => Promise<string[]>,
+): void {
+  dbAllowedHostsProvider = provider;
+}
+
 function hostMatchesAllowlist(hostname: string, allowed: string[]): boolean {
   const lower = hostname.toLowerCase();
   for (const entry of allowed) {
@@ -144,7 +162,20 @@ export async function assertSafeOutboundUrl(
 
   const hostname = parsed.hostname;
 
+  // Env-driven allowlist (synchronous).
   if (hostMatchesAllowlist(hostname, policy.allowedHosts)) return;
+
+  // DB-driven allowlist (admin-configured, async). The provider caches
+  // internally so this is effectively a Map lookup after the first call.
+  if (dbAllowedHostsProvider) {
+    try {
+      const dbHosts = await dbAllowedHostsProvider();
+      if (hostMatchesAllowlist(hostname, dbHosts)) return;
+    } catch {
+      // Provider failure: fall through to IP-based checks rather than
+      // hard-failing every outbound call.
+    }
+  }
 
   // If the host is already a literal IP, check it directly.
   if (isIP(hostname)) {

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -178,6 +178,7 @@ export class ConnectorsService {
       | 'unsupported'
       | 'error';
     httpStatus?: number;
+    suggestedFix?: { action: string; hostname?: string; url?: string };
   }> {
     const connector = await this.findById(id);
 
@@ -253,7 +254,13 @@ export class ConnectorsService {
   private classifyTestError(
     error: any,
     healthcheckPath: string,
-  ): { ok: false; message: string; kind: NonNullable<Awaited<ReturnType<typeof this.testConnection>>['kind']>; httpStatus?: number } {
+  ): {
+    ok: false;
+    message: string;
+    kind: NonNullable<Awaited<ReturnType<typeof this.testConnection>>['kind']>;
+    httpStatus?: number;
+    suggestedFix?: { action: string; hostname?: string; url?: string };
+  } {
     // HTTP responses (axios)
     const status: number | undefined = error?.response?.status;
     if (status === 401 || status === 403) {
@@ -286,6 +293,25 @@ export class ConnectorsService {
 
     // Network-layer errors (DNS, ECONNREFUSED, SSRF guard, timeout)
     const msg = String(error?.message || '');
+
+    // Specifically: SSRF guard blocked an internal hostname. Attach a fix
+    // hint so the UI can deep-link to the admin allowlist page.
+    const ssrfMatch = msg.match(
+      /SSRF guard:\s*hostname '([^']+)' resolves to non-public address/,
+    );
+    if (ssrfMatch) {
+      return {
+        ok: false,
+        kind: 'unreachable',
+        message: msg,
+        suggestedFix: {
+          action: 'add-to-ssrf-allowlist',
+          hostname: ssrfMatch[1],
+          url: '/admin/settings#ssrf',
+        },
+      };
+    }
+
     if (
       /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ETIMEDOUT|timeout|SSRF guard/i.test(
         msg,

--- a/packages/backend/src/settings/settings.module.ts
+++ b/packages/backend/src/settings/settings.module.ts
@@ -3,10 +3,11 @@ import { SiteSettingsService } from './site-settings.service';
 import { OrgSettingsService } from './org-settings.service';
 import { EmailService } from './email.service';
 import { SiteSettingsPublicController, SiteSettingsAdminController } from './site-settings.controller';
+import { SsrfPolicyService } from '../common/ssrf-policy.service';
 
 @Module({
   controllers: [SiteSettingsPublicController, SiteSettingsAdminController],
-  providers: [SiteSettingsService, OrgSettingsService, EmailService],
-  exports: [SiteSettingsService, OrgSettingsService, EmailService],
+  providers: [SiteSettingsService, OrgSettingsService, EmailService, SsrfPolicyService],
+  exports: [SiteSettingsService, OrgSettingsService, EmailService, SsrfPolicyService],
 })
 export class SettingsModule {}

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -15,6 +15,7 @@ import { Roles, RolesGuard } from '../auth/roles.guard';
 import { SiteSettingsService } from './site-settings.service';
 import { OrgSettingsService } from './org-settings.service';
 import { EmailService } from './email.service';
+import { SsrfPolicyService } from '../common/ssrf-policy.service';
 
 class SmtpConfigDto {
   @ApiProperty({ description: 'SMTP server hostname.', example: 'smtp.sendgrid.net' })
@@ -70,6 +71,18 @@ class FooterLinksDto {
   links: FooterLinkDto[];
 }
 
+class SsrfAllowedHostsDto {
+  @ApiProperty({
+    description:
+      'Hostnames (and *.suffix wildcards / plain IPs) that the SSRF guard will let through even when they resolve to a private/loopback address. Replaces the stored list. Hosts merged at request time with whatever is in the SSRF_ALLOWED_HOSTS env var.',
+    type: [String],
+    example: ['koch-filesystem-bridge', '*.internal.example.com', '172.23.0.0'],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  hosts: string[];
+}
+
 // ── Public endpoints (no auth) ──────────────────────────────────────────────
 
 @ApiTags('Site Settings')
@@ -96,6 +109,7 @@ export class SiteSettingsAdminController {
     private readonly siteSettings: SiteSettingsService,
     private readonly orgSettings: OrgSettingsService,
     private readonly emailService: EmailService,
+    private readonly ssrfPolicy: SsrfPolicyService,
   ) {}
 
   @Get('smtp')
@@ -144,5 +158,31 @@ export class SiteSettingsAdminController {
   async updateFooterLinks(@Req() req: any, @Body() dto: FooterLinksDto) {
     await this.orgSettings.setJson(req.user.organizationId, 'footer_links', dto.links);
     return { message: 'Footer links saved' };
+  }
+
+  @Get('ssrf-allowed-hosts')
+  @ApiOperation({
+    summary: 'Get the admin-editable SSRF allowlist (ADMIN)',
+    description:
+      'Returns the DB-backed list of hosts that bypass the SSRF guard. The effective allowlist also includes anything in the SSRF_ALLOWED_HOSTS env var (returned separately so the UI can show them as read-only).',
+  })
+  async getSsrfAllowedHosts() {
+    const dbHosts = await this.ssrfPolicy.getDbAllowedHosts();
+    const envHosts = (process.env.SSRF_ALLOWED_HOSTS || '')
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
+    return { hosts: dbHosts, envHosts };
+  }
+
+  @Put('ssrf-allowed-hosts')
+  @ApiOperation({
+    summary: 'Replace the admin-editable SSRF allowlist (ADMIN)',
+    description:
+      'Use with caution: hostnames added here can be reached by every connector in every organization on this deployment.',
+  })
+  async setSsrfAllowedHosts(@Body() dto: SsrfAllowedHostsDto) {
+    const hosts = await this.ssrfPolicy.setDbAllowedHosts(dto.hosts);
+    return { hosts };
   }
 }

--- a/packages/frontend/src/app/admin/settings/page.tsx
+++ b/packages/frontend/src/app/admin/settings/page.tsx
@@ -23,6 +23,12 @@ export default function AdminSettingsPage() {
   const [footerLinks, setFooterLinks] = useState<Array<{ label: string; url: string }>>([]);
   const [footerMsg, setFooterMsg] = useState('');
 
+  // SSRF allowlist
+  const [ssrfHosts, setSsrfHosts] = useState<string[]>([]);
+  const [ssrfEnvHosts, setSsrfEnvHosts] = useState<string[]>([]);
+  const [ssrfDraft, setSsrfDraft] = useState('');
+  const [ssrfMsg, setSsrfMsg] = useState('');
+
   useEffect(() => {
     if (!token) return;
 
@@ -36,7 +42,30 @@ export default function AdminSettingsPage() {
     }).catch(() => {});
 
     adminSettings.getFooterLinks(token).then(setFooterLinks).catch(() => {});
+
+    adminSettings.getSsrfAllowedHosts(token).then((data) => {
+      setSsrfHosts(data.hosts);
+      setSsrfEnvHosts(data.envHosts);
+      setSsrfDraft(data.hosts.join('\n'));
+    }).catch(() => {});
   }, [token]);
+
+  const handleSaveSsrfHosts = async () => {
+    if (!token) return;
+    const hosts = ssrfDraft
+      .split(/[\n,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    try {
+      const result = await adminSettings.setSsrfAllowedHosts(hosts, token);
+      setSsrfHosts(result.hosts);
+      setSsrfDraft(result.hosts.join('\n'));
+      setSsrfMsg('SSRF allowlist saved');
+      setTimeout(() => setSsrfMsg(''), 3000);
+    } catch (err: any) {
+      setSsrfMsg(`Error: ${err.message}`);
+    }
+  };
 
   const handleSaveSmtp = async () => {
     if (!token) return;
@@ -254,6 +283,64 @@ export default function AdminSettingsPage() {
                 </p>
               )}
             </div>
+          </div>
+
+          {/* SSRF Allowlist */}
+          <div id="ssrf" className="border border-[var(--border)] rounded-lg p-6">
+            <h3 className="text-lg font-medium mb-2">SSRF allowlist</h3>
+            <p className="text-sm text-[var(--muted-foreground)] mb-2">
+              Hostnames (or <code>*.suffix</code> wildcards / plain IPs) that
+              the SSRF guard will let through when they resolve to a private
+              network address. Needed when connectors call services on the
+              internal network — e.g. a Docker-compose service like{' '}
+              <code>koch-filesystem-bridge</code>.
+            </p>
+            <p className="text-xs text-[var(--destructive)] mb-4 font-medium">
+              ⚠ Use with caution. Anything added here can be reached by every
+              connector in every organization on this deployment. Do not add
+              hosts you don&apos;t fully trust.
+            </p>
+
+            {ssrfEnvHosts.length > 0 && (
+              <div className="mb-4">
+                <p className="text-xs font-semibold mb-1">
+                  From <code>SSRF_ALLOWED_HOSTS</code> env var (read-only):
+                </p>
+                <div className="text-xs font-mono bg-[var(--muted)] rounded p-2">
+                  {ssrfEnvHosts.join(', ')}
+                </div>
+              </div>
+            )}
+
+            <label className="block text-sm font-medium mb-1">
+              Admin-editable list (one host per line)
+            </label>
+            <textarea
+              value={ssrfDraft}
+              onChange={(e) => setSsrfDraft(e.target.value)}
+              placeholder="koch-filesystem-bridge&#10;*.internal.example.com&#10;172.23.0.0"
+              rows={5}
+              className="w-full max-w-lg border border-[var(--input)] rounded-md px-3 py-2 text-sm bg-[var(--background)] font-mono"
+            />
+            <div className="flex gap-2 mt-3">
+              <button
+                onClick={handleSaveSsrfHosts}
+                className="bg-[var(--brand)] text-white px-4 py-1.5 rounded text-sm font-medium hover:brightness-90"
+              >
+                Save allowlist
+              </button>
+            </div>
+            {ssrfMsg && (
+              <p
+                className={`text-sm mt-2 ${
+                  ssrfMsg.startsWith('Error')
+                    ? 'text-[var(--destructive)]'
+                    : 'text-[var(--success)]'
+                }`}
+              >
+                {ssrfMsg}
+              </p>
+            )}
           </div>
         </div>
       </main>

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -49,6 +49,7 @@ export default function ConnectorDetailPage() {
     message: string;
     kind?: 'ok' | 'auth_failed' | 'not_found' | 'unreachable' | 'unsupported' | 'error';
     httpStatus?: number;
+    suggestedFix?: { action: string; hostname?: string; url?: string };
   } | null>(null);
 
   // Tool editor state
@@ -458,6 +459,18 @@ export default function ConnectorDetailPage() {
               </span>
             )}
             {testResult.message}
+            {testResult.suggestedFix?.action === 'add-to-ssrf-allowlist' &&
+              testResult.suggestedFix.hostname && (
+                <div className="mt-2 pt-2 border-t border-current/20">
+                  <a
+                    href={testResult.suggestedFix.url || '/admin/settings#ssrf'}
+                    className="underline text-sm font-medium hover:no-underline"
+                  >
+                    → Add <code>{testResult.suggestedFix.hostname}</code> to
+                    the SSRF allowlist
+                  </a>
+                </div>
+              )}
           </div>
         )}
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -178,6 +178,7 @@ export const connectors = {
         | 'unsupported'
         | 'error';
       httpStatus?: number;
+      suggestedFix?: { action: string; hostname?: string; url?: string };
     }>(`/api/connectors/${id}/test`, { method: 'POST', token }),
   importSpec: (id: string, token: string) =>
     request<{ message: string; tools: any[] }>(`/api/connectors/${id}/import-spec`, { method: 'POST', token }),
@@ -296,6 +297,10 @@ export const adminSettings = {
     request<Array<{ label: string; url: string }>>('/api/admin/settings/footer-links', { token }),
   updateFooterLinks: (links: Array<{ label: string; url: string }>, token: string) =>
     request<{ message: string }>('/api/admin/settings/footer-links', { method: 'PUT', body: { links }, token }),
+  getSsrfAllowedHosts: (token: string) =>
+    request<{ hosts: string[]; envHosts: string[] }>('/api/admin/settings/ssrf-allowed-hosts', { token }),
+  setSsrfAllowedHosts: (hosts: string[], token: string) =>
+    request<{ hosts: string[] }>('/api/admin/settings/ssrf-allowed-hosts', { method: 'PUT', body: { hosts }, token }),
 };
 
 // Roles (Admin)


### PR DESCRIPTION
## Problem
\`SSRF_ALLOWED_HOSTS\` was a backend env var only. Onboarding a connector that calls a service on the internal network — e.g. a docker-compose sibling like \`koch-filesystem-bridge\` (a real customer case) — required editing the env, restarting, and there was nothing in the UI explaining the failure or how to fix it.

## Changes

### Backend
- **\`SsrfPolicyService\`** (\`common/ssrf-policy.service.ts\`) — merges \`SSRF_ALLOWED_HOSTS\` env var with a DB-backed list stored in \`SiteSettings\` (\`ssrf_allowed_hosts\` key, JSON array). Cached in-process for 60s; \`invalidate()\` flushes after writes.
- **\`ssrf.util.ts\`** — new \`setDbAllowedHostsProvider()\` hook. \`SsrfPolicyService.onModuleInit\` wires itself in, so every \`assertSafeOutboundUrl\` call consults both layers. No-op when the service isn't loaded (preserves existing unit tests).
- **Admin API**: \`GET\` / \`PUT /api/admin/settings/ssrf-allowed-hosts\`. \`PUT\` validates host shape — accepts hostnames, \`*.suffix\` wildcards, and bare IPs; rejects URLs / whitespace / control chars.
- **Connector test response** now carries a \`suggestedFix\` object when the failure is specifically the SSRF guard:
  \`\`\`json
  { "action": "add-to-ssrf-allowlist", "hostname": "koch-filesystem-bridge", "url": "/admin/settings#ssrf" }
  \`\`\`

### Frontend
- New 'SSRF allowlist' section in \`/admin/settings\` with a red warning, env-var hosts shown read-only, and a textarea for the editable list.
- Connector detail test-result banner renders \`suggestedFix\` as a click-through link: 'Add \`<hostname>\` to the SSRF allowlist'.

## Security notes
- Restricted to org-level \`ADMIN\` via existing \`RolesGuard\`.
- UI has explicit warning copy: 'anything added here can be reached by every connector in every organization on this deployment'.
- The 60s cache means a freshly-added host takes up to a minute to apply across long-running processes. Acceptable trade-off vs. hitting DB on every outbound URL.
- Env-only setups continue to work unchanged.

## Test plan
- [x] \`SsrfPolicyService.spec.ts\` — 7 unit tests (env-only, merge, persist, cache TTL + invalidate, invalid host, accepted shapes, DB-failure fallback).
- [x] \`tsc --noEmit\` exit 0 on backend and frontend.
- [x] Full backend test suite: 631 passed across 26 suites.
- [ ] After deploy: as admin, hit \`/admin/settings\`, add a host, save, then test a connector pointing at it.
- [ ] After deploy: import a connector pointing at an internal-network hostname, hit Test → expect red banner with 'Add … to the SSRF allowlist' link.