### PR TITLE
Drop arm64 from Docker publish (unblock v0.1.24)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,11 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          # arm64 dropped: Prisma 7.8.0's WASM schema engine misparses
+          # `onDelete: Cascade` on linux/arm64 (reads it as empty),
+          # blocking `prisma generate`. Production runs on amd64 droplets;
+          # re-add arm64 once Prisma ships a fix (track upstream).
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Prisma 7.8.0 WASM schema engine hits a parse bug on linux/arm64: `onDelete: Cascade` is read as an empty string, `prisma generate` fails. The amd64 stage of the same build passes cleanly. Two publish attempts for v0.1.24 hit it.

Production deploys on amd64 (DigitalOcean droplet). Multi-arch images were a nice-to-have, not load-bearing. Drop arm64 now to unblock the release; re-add when Prisma ships a fix.