### PR TITLE
Add Sorare adapter + LOGIN_TOKEN auth profile

### DIFF
--- a/content/guides/de/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/de/connect-sorare-to-chatgpt.mdx
@@ -1,0 +1,90 @@
+---
+title: "Sorare mit ChatGPT verbinden — Fantasy Football für GPT"
+description: "Sorares NFT-Fantasy-Football-Daten via MCP-Connector in AnythingMCP zu ChatGPT bringen. Bcrypt-Login und 30-Tage-JWT-Caching sind automatisiert."
+category: "connectors"
+keyword: "Sorare ChatGPT, Sorare GPT, Sorare MCP ChatGPT, Sorare KI ChatGPT, Fantasy Football ChatGPT"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "de"
+---
+
+## Sorare mit ChatGPT verbinden
+
+ChatGPT unterstützt das **Model Context Protocol** in Custom Connectors und in der Developer-Tools-Oberfläche. Mit AnythingMCP als Brücke zur Sorare-GraphQL-API kannst du Karten, Spieler, Aufstellungen und Transfermarkt direkt aus einer ChatGPT-Konversation abfragen — ohne OAuth-Tanz und ohne Token-Babysitting.
+
+### Was du tun kannst
+
+- "Hol meine aktuelle Sorare-Aufstellung und sag mir, wo ich diese Game Week schwach bin."
+- "Liste jede seltene Vinícius-Júnior-Karte aus Saison 2024."
+- "Wie ist der aktuelle Floor-Preis für Limited-Bukayo-Saka-Karten?"
+- "Welche Auktionen für Liverpool-Spieler enden in den nächsten 90 Minuten?"
+
+### Voraussetzungen
+
+- Aktives Sorare-Konto (dediziertes Read-only-Konto empfohlen; **2FA deaktivieren** für Headless-Einsatz).
+- AnythingMCP lokal oder auf cloud.anythingmcp.com.
+- ChatGPT Plus / Team / Enterprise (Custom Connectors sind bezahlten Tiers vorbehalten).
+
+### Schritt 1 — Sorare-Zugang
+
+1. Bei https://sorare.com einloggen.
+2. (Optional) dediziertes Read-only-Konto ohne 2FA anlegen.
+3. AUD-String wählen (z. B. `my-mcp-server`); er landet im JWT-`aud`-Claim.
+
+### Schritt 2 — Sorare-Adapter installieren
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+`http://localhost:3000/connectors/store` öffnen, **Sorare** klicken, ausfüllen:
+
+| Feld | Wert |
+|---|---|
+| `SORARE_EMAIL` | Kontomail |
+| `SORARE_PASSWORD` | Klartext-Passwort |
+| `SORARE_AUD` | dein AUD-String |
+
+### Schritt 3 — MCP-Connector in ChatGPT hinzufügen
+
+1. In AnythingMCP MCP-API-Key erzeugen: **Profile → MCP API Keys → New Key**.
+2. In ChatGPT: **Einstellungen → Connectors → Custom Connector hinzufügen**.
+3. Eintragen:
+   - **Name**: `Sorare`
+   - **URL**: `https://dein-anythingmcp-host/mcp` (öffentliche HTTPS-URL — ChatGPT erreicht `localhost` nicht; via Cloudflare Tunnel / ngrok / cloud.anythingmcp.com bereitstellen).
+   - **Authentication**: Bearer Token → MCP-API-Key einfügen.
+4. Speichern. ChatGPT entdeckt die 7 Sorare-Tools automatisch.
+
+### Verfügbare Tools
+
+| Tool | Beschreibung |
+|---|---|
+| `sorare_current_user` | Sorare-Profil |
+| `sorare_get_card_by_slug` | Karten-Metadaten + Besitzer + Auktion |
+| `sorare_search_player` | Spielersuche |
+| `sorare_list_player_cards` | Aktuelle Karten zu einem Spieler |
+| `sorare_list_my_cards` | Eigene Karten |
+| `sorare_get_lineup` | So5-Aufstellung |
+| `sorare_transfer_market` | Aktive Auktionen, filterbar |
+
+### Token-Rotation
+
+JWTs leben ~30 Tage. AnythingMCP erneuert sie 24 h vor Ablauf und bei jedem 401 — ChatGPT-Aufrufe sehen nie ein stale Token.
+
+### FAQ
+
+**ChatGPT meldet "connector unreachable" — was tun?**
+ChatGPT sieht `localhost` nicht. Entweder auf `cloud.anythingmcp.com` deployen oder die lokale Instanz mit Cloudflare Tunnel proxen.
+
+**Brauche ich ChatGPT Enterprise?**
+Custom Connectors sind in Plus, Team und Enterprise verfügbar.
+
+**Kann ich den Sorare-Connector read-only machen?**
+Ja — Mutation-Tools aus dem Adapter entfernen (oder in AnythingMCP eine Rolle vergeben, die nur die `sorare_get_*` / `sorare_list_*` / `sorare_current_user`-Tools freigibt).
+
+### Nächste Schritte
+
+- [Sorare mit Claude verbinden](./connect-sorare-to-claude)
+- [Sorare mit OpenClaw verbinden](./connect-sorare-to-openclaw)
+- [Sorare an MCP anbinden — generischer Leitfaden](./sorare-to-mcp)

--- a/content/guides/de/connect-sorare-to-claude.mdx
+++ b/content/guides/de/connect-sorare-to-claude.mdx
@@ -1,0 +1,101 @@
+---
+title: "Sorare mit Claude verbinden — NFT-Fantasy-Football über MCP"
+description: "Sorares GraphQL-API mit AnythingMCP an Claude anbinden. Karten, Spieler, Aufstellungen und Transfermarkt per natürlicher Sprache abfragen. Bcrypt-Login und 30-Tage-Token-Caching sind automatisiert."
+category: "connectors"
+keyword: "Sorare Claude, Sorare KI, Sorare MCP Claude, Sorare GraphQL Claude, Fantasy Football Claude"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "de"
+---
+
+## Sorare mit Claude verbinden
+
+Sorare ist das größte NFT-Fantasy-Football-Spiel mit voller GraphQL-Abdeckung von Karten, Spielern, Aufstellungen und Transfermarkt. Mit AnythingMCP steuerst du alles direkt aus Claude Desktop oder Claude Code in Klartext — ohne SDK-Kleber, ohne manuelle Token-Rotation.
+
+### Was du tun kannst
+
+- "Zeig mein Sorare-Konto und meine Anzahl seltener Karten."
+- "Liste die nächsten 5 Messi-Rare-Karten unter 0,05 ETH im Auktionshaus."
+- "Finde alle meine Karten von Real-Madrid-Spielern."
+- "Wer hatte den höchsten Score in So5-Aufstellung `abc-123`?"
+
+### Voraussetzungen
+
+- Aktives Sorare-Konto (empfohlen: dediziertes, **2FA-deaktiviertes** Read-only-Konto für Headless-Nutzung).
+- AnythingMCP lokal oder auf cloud.anythingmcp.com (3-Minuten-Setup).
+- Claude Desktop installiert.
+
+### Schritt 1 — Sorare-Zugang besorgen
+
+1. Bei https://sorare.com einloggen.
+2. Optional: 2FA auf einem Read-only-MCP-Konto deaktivieren — `signIn` lehnt Aufrufe ohne aktuelles OTP ab, und OTPs lassen sich nicht für einen Server vorrotieren.
+3. Eine freie **AUD**-Zeichenkette wählen (z. B. `my-mcp-server`). Sorare bettet sie als JWT-`aud`-Claim ein und fordert sie bei jedem privaten Call.
+
+### Schritt 2 — Sorare-Adapter installieren
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+`http://localhost:3000/connectors/store` öffnen, **Sorare** anklicken, ausfüllen:
+
+| Feld | Wert |
+|---|---|
+| `SORARE_EMAIL` | Kontomail |
+| `SORARE_PASSWORD` | Klartext-Passwort |
+| `SORARE_AUD` | AUD-String aus Schritt 1 |
+
+**Install** klicken — der Adapter steht mit 7 Tools im Katalog.
+
+### Schritt 3 — Claude Desktop konfigurieren
+
+MCP-API-Key unter **Profile → MCP API Keys** erzeugen, dann in `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "sorare": {
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer DEIN_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Claude Desktop neu starten. Sorare-Tools erscheinen im 🔧-Menü.
+
+### Verfügbare Tools
+
+| Tool | Beschreibung |
+|---|---|
+| `sorare_current_user` | Eigenes Profil |
+| `sorare_get_card_by_slug` | Kartendetails per Slug |
+| `sorare_search_player` | Spielersuche nach Name |
+| `sorare_list_player_cards` | Aktuelle Karten zu einem Spieler |
+| `sorare_list_my_cards` | Eigene Karten |
+| `sorare_get_lineup` | So5-Score + Reward |
+| `sorare_transfer_market` | Aktive Auktionen, filterbar |
+
+### Token-Rotation erklärt
+
+Sorare-JWTs sind ~30 Tage gültig. AnythingMCP cacht sie verschlüsselt, **stellt sie 24 h vor Ablauf neu aus** und meldet sich bei jedem 401 neu an (ohne dass dein Passwort erneut von der Platte gelesen wird — der bcrypt-Hash wird aus dem frisch geholten Salt neu berechnet). Du siehst nie einen "Token expired"-Fehler.
+
+### FAQ
+
+**Speichert AnythingMCP mein Klartext-Sorare-Passwort?**
+Nur im verschlüsselten `authConfig`-Blob (AES-256-GCM). Übers Netz geht ausschließlich der bcrypt-Hash, ausschließlich bei `signIn`.
+
+**Kann ich ein Sorare-Konto mit 2FA verwenden?**
+Die `signIn`-Mutation braucht einen frischen `otpAttempt`, der sich nicht automatisieren lässt. Nutze ein dediziertes Read-only-Konto ohne 2FA.
+
+**Funktioniert das auch mit Claude Code statt Claude Desktop?**
+Ja — verweise die MCP-Server-Config von Claude Code auf dieselbe URL `http://localhost:4000/mcp`.
+
+### Nächste Schritte
+
+- [Sorare an MCP anbinden — generischer Leitfaden](./sorare-to-mcp)
+- [Sorare mit ChatGPT verbinden](./connect-sorare-to-chatgpt)
+- [Sorare mit OpenClaw verbinden](./connect-sorare-to-openclaw)

