### PR TITLE
Fix CodeQL easy wins: missing-await + Dockerfile HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,4 +113,9 @@ LABEL org.opencontainers.image.title="AnythingMCP" \
 USER appuser
 EXPOSE 3000 4000
 
+# Health check — backend exposes /health on port 4000.
+# 30s interval, 5s timeout, 30s start period, 3 retries before unhealthy.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:4000/health || exit 1
+
 CMD ["./start.sh"]

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -150,7 +150,9 @@ export class SiteSettingsAdminController {
   @Get('footer-links')
   @ApiOperation({ summary: 'Get footer links for current organization (ADMIN)' })
   async getFooterLinks(@Req() req: any) {
-    return this.orgSettings.getFooterLinks(req.user.organizationId) || [];
+    return (
+      (await this.orgSettings.getFooterLinks(req.user.organizationId)) || []
+    );
   }
 
   @Put('footer-links')


### PR DESCRIPTION
## Summary

Part of the pre-launch CodeQL cleanup. Two small fixes that close two real alerts.

### 1. \`packages/backend/src/settings/site-settings.controller.ts\`
\`getFooterLinks()\` returned the unresolved Promise — \`Promise || []\` is always truthy so the \`|| []\` fallback was dead code. Now properly awaited so the empty-array fallback works.

Closes CodeQL alert [#72](https://github.com/HelpCode-ai/anythingmcp/security/code-scanning/72) (\`js/missing-await\`).

### 2. \`Dockerfile\`
Added \`HEALTHCHECK\` pointing at the backend Terminus \`/health\` endpoint (port 4000). 30s interval, 5s timeout, 30s start period, 3 retries.

Closes CodeQL alert [#3](https://github.com/HelpCode-ai/anythingmcp/security/code-scanning/3) (\`DS-0026\`) and gives Docker/K8s/Compose a proper liveness signal.

## Test plan
- [x] TypeScript compiles
- [ ] After merge: \`docker inspect helpcodeai/anythingmcp\` shows the Healthcheck stanza
- [ ] After merge: CodeQL alerts #72 and #3 auto-close on next scan

## Companion work (separate, not in this PR)
- 7 SQL injection alerts: dismissed as FPs (prepared queries with bind vars)
- 30 remote-property-injection alerts: dismissed as admin-only with prototype-pollution hardening tracked as a follow-up
- 5 request-forgery alerts: dismissed as guarded by \`assertSafeOutboundUrl()\` SSRF allowlist
- 7 ReDoS alerts: dismissed as bounded-input/admin-only
- 4 CVE alerts: 2 dismissed as not-in-our-tree, 2 left to Dependabot
- Helmet CSP, xss-through-exception, loop-bound-injection: dismissed with rationale
- **🚨 Open security issue (not in this PR)**: \`login_user\` cookie used by OAuth flow is base64-encoded but NOT HMAC-signed. Detailed in a separate report.