### PR TITLE
Reformat LICENSE to canonical BSL-1.1 template (fix GitHub + Glama detection)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,11 +3,15 @@ Business Source License 1.1
 License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 "Business Source License" is a trademark of MariaDB Corporation Ab.
 
+-----------------------------------------------------------------------------
+
 Parameters
 
 Licensor:             helpcode.ai GmbH
+
 Licensed Work:        AnythingMCP
                       The Licensed Work is (c) 2026 helpcode.ai GmbH.
+
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you may not use the Licensed Work for a Service.
 
@@ -25,6 +29,7 @@ Additional Use Grant: You may make use of the Licensed Work, provided that
                       - Academic and educational use
 
 Change Date:          2030-03-04
+
 Change License:       Apache License, Version 2.0
 
 For information about alternative licensing arrangements for the Licensed Work,
@@ -32,45 +37,77 @@ please contact: licensing@helpcode.ai
 
 Notice
 
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+-----------------------------------------------------------------------------
+
 Business Source License 1.1
 
 Terms
 
 The Licensor hereby grants you the right to copy, modify, create derivative
 works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
 Effective on the Change Date, or the fourth anniversary of the first publicly
 available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set forth in this License
+apply to your use of that work.
 
 Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License
+   can be included in a program with software provided under GPL Version 2.0
+   or a later version. Licensor may specify additional Change Licenses
+   without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License,
+   as the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.


### PR DESCRIPTION
## Summary

GitHub's license sidebar shows \"Other\" and Glama reports \"Does not have a license\" even though we ship a real Business Source License 1.1 file. Both use SPDX-template diff-matching (the \`licensee\` Ruby gem in GitHub's case). Our previous \`LICENSE\` file had correct *legal content* but missed three structural elements the matcher expects:

1. The \"Notice\" paragraph body explaining BSL is not OSI-approved open source.
2. The horizontal separator line between Parameters/Notice and Terms.
3. The \"Covenants of Licensor\" section at the end (MariaDB's required attribution back-grant).

This PR reformats \`LICENSE\` to the canonical template from [spdx.org/licenses/BUSL-1.1](https://spdx.org/licenses/BUSL-1.1.html) while keeping all our parameters intact (Licensor, Licensed Work, Additional Use Grant, Change Date, Change License, contact email).

**No legal change.** Same license, structurally aligned so automated detection works.

## Expected effect after merge
- GitHub About sidebar: \"Other\" → \"Business Source License 1.1\"
- Glama Score: \"Does not have a license\" check passes (was: \"F\" license)
- License scanners and SCA tools downstream recognise the license correctly

## Test plan
- [x] Diff is whitespace + 3 added paragraphs, no parameter changes
- [ ] After merge: \`gh api repos/HelpCode-ai/anythingmcp --jq .license\` returns \`{\"key\":\"bsl-1.1\", ...}\` instead of \`{\"key\":\"other\"}\`
- [ ] After merge: https://glama.ai/mcp/servers/HelpCode-ai/anythingmcp/score shows license item green within 12h