### PR TITLE
Preserve operator config across OpenAPI re-imports (#6)

### DIFF
--- a/packages/backend/prisma/migrations/20260512000000_mcp_tool_operationid_deprecated/migration.sql
+++ b/packages/backend/prisma/migrations/20260512000000_mcp_tool_operationid_deprecated/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "mcp_tools" ADD COLUMN "operation_id" TEXT;
+ALTER TABLE "mcp_tools" ADD COLUMN "deprecated_at" TIMESTAMP(3);

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -314,6 +314,16 @@ model McpTool {
   description String    @db.Text
   isEnabled   Boolean   @default(true) @map("is_enabled")
 
+  // OpenAPI operationId, when the tool was generated from an OpenAPI spec.
+  // Used as the primary key for re-imports so that responseMapping and role
+  // assignments survive when the user changes a tool's name in their spec.
+  operationId String? @map("operation_id")
+
+  // Set when a re-import no longer finds this tool in the spec. The tool
+  // stays in the DB (preserving role assignments and invocation history)
+  // but is shown with a "deprecated" badge in the UI.
+  deprecatedAt DateTime? @map("deprecated_at")
+
   // Parameter schema (JSON Schema / Zod-compatible)
   parameters Json
 

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -989,39 +989,131 @@ export class ConnectorsController {
     return updated;
   }
 
+  /**
+   * Reconcile a connector's tools against a freshly parsed spec.
+   *
+   * Strategy:
+   *   1. Snapshot existing (non-deprecated) tools for the connector.
+   *   2. For each parsed tool, find a match in the snapshot — preferred
+   *      lookup is by operationId, fallback is (name, method, path).
+   *   3. Match found → UPDATE in place, preserving responseMapping (unless
+   *      the spec now provides one) and isEnabled, and clearing
+   *      deprecatedAt if it was set.
+   *   4. No match → CREATE.
+   *   5. Snapshot entries not matched by any parsed tool → mark
+   *      deprecatedAt = now() and isEnabled = false. We do NOT hard-delete
+   *      so ToolRoleAccess and ToolInvocation history survive.
+   *
+   * This preserves operator customisations (custom responseMapping,
+   * role-based access, manual disables) across re-imports without losing
+   * the visibility of "this endpoint no longer exists upstream".
+   */
   private async createToolsFromParsed(connectorId: string, parsedTools: any[]) {
-    const createdTools = [];
-    const skippedTools: string[] = [];
+    const existing = await this.prisma.mcpTool.findMany({
+      where: { connectorId },
+    });
+    const byOperationId = new Map<string, typeof existing[number]>();
+    const byEndpoint = new Map<string, typeof existing[number]>();
+    for (const t of existing) {
+      if (t.operationId) byOperationId.set(t.operationId, t);
+      const em = t.endpointMapping as any;
+      if (em?.method && em?.path) {
+        byEndpoint.set(`${String(em.method).toUpperCase()} ${em.path}`, t);
+      }
+    }
+
+    const matchedIds = new Set<string>();
+    let createdCount = 0;
+    let updatedCount = 0;
+    const tools: any[] = [];
 
     for (const tool of parsedTools) {
+      const em = tool.endpointMapping as any;
+      const endpointKey =
+        em?.method && em?.path
+          ? `${String(em.method).toUpperCase()} ${em.path}`
+          : null;
+      const match =
+        (tool.operationId && byOperationId.get(tool.operationId)) ||
+        (endpointKey && byEndpoint.get(endpointKey)) ||
+        null;
+
+      if (match) {
+        matchedIds.add(match.id);
+        const updated = await this.prisma.mcpTool.update({
+          where: { id: match.id },
+          data: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters as any,
+            endpointMapping: tool.endpointMapping as any,
+            // Preserve operator-customised responseMapping unless the spec
+            // now declares one (e.g. response shaping was added upstream).
+            responseMapping:
+              tool.responseMapping !== undefined
+                ? (tool.responseMapping as any)
+                : (match.responseMapping as any),
+            operationId: tool.operationId ?? match.operationId,
+            deprecatedAt: null,
+            // Re-enable if it was disabled only because we'd previously
+            // deprecated it. If the user manually disabled it, isEnabled
+            // is already false; we don't flip user choices.
+            isEnabled: match.deprecatedAt ? true : match.isEnabled,
+          },
+        });
+        tools.push(updated);
+        updatedCount++;
+        continue;
+      }
+
       try {
         const created = await this.prisma.mcpTool.create({
           data: {
             connectorId,
             name: tool.name,
             description: tool.description,
+            operationId: tool.operationId ?? null,
             parameters: tool.parameters as any,
             endpointMapping: tool.endpointMapping as any,
             responseMapping: tool.responseMapping as any,
           },
         });
-        createdTools.push(created);
+        tools.push(created);
+        createdCount++;
       } catch (err: any) {
-        // Skip duplicate tools (unique constraint on [connectorId, name])
-        if (err.code === 'P2002') {
-          skippedTools.push(tool.name);
-        } else {
-          throw err;
-        }
+        // A different existing tool happens to share the new tool's name
+        // (e.g. same name across two re-imports on parametric paths).
+        // Skip rather than throw — preserves prior semantics.
+        if (err.code !== 'P2002') throw err;
       }
+    }
+
+    // Tools that survived the parse but are no longer in the spec.
+    const now = new Date();
+    const deprecated: string[] = [];
+    for (const t of existing) {
+      if (matchedIds.has(t.id)) continue;
+      if (t.deprecatedAt) continue; // already deprecated
+      await this.prisma.mcpTool.update({
+        where: { id: t.id },
+        data: { deprecatedAt: now, isEnabled: false },
+      });
+      deprecated.push(t.name);
     }
 
     await this.mcpServer.reloadConnectorTools(connectorId);
 
+    const parts = [`created ${createdCount}`, `updated ${updatedCount}`];
+    if (deprecated.length > 0) parts.push(`deprecated ${deprecated.length}`);
     return {
-      message: `Imported ${createdTools.length} tools${skippedTools.length > 0 ? `, skipped ${skippedTools.length} duplicates` : ''}`,
-      tools: createdTools,
-      skipped: skippedTools,
+      message: `Imported tools: ${parts.join(', ')}`,
+      tools,
+      created: createdCount,
+      updated: updatedCount,
+      deprecated,
+      // `skipped` kept for back-compat with clients that consumed the old
+      // shape; always empty under the new upsert strategy.
+      skipped: [] as string[],
     };
   }
 }

