### PR TITLE
Improve onboarding: prerequisites, admin warning, key rotation, REST quickstart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 # =============================================================================
 # AnythingMCP — Environment Variables
 # =============================================================================
-# Copy this file to packages/backend/.env and fill in the values.
+# The recommended way to generate this file is `./setup.sh`, which writes a
+# fully-populated `.env` to the project root (where docker-compose.yml lives).
+#
+# For manual setup: copy this file to `.env` in the project root, replace the
+# `change-me-…` values with secure secrets, then run `docker compose up -d`.
+# For local development without Docker, copy it to `packages/backend/.env`.
 # =============================================================================
 
 # ── General ──────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -83,11 +83,16 @@ No SDK. No code changes. Just point, configure, and connect.
 
 ## Get Started in 60 Seconds
 
+**Requires:** Docker 24+, `bash`, `openssl`. On macOS, make sure Docker Desktop is running first.
+
 ```bash
 git clone https://github.com/HelpCode-ai/anythingmcp.git
 cd anythingmcp && ./setup.sh
-# Open http://localhost:3000 — done!
+# When setup finishes, open http://localhost:3000 and register
+# the first user — they automatically become the admin.
 ```
+
+> ⚠️ **Register immediately after setup.** The first account to register becomes Admin. If your instance is reachable from the internet during setup, configure firewall rules or run setup with the UI bound to `127.0.0.1` until you've created the admin account.
 
 See the full [Quick Start](#quick-start) below for detailed configuration options.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,26 @@ AnythingMCP handles sensitive data (API keys, database credentials, OAuth tokens
 - **Use OAuth2 mode** — Preferred over legacy bearer tokens for MCP auth
 - **Rotate credentials regularly** — API keys, JWT secrets, encryption keys
 
+## Rotating secrets
+
+### `JWT_SECRET` and `COOKIE_SECRET`
+
+Update the value in `.env` and restart: `docker compose up -d`. Existing sessions invalidate immediately — no re-encryption needed.
+
+### `ENCRYPTION_KEY` (AES-256-GCM, stored credentials)
+
+`ENCRYPTION_KEY` encrypts connector credentials (API keys, OAuth tokens, database passwords) at rest. Rotating it requires re-encrypting every stored secret, because the existing ciphertext was sealed with the old key.
+
+Until a built-in rotation command ships (tracked in [ROADMAP.md](ROADMAP.md)), the safe procedure is:
+
+1. **Take a database backup** — `docker compose exec postgres pg_dump -U amcp anythingmcp > backup-pre-rotation.sql`.
+2. **Export connector configs** — from the Admin UI, export each connector to JSON (this captures the *decrypted* credentials in transit; keep the export file in a secure location and delete it after step 5).
+3. **Generate a new key** — `openssl rand -base64 32 | head -c 32` (must be exactly 32 ASCII chars).
+4. **Replace `ENCRYPTION_KEY` in `.env`, wipe the encrypted columns, and restart** — the simplest path is to drop and re-create the database from backup *without* the connector secrets, then restart the app with the new key.
+5. **Re-import each connector** from the JSON exports. New ciphertext is sealed with the new key.
+
+If your installation has many connectors, prefer waiting for the upcoming rotation CLI (or write your own script against `packages/backend/src/common/crypto/encryption.util.ts`). Do **not** simply swap the key in `.env` without re-encrypting — existing credentials will become unreadable and every connector will fail with a decryption error.
+
 ## Supported Versions
 
 | Version | Supported |

--- a/docs/connectors/rest.md
+++ b/docs/connectors/rest.md
@@ -6,6 +6,31 @@
 
 ---
 
+## 3-minute quickstart
+
+Goal: go from a running AnythingMCP instance to a working MCP tool call against a public API, without writing code.
+
+1. **Register** at `http://localhost:3000` (the first account becomes Admin).
+2. **Create a connector**: *Connectors → New Connector → REST*. Name it `VIES VAT`, Base URL `https://ec.europa.eu/taxation_customs/vies/rest-api`, Auth type `None`. Save.
+3. **Import the spec**: on the connector page, *Import → OpenAPI URL*, paste `https://ec.europa.eu/taxation_customs/vies/rest-api/openapi.json`. AnythingMCP generates one tool per operation. Toggle the tools you want exposed.
+4. **Issue an MCP API key**: *Profile → MCP API Keys → New Key*. Copy the value.
+5. **Point your MCP client at it**. For Claude Desktop, add to `claude_desktop_config.json`:
+   ```json
+   {
+     "mcpServers": {
+       "anythingmcp": {
+         "url": "http://localhost:4000/mcp",
+         "headers": { "Authorization": "Bearer <your-mcp-key>" }
+       }
+     }
+   }
+   ```
+   Restart Claude Desktop, then ask: *"Use AnythingMCP to validate VAT number DE123456789."* The tool call appears in the audit log at `/audit`.
+
+If you'd rather use a pre-built adapter (DHL, DPD, Personio, VIES, …) instead of importing from a spec, see [Pre-configured MCP Connectors](../../README.md#pre-configured-mcp-connectors) — those skip steps 2–3.
+
+---
+
 ## Overview
 
 The REST connector lets you expose HTTP-based APIs as MCP tools. It supports all HTTP methods, authentication types, and can auto-import tool definitions from multiple formats.


### PR DESCRIPTION
## Summary

Five concrete onboarding fixes triggered by an external QA review simulating a skeptical dev/buyer landing on the repo from the Show HN post. Each fix targets a gap a first-time user actually hits in the first 10 minutes.

### Changes

- **`README.md`** — list prerequisites (Docker 24+, bash, openssl), replace misleading `Open http://localhost:3000 — done!` with accurate post-setup instructions, and add a prominent ⚠️ warning that the first registered user becomes Admin (mitigation guidance for instances reachable from the internet during setup).
- **`.env.example`** — rewrite the header comment. `setup.sh` writes `.env` to the repo root (where `docker-compose.yml` lives); the old `Copy to packages/backend/.env` line was only correct for non-Docker local dev. New comment documents both paths.
- **`SECURITY.md`** — add a "Rotating secrets" section. `JWT_SECRET` / `COOKIE_SECRET` rotation is trivial (just restart). `ENCRYPTION_KEY` rotation requires re-encrypting stored credentials; the section documents the manual backup → export → wipe → re-import procedure and explicitly warns against simply swapping the key (which would render existing connector credentials unreadable). Notes that a rotation CLI is still pending.
- **`docs/connectors/rest.md`** — prepend a "3-minute quickstart" block with an end-to-end VIES VAT example so a first-time user has a concrete path from empty dashboard to a working MCP tool call in Claude Desktop. Today the doc is reference-heavy with no narrative flow.

### Why now

The repo's "Get Started in 60 Seconds" promise creates an expectation gap: the setup actually works in 60 seconds, but the path from "setup done" to "first successful MCP tool call" is undocumented. A skeptical evaluator who lands on an empty dashboard with no demo connector and a reference-style REST doc tends to drop off around minute 8.

These fixes don't change any code paths — they're docs/copy only.

## Test plan

- [ ] Render `README.md`, `SECURITY.md`, `.env.example`, `docs/connectors/rest.md` on GitHub and verify formatting (callouts, code fences, tables).
- [ ] Run `./setup.sh` end-to-end on a clean macOS box following only the new README quickstart — confirm a new user with Docker Desktop running can reach the login screen without consulting any other doc.
- [ ] Walk through the new REST quickstart in `docs/connectors/rest.md` with a real Claude Desktop client and confirm the VIES VAT tool call lands and shows up in the audit log.
- [ ] Sanity-check the `SECURITY.md` rotation procedure: the manual steps are accurate and the referenced crypto util path (`packages/backend/src/common/crypto/encryption.util.ts`) exists.