### PR TITLE
Add glama.json to claim the Glama MCP server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "keysersoft"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds \`glama.json\` to the repo root with the maintainers list so we can claim the Glama listing (https://glama.ai/mcp/servers/HelpCode-ai/anythingmcp).

## Why
Glama requires \`glama.json\` for any server living under an organization (HelpCode-ai is an org, not a user). Once we can claim, we get the admin panel and can:
- Configure the Docker build instructions for the Quality check (currently \"not tested\")
- Update the server description
- Receive review notifications

Companion to PR #164 (BUSL-1.1 SPDX fix). Together they should take the Glama score from C → A within the next re-scan window (12-24h).