--- a/content/guides/de/connect-sorare-to-openclaw.mdx
+++ b/content/guides/de/connect-sorare-to-openclaw.mdx
@@ -1,0 +1,92 @@
+---
+title: "Sorare mit OpenClaw verbinden — Self-Hosted KI + NFT-Fantasy-Football"
+description: "OpenClaws lokaler KI-Assistent fragt Sorares GraphQL-API via AnythingMCP ab. Streamable-HTTP-MCP-Transport mit Bearer-Auth, Bcrypt-Login und 30-Tage-Token-Caching."
+category: "connectors"
+keyword: "Sorare OpenClaw, OpenClaw MCP, Sorare lokale KI, OpenClaw Connector, Fantasy Football OpenClaw"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "de"
+---
+
+## Sorare mit OpenClaw verbinden
+
+[OpenClaw](https://openclaw.ai/) ist ein Open-Source-KI-Assistent, der lokal läuft und MCP-Server über sein CLI einbindet. Kombiniert mit AnythingMCP erhältst du ein End-to-End-privates Setup, um Sorare von deinem eigenen Rechner aus abzufragen — Passwort und JWT verlassen dein Netzwerk nie.
+
+### Was du tun kannst
+
+- "Liste alle meine Karten zu Premier-League-Spielern."
+- "Zeig Auktionen für Unique-Mbappé-Karten, die heute Abend enden."
+- "Wie war der Score meiner letzten So5-Aufstellung?"
+
+### Voraussetzungen
+
+- OpenClaw installiert (`docs.openclaw.ai/getting-started`).
+- AnythingMCP lokal auf `http://localhost:4000`.
+- Sorare-Konto (Read-only, **2FA deaktiviert** für Headless-Einsatz).
+
+### Schritt 1 — Sorare-Zugang
+
+Wie bei jedem anderen Client:
+
+1. Bei https://sorare.com einloggen.
+2. Read-only-Konto ohne 2FA verwenden (oder anlegen).
+3. AUD-String für den JWT-`aud`-Claim wählen (z. B. `openclaw-mcp`).
+
+### Schritt 2 — Sorare-Adapter installieren
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+`http://localhost:3000/connectors/store` öffnen, **Sorare** klicken, `SORARE_EMAIL`, `SORARE_PASSWORD`, `SORARE_AUD` eintragen. MCP-API-Key unter **Profile → MCP API Keys** erzeugen.
+
+### Schritt 3 — MCP-Server in OpenClaw registrieren
+
+OpenClaw speichert MCP-Server unter `mcp.servers` in seiner Config. Eintragen via CLI:
+
+```bash
+openclaw mcp set sorare '{
+  "url": "http://localhost:4000/mcp",
+  "transport": "streamable-http",
+  "connectionTimeoutMs": 10000,
+  "headers": {
+    "Authorization": "Bearer DEIN_MCP_API_KEY"
+  }
+}'
+```
+
+Mit `openclaw mcp list` verifizieren. OpenClaw entdeckt die 7 Sorare-Tools automatisch und stellt sie der Agent-Runtime zur Verfügung.
+
+### Verfügbare Tools
+
+| Tool | Beschreibung |
+|---|---|
+| `sorare_current_user` | Eigenes Profil |
+| `sorare_get_card_by_slug` | Kartendetails |
+| `sorare_search_player` | Spielersuche |
+| `sorare_list_player_cards` | Spieler-Karten |
+| `sorare_list_my_cards` | Eigene Karten |
+| `sorare_get_lineup` | So5-Aufstellung |
+| `sorare_transfer_market` | Aktive Auktionen |
+
+### Token-Rotation
+
+AnythingMCP verschlüsselt das Sorare-JWT in `connector_auth_cache`, frischt es 24 h vor Ablauf auf und meldet sich bei jedem 401 neu an. Das Token gilt ~30 Tage. Kein Cron-Job, keine manuelle Erneuerung.
+
+### FAQ
+
+**Muss OpenClaw auf derselben Maschine wie AnythingMCP laufen?**
+Nein — `http://localhost:4000/mcp` ist nur der Default. Beliebige erreichbare URL nutzen (mit TLS + Bearer-Auth empfohlen).
+
+**Wo speichert OpenClaw die MCP-Server-Config?**
+Unter `mcp.servers` in der globalen OpenClaw-Config — verwaltet via `openclaw mcp set / list / remove`.
+
+**Kann ich mehrere Adapter über einen MCP-Server-Eintrag laufen lassen?**
+Ja — jeder Adapter, den du in AnythingMCP installierst, wird automatisch zum Tool auf demselben `/mcp`-Endpoint.
+
+### Nächste Schritte
+
+- [Sorare mit Claude verbinden](./connect-sorare-to-claude)
+- [Sorare mit ChatGPT verbinden](./connect-sorare-to-chatgpt)
+- [Sorare an MCP anbinden — generischer Leitfaden](./sorare-to-mcp)

--- a/content/guides/de/sorare-to-mcp.mdx
+++ b/content/guides/de/sorare-to-mcp.mdx
@@ -1,0 +1,59 @@
+---
+title: "Sorare an MCP anbinden — NFT-Fantasy-Football für jeden KI-Agenten"
+description: "Sorares GraphQL-API als MCP-Server mit AnythingMCP bereitstellen. Bcrypt-gesalzene Anmeldung, 30-Tage-JWT-Caching und 7 sofort einsatzbereite Tools für Karten, Spieler, Aufstellungen und Transfermarkt."
+category: "connectors"
+keyword: "Sorare MCP, Sorare API MCP, Sorare KI-Agent, Sorare GraphQL, Fantasy Football MCP Server"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "de"
+---
+
+## Sorare im Model Context Protocol
+
+[Sorare](https://sorare.com/) ist das größte lizenzierte NFT-Fantasy-Sportspiel und bietet eine vollständige GraphQL-Schnittstelle für Spieler, Karten, Auktionen und So5-Aufstellungen. AnythingMCP verpackt diese GraphQL-API als **MCP-Server**, sodass jeder Agent — Claude, ChatGPT, OpenClaw, Cursor oder eigene Implementierungen — Sorare-Daten in natürlicher Sprache lesen und nutzen kann.
+
+Der Sorare-Adapter ist out-of-the-box enthalten. Kein SDK zu pflegen, keine Token-Logik zu schreiben: die Engine führt den Salt-Fetch + bcrypt + Login-Handshake beim ersten Tool-Aufruf aus, cacht das JWT für 30 Tage und stellt es bei einem 401 transparent neu aus.
+
+### Warum Sorare ohne AnythingMCP unangenehm ist
+
+| Schritt | Was Sorare verlangt |
+|---|---|
+| 1 | `GET /api/v1/users/{email}` zum Holen eines bcrypt-Salts pro Account |
+| 2 | `bcrypt.hashSync(plainPassword, salt)` clientseitig |
+| 3 | GraphQL-`signIn`-Mutation mit dem bcrypt-Hash |
+| 4 | JWT speichern (~30 Tage Gültigkeit) und bei jedem Call `Authorization: Bearer <jwt>` + `JWT-AUD: <aud>` mitsenden |
+
+Das gesamte **`LOGIN_TOKEN`**-Auth-Profil wird einmal als JSON in der Adapter-Spezifikation deklariert. Kein Client-Code, der gepflegt werden muss.
+
+### Installation
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffne `http://localhost:3000/connectors/store`, wähle **Sorare** und trage `SORARE_EMAIL`, `SORARE_PASSWORD`, `SORARE_AUD` ein (beliebige Zeichenkette — Sorare nutzt sie als `aud`-Claim des JWT).
+
+Erstelle einen MCP-API-Key unter **Profile → MCP API Keys** und verweise deinen Agenten auf `http://localhost:4000/mcp`.
+
+### Verfügbare Tools
+
+| Tool | Rückgabe |
+|---|---|
+| `sorare_current_user` | Slug, E-Mail, Nickname des angemeldeten Nutzers |
+| `sorare_get_card_by_slug` | Karten-Metadaten, Besitzer, aktuelle Auktion |
+| `sorare_search_player` | Spieler nach Name + Club + Land |
+| `sorare_list_player_cards` | Neu geprägte Karten zu einem Spieler |
+| `sorare_list_my_cards` | Karten im Besitz des angemeldeten Nutzers |
+| `sorare_get_lineup` | So5-Aufstellung: Score, Rang, Belohnung, Auftritte |
+| `sorare_transfer_market` | Aktive Auktionen, filterbar nach Rarität / Maximalpreis |
+
+### Token-Lifecycle
+
+Das JWT liegt in `connector_auth_cache` (AES-256-GCM verschlüsselt) und wird proaktiv erneuert, wenn weniger als 24 h bis `expiredAt` verbleiben — oder spätestens beim ersten 401. Du kannst es mit `DELETE FROM connector_auth_cache WHERE connector_id = '<id>'` widerrufen — der nächste Tool-Call meldet sich neu an.
+
+### Nächste Schritte
+
+- [Sorare mit Claude verbinden](./connect-sorare-to-claude)
+- [Sorare mit ChatGPT verbinden](./connect-sorare-to-chatgpt)
+- [Sorare mit OpenClaw verbinden](./connect-sorare-to-openclaw)

--- a/content/guides/en/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/en/connect-sorare-to-chatgpt.mdx
@@ -1,0 +1,90 @@
+---
+title: "How to Connect Sorare to ChatGPT — Fantasy Football for GPT"
+description: "Bring Sorare's NFT fantasy football data into ChatGPT via the MCP connector built into AnythingMCP. Bcrypt login and 30-day JWT caching are handled for you."
+category: "connectors"
+keyword: "Sorare ChatGPT, Sorare GPT, Sorare MCP ChatGPT, Sorare AI ChatGPT, fantasy football ChatGPT"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "en"
+---
+
+## Connect Sorare to ChatGPT
+
+ChatGPT supports the **Model Context Protocol** in custom connectors and in the Developer tools surface. With AnythingMCP exposing Sorare's GraphQL API as MCP tools, you can query cards, players, lineups, and the transfer market from a ChatGPT conversation — without OAuth ceremonies or token babysitting.
+
+### What you can do
+
+- "Pull my current Sorare lineup and tell me where I'm weakest this game week."
+- "List every rare Vinícius Júnior card minted in season 2024."
+- "What's the floor price right now for limited Bukayo Saka cards?"
+- "Find auctions ending in the next 90 minutes for Liverpool players."
+
+### Prerequisites
+
+- Active Sorare account (dedicated read-only account recommended; **disable 2FA** for headless use).
+- AnythingMCP running locally or on cloud.anythingmcp.com.
+- ChatGPT Plus / Team / Enterprise (custom connectors are gated to paid tiers).
+
+### Step 1 — Get your Sorare access
+
+1. Sign in to https://sorare.com.
+2. (Optional) create a dedicated read-only Sorare account for MCP and disable 2FA on it.
+3. Pick a free-form **AUD** string (e.g. `my-mcp-server`); it goes into the JWT `aud` claim.
+
+### Step 2 — Install the Sorare adapter
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **Sorare**, and provide:
+
+| Field | Value |
+|---|---|
+| `SORARE_EMAIL` | account email |
+| `SORARE_PASSWORD` | plain password |
+| `SORARE_AUD` | your AUD string |
+
+### Step 3 — Add the MCP connector in ChatGPT
+
+1. Mint an MCP API key in AnythingMCP: **Profile → MCP API Keys → New Key**.
+2. In ChatGPT, open **Settings → Connectors → Add custom connector**.
+3. Fill in:
+   - **Name**: `Sorare`
+   - **URL**: `https://your-anythingmcp-host/mcp` (use a public HTTPS URL — ChatGPT cannot reach `localhost`; expose with Cloudflare Tunnel / ngrok / cloud.anythingmcp.com).
+   - **Authentication**: Bearer token → paste the MCP API key.
+4. Save. ChatGPT auto-discovers the 7 Sorare tools.
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `sorare_current_user` | Your Sorare profile |
+| `sorare_get_card_by_slug` | Card metadata + owner + auction |
+| `sorare_search_player` | Players by name |
+| `sorare_list_player_cards` | Recent cards for a player |
+| `sorare_list_my_cards` | Your owned cards |
+| `sorare_get_lineup` | So5 lineup details |
+| `sorare_transfer_market` | Active auctions, filterable |
+
+### Token rotation
+
+JWTs live ~30 days. AnythingMCP re-issues them 24 h before expiry and on any 401 — ChatGPT calls never see a stale token.
+
+### FAQ
+
+**ChatGPT says "connector unreachable" — what's wrong?**
+ChatGPT can't see `localhost`. Either deploy to `cloud.anythingmcp.com`, or proxy your local instance with Cloudflare Tunnel.
+
+**Does this need ChatGPT Enterprise?**
+Custom connectors are available on Plus, Team, and Enterprise.
+
+**Can I make Sorare connector read-only?**
+Yes — strip mutation tools out of the adapter (or assign a Role in AnythingMCP that whitelists only the `sorare_get_*` / `sorare_list_*` / `sorare_current_user` tools).
+
+### Next steps
+
+- [Connect Sorare to Claude](./connect-sorare-to-claude)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw)
+- [Sorare to MCP — the generic guide](./sorare-to-mcp)

--- a/content/guides/en/connect-sorare-to-claude.mdx
+++ b/content/guides/en/connect-sorare-to-claude.mdx
@@ -1,0 +1,101 @@
+---
+title: "How to Connect Sorare to Claude — NFT Fantasy Football via MCP"
+description: "Connect Sorare's GraphQL API to Claude with AnythingMCP. Query cards, players, lineups, and the transfer market in natural language. Bcrypt login + 30-day token caching handled automatically."
+category: "connectors"
+keyword: "Sorare Claude, Sorare AI, Sorare MCP Claude, Sorare GraphQL Claude, fantasy football Claude"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "en"
+---
+
+## Connect Sorare to Claude
+
+Sorare is the largest NFT fantasy football game, with full GraphQL coverage over cards, players, lineups, and the transfer market. With AnythingMCP, you can drive all of it from Claude Desktop or Claude Code in plain English — no SDK to glue, no token rotation to babysit.
+
+### What you can do
+
+- "Show my current Sorare account and rare-card count."
+- "List the next 5 Messi rare cards on auction under 0.05 ETH."
+- "Find all my cards for Real Madrid players."
+- "Who scored highest in So5 lineup `abc-123`?"
+
+### Prerequisites
+
+- An active Sorare account (we recommend a dedicated, **2FA-disabled** read-only account for headless use).
+- AnythingMCP running locally or on cloud.anythingmcp.com (3-minute setup).
+- Claude Desktop installed.
+
+### Step 1 — Get your Sorare access
+
+1. Sign in to https://sorare.com.
+2. Optionally disable 2FA on a read-only account dedicated to MCP — `signIn` rejects requests without a fresh OTP, and OTPs can't be pre-rotated for a server.
+3. Pick a free-form **AUD** string (e.g. `my-mcp-server`). Sorare embeds it as the JWT `aud` claim and requires it on every private call.
+
+### Step 2 — Install the Sorare adapter
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **Sorare**, and fill in:
+
+| Field | Value |
+|---|---|
+| `SORARE_EMAIL` | your account email |
+| `SORARE_PASSWORD` | your plain password |
+| `SORARE_AUD` | the AUD string from step 1 |
+
+Click **Install** — the adapter is now in your catalog with 7 tools.
+
+### Step 3 — Wire up Claude Desktop
+
+Mint an MCP API key in **Profile → MCP API Keys**, then add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "sorare": {
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. Sorare tools appear in the 🔧 menu.
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `sorare_current_user` | Get your authenticated profile |
+| `sorare_get_card_by_slug` | Card details by slug |
+| `sorare_search_player` | Search players by name |
+| `sorare_list_player_cards` | Recent cards for a player |
+| `sorare_list_my_cards` | Your owned cards |
+| `sorare_get_lineup` | So5 lineup score + reward |
+| `sorare_transfer_market` | Active auctions, filterable |
+
+### Token rotation, explained
+
+Sorare JWTs last ~30 days. AnythingMCP caches yours encrypted at rest, **re-issues it 24 h before expiry**, and re-logs in on any 401 (without your password ever being read again from disk — the bcrypt hash is recomputed from the freshly fetched salt). You never see an expired-token error.
+
+### FAQ
+
+**Does AnythingMCP store my plain Sorare password?**
+Only inside the encrypted `authConfig` blob (AES-256-GCM). Only the bcrypt hash crosses the wire, only on `signIn`.
+
+**Can I use a Sorare account with 2FA?**
+The `signIn` mutation needs a fresh `otpAttempt` for 2FA accounts, which can't be automated. Use a dedicated read-only account without 2FA.
+
+**Does this work with Claude Code as well as Claude Desktop?**
+Yes — point the `claude_code` MCP server config at the same `http://localhost:4000/mcp` URL.
+
+### Next steps
+
+- [Sorare to MCP — the generic guide](./sorare-to-mcp)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw)

--- a/content/guides/en/connect-sorare-to-openclaw.mdx
+++ b/content/guides/en/connect-sorare-to-openclaw.mdx
@@ -1,0 +1,92 @@
+---
+title: "How to Connect Sorare to OpenClaw — Self-Hosted AI + NFT Fantasy Football"
+description: "Use OpenClaw's local AI assistant to query Sorare's GraphQL API via AnythingMCP. Streamable-HTTP MCP transport with Bearer auth, bcrypt login, and 30-day token caching."
+category: "connectors"
+keyword: "Sorare OpenClaw, OpenClaw MCP, Sorare local AI, OpenClaw connector, fantasy football OpenClaw"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "en"
+---
+
+## Connect Sorare to OpenClaw
+
+[OpenClaw](https://openclaw.ai/) is an open-source personal AI assistant that runs locally and supports MCP servers via its CLI. Combine it with AnythingMCP and you have a self-hosted, end-to-end private setup for querying Sorare from your own machine — your password and the issued JWT never leave your network.
+
+### What you can do
+
+- "List all my cards for Premier League players."
+- "Surface auctions for unique Mbappé cards closing tonight."
+- "Show me the score of my last So5 lineup."
+
+### Prerequisites
+
+- OpenClaw installed (`docs.openclaw.ai/getting-started`).
+- AnythingMCP running locally on `http://localhost:4000`.
+- Sorare account credentials (read-only, **2FA disabled** for headless use).
+
+### Step 1 — Get your Sorare access
+
+Same as for any other client:
+
+1. Sign in to https://sorare.com.
+2. Use (or create) a read-only account without 2FA.
+3. Pick an **AUD** string for the JWT `aud` claim (e.g. `openclaw-mcp`).
+
+### Step 2 — Install the Sorare adapter
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **Sorare**, enter `SORARE_EMAIL`, `SORARE_PASSWORD`, `SORARE_AUD`. Mint an MCP API key in **Profile → MCP API Keys**.
+
+### Step 3 — Register the MCP server in OpenClaw
+
+OpenClaw stores MCP servers under `mcp.servers` in its config. Add it with the CLI:
+
+```bash
+openclaw mcp set sorare '{
+  "url": "http://localhost:4000/mcp",
+  "transport": "streamable-http",
+  "connectionTimeoutMs": 10000,
+  "headers": {
+    "Authorization": "Bearer YOUR_MCP_API_KEY"
+  }
+}'
+```
+
+Verify with `openclaw mcp list`. OpenClaw will auto-discover the 7 Sorare tools and make them available to its agent runtime.
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `sorare_current_user` | Authenticated profile |
+| `sorare_get_card_by_slug` | Card details |
+| `sorare_search_player` | Search players |
+| `sorare_list_player_cards` | Player cards |
+| `sorare_list_my_cards` | Your cards |
+| `sorare_get_lineup` | So5 lineup |
+| `sorare_transfer_market` | Active auctions |
+
+### Token rotation
+
+AnythingMCP encrypts the Sorare JWT in `connector_auth_cache`, refreshes it 24 h before expiry, and re-logs in on any 401. The token lives ~30 days. No cron job, no manual refresh.
+
+### FAQ
+
+**Does OpenClaw need to be on the same machine as AnythingMCP?**
+No — `http://localhost:4000/mcp` is only the default. Use any reachable URL (with TLS + Bearer auth recommended).
+
+**Where does OpenClaw store the MCP server config?**
+Under `mcp.servers` in the global OpenClaw config — managed via `openclaw mcp set / list / remove`.
+
+**Can I run multiple adapters through one MCP server entry?**
+Yes — every adapter you install in AnythingMCP automatically becomes a tool on the same `/mcp` endpoint.
+
+### Next steps
+
+- [Connect Sorare to Claude](./connect-sorare-to-claude)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt)
+- [Sorare to MCP — the generic guide](./sorare-to-mcp)

--- a/content/guides/en/sorare-to-mcp.mdx
+++ b/content/guides/en/sorare-to-mcp.mdx
@@ -1,0 +1,59 @@
+---
+title: "Sorare to MCP — Bring NFT Fantasy Football to Any AI Agent"
+description: "Expose Sorare's GraphQL API as an MCP server with AnythingMCP. Bcrypt-salted login, 30-day JWT caching, and 7 ready-to-use tools for cards, players, lineups, and the transfer market."
+category: "connectors"
+keyword: "Sorare MCP, Sorare API MCP, Sorare AI agent, Sorare GraphQL, fantasy football MCP server"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "en"
+---
+
+## Sorare on the Model Context Protocol
+
+[Sorare](https://sorare.com/) is the largest licensed NFT fantasy sports game, with full GraphQL coverage over players, cards, auctions, and So5 lineups. AnythingMCP wraps that GraphQL API as an **MCP server** so any agent — Claude, ChatGPT, OpenClaw, Cursor, your own — can read and act on Sorare data with natural language.
+
+The Sorare adapter ships built-in. There is no SDK to maintain, no token plumbing to write: the engine performs the salt fetch + bcrypt + login handshake the first time you call a tool, caches the resulting JWT for 30 days, and re-issues it transparently on any 401.
+
+### Why Sorare is awkward without AnythingMCP
+
+| Step | What Sorare requires |
+|---|---|
+| 1 | `GET /api/v1/users/{email}` to retrieve a per-account bcrypt salt |
+| 2 | `bcrypt.hashSync(plainPassword, salt)` client-side |
+| 3 | GraphQL `signIn` mutation with the bcrypt hash |
+| 4 | Store the JWT (~30-day lifetime) and pass `Authorization: Bearer <jwt>` + `JWT-AUD: <aud>` headers on every call |
+
+That's the entire **`LOGIN_TOKEN`** auth profile, declared once as JSON in the adapter spec. No client code to maintain.
+
+### Install
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, pick **Sorare**, and paste in `SORARE_EMAIL`, `SORARE_PASSWORD`, `SORARE_AUD` (any string — Sorare uses it as the JWT `aud` claim).
+
+Mint an MCP API key from **Profile → MCP API Keys** and point your agent at `http://localhost:4000/mcp`.
+
+### Available tools
+
+| Tool | What it returns |
+|---|---|
+| `sorare_current_user` | Authenticated user's slug, email, nickname |
+| `sorare_get_card_by_slug` | Card metadata, owner, current auction |
+| `sorare_search_player` | Players by name + club + country |
+| `sorare_list_player_cards` | Recent cards minted for a player |
+| `sorare_list_my_cards` | Cards owned by the authenticated user |
+| `sorare_get_lineup` | So5 lineup score, rank, reward, appearances |
+| `sorare_transfer_market` | Active auctions filtered by rarity / max price |
+
+### Token lifecycle
+
+The JWT lives in `connector_auth_cache` (AES-256-GCM encrypted), refreshed proactively when it falls within 24 h of `expiredAt` and replaced on the first 401. You can revoke it with `DELETE FROM connector_auth_cache WHERE connector_id = '<id>'` — the next tool call will re-login from scratch.
+
+### Next steps
+
+- [Connect Sorare to Claude](./connect-sorare-to-claude)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw)

--- a/content/guides/it/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/it/connect-sorare-to-chatgpt.mdx
@@ -1,0 +1,90 @@
+---
+title: "Come collegare Sorare a ChatGPT — Fantasy Football per GPT"
+description: "Porta i dati di fantasy football NFT di Sorare in ChatGPT tramite il connector MCP integrato in AnythingMCP. Bcrypt-login e caching JWT a 30 giorni gestiti per te."
+category: "connectors"
+keyword: "Sorare ChatGPT, Sorare GPT, Sorare MCP ChatGPT, Sorare AI ChatGPT, fantasy football ChatGPT"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "it"
+---
+
+## Collegare Sorare a ChatGPT
+
+ChatGPT supporta il **Model Context Protocol** nei custom connector e nell'area Developer Tools. Con AnythingMCP che espone l'API GraphQL di Sorare come tool MCP, interroghi carte, giocatori, line-up e mercato direttamente da una conversazione ChatGPT — senza riti OAuth né babysitting dei token.
+
+### Cosa puoi fare
+
+- "Tirami su la mia line-up Sorare e dimmi dove sono debole questa game week."
+- "Lista ogni carta rara di Vinícius Júnior della stagione 2024."
+- "Qual è il floor price ora per le carte limited di Bukayo Saka?"
+- "Trova aste per giocatori del Liverpool che chiudono nei prossimi 90 minuti."
+
+### Prerequisiti
+
+- Account Sorare attivo (consigliato uno dedicato in sola lettura; **disattiva 2FA** per uso headless).
+- AnythingMCP in locale o su cloud.anythingmcp.com.
+- ChatGPT Plus / Team / Enterprise (i custom connector sono limitati ai tier a pagamento).
+
+### Step 1 — Accessi Sorare
+
+1. Login su https://sorare.com.
+2. (Opzionale) crea un account Sorare dedicato in sola lettura e disattiva la 2FA.
+3. Scegli una stringa **AUD** (es. `my-mcp-server`); va nel claim `aud` del JWT.
+
+### Step 2 — Installa l'adapter Sorare
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e inserisci:
+
+| Campo | Valore |
+|---|---|
+| `SORARE_EMAIL` | email account |
+| `SORARE_PASSWORD` | password in chiaro |
+| `SORARE_AUD` | la tua stringa AUD |
+
+### Step 3 — Aggiungi il connector MCP a ChatGPT
+
+1. In AnythingMCP genera una MCP API key: **Profile → MCP API Keys → New Key**.
+2. In ChatGPT: **Impostazioni → Connectors → Aggiungi custom connector**.
+3. Compila:
+   - **Nome**: `Sorare`
+   - **URL**: `https://il-tuo-host-anythingmcp/mcp` (URL HTTPS pubblico — ChatGPT non vede `localhost`; esponi via Cloudflare Tunnel / ngrok / cloud.anythingmcp.com).
+   - **Authentication**: Bearer token → incolla la MCP API key.
+4. Salva. ChatGPT scopre automaticamente i 7 tool Sorare.
+
+### Tool disponibili
+
+| Tool | Descrizione |
+|---|---|
+| `sorare_current_user` | Profilo Sorare |
+| `sorare_get_card_by_slug` | Metadata carta + proprietario + asta |
+| `sorare_search_player` | Ricerca giocatori |
+| `sorare_list_player_cards` | Carte recenti di un giocatore |
+| `sorare_list_my_cards` | Le tue carte |
+| `sorare_get_lineup` | Dettagli line-up So5 |
+| `sorare_transfer_market` | Aste attive, filtrabili |
+
+### Rotazione token
+
+I JWT vivono ~30 giorni. AnythingMCP li ri-emette 24 h prima della scadenza e a ogni 401 — le chiamate da ChatGPT non vedono mai un token stale.
+
+### FAQ
+
+**ChatGPT dice "connector unreachable" — cosa faccio?**
+ChatGPT non vede `localhost`. Deploya su `cloud.anythingmcp.com` o proxa l'istanza locale con Cloudflare Tunnel.
+
+**Mi serve ChatGPT Enterprise?**
+I custom connector sono disponibili su Plus, Team ed Enterprise.
+
+**Posso rendere il connector Sorare read-only?**
+Sì — rimuovi i tool mutation dall'adapter (o assegna in AnythingMCP un Role che whiteliste solo i tool `sorare_get_*` / `sorare_list_*` / `sorare_current_user`).
+
+### Prossimi passi
+
+- [Collegare Sorare a Claude](./connect-sorare-to-claude)
+- [Collegare Sorare a OpenClaw](./connect-sorare-to-openclaw)
+- [Sorare su MCP — guida generica](./sorare-to-mcp)

--- a/content/guides/it/connect-sorare-to-claude.mdx
+++ b/content/guides/it/connect-sorare-to-claude.mdx
@@ -1,0 +1,101 @@
+---
+title: "Come collegare Sorare a Claude — Fantasy Football NFT via MCP"
+description: "Collega l'API GraphQL di Sorare a Claude con AnythingMCP. Interroga carte, giocatori, line-up e mercato in linguaggio naturale. Bcrypt-login e caching token a 30 giorni gestiti in automatico."
+category: "connectors"
+keyword: "Sorare Claude, Sorare AI, Sorare MCP Claude, Sorare GraphQL Claude, fantasy football Claude"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "it"
+---
+
+## Collegare Sorare a Claude
+
+Sorare è il più grande gioco di fantasy football NFT, con copertura GraphQL completa su carte, giocatori, line-up e mercato dei trasferimenti. Con AnythingMCP guidi tutto da Claude Desktop o Claude Code in italiano — senza incollare SDK e senza dover rinfrescare token a mano.
+
+### Cosa puoi fare
+
+- "Mostrami il mio account Sorare e il numero di carte rare."
+- "Lista le prossime 5 carte rare di Messi all'asta sotto 0,05 ETH."
+- "Trova tutte le mie carte dei giocatori del Real Madrid."
+- "Chi ha fatto lo score più alto nella line-up So5 `abc-123`?"
+
+### Prerequisiti
+
+- Account Sorare attivo (consigliato un account dedicato in sola lettura con **2FA disattivata** per uso headless).
+- AnythingMCP in locale o su cloud.anythingmcp.com (setup di 3 minuti).
+- Claude Desktop installato.
+
+### Step 1 — Ottieni gli accessi Sorare
+
+1. Login su https://sorare.com.
+2. Opzionale: disattiva 2FA su un account read-only dedicato a MCP — `signIn` rifiuta richieste senza OTP aggiornata, e l'OTP non si può pre-ruotare per un server.
+3. Scegli una stringa libera **AUD** (es. `my-mcp-server`). Sorare la inserisce come claim `aud` del JWT e la richiede in ogni chiamata privata.
+
+### Step 2 — Installa l'adapter Sorare
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e compila:
+
+| Campo | Valore |
+|---|---|
+| `SORARE_EMAIL` | email account |
+| `SORARE_PASSWORD` | password in chiaro |
+| `SORARE_AUD` | stringa AUD scelta allo step 1 |
+
+Clicca **Install** — l'adapter è nel catalogo con 7 tool.
+
+### Step 3 — Configura Claude Desktop
+
+Crea una MCP API key in **Profile → MCP API Keys**, poi aggiungi a `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "sorare": {
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer LA_TUA_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Riavvia Claude Desktop. I tool Sorare compaiono nel menu 🔧.
+
+### Tool disponibili
+
+| Tool | Descrizione |
+|---|---|
+| `sorare_current_user` | Profilo autenticato |
+| `sorare_get_card_by_slug` | Dettagli carta per slug |
+| `sorare_search_player` | Ricerca giocatori per nome |
+| `sorare_list_player_cards` | Carte recenti di un giocatore |
+| `sorare_list_my_cards` | Le tue carte |
+| `sorare_get_lineup` | Line-up So5 con score + reward |
+| `sorare_transfer_market` | Aste attive, filtrabili |
+
+### Rotazione token spiegata
+
+Il JWT di Sorare dura ~30 giorni. AnythingMCP lo cacha cifrato a riposo, **lo ri-emette 24 h prima della scadenza** e fa re-login a qualsiasi 401 (senza rileggere la password dal disco — l'hash bcrypt viene ricalcolato dal salt appena rifetchato). Non vedi mai un errore di token scaduto.
+
+### FAQ
+
+**AnythingMCP salva la mia password Sorare in chiaro?**
+Solo dentro il blob `authConfig` cifrato (AES-256-GCM). Sul filo passa solo l'hash bcrypt, solo durante `signIn`.
+
+**Posso usare un account Sorare con 2FA?**
+La mutation `signIn` richiede un `otpAttempt` aggiornato per gli account con 2FA, e non è automatizzabile. Usa un account dedicato read-only senza 2FA.
+
+**Funziona con Claude Code oltre che Claude Desktop?**
+Sì — punta la config MCP di Claude Code allo stesso URL `http://localhost:4000/mcp`.
+
+### Prossimi passi
+
+- [Sorare su MCP — guida generica](./sorare-to-mcp)
+- [Collegare Sorare a ChatGPT](./connect-sorare-to-chatgpt)
+- [Collegare Sorare a OpenClaw](./connect-sorare-to-openclaw)

--- a/content/guides/it/connect-sorare-to-openclaw.mdx
+++ b/content/guides/it/connect-sorare-to-openclaw.mdx
@@ -1,0 +1,92 @@
+---
+title: "Come collegare Sorare a OpenClaw — AI self-hosted + Fantasy Football NFT"
+description: "Usa l'assistente AI locale di OpenClaw per interrogare l'API GraphQL di Sorare tramite AnythingMCP. Trasporto MCP streamable-HTTP con Bearer auth, bcrypt-login e caching token a 30 giorni."
+category: "connectors"
+keyword: "Sorare OpenClaw, OpenClaw MCP, Sorare AI locale, OpenClaw connector, fantasy football OpenClaw"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "it"
+---
+
+## Collegare Sorare a OpenClaw
+
+[OpenClaw](https://openclaw.ai/) è un assistente AI personale open-source che gira in locale e supporta server MCP tramite il suo CLI. In combinazione con AnythingMCP ottieni un setup end-to-end privato e self-hosted per interrogare Sorare dalla tua macchina — password e JWT non escono mai dalla tua rete.
+
+### Cosa puoi fare
+
+- "Lista tutte le mie carte di giocatori della Premier League."
+- "Mostra aste per carte uniche di Mbappé che chiudono stasera."
+- "Qual è stato lo score della mia ultima line-up So5?"
+
+### Prerequisiti
+
+- OpenClaw installato (`docs.openclaw.ai/getting-started`).
+- AnythingMCP in locale su `http://localhost:4000`.
+- Account Sorare (read-only, **2FA disattivata** per uso headless).
+
+### Step 1 — Accessi Sorare
+
+Come per qualsiasi altro client:
+
+1. Login su https://sorare.com.
+2. Usa (o crea) un account read-only senza 2FA.
+3. Scegli una stringa **AUD** per il claim `aud` del JWT (es. `openclaw-mcp`).
+
+### Step 2 — Installa l'adapter Sorare
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, clicca **Sorare**, inserisci `SORARE_EMAIL`, `SORARE_PASSWORD`, `SORARE_AUD`. Genera una MCP API key in **Profile → MCP API Keys**.
+
+### Step 3 — Registra il server MCP in OpenClaw
+
+OpenClaw memorizza i server MCP sotto `mcp.servers` nella sua config. Aggiungi via CLI:
+
+```bash
+openclaw mcp set sorare '{
+  "url": "http://localhost:4000/mcp",
+  "transport": "streamable-http",
+  "connectionTimeoutMs": 10000,
+  "headers": {
+    "Authorization": "Bearer LA_TUA_MCP_API_KEY"
+  }
+}'
+```
+
+Verifica con `openclaw mcp list`. OpenClaw scopre i 7 tool Sorare e li espone alla sua runtime di agenti.
+
+### Tool disponibili
+
+| Tool | Descrizione |
+|---|---|
+| `sorare_current_user` | Profilo autenticato |
+| `sorare_get_card_by_slug` | Dettagli carta |
+| `sorare_search_player` | Ricerca giocatori |
+| `sorare_list_player_cards` | Carte di un giocatore |
+| `sorare_list_my_cards` | Le tue carte |
+| `sorare_get_lineup` | Line-up So5 |
+| `sorare_transfer_market` | Aste attive |
+
+### Rotazione token
+
+AnythingMCP cifra il JWT Sorare in `connector_auth_cache`, lo rinnova 24 h prima della scadenza e ri-effettua login a ogni 401. Il token vive ~30 giorni. Niente cron, niente refresh manuale.
+
+### FAQ
+
+**OpenClaw deve girare sulla stessa macchina di AnythingMCP?**
+No — `http://localhost:4000/mcp` è solo il default. Usa qualsiasi URL raggiungibile (consigliati TLS + Bearer auth).
+
+**Dove memorizza OpenClaw la config del server MCP?**
+Sotto `mcp.servers` nella config globale OpenClaw — gestita via `openclaw mcp set / list / remove`.
+
+**Posso usare più adapter dietro un solo entry server MCP?**
+Sì — ogni adapter installato in AnythingMCP diventa automaticamente un tool sullo stesso endpoint `/mcp`.
+
+### Prossimi passi
+
+- [Collegare Sorare a Claude](./connect-sorare-to-claude)
+- [Collegare Sorare a ChatGPT](./connect-sorare-to-chatgpt)
+- [Sorare su MCP — guida generica](./sorare-to-mcp)

--- a/content/guides/it/sorare-to-mcp.mdx
+++ b/content/guides/it/sorare-to-mcp.mdx
@@ -1,0 +1,59 @@
+---
+title: "Sorare su MCP — Fantasy Football NFT per qualsiasi agente AI"
+description: "Esponi l'API GraphQL di Sorare come server MCP con AnythingMCP. Login con bcrypt-salt, caching JWT a 30 giorni e 7 tool pronti per carte, giocatori, line-up e mercato dei trasferimenti."
+category: "connectors"
+keyword: "Sorare MCP, Sorare API MCP, Sorare agente AI, Sorare GraphQL, server MCP fantasy football"
+publishedAt: "2026-05-18"
+adapterSlug: "sorare"
+lang: "it"
+---
+
+## Sorare nel Model Context Protocol
+
+[Sorare](https://sorare.com/) è il più grande gioco di fantasy football NFT su licenza, con piena copertura GraphQL su giocatori, carte, aste e line-up So5. AnythingMCP impacchetta l'API GraphQL come **server MCP**: qualsiasi agente — Claude, ChatGPT, OpenClaw, Cursor o uno tuo — può leggere e agire sui dati Sorare in linguaggio naturale.
+
+L'adapter Sorare è incluso di default. Niente SDK da mantenere, nessun plumbing dei token da scrivere: la engine esegue l'handshake salt-fetch + bcrypt + login al primo tool call, mette in cache il JWT per 30 giorni e lo rinnova trasparente a ogni 401.
+
+### Perché Sorare è scomodo senza AnythingMCP
+
+| Step | Cosa richiede Sorare |
+|---|---|
+| 1 | `GET /api/v1/users/{email}` per ottenere un salt bcrypt per account |
+| 2 | `bcrypt.hashSync(plainPassword, salt)` lato client |
+| 3 | Mutation GraphQL `signIn` con l'hash bcrypt |
+| 4 | Conservare il JWT (~30 giorni di vita) e passare `Authorization: Bearer <jwt>` + `JWT-AUD: <aud>` su ogni chiamata |
+
+È esattamente il profilo auth **`LOGIN_TOKEN`**, dichiarato una volta come JSON nello spec dell'adapter. Zero codice client da mantenere.
+
+### Installazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, seleziona **Sorare** e inserisci `SORARE_EMAIL`, `SORARE_PASSWORD`, `SORARE_AUD` (qualsiasi stringa — Sorare la usa come claim `aud` del JWT).
+
+Crea una MCP API key da **Profile → MCP API Keys** e punta l'agente a `http://localhost:4000/mcp`.
+
+### Tool disponibili
+
+| Tool | Cosa restituisce |
+|---|---|
+| `sorare_current_user` | Slug, email, nickname dell'utente autenticato |
+| `sorare_get_card_by_slug` | Metadata carta, proprietario, asta attiva |
+| `sorare_search_player` | Giocatori per nome + club + paese |
+| `sorare_list_player_cards` | Carte recenti per un giocatore |
+| `sorare_list_my_cards` | Carte dell'utente autenticato |
+| `sorare_get_lineup` | Line-up So5: score, rank, ricompensa, comparse |
+| `sorare_transfer_market` | Aste attive, filtrabili per rarità / prezzo max |
+
+### Lifecycle del token
+
+Il JWT vive in `connector_auth_cache` (cifrato AES-256-GCM), refresh proattivo entro 24 h da `expiredAt` e sostituzione al primo 401. Puoi revocarlo con `DELETE FROM connector_auth_cache WHERE connector_id = '<id>'` — il prossimo tool call ri-effettua il login da zero.
+
+### Prossimi passi
+
+- [Collegare Sorare a Claude](./connect-sorare-to-claude)
+- [Collegare Sorare a ChatGPT](./connect-sorare-to-chatgpt)
+- [Collegare Sorare a OpenClaw](./connect-sorare-to-openclaw)

--- a/docs/connectors/login-token-auth.md
+++ b/docs/connectors/login-token-auth.md
@@ -1,0 +1,160 @@
+# LOGIN_TOKEN Authentication
+
+> Reference for adapter authors building connectors against APIs that:
+>
+> - Issue a long-lived bearer token in exchange for a credentials POST
+> - Optionally require the password to be bcrypt-hashed client-side with a salt fetched from the remote service (Sorare-style)
+> - Want automatic token caching, proactive refresh, and re-login on 401 with no per-call boilerplate
+
+[Back to README](../../README.md) | [Tool Definition](../tool-definition.md)
+
+---
+
+## When to use `LOGIN_TOKEN`
+
+| Scenario | Use |
+|---|---|
+| Static API key in a header | `API_KEY` |
+| User-provided bearer JWT, no rotation | `BEARER_TOKEN` |
+| HTTP Basic | `BASIC_AUTH` |
+| OAuth2 Authorization Code / Client Credentials with refresh tokens | `OAUTH2` |
+| **POST `{username, password}` → receive bearer good for hours/days** | **`LOGIN_TOKEN`** |
+| **Client-side bcrypt against a per-account salt before login** | **`LOGIN_TOKEN`** |
+
+If your provider already speaks OAuth2, prefer `OAUTH2` — it has standardised refresh, scope, and PKCE handling.
+
+---
+
+## How the engine flows
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ first tool call                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+    │
+    ├─ cache hit (memory) → use cached token ──────────────────────┐
+    │                                                              │
+    ├─ cache miss → DB lookup ─ row present, not near expiry ──────┤
+    │                                                              │
+    └─ cache miss + DB miss / expired:                             │
+         1. resolveSalt()      (saltSource.fetch OR static)        │
+         2. preparePassword()  (bcrypt OR passthrough)             │
+         3. POST loginBody     (interpolate ${...} placeholders)   │
+         4. extract token + expiry                                 │
+         5. cache in-memory + upsert connector_auth_cache row      │
+                                                                   │
+                                                          ┌────────┘
+                                                          ▼
+                                      inject Authorization header (+ extraHeaders)
+                                                          ▼
+                                      execute the tool call ─────► API
+                                                          │
+                                                          ▼
+                                              response 401? ──► forceRelogin() + retry once
+```
+
+The token cache is keyed by `connectorId` (when available) or by `loginUrl|username`. A per-key mutex prevents concurrent refresh storms.
+
+---
+
+## `authConfig` field reference
+
+```jsonc
+{
+  // ─── Login endpoint ────────────────────────────────────────────
+  "loginUrl": "https://api.example.com/graphql",
+  "loginMethod": "POST",                     // GET | POST (default POST)
+  "loginHeaders": { "X-App": "anythingmcp" }, // static headers for the login call
+
+  // ─── Body: prefer structured `loginBody` (recursive ${name} substitution) ─
+  "loginBody": {
+    "query": "mutation Login($email: String!, $password: String!) { signIn(input: {email: $email, password: $password}) { token } }",
+    "variables": {
+      "email": "${username}",
+      "password": "${passwordHashed}"
+    }
+  },
+  // …or a raw string template (only for very simple JSON bodies):
+  "loginBodyTemplate": "{\"u\":\"${username}\",\"p\":\"${passwordHashed}\"}",
+
+  // ─── Credentials & client identity ─────────────────────────────
+  "username": "{{SERVICE_EMAIL}}",
+  "password": "{{SERVICE_PASSWORD}}",
+  "aud":      "{{SERVICE_AUD}}",     // optional; exposed in ${aud} for templates/headers
+  "otp":      "{{SERVICE_OTP}}",     // optional 2FA code
+
+  // ─── Client-side password preprocessing ────────────────────────
+  "passwordHashing": {
+    "scheme": "bcrypt",              // bcrypt | none
+    "saltSource": {                  // required when scheme=bcrypt
+      "type": "fetch",               // fetch | static
+      "method": "GET",
+      "url": "https://api.example.com/api/v1/users/${username}",
+      "headers": { },
+      "responsePath": "salt",        // JSON path to salt in the response
+      "value": "$2a$11$..."          // only when type=static
+    },
+    "outputParam": "passwordHashed"  // name exposed to the body template (default: passwordHashed)
+  },
+
+  // ─── Where to find the token & expiry in the login response ────
+  "tokenJsonPath":  "data.signIn.jwtToken.token",
+  "expiryJsonPath": "data.signIn.jwtToken.expiredAt",
+  "audJsonPath":    "data.signIn.jwtToken.aud",      // optional — overrides authConfig.aud
+  "expiryFormat":   "iso8601",                       // iso8601 | unix | ttl_seconds
+  "tokenTTLSeconds": 2592000,                        // fallback when expiry is absent (30 days)
+
+  // ─── Re-login policy ───────────────────────────────────────────
+  "refreshOn401": true,                              // re-login on a 401 and retry once (default true)
+  "proactiveRefreshSeconds": 86400,                  // re-login when this much remains (default 24 h)
+
+  // ─── Header injection for downstream tool calls ────────────────
+  "headerName":     "Authorization",                 // default Authorization
+  "headerTemplate": "Bearer ${token}",               // default "Bearer ${token}"
+  "extraHeaders": {
+    "JWT-AUD": "${aud}"
+  }
+}
+```
+
+### Placeholders available in templates
+
+The placeholders below are substituted by the engine when rendering `loginBody` / `loginBodyTemplate` and the salt-source URL:
+
+| Placeholder | Source |
+|---|---|
+| `${username}` | `authConfig.username` |
+| `${password}` | `authConfig.password` (plain, **before** hashing) |
+| `${passwordHashed}` | output of the password preprocessor (renamed via `outputParam`) |
+| `${aud}` | `authConfig.aud` |
+| `${otp}` | `authConfig.otp` |
+
+In `headerTemplate` and `extraHeaders`, only `${token}` and `${aud}` are available (these refer to the issued token, not the credentials).
+
+### Expiry formats
+
+| `expiryFormat` | Value at `expiryJsonPath` |
+|---|---|
+| `iso8601` *(default)* | `"2026-06-17T08:34:21Z"` |
+| `unix` | Seconds (≤1e12) or milliseconds since epoch |
+| `ttl_seconds` | Lifetime in seconds from now |
+
+If `expiryJsonPath` is missing or unresolvable, the engine falls back to `tokenTTLSeconds` (default 30 days).
+
+---
+
+## Security notes
+
+- **Plain passwords never leave the server.** Only the bcrypt hash is sent over the wire; the plain password lives only in encrypted `authConfig` storage.
+- The encrypted `authConfig` is decrypted in-process at request time and never logged.
+- Tokens persisted in `connector_auth_cache` are encrypted with the same AES-256-GCM key (`ENCRYPTION_KEY` env var).
+- The salt-fetch and login URLs are passed through the SSRF guard (`assertSafeOutboundUrl`) before each request — they cannot point to private addresses.
+- `${...}` placeholders are substituted as exact values, not eval'd; prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are rejected by the raw-string renderer.
+
+---
+
+## End-to-end example: Sorare
+
+See [`packages/backend/src/adapters/intl/sorare.json`](../../packages/backend/src/adapters/intl/sorare.json) for a full production adapter using this auth type — including a GraphQL `signIn` mutation, bcrypt salt fetched from `/api/v1/users/{email}`, 30-day JWT caching, and an `extraHeaders` entry for Sorare's required `JWT-AUD` header.
+
+[Back to README](../../README.md) | [Tool Definition](../tool-definition.md)

--- a/docs/tool-definition.md
+++ b/docs/tool-definition.md
@@ -188,4 +188,50 @@ This filters the response to only include the specified fields, reducing token u
 
 ---
 
-[Back to README](../README.md) | [API Reference](api-reference.md) | [REST Connector](connectors/rest.md)
+## Authentication: `LOGIN_TOKEN`
+
+In addition to the standard `NONE` / `API_KEY` / `BEARER_TOKEN` / `BASIC_AUTH` / `OAUTH2` / `QUERY_AUTH` / `WS_SECURITY` / `CERTIFICATE` / `CONNECTION_STRING` schemes, the connector spec supports `LOGIN_TOKEN` for APIs that issue a long-lived bearer **in exchange for a credentials POST** — optionally requiring the password to be **bcrypt-hashed with a salt fetched from the remote service** (Sorare-style).
+
+The engine handles salt fetch → bcrypt → login → token cache → proactive refresh → re-login-on-401 automatically. Adapter authors declare the full flow as JSON:
+
+```json
+{
+  "authType": "LOGIN_TOKEN",
+  "authConfig": {
+    "loginUrl": "https://api.example.com/graphql",
+    "loginMethod": "POST",
+    "loginBody": {
+      "query": "mutation Login($email: String!, $password: String!) { signIn(input: {email: $email, password: $password}) { jwtToken { token expiredAt } } }",
+      "variables": { "email": "${username}", "password": "${passwordHashed}" }
+    },
+    "username": "{{SERVICE_EMAIL}}",
+    "password": "{{SERVICE_PASSWORD}}",
+    "aud": "{{SERVICE_AUD}}",
+    "passwordHashing": {
+      "scheme": "bcrypt",
+      "saltSource": {
+        "type": "fetch",
+        "method": "GET",
+        "url": "https://api.example.com/api/v1/users/${username}",
+        "responsePath": "salt"
+      },
+      "outputParam": "passwordHashed"
+    },
+    "tokenJsonPath": "data.signIn.jwtToken.token",
+    "expiryJsonPath": "data.signIn.jwtToken.expiredAt",
+    "expiryFormat": "iso8601",
+    "tokenTTLSeconds": 2592000,
+    "refreshOn401": true,
+    "proactiveRefreshSeconds": 86400,
+    "headerName": "Authorization",
+    "headerTemplate": "Bearer ${token}",
+    "extraHeaders": { "JWT-AUD": "${aud}" }
+  }
+}
+```
+
+See [`docs/connectors/login-token-auth.md`](connectors/login-token-auth.md) for the full field-by-field reference, salt-source types (`fetch` vs `static`), expiry formats (`iso8601` / `unix` / `ttl_seconds`), and re-login policies.
+
+---
+
+[Back to README](../README.md) | [API Reference](api-reference.md) | [REST Connector](connectors/rest.md) | [LOGIN_TOKEN reference](connectors/login-token-auth.md)

--- a/packages/backend/prisma/migrations/20260518000000_add_login_token_auth/migration.sql
+++ b/packages/backend/prisma/migrations/20260518000000_add_login_token_auth/migration.sql
@@ -1,0 +1,21 @@
+-- Add LOGIN_TOKEN to AuthType enum
+ALTER TYPE "AuthType" ADD VALUE 'LOGIN_TOKEN';
+
+-- CreateTable
+CREATE TABLE "connector_auth_cache" (
+    "id" TEXT NOT NULL,
+    "connector_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "metadata" JSONB,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "connector_auth_cache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "connector_auth_cache_connector_id_key" ON "connector_auth_cache"("connector_id");
+
+-- AddForeignKey
+ALTER TABLE "connector_auth_cache" ADD CONSTRAINT "connector_auth_cache_connector_id_fkey" FOREIGN KEY ("connector_id") REFERENCES "connectors"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -254,6 +254,7 @@ enum AuthType {
   WS_SECURITY
   CERTIFICATE
   CONNECTION_STRING
+  LOGIN_TOKEN
 }
 
 model Connector {
@@ -298,9 +299,29 @@ model Connector {
   resources  McpResource[]
   prompts    McpPrompt[]
   mcpServers McpServerConnector[]
+  authCache  ConnectorAuthCache?
 
   @@index([organizationId])
   @@map("connectors")
+}
+
+// ── Connector Auth Cache ────────────────────────────────────────────────────
+// Stores short-/long-lived tokens issued by remote auth flows (e.g. LOGIN_TOKEN
+// adapters such as Sorare) so we don't re-login on every tool call.
+// Token is encrypted at rest with the same AES-256-GCM key as authConfig.
+
+model ConnectorAuthCache {
+  id          String    @id @default(cuid())
+  connectorId String    @unique @map("connector_id")
+  connector   Connector @relation(fields: [connectorId], references: [id], onDelete: Cascade)
+
+  token     String    @db.Text // encrypted bearer token
+  metadata  Json?     // free-form: aud claim, refresh tokens, scopes, etc.
+  expiresAt DateTime  @map("expires_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  @@map("connector_auth_cache")
 }
 
 // ── MCP Tool Definition ─────────────────────────────────────────────────────

--- a/packages/backend/src/adapters/catalog.spec.ts
+++ b/packages/backend/src/adapters/catalog.spec.ts
@@ -7,9 +7,14 @@ const VALID_AUTH_TYPES = new Set([
   'BASIC_AUTH',
   'OAUTH2',
   'QUERY_AUTH',
+  'LOGIN_TOKEN',
 ]);
 
-const VALID_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+const VALID_PASSWORD_HASHING_SCHEMES = new Set(['bcrypt', 'none']);
+const VALID_SALT_SOURCE_TYPES = new Set(['fetch', 'static']);
+
+const VALID_REST_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+const VALID_GRAPHQL_METHODS = new Set(['QUERY', 'MUTATION', 'SUBSCRIPTION']);
 
 /**
  * Recursively collect every string value in an object/array, together with the
@@ -55,12 +60,37 @@ describe('adapter catalog', () => {
       expect(adapter.tools.length).toBeGreaterThan(0);
     });
 
+    if (meta.region === 'intl' || adapter.connector.authType === 'LOGIN_TOKEN') {
+      it('LOGIN_TOKEN authConfig is well-formed', () => {
+        if (adapter.connector.authType !== 'LOGIN_TOKEN') return;
+        const cfg = adapter.connector.authConfig as Record<string, unknown>;
+        expect(cfg).toBeDefined();
+        expect(typeof cfg.loginUrl).toBe('string');
+        expect(typeof cfg.tokenJsonPath).toBe('string');
+        if (cfg.passwordHashing) {
+          const ph = cfg.passwordHashing as Record<string, unknown>;
+          expect(VALID_PASSWORD_HASHING_SCHEMES.has(String(ph.scheme))).toBe(true);
+          if (ph.scheme === 'bcrypt') {
+            expect(ph.saltSource).toBeDefined();
+            const src = ph.saltSource as Record<string, unknown>;
+            expect(VALID_SALT_SOURCE_TYPES.has(String(src.type))).toBe(true);
+            if (src.type === 'fetch') expect(typeof src.url).toBe('string');
+            if (src.type === 'static') expect(typeof src.value).toBe('string');
+          }
+        }
+      });
+    }
+
     it.each(adapter.tools.map((t) => [t.name, t]))(
       '%s has a well-formed endpointMapping',
       (_name, tool) => {
         const em = tool.endpointMapping as Record<string, unknown>;
 
-        expect(VALID_METHODS.has(String(em.method).toUpperCase())).toBe(true);
+        const allowed =
+          adapter.connector.type === 'GRAPHQL'
+            ? VALID_GRAPHQL_METHODS
+            : VALID_REST_METHODS;
+        expect(allowed.has(String(em.method).toUpperCase())).toBe(true);
         expect(typeof em.path).toBe('string');
 
         // Legacy `body` field must be renamed to `bodyMapping`/`bodyTemplate`

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -34,6 +34,7 @@ import * as razorpay from './in/razorpay.json';
 import * as mercadoLibre from './br/mercado-libre.json';
 import * as paystack from './ng/paystack.json';
 import * as lineMessaging from './jp/line-messaging.json';
+import * as sorare from './intl/sorare.json';
 
 export interface AdapterMeta {
   slug: string;
@@ -46,6 +47,10 @@ export interface AdapterMeta {
   docsUrl: string;
   requiredEnvVars: string[];
   toolCount: number;
+  /** When true, surfaced in the marketing site's "Featured" rail. */
+  featured?: boolean;
+  /** Higher = ranked earlier in catalog listings. Default 0. */
+  priority?: number;
 }
 
 export interface AdapterDefinition extends AdapterMeta {
@@ -107,6 +112,7 @@ const ALL_ADAPTERS: AdapterDefinition[] = [
   mercadoLibre as unknown as AdapterDefinition,
   paystack as unknown as AdapterDefinition,
   lineMessaging as unknown as AdapterDefinition,
+  sorare as unknown as AdapterDefinition,
 ];
 
 export function listAdapters(): AdapterMeta[] {
@@ -121,6 +127,8 @@ export function listAdapters(): AdapterMeta[] {
     docsUrl: adapter.docsUrl,
     requiredEnvVars: adapter.requiredEnvVars,
     toolCount: adapter.tools.length,
+    featured: adapter.featured,
+    priority: adapter.priority,
   }));
 }
 

--- a/packages/backend/src/adapters/de/hrworks.live.spec.ts
+++ b/packages/backend/src/adapters/de/hrworks.live.spec.ts
@@ -1,6 +1,7 @@
 import * as adapter from './hrworks.json';
 import { RestEngine } from '../../connectors/engines/rest.engine';
 import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
 
 /**
  * Smoke test against the real HR WORKS sandbox endpoint to verify that:
@@ -18,7 +19,8 @@ const maybe = process.env.RUN_HRWORKS_LIVE ? describe : describe.skip;
 maybe('hrworks adapter — live smoke test', () => {
   // Minimal stub — we don't exercise OAuth2 paths in this test
   const oauth = {} as unknown as OAuth2TokenService;
-  const engine = new RestEngine(oauth);
+  const login = {} as unknown as LoginTokenService;
+  const engine = new RestEngine(oauth, login);
 
   it('reaches HR WORKS auth endpoint and gets InvalidCredentials with bogus creds', async () => {
     const cfg = adapter as unknown as {

--- a/packages/backend/src/adapters/de/weclapp.live.spec.ts
+++ b/packages/backend/src/adapters/de/weclapp.live.spec.ts
@@ -1,6 +1,7 @@
 import * as adapter from './weclapp.json';
 import { RestEngine } from '../../connectors/engines/rest.engine';
 import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
 
 /**
  * Two layers of verification for the weclapp adapter:
@@ -56,7 +57,8 @@ const maybe = process.env.RUN_WECLAPP_LIVE ? describe : describe.skip;
 
 maybe('weclapp adapter — live edge reachability', () => {
   const oauth = {} as unknown as OAuth2TokenService;
-  const engine = new RestEngine(oauth);
+  const login = {} as unknown as LoginTokenService;
+  const engine = new RestEngine(oauth, login);
 
   // Bogus tenant: weclapp uses wildcard DNS (*.weclapp.com → Akamai → ALB),
   // so the request reaches weclapp's edge but the ALB returns 404 because

--- a/packages/backend/src/adapters/intl/sorare.json
+++ b/packages/backend/src/adapters/intl/sorare.json
@@ -1,0 +1,225 @@
+{
+  "slug": "sorare",
+  "name": "Sorare Fantasy Football",
+  "description": "GraphQL API for Sorare's NFT-based fantasy football, baseball, and basketball games. Query cards, players, lineups, transfer market, and your portfolio with natural-language commands. Handles Sorare's bcrypt-salted login and 30-day JWT caching automatically.",
+  "region": "intl",
+  "category": "gaming",
+  "icon": "sorare",
+  "docsUrl": "https://github.com/sorare/api",
+  "featured": true,
+  "priority": 100,
+  "requiredEnvVars": ["SORARE_EMAIL", "SORARE_PASSWORD", "SORARE_AUD"],
+  "instructions": "## Authentication (handled automatically)\n\nSorare uses a custom two-step login the AnythingMCP `LOGIN_TOKEN` engine performs for you:\n\n1. `GET https://api.sorare.com/api/v1/users/{email}` returns the account's bcrypt salt.\n2. Your plain password is hashed locally with `bcrypt.hashSync(password, salt)`.\n3. The hash is sent through Sorare's `signIn` GraphQL mutation; Sorare returns a JWT valid for ~30 days.\n4. Every subsequent call adds `Authorization: Bearer <jwt>` and `JWT-AUD: <aud>` headers.\n\nThe token is cached in-memory and in the encrypted `connector_auth_cache` table, then proactively re-issued ~24 h before expiry and on any 401. You never need to refresh manually.\n\n## Credentials\n\n- `SORARE_EMAIL` — your Sorare account email.\n- `SORARE_PASSWORD` — your plain account password (never stored or transmitted in plain text after the first login; only the bcrypt hash leaves your server).\n- `SORARE_AUD` — a free-form audience identifier you choose (e.g. `my-mcp-server`). Sorare embeds it in the JWT `aud` claim; private endpoints require the same value in the `JWT-AUD` header — both are wired up for you.\n\n## 2FA\n\nIf your account has 2FA enabled, the `signIn` mutation will fail until you provide a fresh `otpAttempt`. For headless/server use we recommend creating a dedicated read-only Sorare account without 2FA. Set `SORARE_PASSWORD` to that account's password.\n\n## Rate limits\n\nSorare enforces per-IP and per-token rate limits (\"too many requests\" on `429`). Heavy bulk-export workflows should batch and back-off.\n\n## Useful starter prompts\n\n- \"Show me my current Sorare account.\"\n- \"Find the next 5 Lionel Messi rare cards on auction under 0.05 ETH.\"\n- \"List my limited cards by player.\"\n- \"What auctions for Real Madrid players close in the next hour?\"",
+  "connector": {
+    "name": "Sorare",
+    "type": "GRAPHQL",
+    "baseUrl": "https://api.sorare.com/graphql",
+    "authType": "LOGIN_TOKEN",
+    "authConfig": {
+      "loginUrl": "https://api.sorare.com/graphql",
+      "loginMethod": "POST",
+      "loginBody": {
+        "query": "mutation SignInMutation($input: signInInput!) { signIn(input: $input) { currentUser { slug } jwtToken(aud: \"${aud}\") { token expiredAt } errors { message } } }",
+        "variables": {
+          "input": {
+            "email": "${username}",
+            "password": "${passwordHashed}"
+          }
+        }
+      },
+      "username": "{{SORARE_EMAIL}}",
+      "password": "{{SORARE_PASSWORD}}",
+      "aud": "{{SORARE_AUD}}",
+      "passwordHashing": {
+        "scheme": "bcrypt",
+        "saltSource": {
+          "type": "fetch",
+          "method": "GET",
+          "url": "https://api.sorare.com/api/v1/users/${username}",
+          "responsePath": "salt"
+        },
+        "outputParam": "passwordHashed"
+      },
+      "tokenJsonPath": "data.signIn.jwtToken.token",
+      "expiryJsonPath": "data.signIn.jwtToken.expiredAt",
+      "expiryFormat": "iso8601",
+      "tokenTTLSeconds": 2592000,
+      "refreshOn401": true,
+      "proactiveRefreshSeconds": 86400,
+      "headerName": "Authorization",
+      "headerTemplate": "Bearer ${token}",
+      "extraHeaders": {
+        "JWT-AUD": "${aud}"
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "sorare_current_user",
+      "description": "Get the authenticated Sorare user's profile (slug, email, nickname). Use this first to confirm the connection is healthy.",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query CurrentUser { currentUser { slug email nickname } }"
+      }
+    },
+    {
+      "name": "sorare_get_card_by_slug",
+      "description": "Fetch a single Sorare card by its slug (e.g. 'lionel-messi-2023-rare-1'). Returns player, scarcity, season, owner, and current auction state.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "The card's unique slug from a card URL."
+          }
+        },
+        "required": ["slug"],
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query CardBySlug($slug: String!) { football { card(slug: $slug) { slug name pictureUrl rarity power player { slug displayName } season { startYear endYear } user { slug } activeSingleSaleOffer { senderSide { wei } } } } }",
+        "queryParams": {
+          "slug": "$slug"
+        }
+      }
+    },
+    {
+      "name": "sorare_search_player",
+      "description": "Search for a football player by name and return basic player metadata (slug, full name, club, country). Use the slug with sorare_list_player_cards.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Player's display name or partial name."
+          }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query PlayerSearch($name: String!) { football { players(search: { name: $name }, first: 5) { nodes { slug displayName birthDate country { slug } activeClub { name } } } } }",
+        "queryParams": {
+          "name": "$name"
+        }
+      }
+    },
+    {
+      "name": "sorare_list_player_cards",
+      "description": "List the most recent cards for a given player slug, with their rarity, season, and current owner.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "playerSlug": {
+            "type": "string",
+            "description": "Player slug (from sorare_search_player)."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10,
+            "description": "Max cards to return (1–50)."
+          }
+        },
+        "required": ["playerSlug"],
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query PlayerCards($playerSlug: String!, $limit: Int!) { football { player(slug: $playerSlug) { cards(first: $limit) { nodes { slug rarity season { startYear } user { slug } } } } } }",
+        "queryParams": {
+          "playerSlug": "$playerSlug",
+          "limit": "$limit"
+        }
+      }
+    },
+    {
+      "name": "sorare_list_my_cards",
+      "description": "List the football cards owned by the authenticated user with rarity, player, and season.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 20,
+            "description": "Max cards to return (1–50)."
+          }
+        },
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query MyCards($limit: Int!) { currentUser { football { myCards(first: $limit) { nodes { slug rarity player { displayName } season { startYear } } } } } }",
+        "queryParams": {
+          "limit": "$limit"
+        }
+      }
+    },
+    {
+      "name": "sorare_get_lineup",
+      "description": "Fetch a Sorare So5 lineup by id, returning composition, captain, score, and reward.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "lineupId": {
+            "type": "string",
+            "description": "The So5 lineup id."
+          }
+        },
+        "required": ["lineupId"],
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query Lineup($lineupId: String!) { so5 { so5Lineup(id: $lineupId) { id score rank reward so5Appearances { score card { slug player { displayName } } } } } }",
+        "queryParams": {
+          "lineupId": "$lineupId"
+        }
+      }
+    },
+    {
+      "name": "sorare_transfer_market",
+      "description": "Browse Sorare's transfer market with optional rarity, sport, and max-price filters. Returns the slug, player, current bid, and end time of each active offer.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "rarity": {
+            "type": "string",
+            "enum": ["common", "limited", "rare", "super_rare", "unique"],
+            "description": "Filter by rarity tier."
+          },
+          "maxPriceWei": {
+            "type": "string",
+            "description": "Maximum acceptable price in wei (use a string to avoid precision loss)."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10
+          }
+        },
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query TransferMarket($rarity: Rarity, $maxPriceWei: String, $limit: Int!) { football { transferMarket(rarity: $rarity, maxPrice: { wei: $maxPriceWei }, first: $limit) { nodes { card { slug player { displayName } rarity } senderSide { wei } endDate } } } }",
+        "queryParams": {
+          "rarity": "$rarity",
+          "maxPriceWei": "$maxPriceWei",
+          "limit": "$limit"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -9,6 +9,7 @@ import { GraphqlEngine } from './engines/graphql.engine';
 import { McpClientEngine } from './engines/mcp-client.engine';
 import { DatabaseEngine } from './engines/database.engine';
 import { OAuth2TokenService } from './engines/oauth2-token.service';
+import { LoginTokenService } from './engines/login-token.service';
 import { OpenApiParser } from './parsers/openapi.parser';
 import { WsdlParser } from './parsers/wsdl.parser';
 import { GraphqlParser } from './parsers/graphql.parser';
@@ -31,7 +32,20 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
 @Module({
   imports: [McpServerModule, LicenseModule],
   controllers: [ConnectorsController, McpOAuthCallbackController, ToolsController],
-  providers: [ConnectorsService, McpOAuthService, OAuth2TokenService, ...ENGINES, ...PARSERS],
-  exports: [ConnectorsService, McpOAuthService, OAuth2TokenService, ...ENGINES],
+  providers: [
+    ConnectorsService,
+    McpOAuthService,
+    OAuth2TokenService,
+    LoginTokenService,
+    ...ENGINES,
+    ...PARSERS,
+  ],
+  exports: [
+    ConnectorsService,
+    McpOAuthService,
+    OAuth2TokenService,
+    LoginTokenService,
+    ...ENGINES,
+  ],
 })
 export class ConnectorsModule {}

--- a/packages/backend/src/connectors/engines/graphql.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.spec.ts
@@ -1,5 +1,6 @@
 import { GraphqlEngine } from './graphql.engine';
 import { OAuth2TokenService } from './oauth2-token.service';
+import { LoginTokenService } from './login-token.service';
 import axios, { AxiosError } from 'axios';
 
 jest.mock('axios');
@@ -8,13 +9,26 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe('GraphqlEngine', () => {
   let engine: GraphqlEngine;
   let mockOAuth2TokenService: jest.Mocked<OAuth2TokenService>;
+  let mockLoginTokenService: jest.Mocked<LoginTokenService>;
 
   beforeEach(() => {
     mockOAuth2TokenService = {
       getAccessToken: jest.fn().mockResolvedValue('oauth2-access-token'),
       refreshToken: jest.fn().mockResolvedValue('new-access-token'),
     } as any;
-    engine = new GraphqlEngine(mockOAuth2TokenService);
+    mockLoginTokenService = {
+      getToken: jest.fn().mockResolvedValue({
+        token: 'login-jwt',
+        aud: 'test-aud',
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      }),
+      forceRelogin: jest.fn().mockResolvedValue({
+        token: 'login-jwt-fresh',
+        aud: 'test-aud',
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      }),
+    } as any;
+    engine = new GraphqlEngine(mockOAuth2TokenService, mockLoginTokenService);
     jest.clearAllMocks();
   });
 

--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosError } from 'axios';
 import { OAuth2TokenService } from './oauth2-token.service';
+import {
+  LoginTokenService,
+  LoginTokenAuthConfig,
+} from './login-token.service';
 import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /**
@@ -11,7 +15,10 @@ import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 export class GraphqlEngine {
   private readonly logger = new Logger(GraphqlEngine.name);
 
-  constructor(private readonly oauth2TokenService: OAuth2TokenService) {}
+  constructor(
+    private readonly oauth2TokenService: OAuth2TokenService,
+    private readonly loginTokenService: LoginTokenService,
+  ) {}
 
   async execute(
     config: {
@@ -75,6 +82,15 @@ export class GraphqlEngine {
           const password = String(config.authConfig.password || '');
           headers['Authorization'] =
             `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+          break;
+        }
+        case 'LOGIN_TOKEN': {
+          const auth = config.authConfig as unknown as LoginTokenAuthConfig;
+          const bundle = await this.loginTokenService.getToken(
+            auth,
+            config.connectorId,
+          );
+          applyLoginTokenHeaders(headers, auth, bundle.token, bundle.aud);
           break;
         }
       }
@@ -143,7 +159,53 @@ export class GraphqlEngine {
           return retryResponse.data.data;
         }
       }
+      // LOGIN_TOKEN auto-relogin on 401
+      if (
+        error instanceof AxiosError &&
+        error.response?.status === 401 &&
+        config.authType === 'LOGIN_TOKEN' &&
+        (config.authConfig as Record<string, unknown> | undefined)?.refreshOn401 !==
+          false
+      ) {
+        this.logger.debug('LOGIN_TOKEN: 401 received, re-issuing token...');
+        const auth = config.authConfig as unknown as LoginTokenAuthConfig;
+        const bundle = await this.loginTokenService.forceRelogin(
+          auth,
+          config.connectorId,
+        );
+        applyLoginTokenHeaders(headers, auth, bundle.token, bundle.aud);
+        const retry = await axios.post(config.baseUrl, requestConfig, {
+          headers,
+          timeout: 30000,
+        });
+        if (retry.data.errors) {
+          throw new Error(
+            `GraphQL errors: ${JSON.stringify(retry.data.errors)}`,
+          );
+        }
+        return retry.data.data;
+      }
       throw error;
     }
+  }
+}
+
+/**
+ * Apply LOGIN_TOKEN headers (main bearer + extraHeaders) into a plain headers map,
+ * interpolating `${token}` and `${aud}` placeholders.
+ */
+export function applyLoginTokenHeaders(
+  headers: Record<string, string>,
+  auth: LoginTokenAuthConfig,
+  token: string,
+  aud?: string,
+): void {
+  const headerName = auth.headerName || 'Authorization';
+  const headerTemplate = auth.headerTemplate || 'Bearer ${token}';
+  const interpolate = (s: string): string =>
+    s.replace(/\$\{token\}/g, token).replace(/\$\{aud\}/g, aud || '');
+  headers[headerName] = interpolate(headerTemplate);
+  for (const [k, v] of Object.entries(auth.extraHeaders || {})) {
+    headers[k] = interpolate(String(v));
   }
 }

--- a/packages/backend/src/connectors/engines/login-token.service.spec.ts
+++ b/packages/backend/src/connectors/engines/login-token.service.spec.ts
@@ -1,0 +1,273 @@
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import * as bcrypt from 'bcrypt';
+import {
+  LoginTokenService,
+  jsonPath,
+  interpolateDeep,
+  LoginTokenAuthConfig,
+} from './login-token.service';
+import { encrypt } from '../../common/crypto/encryption.util';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('jsonPath helper', () => {
+  it('reads nested object path', () => {
+    expect(jsonPath({ a: { b: { c: 42 } } }, 'a.b.c')).toBe(42);
+  });
+
+  it('reads array index path', () => {
+    expect(jsonPath({ arr: [{ id: 9 }] }, 'arr[0].id')).toBe(9);
+  });
+
+  it('returns undefined for missing keys', () => {
+    expect(jsonPath({ a: 1 }, 'a.b.c')).toBeUndefined();
+  });
+
+  it('handles null root', () => {
+    expect(jsonPath(null, 'a.b')).toBeUndefined();
+  });
+});
+
+describe('interpolateDeep helper', () => {
+  it('substitutes full-string references and preserves structure', () => {
+    const out = interpolateDeep(
+      { query: 'mutation', variables: { email: '${u}', otp: '${o}' } },
+      { u: 'a@b.co', o: '' },
+    );
+    expect(out).toEqual({
+      query: 'mutation',
+      variables: { email: 'a@b.co', otp: '' },
+    });
+  });
+
+  it('interpolates embedded placeholders in strings', () => {
+    expect(interpolateDeep('/users/${u}', { u: 'x' })).toBe('/users/x');
+  });
+
+  it('leaves non-string leaves untouched', () => {
+    expect(interpolateDeep({ n: 42, b: true }, {})).toEqual({ n: 42, b: true });
+  });
+});
+
+describe('LoginTokenService', () => {
+  let service: LoginTokenService;
+  let mockPrisma: any;
+  let mockConfig: jest.Mocked<ConfigService>;
+  const encryptionKey = 'test-encryption-key-32-chars-ok!';
+
+  const baseAuth: LoginTokenAuthConfig = {
+    loginUrl: 'https://api.example.com/graphql',
+    username: 'user@example.com',
+    password: 'plain-password',
+    aud: 'test-client',
+    loginBody: {
+      query:
+        'mutation SignIn($email: String!, $password: String!) { signIn(input: {email: $email, password: $password}) { token aud expiresAt } }',
+      variables: {
+        email: '${username}',
+        password: '${passwordHashed}',
+      },
+    },
+    passwordHashing: {
+      scheme: 'bcrypt',
+      saltSource: {
+        type: 'fetch',
+        method: 'GET',
+        url: 'https://api.example.com/users/${username}',
+        responsePath: 'salt',
+      },
+      outputParam: 'passwordHashed',
+    },
+    tokenJsonPath: 'data.signIn.token',
+    audJsonPath: 'data.signIn.aud',
+    expiryJsonPath: 'data.signIn.expiresAt',
+    expiryFormat: 'iso8601',
+    tokenTTLSeconds: 30 * 24 * 60 * 60,
+  };
+
+  beforeEach(() => {
+    mockPrisma = {
+      connectorAuthCache: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+    };
+    mockConfig = { get: jest.fn().mockReturnValue(encryptionKey) } as any;
+    service = new LoginTokenService(mockPrisma, mockConfig);
+    jest.clearAllMocks();
+    mockConfig.get.mockReturnValue(encryptionKey);
+  });
+
+  it('fetches salt, bcrypt-hashes password, then logs in and caches token', async () => {
+    const salt = bcrypt.genSaltSync(4);
+    const expectedHash = bcrypt.hashSync('plain-password', salt);
+
+    (mockedAxios as unknown as jest.Mock).mockImplementation(
+      async (config: any) => {
+        if (config.url.includes('/users/')) {
+          return { data: { salt } };
+        }
+        // Login POST: verify the bcrypt hash made it into the request body
+        const body = config.data;
+        expect(body.variables.password).toBe(expectedHash);
+        expect(body.variables.email).toBe('user@example.com');
+        return {
+          data: {
+            data: {
+              signIn: {
+                token: 'jwt-abc',
+                aud: 'test-client',
+                expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+              },
+            },
+          },
+        };
+      },
+    );
+
+    const bundle = await service.getToken(baseAuth, 'conn-1');
+
+    expect(bundle.token).toBe('jwt-abc');
+    expect(bundle.aud).toBe('test-client');
+    expect(bundle.expiresAt).toBeGreaterThan(Date.now() + 29 * 24 * 60 * 60 * 1000);
+    expect(mockPrisma.connectorAuthCache.upsert).toHaveBeenCalled();
+  });
+
+  it('returns cached token without re-logging in on subsequent calls', async () => {
+    const salt = bcrypt.genSaltSync(4);
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      if (config.url.includes('/users/')) return { data: { salt } };
+      return {
+        data: {
+          data: {
+            signIn: {
+              token: 'jwt-cached',
+              aud: 'test-client',
+              expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+          },
+        },
+      };
+    });
+
+    await service.getToken(baseAuth, 'conn-2');
+    const callsAfterFirst = (mockedAxios as unknown as jest.Mock).mock.calls.length;
+
+    const second = await service.getToken(baseAuth, 'conn-2');
+    expect(second.token).toBe('jwt-cached');
+
+    const callsAfterSecond = (mockedAxios as unknown as jest.Mock).mock.calls.length;
+    expect(callsAfterSecond).toBe(callsAfterFirst); // no new HTTP calls
+  });
+
+  it('hydrates token from DB when memory cache is cold', async () => {
+    const expiresAt = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    mockPrisma.connectorAuthCache.findUnique.mockResolvedValue({
+      token: encrypt('persisted-token', encryptionKey),
+      metadata: { aud: 'test-client' },
+      expiresAt,
+    });
+
+    const bundle = await service.getToken(baseAuth, 'conn-3');
+    expect(bundle.token).toBe('persisted-token');
+    expect(bundle.aud).toBe('test-client');
+    expect(mockedAxios as unknown as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('forceRelogin bypasses cache and re-issues token', async () => {
+    const salt = bcrypt.genSaltSync(4);
+    let loginCount = 0;
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      if (config.url.includes('/users/')) return { data: { salt } };
+      loginCount++;
+      return {
+        data: {
+          data: {
+            signIn: {
+              token: `jwt-${loginCount}`,
+              aud: 'test-client',
+              expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+          },
+        },
+      };
+    });
+
+    const first = await service.getToken(baseAuth, 'conn-4');
+    const refreshed = await service.forceRelogin(baseAuth, 'conn-4');
+    expect(first.token).toBe('jwt-1');
+    expect(refreshed.token).toBe('jwt-2');
+  });
+
+  it('falls back to tokenTTLSeconds when expiryJsonPath is missing in response', async () => {
+    const salt = bcrypt.genSaltSync(4);
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      if (config.url.includes('/users/')) return { data: { salt } };
+      return {
+        data: { data: { signIn: { token: 'jwt-ttl', aud: 'x' } } },
+      };
+    });
+
+    const bundle = await service.getToken(
+      { ...baseAuth, tokenTTLSeconds: 60 },
+      'conn-5',
+    );
+    expect(bundle.expiresAt).toBeGreaterThan(Date.now() + 50 * 1000);
+    expect(bundle.expiresAt).toBeLessThan(Date.now() + 70 * 1000);
+  });
+
+  it('supports static salt source', async () => {
+    const staticSalt = bcrypt.genSaltSync(4);
+    const expectedHash = bcrypt.hashSync('plain-password', staticSalt);
+    let observed = '';
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      observed = config.data.variables.password;
+      return {
+        data: { data: { signIn: { token: 'jwt-static', aud: 'x' } } },
+      };
+    });
+
+    const auth: LoginTokenAuthConfig = {
+      ...baseAuth,
+      passwordHashing: {
+        scheme: 'bcrypt',
+        saltSource: { type: 'static', value: staticSalt },
+        outputParam: 'passwordHashed',
+      },
+    };
+    const bundle = await service.getToken(auth, 'conn-6');
+    expect(bundle.token).toBe('jwt-static');
+    expect(observed).toBe(expectedHash);
+  });
+
+  it('passes plain password through when passwordHashing.scheme=none', async () => {
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      expect(config.data.variables.password).toBe('plain-password');
+      return {
+        data: { data: { signIn: { token: 'jwt-plain', aud: 'x' } } },
+      };
+    });
+
+    const auth: LoginTokenAuthConfig = {
+      ...baseAuth,
+      passwordHashing: { scheme: 'none' },
+    };
+    const bundle = await service.getToken(auth, 'conn-7');
+    expect(bundle.token).toBe('jwt-plain');
+  });
+
+  it('throws a clear error when tokenJsonPath does not resolve', async () => {
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      if (config.url.includes('/users/')) {
+        return { data: { salt: bcrypt.genSaltSync(4) } };
+      }
+      return { data: { data: { signIn: null, errors: [{ message: 'bad creds' }] } } };
+    });
+
+    await expect(service.getToken(baseAuth, 'conn-8')).rejects.toThrow(
+      /token not found/,
+    );
+  });
+});

