### PR TITLE
hotfix(cloud): pin app image to v0.1.24 for rollback

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -29,7 +29,7 @@ services:
 
   # NestJS Backend + Next.js Frontend (single container)
   app:
-    image: helpcodeai/anythingmcp:latest
+    image: helpcodeai/anythingmcp:2a40cff
     container_name: amcp-cloud-app
     expose:
       - "3000"


### PR DESCRIPTION
Temporary pin to restore cloud service while PR #201 hotfix image rebuilds. Will revert to `:latest` once the hotfix image is published and verified.