### PR TITLE
Fix: provide LoginTokenService to McpServerModule (hotfix for cloud outage)

### DIFF
--- a/packages/backend/src/mcp-server/mcp-server.module.ts
+++ b/packages/backend/src/mcp-server/mcp-server.module.ts
@@ -10,6 +10,7 @@ import { SoapEngine } from '../connectors/engines/soap.engine';
 import { McpClientEngine } from '../connectors/engines/mcp-client.engine';
 import { DatabaseEngine } from '../connectors/engines/database.engine';
 import { OAuth2TokenService } from '../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../connectors/engines/login-token.service';
 import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 import { LicenseModule } from '../license/license.module';
 
@@ -24,7 +25,7 @@ const ENGINES = [
 @Module({
   imports: [McpServersModule, LicenseModule],
   controllers: [McpEndpointController],
-  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, OAuth2TokenService, ...ENGINES],
+  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, OAuth2TokenService, LoginTokenService, ...ENGINES],
   exports: [McpServerService, ToolRegistry],
 })
 export class McpServerModule {}


### PR DESCRIPTION
## Root cause

\`McpServerModule\` registers its own copy of \`RestEngine\` and \`GraphqlEngine\` as providers (separate from \`ConnectorsModule\`'s registration). After PR #199 added \`LoginTokenService\` as a constructor dependency of both engines, \`McpServerModule\` could no longer resolve them — Nest throws \`UnknownDependenciesException\` at startup, the backend never reaches the \`/health\` endpoint, the container is killed by the unhealthy probe, and the cloud goes down.

Logs from \`amcp-cloud-app\`:

\`\`\`
ERROR [ExceptionHandler] UnknownDependenciesException [Error]: Nest can't resolve dependencies of the RestEngine (OAuth2TokenService, ?). Please make sure that the argument LoginTokenService at index [1] is available in the McpServerModule module.
\`\`\`

## Fix

Add \`LoginTokenService\` to \`McpServerModule\`'s providers list, alongside the existing \`OAuth2TokenService\`. One-line change.

## Test plan

- [x] \`npm test\` — 704 tests pass
- [ ] After merge → rebuild image → redeploy → \`amcp-cloud-app\` becomes healthy → \`https://cloud.anythingmcp.com\` reachable → Sorare adapter visible in catalog