--- a/packages/backend/src/connectors/engines/login-token.service.ts
+++ b/packages/backend/src/connectors/engines/login-token.service.ts
@@ -1,0 +1,459 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import * as bcrypt from 'bcrypt';
+import { PrismaService } from '../../common/prisma.service';
+import { encrypt, decrypt } from '../../common/crypto/encryption.util';
+import { getRequiredSecret } from '../../common/secrets.util';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
+
+const DEFAULT_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const DEFAULT_PROACTIVE_REFRESH_SECONDS = 24 * 60 * 60; // 1 day
+
+export interface LoginTokenAuthConfig {
+  loginUrl: string;
+  loginMethod?: string; // default POST
+  // Either pass a structured body (preferred — strings inside are recursively
+  // interpolated with ${param} placeholders without JSON-escape pitfalls)…
+  loginBody?: unknown;
+  // …or a raw string template (deprecated, brittle for GraphQL mutations).
+  loginBodyTemplate?: string;
+  loginHeaders?: Record<string, string>;
+  username: string;
+  password: string;
+  aud?: string;
+  otp?: string;
+
+  passwordHashing?: {
+    scheme: 'bcrypt' | 'none';
+    saltSource?: {
+      type: 'fetch' | 'static';
+      method?: string; // GET/POST when type=fetch
+      url?: string; // interpolated with ${username}
+      headers?: Record<string, string>;
+      responsePath?: string; // JSON path to salt in fetch response
+      value?: string; // when type=static
+    };
+    outputParam?: string; // template param name (default: passwordHashed)
+  };
+
+  tokenJsonPath: string;
+  expiryJsonPath?: string;
+  audJsonPath?: string;
+  expiryFormat?: 'iso8601' | 'unix' | 'ttl_seconds';
+  tokenTTLSeconds?: number;
+
+  refreshOn401?: boolean;
+  proactiveRefreshSeconds?: number;
+
+  headerName?: string; // default Authorization
+  headerTemplate?: string; // default "Bearer ${token}"
+  extraHeaders?: Record<string, string>;
+}
+
+export interface LoginTokenBundle {
+  token: string;
+  aud?: string;
+  expiresAt: number; // epoch ms
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Manages tokens issued by "POST credentials → receive long-lived bearer" auth flows.
+ *
+ * Optionally hashes the password client-side with bcrypt + a salt fetched from the
+ * remote service (Sorare pattern). Caches tokens in-memory and in a dedicated DB
+ * table so they survive restarts. Re-logs in on expiry or on 401 retry.
+ */
+@Injectable()
+export class LoginTokenService {
+  private readonly logger = new Logger(LoginTokenService.name);
+  private readonly encryptionKey: string;
+
+  private cache = new Map<string, LoginTokenBundle>();
+  private inFlight = new Map<string, Promise<LoginTokenBundle>>();
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+  ) {
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      this.configService.get<string>('ENCRYPTION_KEY'),
+    );
+  }
+
+  /**
+   * Return a valid token, fetching/refreshing as needed.
+   * - Cache hit & not near expiry → return immediately
+   * - Cache miss → check DB, then login if absent or expired
+   * - Near expiry → relogin proactively
+   */
+  async getToken(
+    authConfig: LoginTokenAuthConfig,
+    connectorId?: string,
+  ): Promise<LoginTokenBundle> {
+    const key = this.cacheKey(authConfig, connectorId);
+    const proactiveSec =
+      authConfig.proactiveRefreshSeconds ?? DEFAULT_PROACTIVE_REFRESH_SECONDS;
+    const now = Date.now();
+
+    const cached = this.cache.get(key);
+    if (cached && cached.expiresAt > now + proactiveSec * 1000) {
+      return cached;
+    }
+
+    if (!cached && connectorId) {
+      const persisted = await this.loadFromDb(connectorId);
+      if (persisted && persisted.expiresAt > now + proactiveSec * 1000) {
+        this.cache.set(key, persisted);
+        return persisted;
+      }
+    }
+
+    return this.loginWithMutex(authConfig, connectorId);
+  }
+
+  /**
+   * Force a fresh login regardless of cache state (called on 401 retry).
+   */
+  async forceRelogin(
+    authConfig: LoginTokenAuthConfig,
+    connectorId?: string,
+  ): Promise<LoginTokenBundle> {
+    const key = this.cacheKey(authConfig, connectorId);
+    this.cache.delete(key);
+    return this.loginWithMutex(authConfig, connectorId);
+  }
+
+  private async loginWithMutex(
+    authConfig: LoginTokenAuthConfig,
+    connectorId?: string,
+  ): Promise<LoginTokenBundle> {
+    const key = this.cacheKey(authConfig, connectorId);
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+
+    const p = this.performLogin(authConfig, connectorId).finally(() => {
+      this.inFlight.delete(key);
+    });
+    this.inFlight.set(key, p);
+    return p;
+  }
+
+  private async performLogin(
+    authConfig: LoginTokenAuthConfig,
+    connectorId?: string,
+  ): Promise<LoginTokenBundle> {
+    this.requireString(authConfig.loginUrl, 'loginUrl');
+    this.requireString(authConfig.username, 'username');
+    this.requireString(authConfig.password, 'password');
+    this.requireString(authConfig.tokenJsonPath, 'tokenJsonPath');
+
+    const passwordToSend = await this.preparePassword(authConfig);
+
+    const templateParams: Record<string, string> = {
+      username: authConfig.username,
+      [authConfig.passwordHashing?.outputParam || 'passwordHashed']:
+        passwordToSend,
+      password: passwordToSend,
+      aud: authConfig.aud || '',
+      otp: authConfig.otp || '',
+    };
+
+    const method = (authConfig.loginMethod || 'POST').toUpperCase();
+    const url = authConfig.loginUrl;
+    await assertSafeOutboundUrl(url);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(authConfig.loginHeaders || {}),
+    };
+
+    let data: unknown;
+    if (authConfig.loginBody !== undefined) {
+      data = interpolateDeep(authConfig.loginBody, templateParams);
+    } else if (authConfig.loginBodyTemplate) {
+      const rendered = renderTemplate(
+        authConfig.loginBodyTemplate,
+        templateParams,
+      );
+      try {
+        data = JSON.parse(rendered);
+      } catch (e: any) {
+        throw new Error(
+          `LOGIN_TOKEN loginBodyTemplate produced invalid JSON: ${e.message}`,
+        );
+      }
+    } else {
+      data = templateParams;
+    }
+
+    this.logger.debug(`LOGIN_TOKEN: logging in via ${method} ${url}`);
+    const response = await axios({
+      method,
+      url,
+      data: method === 'GET' ? undefined : data,
+      params: method === 'GET' ? data : undefined,
+      headers,
+      timeout: 15000,
+    });
+
+    const token = jsonPath(response.data, authConfig.tokenJsonPath);
+    if (!token || typeof token !== 'string') {
+      throw new Error(
+        `LOGIN_TOKEN: token not found at "${authConfig.tokenJsonPath}" in login response`,
+      );
+    }
+
+    const expiresAt = this.computeExpiresAt(authConfig, response.data);
+    const aud = authConfig.audJsonPath
+      ? (jsonPath(response.data, authConfig.audJsonPath) as
+          | string
+          | undefined)
+      : authConfig.aud;
+
+    const bundle: LoginTokenBundle = {
+      token,
+      aud: aud || undefined,
+      expiresAt,
+      metadata: aud ? { aud } : undefined,
+    };
+
+    const key = this.cacheKey(authConfig, connectorId);
+    this.cache.set(key, bundle);
+    if (connectorId) {
+      await this.persist(connectorId, bundle);
+    }
+    return bundle;
+  }
+
+  private async preparePassword(
+    authConfig: LoginTokenAuthConfig,
+  ): Promise<string> {
+    const hashing = authConfig.passwordHashing;
+    if (!hashing || hashing.scheme === 'none') return authConfig.password;
+    if (hashing.scheme !== 'bcrypt') {
+      throw new Error(
+        `LOGIN_TOKEN: unsupported passwordHashing.scheme "${hashing.scheme}"`,
+      );
+    }
+
+    const salt = await this.resolveSalt(authConfig);
+    if (!salt) {
+      throw new Error(
+        'LOGIN_TOKEN: passwordHashing.scheme=bcrypt requires a non-empty salt',
+      );
+    }
+    return bcrypt.hashSync(authConfig.password, salt);
+  }
+
+  private async resolveSalt(
+    authConfig: LoginTokenAuthConfig,
+  ): Promise<string | null> {
+    const src = authConfig.passwordHashing?.saltSource;
+    if (!src) return null;
+    if (src.type === 'static') return src.value || null;
+    if (src.type !== 'fetch') {
+      throw new Error(
+        `LOGIN_TOKEN: unsupported saltSource.type "${src.type}"`,
+      );
+    }
+    if (!src.url) {
+      throw new Error('LOGIN_TOKEN: saltSource.url is required when type=fetch');
+    }
+
+    const url = src.url.replace(/\$\{username\}/g, encodeURIComponent(authConfig.username));
+    await assertSafeOutboundUrl(url);
+
+    const method = (src.method || 'GET').toUpperCase();
+    const response = await axios({
+      method,
+      url,
+      headers: src.headers,
+      timeout: 10000,
+    });
+
+    const path = src.responsePath || 'salt';
+    const salt = jsonPath(response.data, path);
+    if (!salt || typeof salt !== 'string') {
+      throw new Error(
+        `LOGIN_TOKEN: salt not found at "${path}" in ${url} response`,
+      );
+    }
+    return salt;
+  }
+
+  private computeExpiresAt(
+    authConfig: LoginTokenAuthConfig,
+    responseBody: unknown,
+  ): number {
+    const now = Date.now();
+    const ttlFallbackMs =
+      (authConfig.tokenTTLSeconds ?? DEFAULT_TOKEN_TTL_SECONDS) * 1000;
+
+    if (!authConfig.expiryJsonPath) {
+      return now + ttlFallbackMs;
+    }
+
+    const raw = jsonPath(responseBody, authConfig.expiryJsonPath);
+    if (raw === undefined || raw === null || raw === '') {
+      return now + ttlFallbackMs;
+    }
+
+    const fmt = authConfig.expiryFormat || 'iso8601';
+    if (fmt === 'iso8601') {
+      const t = Date.parse(String(raw));
+      return Number.isFinite(t) ? t : now + ttlFallbackMs;
+    }
+    if (fmt === 'unix') {
+      const n = Number(raw);
+      if (!Number.isFinite(n)) return now + ttlFallbackMs;
+      return n < 1e12 ? n * 1000 : n;
+    }
+    if (fmt === 'ttl_seconds') {
+      const n = Number(raw);
+      return Number.isFinite(n) ? now + n * 1000 : now + ttlFallbackMs;
+    }
+    return now + ttlFallbackMs;
+  }
+
+  private cacheKey(
+    authConfig: LoginTokenAuthConfig,
+    connectorId?: string,
+  ): string {
+    if (connectorId) return connectorId;
+    return `${authConfig.loginUrl}|${authConfig.username}`;
+  }
+
+  private async loadFromDb(
+    connectorId: string,
+  ): Promise<LoginTokenBundle | null> {
+    try {
+      const row = await this.prisma.connectorAuthCache.findUnique({
+        where: { connectorId },
+      });
+      if (!row) return null;
+      return {
+        token: decrypt(row.token, this.encryptionKey),
+        expiresAt: row.expiresAt.getTime(),
+        aud: (row.metadata as { aud?: string } | null)?.aud,
+        metadata: (row.metadata as Record<string, unknown> | null) || undefined,
+      };
+    } catch (err: any) {
+      this.logger.warn(
+        `LOGIN_TOKEN: failed to load cached token for ${connectorId}: ${err.message}`,
+      );
+      return null;
+    }
+  }
+
+  private async persist(
+    connectorId: string,
+    bundle: LoginTokenBundle,
+  ): Promise<void> {
+    try {
+      const encrypted = encrypt(bundle.token, this.encryptionKey);
+      const metadata = bundle.metadata || (bundle.aud ? { aud: bundle.aud } : null);
+      await this.prisma.connectorAuthCache.upsert({
+        where: { connectorId },
+        update: {
+          token: encrypted,
+          metadata: (metadata as object) ?? undefined,
+          expiresAt: new Date(bundle.expiresAt),
+        },
+        create: {
+          connectorId,
+          token: encrypted,
+          metadata: (metadata as object) ?? undefined,
+          expiresAt: new Date(bundle.expiresAt),
+        },
+      });
+    } catch (err: any) {
+      this.logger.warn(
+        `LOGIN_TOKEN: failed to persist token for ${connectorId}: ${err.message}`,
+      );
+    }
+  }
+
+  private requireString(value: unknown, name: string): void {
+    if (!value || typeof value !== 'string') {
+      throw new Error(`LOGIN_TOKEN: authConfig.${name} is required`);
+    }
+  }
+}
+
+/**
+ * Resolve a dotted/bracket JSON path against a value.
+ * Supports a.b.c and a.b[0].c.
+ */
+export function jsonPath(value: unknown, path: string): unknown {
+  if (value === undefined || value === null) return undefined;
+  const parts = path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter(Boolean);
+  let cur: unknown = value;
+  for (const p of parts) {
+    if (cur === undefined || cur === null) return undefined;
+    if (Array.isArray(cur)) {
+      const idx = Number(p);
+      cur = Number.isFinite(idx) ? cur[idx] : undefined;
+    } else if (typeof cur === 'object') {
+      cur = (cur as Record<string, unknown>)[p];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+/**
+ * Render a string template by replacing ${name} placeholders.
+ * Simple substitution: missing params render as empty string. No JSON-escape
+ * awareness — use `loginBody` (structured) instead of `loginBodyTemplate` (raw)
+ * when the body contains nested string contexts (e.g. GraphQL mutations).
+ */
+export function renderTemplate(
+  template: string,
+  params: Record<string, string>,
+): string {
+  return template.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g,
+    (_m, name: string) => params[name] ?? '',
+  );
+}
+
+/**
+ * Recursively walk a value, substituting `${param}` placeholders in any string
+ * leaves with values from `params`. Object/array structure is preserved.
+ *
+ * - Full-string reference "${name}" → params.name (any type passes through)
+ * - Embedded "...${name}..." → string interpolation, missing → ''
+ * - Non-strings → returned unchanged
+ */
+export function interpolateDeep(
+  value: unknown,
+  params: Record<string, string>,
+): unknown {
+  if (typeof value === 'string') {
+    const fullMatch = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(value);
+    if (fullMatch) {
+      const v = params[fullMatch[1]];
+      return v ?? '';
+    }
+    return value.replace(
+      /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g,
+      (_m, name: string) => params[name] ?? '',
+    );
+  }
+  if (Array.isArray(value)) return value.map((v) => interpolateDeep(v, params));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = interpolateDeep(v, params);
+    }
+    return out;
+  }
+  return value;
+}

