### PR TITLE
Sharpen positioning, add AUTHORS.md, disclose AI-assisted development

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,23 @@
+# Authors
+
+AnythingMCP is built by **helpcode.ai GmbH**, an independent team based in Freiburg, Germany.
+
+## Core team
+
+- **Matteo Morelli** ([@keysersoft](https://github.com/keysersoft)) — Architecture, backend, adapters
+
+## Development approach
+
+AnythingMCP is built by a small team using AI coding assistants (primarily Claude). Every commit is human-reviewed before merge; every adapter is validated by the catalog test suite (`packages/backend/src/adapters/catalog.spec.ts`); production deployments — including the one running this gateway since 2025 at the original industrial group that gave rise to the project — are operated by humans.
+
+We disclose this because trust is the whole point of a self-hosted MCP gateway. If you're evaluating AnythingMCP for production use, you should know exactly what you're getting: a project with a real-world origin story, a small team, an automated test suite, and AI-augmented velocity. The [GitHub contributor graph](https://github.com/HelpCode-ai/anythingmcp/graphs/contributors) reflects this honestly — including the `claude` co-author trailer that appears on AI-assisted commits.
+
+## Why we say this out loud
+
+In 2026 AI-assisted development is the norm, not the exception. We've found that *not* talking about it does more damage to trust than the practice itself ever could — buyers and contributors are quick to notice the gap between "production for 6 months" and a one-person contributor graph. So we name it: humans own every decision, AI helps us move faster, and the test suite + production deployment are the proof that the result works.
+
+## Contributors
+
+See the [GitHub contributors page](https://github.com/HelpCode-ai/anythingmcp/graphs/contributors) for the full list, including community PRs and the AI co-author trailers.
+
+If you'd like to be added to the core team list above (or removed from it), open a PR against this file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,17 @@ AnythingMCP is licensed under the [Business Source License 1.1](LICENSE) (BSL-1.
 2. You grant helpcode.ai GmbH a perpetual, irrevocable license to use, modify, and distribute your contribution under the project's license terms.
 3. You understand that your contribution may be re-licensed under Apache 2.0 on the Change Date (2030-03-04).
 
+## AI-assisted contributions
+
+We use AI assistants (Claude Code, GitHub Copilot, etc.) in our own development and we welcome contributions made with the same tools. The standards are the same as any human contribution:
+
+- You take responsibility for the code you submit — review every line before opening a PR.
+- The catalog test suite (`npm test`) must pass.
+- Adapter JSON must validate against [`docs/tool-definition.md`](docs/tool-definition.md).
+- Don't paste AI output blindly into the PR description; write the *why* in your own words.
+
+We will not refuse a PR because it was AI-assisted, and we will not single it out either. See [AUTHORS.md](AUTHORS.md) for how we use AI ourselves.
+
 ## Getting Started
 
 1. **Fork** the repository on GitHub

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <p align="center">
-  <h1 align="center">AnythingMCP — Self-Hosted MCP Server & API Gateway</h1>
+  <h1 align="center">AnythingMCP — The Self-Hosted MCP Gateway for Legacy &amp; Modern APIs</h1>
   <p align="center">
-    <strong>Turn any backend into an MCP server in minutes — APIs, databases, and other MCP servers.</strong><br/>
+    <strong>Turn REST, SOAP/WSDL, GraphQL and SQL endpoints into MCP tools — on your infrastructure, with full audit.</strong><br/>
+    Built for teams who can't (or won't) hand their credentials to a SaaS.<br/>
     REST to MCP &bull; SOAP to MCP &bull; GraphQL to MCP &bull; Database to MCP &bull; MCP Gateway &bull; MCP Middleware
   </p>
   <p align="center">
@@ -53,7 +54,7 @@
 
 </details>
 
-> 🏭 **Origin story** — AnythingMCP started inside a German industrial group that needed AI agents to talk to 15+ legacy systems (ERP, CRM, custom SOAP, on-prem Postgres). Writing one MCP server per system would have taken weeks each; we extracted the common gateway after the third rewrite and have been running it in production for ~6 months.
+> 🏭 **Origin story** — AnythingMCP started inside a German industrial group that needed AI agents to talk to 15+ legacy systems (ERP, CRM, custom SOAP, on-prem Postgres). Writing one MCP server per system would have taken weeks each; we extracted the common gateway after the third rewrite and have been running it in production for ~6 months. We open-sourced the gateway because the catalog grows faster as a community than as a single vendor. Built by a small team using AI coding assistants — see [AUTHORS.md](AUTHORS.md).
 
 ---
 
@@ -118,22 +119,25 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 | You have legacy SOAP/WSDL services | **SOAP to MCP** bridge with automatic WSDL parsing |
 | You need to query databases from AI agents | **Database to MCP** with auto-generated query tools |
 | You want one MCP gateway for all your APIs | **MCP middleware** that aggregates multiple connectors |
-| You need an MCP server for DHL/DPD/GLS/DATEV/Weclapp/etc. | **29 pre-built adapters** — install in one click |
+| You need an MCP server for DHL/DPD/GLS/DATEV/Weclapp/etc. | **30+ pre-built adapters** — install in one click |
 | You need auth, audit logs, and role-based access | Built-in **auth, audit log, and RBAC** |
+| You can't ship your API credentials to a SaaS gateway | **Runs entirely on your infrastructure** — credentials encrypted AES-256-GCM at rest, audit log stays on your DB |
+| You have SOAP / WSDL services or on-prem databases AI clients can't speak | **First-class SOAP & SQL support** — not just REST/SaaS integrations |
 
 ---
 
 ## How AnythingMCP Compares
 
-| Feature | AnythingMCP | Custom MCP Server | Other Gateways |
-|---------|:-----------:|:-----------------:|:--------------:|
+| Feature | AnythingMCP | Custom MCP Server | Hosted MCP Gateways |
+|---------|:-----------:|:-----------------:|:-------------------:|
 | No-code setup | ✅ Visual editor | ❌ Write code | ⚠️ Config files |
-| SOAP / WSDL support | ✅ Built-in | ❌ Manual | ❌ Rare |
+| SOAP / WSDL support | ✅ Built-in | ❌ Manual | ❌ Typically not supported |
 | Database connectors | ✅ 7 engines | ❌ Build yourself | ⚠️ Limited |
 | Visual tool editor | ✅ | ❌ | ❌ |
 | Auth & audit trail | ✅ OAuth2, RBAC, logs | ❌ DIY | ⚠️ Partial |
-| Self-hosted or Cloud | ✅ Docker / Railway / DigitalOcean / [Cloud](https://cloud.anythingmcp.com) | ✅ | ⚠️ Often SaaS-only |
-| Pre-built SaaS adapters | ✅ 29+ ready-to-use | ❌ Build each | ⚠️ Few |
+| Where credentials live | ✅ On your infra (AES-256-GCM) | ✅ Your code | ⚠️ On the gateway provider |
+| Self-hosted option | ✅ Docker / Railway / DigitalOcean / [Cloud](https://cloud.anythingmcp.com) | ✅ | ⚠️ Often SaaS-only |
+| Pre-built SaaS adapters | ✅ 30+ ready-to-use | ❌ Build each | ⚠️ Few |
 | Multi-client support | ✅ Claude, ChatGPT, Gemini, Copilot, Cursor | ✅ | ⚠️ Varies |
 
 ---
@@ -142,7 +146,7 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 
 - **5 Connector Types** — [REST](docs/connectors/rest.md), [SOAP](docs/connectors/soap.md), [GraphQL](docs/connectors/graphql.md), [Database](docs/connectors/database.md) (PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, MongoDB, SQLite), [MCP-to-MCP Bridge](docs/connectors/mcp-bridge.md)
 - **6 Import Formats** — OpenAPI/Swagger, Postman Collections, cURL commands, WSDL, GraphQL introspection, custom JSON
-- **29 Pre-built Adapters** — Install logistics, ERP, HR, public-data and e-commerce MCP servers from a single JSON file — see [list](#pre-configured-mcp-connectors)
+- **30+ Pre-built Adapters** — Install logistics, ERP, HR, public-data and e-commerce MCP servers from a single JSON file — see [list](#pre-configured-mcp-connectors)
 - **Dynamic MCP Server** — Tools registered at runtime, no restart needed
 - **Visual Tool Editor** — Map parameters to path, query, body, headers visually
 - **Database Auto-Tools** — Schema introspection + dynamic query execution out of the box
@@ -157,7 +161,7 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 
 ## Pre-configured MCP Connectors
 
-AnythingMCP ships with **29 ready-to-use MCP server adapters** — provide your API credentials at import time and the tools become available to your AI client immediately. Each adapter has its own setup guide on [anythingmcp.com](https://anythingmcp.com/guides) (English, German, Italian).
+AnythingMCP ships with **30+ ready-to-use MCP server adapters** — provide your API credentials at import time and the tools become available to your AI client immediately. Each adapter has its own setup guide on [anythingmcp.com](https://anythingmcp.com/guides) (English, German, Italian).
 
 > 📍 **Heads-up on the catalog:** the starting set leans heavily DACH (Germany / Austria / Switzerland) because that's where we built this in production first. US/UK/APAC SaaS adapters are very welcome as community PRs — there's a [good first issue](https://github.com/HelpCode-ai/anythingmcp/issues/150) walking you through adding one in ~30 minutes (it's a single JSON file).
 


### PR DESCRIPTION
## Summary

Two of the discoverability blockers identified in the onboarding audit, addressed together in one PR because they share a single coherent narrative: *who AnythingMCP is for* and *who is building it*. No competitor is named or attacked.

### README — positioning rewrite

- **Hero** now leads with what no competing MCP gateway offers — SOAP/WSDL + on-prem credentials. New subhead names the target audience directly: *"teams who can't (or won't) hand their credentials to a SaaS"*.
- **Origin story** extended with one sentence on why the project is open (the catalog grows faster as a community than as a single vendor) and a pointer to the new AUTHORS.md.
- **"Why AnythingMCP?" table** gains two rows that make the credentials-on-your-infra and SOAP/SQL differentiators explicit instead of implied.
- **"How AnythingMCP Compares" table** — column rename from `Other Gateways` to `Hosted MCP Gateways` (descriptive, not pejorative); new "Where credentials live" row.
- **Adapter count** standardised on "30+" everywhere it appeared. The previous mix of "29", "29+" and "30" was inconsistent. "30+" matches the new GitHub repo description and stays accurate as the catalog grows.

### AUTHORS.md (new)

- Names helpcode.ai GmbH and the core team.
- Direct disclosure: *"built by a small team using AI coding assistants (primarily Claude). Every commit human-reviewed."* Framed as the 2026 norm, not an apology.
- Explains why disclosure *strengthens* trust for a self-hosted gateway: the gap between "in production for ~6 months" and a one-person contributor graph is what damaged credibility, not the practice itself.

### CONTRIBUTING.md

- New "AI-assisted contributions" section after the license-grant block. Welcomes AI-assisted PRs with the same quality bar as human PRs and cross-references AUTHORS.md.

## Why now

The onboarding audit identified that the first 30 seconds on the repo / first ~100 lines of README don't differentiate AnythingMCP from Composio / Smithery / mcp.run / Cloudflare MCP — competitors that have appeared in the last 6 months and that already have a much larger marketing footprint. The trust narrative gap (the `claude` co-author user appearing alongside the sole human contributor with no explanation) compounded that problem for skeptical buyers.

Both fixes are docs-only — no behaviour change, no migration risk.

## Test plan

- [ ] Render README.md on GitHub and confirm: hero is clear in <10 seconds; "Why" and "Compares" tables show the new rows; no broken markdown.
- [ ] Open AUTHORS.md and confirm the team listing is correct (add other team members in a follow-up if needed).
- [ ] Open CONTRIBUTING.md and verify the new section renders correctly between "License" and "Getting Started".
- [ ] Cold-reader test: someone who's never seen the repo reads the first 60 lines and tells you, in their own words, who AnythingMCP is for. Target answer: *"a self-hosted MCP gateway, especially for SOAP/legacy and teams who can't send credentials to a SaaS."*