### PR TITLE
Add 6 non-DACH adapters: Companies House UK, Wise, Razorpay, Mercado Libre, Paystack, LINE

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 | You have legacy SOAP/WSDL services | **SOAP to MCP** bridge with automatic WSDL parsing |
 | You need to query databases from AI agents | **Database to MCP** with auto-generated query tools |
 | You want one MCP gateway for all your APIs | **MCP middleware** that aggregates multiple connectors |
-| You need an MCP server for DHL/DPD/GLS/DATEV/Weclapp/etc. | **30+ pre-built adapters** — install in one click |
+| You need an MCP server for DHL/DPD/GLS/DATEV/Weclapp/etc. | **36 pre-built adapters** — install in one click |
 | You need auth, audit logs, and role-based access | Built-in **auth, audit log, and RBAC** |
 | You can't ship your API credentials to a SaaS gateway | **Runs entirely on your infrastructure** — credentials encrypted AES-256-GCM at rest, audit log stays on your DB |
 | You have SOAP / WSDL services or on-prem databases AI clients can't speak | **First-class SOAP & SQL support** — not just REST/SaaS integrations |
@@ -146,7 +146,7 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 
 - **5 Connector Types** — [REST](docs/connectors/rest.md), [SOAP](docs/connectors/soap.md), [GraphQL](docs/connectors/graphql.md), [Database](docs/connectors/database.md) (PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, MongoDB, SQLite), [MCP-to-MCP Bridge](docs/connectors/mcp-bridge.md)
 - **6 Import Formats** — OpenAPI/Swagger, Postman Collections, cURL commands, WSDL, GraphQL introspection, custom JSON