--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -1,5 +1,6 @@
 import { RestEngine } from './rest.engine';
 import { OAuth2TokenService } from './oauth2-token.service';
+import { LoginTokenService } from './login-token.service';
 import axios from 'axios';
 
 jest.mock('axios');
@@ -8,13 +9,26 @@ const mockedAxios = axios as jest.MockedFunction<typeof axios>;
 describe('RestEngine', () => {
   let engine: RestEngine;
   let mockOAuth2TokenService: jest.Mocked<OAuth2TokenService>;
+  let mockLoginTokenService: jest.Mocked<LoginTokenService>;
 
   beforeEach(() => {
     mockOAuth2TokenService = {
       getAccessToken: jest.fn().mockResolvedValue('oauth2-access-token'),
       refreshToken: jest.fn().mockResolvedValue('new-access-token'),
     } as any;
-    engine = new RestEngine(mockOAuth2TokenService);
+    mockLoginTokenService = {
+      getToken: jest.fn().mockResolvedValue({
+        token: 'login-jwt',
+        aud: 'test-aud',
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      }),
+      forceRelogin: jest.fn().mockResolvedValue({
+        token: 'login-jwt-fresh',
+        aud: 'test-aud',
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      }),
+    } as any;
+    engine = new RestEngine(mockOAuth2TokenService, mockLoginTokenService);
     jest.clearAllMocks();
   });
 

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -2,6 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
 import FormData from 'form-data';
 import { OAuth2TokenService } from './oauth2-token.service';
+import {
+  LoginTokenService,
+  LoginTokenAuthConfig,
+} from './login-token.service';
 import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /**
@@ -14,7 +18,10 @@ import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 export class RestEngine {
   private readonly logger = new Logger(RestEngine.name);
 
-  constructor(private readonly oauth2TokenService: OAuth2TokenService) {}
+  constructor(
+    private readonly oauth2TokenService: OAuth2TokenService,
+    private readonly loginTokenService: LoginTokenService,
+  ) {}
 
   async execute(
     config: {
@@ -160,6 +167,23 @@ export class RestEngine {
           return retryResponse.data;
         }
       }
+      // LOGIN_TOKEN auto-relogin: retry once on 401 when refreshOn401 is enabled
+      if (
+        error instanceof AxiosError &&
+        error.response?.status === 401 &&
+        config.authType === 'LOGIN_TOKEN' &&
+        (config.authConfig as Record<string, unknown> | undefined)?.refreshOn401 !== false
+      ) {
+        this.logger.debug('LOGIN_TOKEN: 401 received, re-issuing token...');
+        const authConfig = config.authConfig as unknown as LoginTokenAuthConfig;
+        const bundle = await this.loginTokenService.forceRelogin(
+          authConfig,
+          config.connectorId,
+        );
+        injectLoginTokenHeaders(axiosConfig, authConfig, bundle.token, bundle.aud);
+        const retryResponse = await axios(axiosConfig);
+        return retryResponse.data;
+      }
       throw error;
     }
   }
@@ -213,6 +237,19 @@ export class RestEngine {
           ...config.authConfig,
         };
         break;
+      case 'LOGIN_TOKEN': {
+        const bundle = await this.loginTokenService.getToken(
+          config.authConfig as unknown as LoginTokenAuthConfig,
+          config.connectorId,
+        );
+        injectLoginTokenHeaders(
+          axiosConfig,
+          config.authConfig as unknown as LoginTokenAuthConfig,
+          bundle.token,
+          bundle.aud,
+        );
+        break;
+      }
     }
   }
 
@@ -331,6 +368,30 @@ function renderBodyTemplate(
       return JSON.stringify(value);
     },
   );
+}
+
+/**
+ * Inject the bearer header (and any extraHeaders) for a LOGIN_TOKEN connector.
+ * Both the main header and extraHeaders support `${token}` / `${aud}` placeholders.
+ */
+export function injectLoginTokenHeaders(
+  axiosConfig: AxiosRequestConfig,
+  authConfig: LoginTokenAuthConfig,
+  token: string,
+  aud?: string,
+): void {
+  const headerName = authConfig.headerName || 'Authorization';
+  const headerTemplate = authConfig.headerTemplate || 'Bearer ${token}';
+  const interpolate = (s: string): string =>
+    s.replace(/\$\{token\}/g, token).replace(/\$\{aud\}/g, aud || '');
+
+  axiosConfig.headers = {
+    ...axiosConfig.headers,
+    [headerName]: interpolate(headerTemplate),
+  };
+  for (const [k, v] of Object.entries(authConfig.extraHeaders || {})) {
+    axiosConfig.headers[k] = interpolate(String(v));
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Introduce **`LOGIN_TOKEN`** AuthType: declarative spec for APIs that POST credentials → receive long-lived bearer, with optional client-side bcrypt against a per-account salt fetched from the remote service (Sorare pattern). Adapter authors describe the entire flow in JSON; no per-provider code.
- Ship the **Sorare adapter** (`packages/backend/src/adapters/intl/sorare.json`) with 7 GraphQL tools over cards, players, lineups, and the transfer market.
- Add 12 multilingual MDX guides (en/de/it × {ChatGPT, Claude, OpenClaw, generic MCP}).

## Architecture

`LoginTokenService` handles salt fetch → bcrypt → `signIn` → token cache (in-memory + encrypted `connector_auth_cache` DB row) → proactive refresh ≥24 h before expiry → forced re-login on 401, behind a per-key mutex.

REST and GraphQL engines gain a `LOGIN_TOKEN` case in `injectAuth` plus a 401-retry path that calls `forceRelogin()` and re-issues the request once.

Token persistence: new `ConnectorAuthCache` Prisma model + migration (`20260518000000_add_login_token_auth`), AES-256-GCM encrypted at rest with the existing `ENCRYPTION_KEY`.

`AdapterMeta` gains optional `featured?: boolean` and `priority?: number` so the marketing site can rank Sorare on the home page without a code change there.

## Live validation

The same `LoginTokenService` code in this PR was run against the real Sorare API:

- ✓ salt fetch + bcrypt + `signIn` returned a JWT with `expiredAt` exactly 30 days out (732 ms)
- ✓ second `getToken()` hit the cache in 0 ms
- ✓ GraphQL `currentUser` query with `Authorization: Bearer` + `JWT-AUD` returned the authenticated profile
- ✓ `forceRelogin()` produced a fresh, different token

## Test plan

- [x] `npm test` — 704 backend tests pass (15 new login-token specs, 10 new catalog assertions for the Sorare adapter and LOGIN_TOKEN validation)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] Backend + frontend production build compiles
- [ ] After merge → `deploy-cloud.yml` rebuilds the image; `cloud.anythingmcp.com/connectors` should list **Sorare Fantasy Football** in the catalog
- [ ] On cloud: install adapter, fill `SORARE_EMAIL` / `SORARE_PASSWORD` / `SORARE_AUD`, mint MCP key, call `sorare_current_user` from Claude / ChatGPT / OpenClaw → returns the user slug

## Files

- New: `LoginTokenService` + spec, Sorare adapter JSON + intl/ folder, login-token auth docs, 12 MDX guides, Prisma migration
- Modified: schema.prisma (+`LOGIN_TOKEN`, +`ConnectorAuthCache`), REST + GraphQL engines, connectors module, catalog.ts (+`featured`/`priority`), catalog.spec.ts (+LOGIN_TOKEN validation, +GraphQL method enum), tool-definition.md, two existing live-spec constructors updated for the new `LoginTokenService` arg