### PR TITLE
Security: HMAC-sign login_user cookie + drop Origin/Referer fallback in frontend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ JWT_SECRET=change-me-in-production-min-32-chars
 # AES-256-GCM encryption key for stored credentials (exactly 32 characters)
 ENCRYPTION_KEY=change-me-in-production-exactly-32
 
+# HMAC secret for signed cookies (OAuth callback flow). Optional — falls back
+# to JWT_SECRET if unset. Set it separately for defense in depth (rotate it
+# independently from JWT_SECRET).
+# COOKIE_SECRET=change-me-in-production-min-32-chars
+
 # ── Frontend ─────────────────────────────────────────────────────────────────
 FRONTEND_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -147,22 +147,11 @@ export class AuthController {
     private readonly organizationsService: OrganizationsService,
   ) {}
 
-  private getFrontendUrl(req?: any): string {
-    // Derive from the incoming request so links match the domain the user is on,
-    // even when FRONTEND_URL env var is stale or misconfigured.
-    if (req?.headers) {
-      const origin = req.headers['origin'];
-      if (origin) return origin.replace(/\/+$/, '');
-
-      const referer = req.headers['referer'];
-      if (referer) {
-        try {
-          const url = new URL(referer);
-          return url.origin;
-        } catch {}
-      }
-    }
-
+  private getFrontendUrl(_req?: any): string {
+    // SECURITY: we deliberately ignore req.headers.origin / req.headers.referer
+    // here. They are attacker-controlled and previously got interpolated into
+    // password-reset email HTML, enabling XSS via Origin-header injection.
+    // The frontend URL must come from server-side config only.
     return (
       this.configService.get<string>('FRONTEND_URL') ||
       this.configService.get<string>('SERVER_URL') ||

--- a/packages/backend/src/auth/local-oauth.strategy.ts
+++ b/packages/backend/src/auth/local-oauth.strategy.ts
@@ -52,9 +52,11 @@ export class LocalOAuthStrategy extends Strategy {
       } as any;
     }
 
-    // Check if the user has already authenticated via the login form
-    // (login controller sets a signed cookie with user profile)
-    const loginUserCookie = (req as any).cookies?.login_user;
+    // Check if the user has already authenticated via the login form.
+    // We REQUIRE the cookie to be HMAC-signed (req.signedCookies). Unsigned
+    // values in req.cookies are rejected to prevent an attacker forging a
+    // base64-encoded profile to bypass authentication.
+    const loginUserCookie = (req as any).signedCookies?.login_user;
 
     if (loginUserCookie) {
       try {

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -100,6 +100,7 @@ export class LoginController {
       secure: isSecure,
       maxAge: 60 * 1000, // 1 minute — just enough for the redirect
       sameSite: isSecure ? 'none' : 'lax',
+      signed: true, // HMAC-signed: rejects forged cookies in the OAuth strategy
     });
 
     // Derive callback URL from the request origin (works behind proxy/tunnel)

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -18,7 +18,7 @@ import { startTracing } from './tracing';
 startTracing();
 
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { Logger as PinoLogger } from 'nestjs-pino';
@@ -48,12 +48,32 @@ async function bootstrap() {
   app.use(json({ limit: '10mb' }));
   app.use(urlencoded({ extended: true, limit: '10mb' }));
 
-  // Cookie parser is required for OAuth2 session management
-  app.use(cookieParser());
-
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT') || 4000;
   const isProduction = configService.get<string>('NODE_ENV') === 'production';
+
+  // Cookie parser with HMAC secret so we can use signed cookies for the
+  // OAuth callback flow. Falls back to JWT_SECRET to avoid forcing every
+  // self-hoster to add a new env var; logs a startup warning when the
+  // fallback is used in production.
+  const cookieSecret =
+    configService.get<string>('COOKIE_SECRET') ||
+    configService.get<string>('JWT_SECRET');
+  if (!cookieSecret) {
+    throw new Error(
+      'COOKIE_SECRET (or fallback JWT_SECRET) must be set for signed cookies',
+    );
+  }
+  if (
+    isProduction &&
+    !configService.get<string>('COOKIE_SECRET')
+  ) {
+    Logger.warn(
+      'COOKIE_SECRET not set in production — falling back to JWT_SECRET. Set COOKIE_SECRET to a separate value for defense-in-depth.',
+      'Bootstrap',
+    );
+  }
+  app.use(cookieParser(cookieSecret));
 
   // Security headers (CSP relaxed because Swagger UI ships inline scripts/styles)
   app.use(


### PR DESCRIPTION
## Summary

Two real CodeQL findings, both auth-adjacent, both pre-launch blockers.

### 1. \`login_user\` cookie was forgeable (CodeQL [#56](https://github.com/HelpCode-ai/anythingmcp/security/code-scanning/56) \`js/user-controlled-bypass\`)

\`local-oauth.strategy.ts\` read \`req.cookies.login_user\`, base64-decoded the JSON, and trusted the resulting profile as the authenticated user. The cookie was set without a secret in \`cookieParser()\`, so it was **NOT** HMAC-signed — anyone who knew a target user's id/email could forge a profile, set the cookie in their browser, navigate to \`/callback\`, and log in as that user.

Fix:
- \`main.ts\` — initialise \`cookieParser(secret)\` with \`COOKIE_SECRET\` (or \`JWT_SECRET\` as fallback). Throws at startup if neither is present. Logs a warning in production when the fallback is used.
- \`login.controller.ts\` — set the cookie with \`{ signed: true }\`.
- \`local-oauth.strategy.ts\` — read from \`req.signedCookies\` (not \`req.cookies\`). Unsigned/forged cookies silently rejected → redirect to login.
- \`.env.example\` — document \`COOKIE_SECRET\` as optional separate secret for defense in depth.

### 2. XSS in password-reset email via Origin header (CodeQL [#11](https://github.com/HelpCode-ai/anythingmcp/security/code-scanning/11) \`js/xss\`)

\`auth.controller.ts#getFrontendUrl()\` preferred \`req.headers.origin\` over the \`FRONTEND_URL\` env var. That value was then interpolated into the password-reset email HTML inside an \`<a href>\` attribute. Attacker crafting an Origin header like \`\" onmouseover=\"alert(...)\" \` could inject HTML attribute content into the recipient's email.

Fix: drop the Origin/Referer fallback entirely. Frontend URL must come from server-side config (\`FRONTEND_URL\` → \`SERVER_URL\` → \`localhost\`), which is operator-controlled.

## Test plan
- [x] Lint clean on the modified files
- [ ] After merge: existing OAuth login flow still works (cookie now signed, but cookieParser auto-signs/verifies — frontend doesn't notice anything)
- [ ] After merge: password-reset email uses FRONTEND_URL, not request Origin
- [ ] After merge: CodeQL alerts #56 and #11 auto-close on next scan
- [ ] Manual check: setting a hand-crafted \`login_user\` cookie in a fresh browser no longer logs in — redirects to /login

## Migration note for self-hosters

No env-var change required for existing deployments (falls back to \`JWT_SECRET\` if \`COOKIE_SECRET\` not set). Strongly recommended to add a separate \`COOKIE_SECRET=<32+ chars>\` in production .env for defense in depth.