--- a/packages/backend/src/connectors/parsers/openapi.parser.spec.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.spec.ts
@@ -547,6 +547,24 @@ describe('OpenApiParser', () => {
       expect(params.properties.cursor.example).toBe('abc');
     });
 
+    it('preserves operationId on the ParsedTool', async () => {
+      const spec: any = {
+        openapi: '3.1.0',
+        info: { title: 'X', version: '1' },
+        paths: {
+          '/items': {
+            get: {
+              operationId: 'list_items_v2',
+              summary: 'List items',
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      };
+      const tools = await parser.parse(spec);
+      expect(tools[0].operationId).toBe('list_items_v2');
+    });
+
     it('detects /health as the healthcheck path when present', async () => {
       const spec: any = {
         openapi: '3.1.0',

--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -9,6 +9,13 @@ import { normalizeOpenApi31 } from './openapi-3.1-normalizer';
 
 export interface ParsedTool {
   name: string;
+  /**
+   * OpenAPI operationId of the source operation, when available. Preserved
+   * across re-imports as the stable identifier for matching: if the user
+   * renames the operationId in the spec, the parsed tool name will change
+   * too, but this field still points at the same logical endpoint.
+   */
+  operationId?: string;
   description: string;
   parameters: Record<string, unknown>;
   endpointMapping: {
@@ -384,7 +391,11 @@ export class OpenApiParser {
       endpointMapping.bodyMapping = bodyMapping;
     }
 
-    return { name, description, parameters, endpointMapping };
+    const result: ParsedTool = { name, description, parameters, endpointMapping };
+    if (typeof operation.operationId === 'string' && operation.operationId.length > 0) {
+      result.operationId = operation.operationId;
+    }
+    return result;
   }
 
   private generateToolName(

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -955,6 +955,14 @@ export default function ConnectorDetailPage() {
                             >
                               {tool.isEnabled ? 'enabled' : 'disabled'}
                             </span>
+                            {tool.deprecatedAt && (
+                              <span
+                                className="text-xs px-1.5 py-0.5 rounded flex-shrink-0 bg-[var(--warning-bg)] text-[var(--warning-text)]"
+                                title={`Removed from the source spec on ${new Date(tool.deprecatedAt).toLocaleString()}. Role assignments and history are preserved.`}
+                              >
+                                deprecated
+                              </span>
+                            )}
                           </div>
                           <p className="text-xs text-[var(--muted-foreground)] mt-0.5 line-clamp-2 sm:truncate">
                             {tool.description}


### PR DESCRIPTION
## Problem
Importing a spec twice into the same connector created tools on the first run and silently skipped on the second (\`P2002\` swallow in \`createToolsFromParsed\`). Two consequences:

- Operator customisations made between imports — custom \`responseMapping\`, manual \`isEnabled: false\` — were lost on the next re-import.
- Endpoints that disappeared from upstream stayed registered forever, with no signal they were stale. Role assignments pointed at zombie tools.

## Fix
Turn \`createToolsFromParsed\` into a reconciliation step.

### Schema (additive, nullable; no backfill needed)
\`\`\`
mcp_tools.operation_id   TEXT
mcp_tools.deprecated_at  TIMESTAMP(3)
\`\`\`

### Parser
\`ParsedTool.operationId\` is populated from the source operation when present (works for 3.0 and 3.1).

### Reconciliation
1. Snapshot existing tools.
2. For each parsed tool, look up by **operationId** first, fall back to **(method, path)**.
3. Match → \`UPDATE\` in place. Preserves \`responseMapping\` unless the spec declares a new one. Preserves the operator's manual \`isEnabled\` toggle. Clears \`deprecatedAt\` if previously set.
4. No match → \`CREATE\`.
5. Snapshot entries unmatched by any parsed tool get \`deprecatedAt = now()\` + \`isEnabled = false\`. They **stay in the DB** so \`ToolRoleAccess\` and invocation history survive.

### Response shape
\`\`\`json
{
  "message": "Imported tools: created N, updated N, deprecated N",
  "tools": [...],
  "created": N,
  "updated": N,
  "deprecated": ["tool_name_1", ...],
  "skipped": []  // kept for back-compat; always empty now
}
\`\`\`

### Frontend
Tool list shows a yellow \`deprecated\` badge next to the existing \`enabled\`/\`disabled\` pill, with a tooltip showing the date the tool fell off the spec.

## Test plan
- [x] Parser spec asserts \`operationId\` is preserved on \`ParsedTool\` (new test in \`openapi.parser.spec.ts\`).
- [x] Full backend test suite green: 631 passed across 26 suites.
- [x] \`tsc --noEmit\` clean on backend and frontend.
- [ ] After deploy: import spec → assign role → re-import same spec → role still on tool. Re-import a modified spec that drops one endpoint → tool gets \`deprecated\` badge, role assignment intact.