-- **30+ Pre-built Adapters** — Install logistics, ERP, HR, public-data and e-commerce MCP servers from a single JSON file — see [list](#pre-configured-mcp-connectors)
+- **36 Pre-built Adapters** — Install logistics, ERP, HR, public-data, payments, e-commerce and messaging MCP servers from a single JSON file — see [list](#pre-configured-mcp-connectors)
 - **Dynamic MCP Server** — Tools registered at runtime, no restart needed
 - **Visual Tool Editor** — Map parameters to path, query, body, headers visually
 - **Database Auto-Tools** — Schema introspection + dynamic query execution out of the box
@@ -161,9 +161,9 @@ See the full [Quick Start](#quick-start) below for detailed configuration option
 
 ## Pre-configured MCP Connectors
 
-AnythingMCP ships with **30+ ready-to-use MCP server adapters** — provide your API credentials at import time and the tools become available to your AI client immediately. Each adapter has its own setup guide on [anythingmcp.com](https://anythingmcp.com/guides) (English, German, Italian).
+AnythingMCP ships with **36 ready-to-use MCP server adapters** — DACH-rooted but now reaching the UK, India, Brasil, Nigeria and Japan. Provide your API credentials at import time and the tools become available to your AI client immediately. Each adapter has its own setup guide on [anythingmcp.com](https://anythingmcp.com/guides) (English, German, Italian).
 
-> 📍 **Heads-up on the catalog:** the starting set leans heavily DACH (Germany / Austria / Switzerland) because that's where we built this in production first. US/UK/APAC SaaS adapters are very welcome as community PRs — there's a [good first issue](https://github.com/HelpCode-ai/anythingmcp/issues/150) walking you through adding one in ~30 minutes (it's a single JSON file).
+> 📍 **Heads-up on the catalog:** the starting set leans DACH (Germany / Austria / Switzerland) because that's where we built this in production first, with first-wave international coverage now landing across the UK 🇬🇧, India 🇮🇳, Brasil 🇧🇷, Nigeria 🇳🇬 and Japan 🇯🇵. US/APAC SaaS adapters are very welcome as community PRs — there's a [good first issue](https://github.com/HelpCode-ai/anythingmcp/issues/150) walking you through adding one in ~30 minutes (it's a single JSON file).
 
 ### Logistics & Shipping
 
@@ -197,6 +197,7 @@ AnythingMCP ships with **30+ ready-to-use MCP server adapters** — provide your
 | **Shopware 6** | Storefront API — products, categories, search | [Shopware 6 MCP Server](https://anythingmcp.com/guides/shopware-6-to-mcp) |
 | **Oxomi** | Baustoff catalog & media portal (datasheets, CAD, safety sheets) | [Oxomi MCP Server](https://anythingmcp.com/guides/oxomi-to-mcp) |
 | **ImmobilienScout24** | German real-estate listings — search, manage, market data | [ImmobilienScout24 MCP Server](https://anythingmcp.com/guides/immobilienscout24-to-mcp) |
+| **Mercado Libre** 🌎 | LATAM marketplace (BR, AR, MX, CL, CO, PE, UY) — search items, fetch products, list seller orders | [Mercado Libre MCP Server](https://anythingmcp.com/guides/mercado-libre-to-mcp) |
 
 ### HR & Field Service
 
@@ -212,6 +213,7 @@ AnythingMCP ships with **30+ ready-to-use MCP server adapters** — provide your
 |-----------|-------------|-------|
 | **VIES VAT Validation** | Validate EU VAT numbers — official European Commission API | [VIES MCP Server](https://anythingmcp.com/guides/vies-vat-to-mcp) |
 | **Handelsregister** | German commercial register — companies, shareholders, documents | [Handelsregister MCP Server](https://anythingmcp.com/guides/handelsregister-to-mcp) |
+| **UK Companies House** 🇬🇧 | UK companies register — search, profiles, officers, filings (free tier) | [UK Companies House MCP Server](https://anythingmcp.com/guides/uk-companies-house-to-mcp) |
 | **OpenPLZ Germany** | Postal codes, localities, streets, federal districts (BKG data) | [OpenPLZ MCP Server](https://anythingmcp.com/guides/openplz-to-mcp) |
 | **Bundesbank Statistics** | German central bank — exchange rates, monetary, financial markets | [Bundesbank MCP Server](https://anythingmcp.com/guides/bundesbank-to-mcp) |
 | **DESTATIS Genesis** | Federal Statistical Office — demographics, economy, trade | [DESTATIS MCP Server](https://anythingmcp.com/guides/destatis-genesis-to-mcp) |
@@ -222,7 +224,10 @@ AnythingMCP ships with **30+ ready-to-use MCP server adapters** — provide your
 | Connector | Description | Guide |
 |-----------|-------------|-------|
 | **N26 Open Banking** | PSD2 access — balances, transactions, payment initiation | [N26 MCP Server](https://anythingmcp.com/guides/n26-openbanking-to-mcp) |
+| **Wise** 🇬🇧 | International money transfers — profiles, balances, quotes, transfers (sandbox available) | [Wise MCP Server](https://anythingmcp.com/guides/wise-to-mcp) |
 | **PAYONE** | Payment processing — transactions, refunds, status | [PAYONE MCP Server](https://anythingmcp.com/guides/payone-to-mcp) |
+| **Razorpay** 🇮🇳 | India's leading payment gateway — UPI, cards, netbanking, payment links, refunds (test mode no-KYC) | [Razorpay MCP Server](https://anythingmcp.com/guides/razorpay-to-mcp) |
+| **Paystack** 🇳🇬 | Leading African payment processor (NG, GH, ZA, KE) — transactions, customers, refunds (test mode no-KYC) | [Paystack MCP Server](https://anythingmcp.com/guides/paystack-to-mcp) |
 | **TeamViewer** | Remote-access devices, sessions, users | [TeamViewer MCP Server](https://anythingmcp.com/guides/teamviewer-to-mcp) |
 
 ### Construction & Mapping
@@ -231,6 +236,12 @@ AnythingMCP ships with **30+ ready-to-use MCP server adapters** — provide your
 |-----------|-------------|-------|
 | **PlanRadar** | Construction & real-estate project management — tickets, layers | [PlanRadar MCP Server](https://anythingmcp.com/guides/planradar-to-mcp) |
 | **HERE Geocoding** | Worldwide geocoding, autocomplete, place discovery (free tier) | [HERE MCP Server](https://anythingmcp.com/guides/here-geocoding-to-mcp) |
+
+### Messaging & Communication
+
+| Connector | Description | Guide |
+|-----------|-------------|-------|
+| **LINE Messaging API** 🇯🇵 | Dominant chat platform in JP/TW/TH — push, reply and broadcast from a LINE Official Account (500 free pushes/month, unlimited replies) | [LINE MCP Server](https://anythingmcp.com/guides/line-messaging-to-mcp) |
 
 </details>
 

--- a/packages/backend/src/adapters/br/mercado-libre.json
+++ b/packages/backend/src/adapters/br/mercado-libre.json
@@ -1,0 +1,143 @@
+{
+  "slug": "mercado-libre",
+  "name": "Mercado Libre",
+  "description": "LATAM's largest e-commerce marketplace — search items, fetch product details, look up users, and list seller orders across Brasil (MLB), Argentina (MLA), Mexico (MLM), Chile (MLC), Colombia (MCO), Peru (MPE), Uruguay (MLU). OAuth2 access token required for every endpoint.",
+  "instructions": "This connector uses the Mercado Libre REST API.\n\n**All endpoints now require OAuth2.** Historically `/sites/{site_id}/search`, `/items/{item_id}` and `/users/{user_id}` were public, but as of 2025 Mercado Libre returns HTTP 403 on unauthenticated calls. You need a valid access token for every tool in this adapter.\n\n**Creating an app**: register at https://developers.mercadolibre.com/devcenter → 'Create app' → set a redirect URI (e.g. `https://your-anythingmcp-host/oauth/callback`). Copy `client_id` and `client_secret` into the env vars.\n\n**Authorization URL**: pick the country-specific URL based on the seller's marketplace:\n- Brasil: `https://auth.mercadolivre.com.br/authorization`\n- Argentina: `https://auth.mercadolibre.com.ar/authorization`\n- Mexico: `https://auth.mercadolibre.com.mx/authorization`\n- (and similar for .cl, .co, .pe, .com.uy)\n\nThis adapter defaults to Brasil — change it after import if your seller is on a different marketplace.\n\n**Site ids** (used by `search_items` and `get_item`):\n- MLB = Brasil, MLA = Argentina, MLM = Mexico, MLC = Chile, MCO = Colombia, MPE = Peru, MLU = Uruguay\n\n**Item ids**: format `{SITE}{NUMBER}` (e.g. `MLB1234567890`). Always include the site prefix.\n\n**Rate limits**: 60,000 calls/hour per app for read endpoints; lower for write endpoints. Returns 429 with `X-RateLimit-*` headers when exceeded.\n\n**Seller-specific endpoints** (`list_orders`) require the OAuth2 token to belong to the seller whose orders you're querying — you cannot view another seller's orders even with valid auth.",
+  "region": "br",
+  "category": "ecommerce",
+  "icon": "mercado-libre",
+  "docsUrl": "https://developers.mercadolibre.com/en_us/api-docs-en",
+  "requiredEnvVars": ["MERCADO_LIBRE_CLIENT_ID", "MERCADO_LIBRE_CLIENT_SECRET"],
+  "connector": {
+    "name": "Mercado Libre",
+    "type": "REST",
+    "baseUrl": "https://api.mercadolibre.com",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "clientId": "{{MERCADO_LIBRE_CLIENT_ID}}",
+      "clientSecret": "{{MERCADO_LIBRE_CLIENT_SECRET}}",
+      "authorizationUrl": "https://auth.mercadolivre.com.br/authorization",
+      "tokenUrl": "https://api.mercadolibre.com/oauth/token",
+      "scopes": "offline_access read write"
+    }
+  },
+  "tools": [
+    {
+      "name": "mercado_libre_search_items",
+      "description": "Search items in a Mercado Libre site (country marketplace). Returns matches with item id (e.g. 'MLB1234567890'), title, price, currency, condition (new/used), thumbnail, seller id, available_quantity, and permalink to the listing.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "site_id": {
+            "type": "string",
+            "description": "Site code: MLB=Brasil, MLA=Argentina, MLM=Mexico, MLC=Chile, MCO=Colombia, MPE=Peru, MLU=Uruguay."
+          },
+          "q": {
+            "type": "string",
+            "description": "Search query — free-text product keywords."
+          },
+          "category": {
+            "type": "string",
+            "description": "Optional Mercado Libre category id to scope the search (e.g. 'MLB1144' for video games on the Brasil site)."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default 50, max 50)."
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination (max 1000)."
+          }
+        },
+        "required": ["site_id", "q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sites/{site_id}/search",
+        "queryParams": {
+          "q": "$q",
+          "category": "$category",
+          "limit": "$limit",
+          "offset": "$offset"
+        }
+      }
+    },
+    {
+      "name": "mercado_libre_get_item",
+      "description": "Fetch full details for a Mercado Libre item by id. Returns title, description, price, currency, listing type, all attributes (brand, model, condition, …), pictures, available_quantity, sold_quantity, warranty, seller_id, and shipping options.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "item_id": {
+            "type": "string",
+            "description": "Mercado Libre item id including site prefix (e.g. 'MLB1234567890')."
+          }
+        },
+        "required": ["item_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/items/{item_id}"
+      }
+    },
+    {
+      "name": "mercado_libre_get_user",
+      "description": "Get a user's public profile (typically used to inspect a seller). Returns id, nickname, country_id, registration_date, seller_reputation (level_id, transactions completed/canceled, ratings positive/neutral/negative), and listing site.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "description": "Mercado Libre user/seller id (numeric, e.g. '123456789')."
+          }
+        },
+        "required": ["user_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/users/{user_id}"
+      }
+    },
+    {
+      "name": "mercado_libre_list_orders",
+      "description": "List orders for an authenticated seller. Requires an OAuth2 token belonging to the seller. Returns order id, status (paid/cancelled/confirmed), date_created, total amount, buyer summary, order items, and shipping details.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "seller": {
+            "type": "string",
+            "description": "Seller id (must match the authenticated user's id)."
+          },
+          "order_status": {
+            "type": "string",
+            "description": "Optional filter: 'paid', 'cancelled', 'confirmed', 'payment_required', 'payment_in_process'."
+          },
+          "sort": {
+            "type": "string",
+            "description": "Sort order: 'date_asc' or 'date_desc' (default)."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default 50, max 50)."
+          },
+          "offset": {
+            "type": "number",
+            "description": "Offset for pagination."
+          }
+        },
+        "required": ["seller"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/search",
+        "queryParams": {
+          "seller": "$seller",
+          "order.status": "$order_status",
+          "sort": "$sort",
+          "limit": "$limit",
+          "offset": "$offset"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -28,6 +28,12 @@ import * as shopware6 from './de/shopware-6.json';
 import * as hereGeocoding from './de/here-geocoding.json';
 import * as personio from './de/personio.json';
 import * as hrworks from './de/hrworks.json';
+import * as companiesHouse from './gb/companies-house.json';
+import * as wise from './gb/wise.json';
+import * as razorpay from './in/razorpay.json';
+import * as mercadoLibre from './br/mercado-libre.json';
+import * as paystack from './ng/paystack.json';
+import * as lineMessaging from './jp/line-messaging.json';
 
 export interface AdapterMeta {
   slug: string;
@@ -95,6 +101,12 @@ const ALL_ADAPTERS: AdapterDefinition[] = [
   hereGeocoding as unknown as AdapterDefinition,
   personio as unknown as AdapterDefinition,
   hrworks as unknown as AdapterDefinition,
+  companiesHouse as unknown as AdapterDefinition,
+  wise as unknown as AdapterDefinition,
+  razorpay as unknown as AdapterDefinition,
+  mercadoLibre as unknown as AdapterDefinition,
+  paystack as unknown as AdapterDefinition,
+  lineMessaging as unknown as AdapterDefinition,
 ];
 
 export function listAdapters(): AdapterMeta[] {

--- a/packages/backend/src/adapters/gb/companies-house.json
+++ b/packages/backend/src/adapters/gb/companies-house.json
@@ -1,0 +1,132 @@
+{
+  "slug": "companies-house",
+  "name": "UK Companies House",
+  "description": "Search and inspect the official UK companies register: company profiles, directors and secretaries, filing history. Free public API with a 600 requests / 5 minutes rate limit. The UK equivalent of the German Handelsregister.",
+  "instructions": "This connector uses the UK Companies House Public Data API v1.\n\n**Getting an API key**: register a free account at https://developer.company-information.service.gov.uk → 'Manage applications' → 'Create an application' (pick Live or Test) → 'Create new key' → REST. Copy the generated key into `COMPANIES_HOUSE_API_KEY`.\n\n**Authentication quirk**: Companies House uses HTTP Basic Auth where the API key is the **username** and the **password is empty** (the canonical curl shape is `-u API_KEY:`). This adapter mirrors that — leave the password configuration empty.\n\n**Company numbers**: always 8 characters, zero-padded (e.g. `00006400` not `6400`). The search endpoint returns matches with the canonical number you can feed into the other tools.\n\n**Rate limit**: 600 requests per 5-minute window per API key. Returns HTTP 429 with `Retry-After` when exceeded.\n\n**Free**: no paid tier required for the Public Data API. Streaming/companies-bulk products require separate registration.",
+  "region": "gb",
+  "category": "government",
+  "icon": "companies-house",
+  "docsUrl": "https://developer.company-information.service.gov.uk/",
+  "requiredEnvVars": ["COMPANIES_HOUSE_API_KEY"],
+  "connector": {
+    "name": "UK Companies House",
+    "type": "REST",
+    "baseUrl": "https://api.company-information.service.gov.uk",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{COMPANIES_HOUSE_API_KEY}}",
+      "password": ""
+    }
+  },
+  "tools": [
+    {
+      "name": "companies_house_search_company",
+      "description": "Search the UK companies register by company name or number. Returns up to `items_per_page` matches with company number, title, status (active/dissolved/liquidation), address snippet, and incorporation date.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search query — company name, partial name, or company number."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Max results to return (default 20, max 100)."
+          },
+          "start_index": {
+            "type": "number",
+            "description": "Offset for pagination (0-based)."
+          }
+        },
+        "required": ["q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/search/companies",
+        "queryParams": {
+          "q": "$q",
+          "items_per_page": "$items_per_page",
+          "start_index": "$start_index"
+        }
+      }
+    },
+    {
+      "name": "companies_house_get_company_profile",
+      "description": "Fetch the full profile for a UK company by its 8-character zero-padded company number. Returns registered office address, company status, type (ltd/plc/llp/…), incorporation date, SIC codes, accounts and confirmation-statement filing dates.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "company_number": {
+            "type": "string",
+            "description": "8-character zero-padded company number (e.g. '00006400'). Obtain from companies_house_search_company."
+          }
+        },
+        "required": ["company_number"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/{company_number}"
+      }
+    },
+    {
+      "name": "companies_house_list_officers",
+      "description": "List directors, secretaries and other officers (current and resigned) for a UK company. Returns officer name, role, appointment date, resignation date if any, date of birth (month/year only), nationality, country of residence.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "company_number": {
+            "type": "string",
+            "description": "8-character zero-padded company number."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Max results (default 35, max 100)."
+          },
+          "register_view": {
+            "type": "boolean",
+            "description": "If true, show only the officers currently in the register view."
+          }
+        },
+        "required": ["company_number"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/{company_number}/officers",
+        "queryParams": {
+          "items_per_page": "$items_per_page",
+          "register_view": "$register_view"
+        }
+      }
+    },
+    {
+      "name": "companies_house_list_filings",
+      "description": "List the filing history (accounts, confirmation statements, officer appointments, share allotments, …) for a UK company. Returns filing type, description, date, and a link to the underlying document on the Companies House website.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "company_number": {
+            "type": "string",
+            "description": "8-character zero-padded company number."
+          },
+          "category": {
+            "type": "string",
+            "description": "Filter by category: 'accounts', 'address', 'annual-return', 'capital', 'change-of-name', 'incorporation', 'officers', 'persons-with-significant-control', 'resolution'."
+          },
+          "items_per_page": {
+            "type": "number",
+            "description": "Max results (default 25, max 100)."
+          }
+        },
+        "required": ["company_number"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/company/{company_number}/filing-history",
+        "queryParams": {
+          "category": "$category",
+          "items_per_page": "$items_per_page"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/gb/wise.json
+++ b/packages/backend/src/adapters/gb/wise.json
@@ -1,0 +1,157 @@
+{
+  "slug": "wise",
+  "name": "Wise (formerly TransferWise)",
+  "description": "Manage international money transfers via the Wise Platform API: list personal and business profiles, view balances, create quotes, list past transfers. Sandbox environment available for free at sandbox.transferwise.tech.",
+  "instructions": "This connector uses the Wise Platform API.\n\n**Production base URL**: `https://api.wise.com` (default).\n\n**Sandbox base URL**: `https://api.sandbox.transferwise.tech`. If you want to use the sandbox, override the connector's base URL after import — sandbox API tokens do not work against the production host and vice versa.\n\n**Getting an API token**:\n- Production: log in to wise.com → Settings → API tokens → Create new token. Choose `Read` for read-only tools, `Full access` for create-quote.\n- Sandbox: sign up at https://sandbox.transferwise.tech → Settings → API tokens. Sandbox tokens are free and unlimited for testing.\n\n**Profile types**: Wise accounts have one personal profile (`type=personal`) and optionally one or more business profiles (`type=business`). All other endpoints require a `profileId` returned by `wise_list_profiles`.\n\n**Idempotency**: `wise_create_quote` requires an `X-idempotency-key` header — pass a unique UUID per logical request so retries don't create duplicate quotes.\n\n**Currencies**: ISO-4217 three-letter codes (USD, EUR, GBP, …).",
+  "region": "gb",
+  "category": "banking",
+  "icon": "wise",
+  "docsUrl": "https://docs.wise.com/api-docs",
+  "requiredEnvVars": ["WISE_API_TOKEN"],
+  "connector": {
+    "name": "Wise",
+    "type": "REST",
+    "baseUrl": "https://api.wise.com",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{WISE_API_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "wise_list_profiles",
+      "description": "List all personal and business profiles linked to the API token. Returns profile id, type (personal/business), full name or business name, and details object. The profile id is needed for every other Wise tool.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/profiles"
+      }
+    },
+    {
+      "name": "wise_get_balances",
+      "description": "Get all balances for a profile (one balance per currency held). Returns balance id, currency, available amount, reserved amount, and the linked bank-details record if any.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "profileId": {
+            "type": "string",
+            "description": "Wise profile id from wise_list_profiles."
+          },
+          "types": {
+            "type": "string",
+            "description": "Comma-separated balance types to include: 'STANDARD' (default), 'SAVINGS'."
+          }
+        },
+        "required": ["profileId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v4/profiles/{profileId}/balances",
+        "queryParams": {
+          "types": "$types"
+        }
+      }
+    },
+    {
+      "name": "wise_create_quote",
+      "description": "Create a Wise quote for an international transfer. Quotes are valid for 30 minutes and contain the live FX rate, fees, and arrival estimate. Specify exactly one of sourceAmount or targetAmount — Wise calculates the other side.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "profileId": {
+            "type": "string",
+            "description": "Wise profile id from wise_list_profiles."
+          },
+          "sourceCurrency": {
+            "type": "string",
+            "description": "ISO-4217 source currency code (e.g. 'GBP')."
+          },
+          "targetCurrency": {
+            "type": "string",
+            "description": "ISO-4217 target currency code (e.g. 'EUR')."
+          },
+          "sourceAmount": {
+            "type": "number",
+            "description": "Amount to send in source currency. Set EITHER sourceAmount OR targetAmount, not both."
+          },
+          "targetAmount": {
+            "type": "number",
+            "description": "Amount to receive in target currency. Set EITHER sourceAmount OR targetAmount, not both."
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Unique UUID per logical request — Wise uses this to dedupe retries. Required."
+          }
+        },
+        "required": ["profileId", "sourceCurrency", "targetCurrency", "idempotencyKey"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/v3/profiles/{profileId}/quotes",
+        "headers": {
+          "X-idempotency-key": "$idempotencyKey"
+        },
+        "bodyMapping": {
+          "sourceCurrency": "$sourceCurrency",
+          "targetCurrency": "$targetCurrency",
+          "sourceAmount": "$sourceAmount",
+          "targetAmount": "$targetAmount"
+        }
+      }
+    },
+    {
+      "name": "wise_list_transfers",
+      "description": "List past transfers for a profile, with optional filters by status (incoming_payment_waiting, processing, funds_converted, outgoing_payment_sent, cancelled, …), creation date range, and source/target currency.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "type": "string",
+            "description": "Wise profile id from wise_list_profiles."
+          },
+          "status": {
+            "type": "string",
+            "description": "Filter by transfer status."
+          },
+          "sourceCurrency": {
+            "type": "string",
+            "description": "ISO-4217 source currency code."
+          },
+          "targetCurrency": {
+            "type": "string",
+            "description": "ISO-4217 target currency code."
+          },
+          "createdDateStart": {
+            "type": "string",
+            "description": "ISO-8601 start date (e.g. '2026-01-01T00:00:00.000Z')."
+          },
+          "createdDateEnd": {
+            "type": "string",
+            "description": "ISO-8601 end date."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Max results (default 100)."
+          }
+        },
+        "required": ["profile"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v1/transfers",
+        "queryParams": {
+          "profile": "$profile",
+          "status": "$status",
+          "sourceCurrency": "$sourceCurrency",
+          "targetCurrency": "$targetCurrency",
+          "createdDateStart": "$createdDateStart",
+          "createdDateEnd": "$createdDateEnd",
+          "limit": "$limit"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/in/razorpay.json
+++ b/packages/backend/src/adapters/in/razorpay.json
@@ -1,0 +1,163 @@
+{
+  "slug": "razorpay",
+  "name": "Razorpay",
+  "description": "India's leading payment gateway. Create orders, fetch payments, manage refunds, and issue payment links. Supports UPI, cards, netbanking, wallets. Test mode keys (`rzp_test_*`) require no KYC — sign up and create in minutes.",
+  "instructions": "This connector uses the Razorpay v1 REST API.\n\n**Getting test API keys**: sign up at https://dashboard.razorpay.com → Settings → API Keys → Generate Test Key. You get a `key_id` (prefix `rzp_test_`) and a `key_secret`. Both are required.\n\n**Authentication**: HTTP Basic Auth with `key_id` as username and `key_secret` as password.\n\n**Amount convention**: Razorpay amounts are integers in the **smallest currency unit** — for INR this is **paise**, so ₹100 = `10000`. Same for other currencies (USD → cents, EUR → cents). Pass the value already multiplied; do NOT pass decimals.\n\n**Test mode**: completely free, no KYC required. Test cards: card number `4111 1111 1111 1111`, any future expiry, any CVV. UPI test handle: `success@razorpay`.\n\n**Production**: requires Razorpay KYC (business documents, bank account verification). Live keys start with `rzp_live_` — never commit them.",
+  "region": "in",
+  "category": "payments",
+  "icon": "razorpay",
+  "docsUrl": "https://razorpay.com/docs/api/",
+  "requiredEnvVars": ["RAZORPAY_KEY_ID", "RAZORPAY_KEY_SECRET"],
+  "connector": {
+    "name": "Razorpay",
+    "type": "REST",
+    "baseUrl": "https://api.razorpay.com/v1",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{RAZORPAY_KEY_ID}}",
+      "password": "{{RAZORPAY_KEY_SECRET}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "razorpay_create_order",
+      "description": "Create a Razorpay order. Orders are the recommended flow: create on the server, attach to a checkout, receive payment, then verify the resulting payment. Returns the order id (prefix `order_`) needed for the checkout.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "Amount in the smallest currency unit (e.g. 10000 = ₹100.00 for INR)."
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO-4217 currency code: 'INR', 'USD', 'EUR', 'GBP', etc."
+          },
+          "receipt": {
+            "type": "string",
+            "description": "Your internal receipt / order id (max 40 chars). Shown on the Razorpay dashboard for reconciliation."
+          },
+          "notes": {
+            "type": "object",
+            "description": "Optional key-value object of arbitrary metadata (max 15 keys, key+value ≤ 256 chars)."
+          },
+          "payment_capture": {
+            "type": "number",
+            "description": "1 = auto-capture on payment success (default), 0 = authorize only, capture later via API."
+          }
+        },
+        "required": ["amount", "currency"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/orders",
+        "bodyMapping": {
+          "amount": "$amount",
+          "currency": "$currency",
+          "receipt": "$receipt",
+          "notes": "$notes",
+          "payment_capture": "$payment_capture"
+        }
+      }
+    },
+    {
+      "name": "razorpay_fetch_payment",
+      "description": "Fetch a single payment by its id (prefix `pay_`). Returns status (created/authorized/captured/refunded/failed), amount, method (card/upi/netbanking/wallet/emi), card/bank/upi details, fees, tax, and any error code/description.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "payment_id": {
+            "type": "string",
+            "description": "Razorpay payment id (prefix 'pay_')."
+          }
+        },
+        "required": ["payment_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/payments/{payment_id}"
+      }
+    },
+    {
+      "name": "razorpay_list_refunds",
+      "description": "List refunds across the account, optionally filtered by payment id. Returns refund id, payment id, amount, status (pending/processed/failed), created_at, and speed (normal/optimum/instant).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "payment_id": {
+            "type": "string",
+            "description": "Optional — return only refunds for this payment id."
+          },
+          "count": {
+            "type": "number",
+            "description": "Max results (default 10, max 100)."
+          },
+          "skip": {
+            "type": "number",
+            "description": "Offset for pagination."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/refunds",
+        "queryParams": {
+          "payment_id": "$payment_id",
+          "count": "$count",
+          "skip": "$skip"
+        }
+      }
+    },
+    {
+      "name": "razorpay_create_payment_link",
+      "description": "Create a Razorpay-hosted payment link (short_url) you can send by email/SMS/WhatsApp. The customer pays on Razorpay's page; you get a webhook + can verify via fetch_payment. Returns the link id and short_url.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "Amount in smallest currency unit (e.g. 10000 = ₹100 for INR)."
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO-4217 currency code (e.g. 'INR')."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description shown to the customer on the payment page (max 2048 chars)."
+          },
+          "customer": {
+            "type": "object",
+            "description": "Customer object: { name, email, contact }. Pre-fills the checkout form."
+          },
+          "notify": {
+            "type": "object",
+            "description": "Channels to send the link on: { sms: true/false, email: true/false }."
+          },
+          "reminder_enable": {
+            "type": "boolean",
+            "description": "Whether Razorpay should send automatic reminders before expiry."
+          },
+          "expire_by": {
+            "type": "number",
+            "description": "Unix epoch seconds — link expires at this time."
+          }
+        },
+        "required": ["amount", "currency", "description"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/payment_links",
+        "bodyMapping": {
+          "amount": "$amount",
+          "currency": "$currency",
+          "description": "$description",
+          "customer": "$customer",
+          "notify": "$notify",
+          "reminder_enable": "$reminder_enable",
+          "expire_by": "$expire_by"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/jp/line-messaging.json
+++ b/packages/backend/src/adapters/jp/line-messaging.json
@@ -1,0 +1,128 @@
+{
+  "slug": "line-messaging",
+  "name": "LINE Messaging API",
+  "description": "Send push, reply and broadcast messages from a LINE Official Account — LINE is the dominant chat platform in Japan, Taiwan and Thailand. Free tier of 500 push messages per month, unlimited reply messages, channel access tokens require no KYC.",
+  "instructions": "This connector uses the LINE Messaging API v2.\n\n**Creating a channel**: log in to https://developers.line.biz/console → create a Provider → 'Create a new channel' → 'Messaging API'. Set up the LINE Official Account (auto-created with the channel), then under the channel's 'Messaging API' tab, scroll to 'Channel access token' → 'Issue' a long-lived token. Paste it as `LINE_CHANNEL_ACCESS_TOKEN`.\n\n**Authentication**: Bearer Token (the channel access token). Note: this token belongs to the channel, not to a user — anyone with the token can post as that Official Account, so keep it secret.\n\n**Message shape**: LINE messages are objects with a `type` field. Simplest example: `{\"type\": \"text\", \"text\": \"Hello\"}`. Other types: `sticker`, `image`, `video`, `audio`, `location`, `template`, `flex`. The `messages` parameter on every tool is an **array of up to 5** message objects.\n\n**`to` userId**: cannot be looked up cold — you only get a userId from webhook events when a user interacts with the Official Account. Store the userId on first webhook contact, then use it for push.\n\n**`replyToken`**: returned in webhook events. Valid for **~30 seconds** after the original user message. Use `line_reply_message` (free, unlimited) instead of `line_push_message` (counts against the 500/month free quota) whenever possible.\n\n**Broadcast**: sends to ALL friends of the Official Account. Counts heavily against the push quota — use sparingly.\n\n**Pricing**: free tier = 500 push messages/month. Paid tiers from JP¥5,000/month for higher quotas.",
+  "region": "jp",
+  "category": "messaging",
+  "icon": "line",
+  "docsUrl": "https://developers.line.biz/en/reference/messaging-api/",
+  "requiredEnvVars": ["LINE_CHANNEL_ACCESS_TOKEN"],
+  "connector": {
+    "name": "LINE Messaging API",
+    "type": "REST",
+    "baseUrl": "https://api.line.me",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{LINE_CHANNEL_ACCESS_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "line_push_message",
+      "description": "Send a push message to a specific userId, groupId, or roomId. Counts against the monthly push quota (500/month free). Use line_reply_message instead whenever you have a fresh replyToken.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "to": {
+            "type": "string",
+            "description": "Destination — userId (from a webhook event), groupId, or roomId. Cannot be looked up; obtain from webhook."
+          },
+          "messages": {
+            "type": "array",
+            "description": "Array of 1–5 LINE message objects. Simplest text: [{\"type\": \"text\", \"text\": \"Hello\"}]. See https://developers.line.biz/en/reference/messaging-api/#message-objects for full schema."
+          },
+          "notificationDisabled": {
+            "type": "boolean",
+            "description": "If true, the user is not notified (silent push). Default false."
+          }
+        },
+        "required": ["to", "messages"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/v2/bot/message/push",
+        "bodyMapping": {
+          "to": "$to",
+          "messages": "$messages",
+          "notificationDisabled": "$notificationDisabled"
+        }
+      }
+    },
+    {
+      "name": "line_reply_message",
+      "description": "Reply to a webhook-received message using its replyToken. FREE and unlimited (does not count against the push quota). The replyToken is valid for ~30 seconds after the user's message — call this synchronously from your webhook handler.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "replyToken": {
+            "type": "string",
+            "description": "The replyToken from a webhook event. Single-use, expires after ~30 seconds."
+          },
+          "messages": {
+            "type": "array",
+            "description": "Array of 1–5 LINE message objects."
+          },
+          "notificationDisabled": {
+            "type": "boolean",
+            "description": "If true, the user is not notified (silent reply). Default false."
+          }
+        },
+        "required": ["replyToken", "messages"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/v2/bot/message/reply",
+        "bodyMapping": {
+          "replyToken": "$replyToken",
+          "messages": "$messages",
+          "notificationDisabled": "$notificationDisabled"
+        }
+      }
+    },
+    {
+      "name": "line_get_profile",
+      "description": "Get a user's display name, profile picture URL, status message and BCP-47 language tag. Only works for users who have added the Official Account as a friend.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "LINE userId (from a webhook event)."
+          }
+        },
+        "required": ["userId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/v2/bot/profile/{userId}"
+      }
+    },
+    {
+      "name": "line_broadcast_message",
+      "description": "Broadcast a message to ALL friends of the Official Account. Heavy on the monthly push quota (1 message × N friends = N counted pushes). Use sparingly. Returns 202 Accepted; delivery happens asynchronously.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "description": "Array of 1–5 LINE message objects to broadcast."
+          },
+          "notificationDisabled": {
+            "type": "boolean",
+            "description": "If true, recipients are not notified. Default false."
+          }
+        },
+        "required": ["messages"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/v2/bot/message/broadcast",
+        "bodyMapping": {
+          "messages": "$messages",
+          "notificationDisabled": "$notificationDisabled"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/ng/paystack.json
+++ b/packages/backend/src/adapters/ng/paystack.json
@@ -1,0 +1,162 @@
+{
+  "slug": "paystack",
+  "name": "Paystack",
+  "description": "Leading African payment processor (Nigeria-led, also supports Ghana, South Africa, Kenya, Côte d'Ivoire). Initialize transactions, verify payments, list customers, issue refunds. Test secret keys (`sk_test_*`) require no KYC and work in minutes.",
+  "instructions": "This connector uses the Paystack REST API v1.\n\n**Getting test API keys**: sign up at https://dashboard.paystack.com → Settings → API Keys & Webhooks. You get a `sk_test_*` (secret key — server-side, used here) and a `pk_test_*` (public key — for client-side checkout). This adapter only needs the **secret key**.\n\n**Authentication**: Bearer Token. Header: `Authorization: Bearer sk_test_xxxxx`.\n\n**Amount convention**: amounts are integers in the **smallest currency subunit** — for NGN this is **kobo**, so ₦100 = `10000`. Same for ZAR (cents), GHS (pesewas), KES (cents).\n\n**Supported currencies**: NGN (default), USD, GHS, ZAR, KES, XOF (CFA franc).\n\n**Test cards** (test mode only): card number `4084 0840 8408 4081`, CVV `408`, expiry any future date, PIN `0000`, OTP `123456`.\n\n**Webhooks**: real-money flows should verify payments via `paystack_verify_transaction` from a webhook handler, not by polling. The verify endpoint is idempotent and free.\n\n**Production**: requires Paystack KYC (business documents, settlement bank account). Live keys start with `sk_live_` — never commit them.",
+  "region": "ng",
+  "category": "payments",
+  "icon": "paystack",
+  "docsUrl": "https://paystack.com/docs/api/",
+  "requiredEnvVars": ["PAYSTACK_SECRET_KEY"],
+  "connector": {
+    "name": "Paystack",
+    "type": "REST",
+    "baseUrl": "https://api.paystack.co",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{PAYSTACK_SECRET_KEY}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "paystack_initialize_transaction",
+      "description": "Initialize a Paystack transaction. Returns an `authorization_url` you redirect the customer to (Paystack-hosted checkout) and a `reference` you later pass to paystack_verify_transaction. Use this rather than charging cards directly — Paystack handles PCI on their side.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Customer email (required by Paystack for every transaction)."
+          },
+          "amount": {
+            "type": "number",
+            "description": "Amount in the smallest currency subunit (e.g. 10000 = ₦100.00 for NGN, 10000 = $100.00 for USD)."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Optional. ISO-4217 currency code: 'NGN' (default), 'USD', 'GHS', 'ZAR', 'KES', 'XOF'."
+          },
+          "reference": {
+            "type": "string",
+            "description": "Optional. Your own reference for this transaction. If omitted, Paystack generates one. Must be unique across the merchant account."
+          },
+          "callback_url": {
+            "type": "string",
+            "description": "Optional. URL Paystack redirects the customer to after payment. Overrides the dashboard-configured default."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Optional. Arbitrary key-value object stored on the transaction and echoed in webhooks."
+          }
+        },
+        "required": ["email", "amount"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/transaction/initialize",
+        "bodyMapping": {
+          "email": "$email",
+          "amount": "$amount",
+          "currency": "$currency",
+          "reference": "$reference",
+          "callback_url": "$callback_url",
+          "metadata": "$metadata"
+        }
+      }
+    },
+    {
+      "name": "paystack_verify_transaction",
+      "description": "Verify a Paystack transaction by reference. Returns status ('success', 'failed', 'abandoned'), amount, currency, paid_at, channel (card/bank/ussd/qr/mobile_money/bank_transfer), customer object, and authorization details if a card was used. Free, idempotent — safe to call multiple times.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reference": {
+            "type": "string",
+            "description": "The transaction reference returned by paystack_initialize_transaction (or supplied by you)."
+          }
+        },
+        "required": ["reference"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/transaction/verify/{reference}"
+      }
+    },
+    {
+      "name": "paystack_list_customers",
+      "description": "List customers on the merchant account. Returns customer id, customer_code, first_name, last_name, email, phone, total_transactions, total_transaction_value, dedicated_account if any, and risk_action.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "perPage": {
+            "type": "number",
+            "description": "Records per page (default 50, max 100)."
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number (1-based)."
+          },
+          "from": {
+            "type": "string",
+            "description": "Optional ISO-8601 start date filter (e.g. '2026-01-01')."
+          },
+          "to": {
+            "type": "string",
+            "description": "Optional ISO-8601 end date filter."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customer",
+        "queryParams": {
+          "perPage": "$perPage",
+          "page": "$page",
+          "from": "$from",
+          "to": "$to"
+        }
+      }
+    },
+    {
+      "name": "paystack_create_refund",
+      "description": "Create a refund for a transaction. Refunds are partial by default (use the full amount to do a full refund). Returns refund id, status (pending/processed/processing/failed), transaction object, refunded_at, expected_at, and reason.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "transaction": {
+            "type": "string",
+            "description": "Transaction id or reference to refund."
+          },
+          "amount": {
+            "type": "number",
+            "description": "Optional. Amount in smallest subunit to refund. Omit to refund the full transaction amount."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Optional. Must match the original transaction currency. Defaults to NGN."
+          },
+          "customer_note": {
+            "type": "string",
+            "description": "Optional. Note shown to the customer on the refund record (max 100 chars)."
+          },
+          "merchant_note": {
+            "type": "string",
+            "description": "Optional. Internal note on the refund (max 100 chars)."
+          }
+        },
+        "required": ["transaction"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/refund",
+        "bodyMapping": {
+          "transaction": "$transaction",
+          "amount": "$amount",
+          "currency": "$currency",
+          "customer_note": "$customer_note",
+          "merchant_note": "$merchant_note"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Broadens the pre-built adapter catalog beyond DACH (28 of the previous 30 adapters were Germany-specific) with the first wave of international coverage. Six new adapters across five regions — UK, India, Brasil, Nigeria, Japan — chosen for high regional name recognition and the absence of an existing MCP server.

| Adapter | Region | Category | Auth | Tools |
|---------|--------|----------|------|-------|
| UK Companies House | 🇬🇧 GB | Government | Basic Auth | search_company, get_company_profile, list_officers, list_filings |
| Wise (formerly TransferWise) | 🇬🇧 GB | Banking | Bearer Token | list_profiles, get_balances, create_quote, list_transfers |
| Razorpay | 🇮🇳 IN | Payments | Basic Auth | create_order, fetch_payment, list_refunds, create_payment_link |
| Mercado Libre | 🇧🇷 BR | E-commerce | OAuth2 | search_items, get_item, get_user, list_orders |
| Paystack | 🇳🇬 NG | Payments | Bearer Token | initialize_transaction, verify_transaction, list_customers, create_refund |
| LINE Messaging API | 🇯🇵 JP | Messaging | Bearer Token | push_message, reply_message, get_profile, broadcast_message |

All 6 use the existing JSON adapter schema (`docs/tool-definition.md`); no engine code changes.

## Verification

- [x] **Schema validation** — `npm test -- --testPathPatterns=catalog.spec` → 332/332 green (was 308 before, +24 = 6 adapters × 4 tools each).
- [x] **Live curl probes** — confirmed every vendor host responds:
  - Companies House → 401 (auth required, host live)
  - Razorpay → 401
  - Paystack → 401 with documented JSON error shape
  - Wise → 401
  - LINE → 401 with documented JSON error shape
  - Mercado Libre → 403 (newly auth-gated even on previously-public endpoints — instructions updated to reflect this)
- [ ] **End-to-end live test with sandbox credentials** — pending. Each vendor below has a free, no-KYC sandbox you can sign up for in <5 minutes:

| Adapter | Sandbox sign-up | Token prefix |
|---------|-----------------|--------------|
| Companies House | https://developer.company-information.service.gov.uk → 'Create test key' | (free key) |
| Wise | https://sandbox.transferwise.tech → Settings → API tokens | (sandbox token) |
| Razorpay | https://dashboard.razorpay.com → Settings → API Keys → Generate Test | `rzp_test_*` |
| Mercado Libre | https://developers.mercadolibre.com/devcenter → Create app | OAuth2 (no test mode — use a personal seller account) |
| Paystack | https://dashboard.paystack.com → Settings → API Keys & Webhooks | `sk_test_*` |
| LINE | https://developers.line.biz/console → Provider → Messaging API channel | (channel access token) |

After merging, import each adapter on a running AnythingMCP instance, supply the sandbox credential, and trigger one tool call from Claude Desktop. The catalog test suite already proves the schema is well-formed; this final step proves the runtime request/response shape matches what the vendor returns.

## Why this set

The plan considered ~15 candidates across LATAM, MENA, India, APAC, Nordics, France and UK. These 6 won on three criteria:

1. **No existing MCP server** for the vendor (checked Smithery, Glama, mcp.run registries as of 2026-05-16).
2. **Famous in the region** — first thing a buyer in that geography recognises.
3. **Free, no-KYC sandbox / test mode** — community contributors can iterate without paperwork.

Strong runners-up cut for scope (would be a good follow-up PR): Mercado Pago 🇲🇽, Klarna 🇸🇪, Afterpay 🇦🇺, Fatture in Cloud 🇮🇹, Qonto 🇫🇷.

## Coordination with sibling PRs

- **#181** (description sync) — independent, no overlap.
- **#182** (positioning rewrite + AUTHORS.md + CONTRIBUTING.md) — overlaps with this PR on the README adapter count (29 → 30+ vs 29 → 36). Whichever merges second needs a 1-line conflict resolution: keep `36` (the actual count after this PR lands) and the new "Messaging & Communication" subsection.

## Test plan

- [x] `npm install` clean
- [x] `npm test -- --testPathPatterns=catalog.spec` → 332/332 green
- [x] curl probe each vendor host
- [ ] Sandbox live-test on running instance (post-merge, see table above)