### PR TITLE
Restore cloud app image to :latest

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -29,7 +29,7 @@ services:
 
   # NestJS Backend + Next.js Frontend (single container)
   app:
-    image: helpcodeai/anythingmcp:2a40cff
+    image: helpcodeai/anythingmcp:latest
     container_name: amcp-cloud-app
     expose:
       - "3000"


### PR DESCRIPTION
Hotfix image from PR #201 is now `:latest` on Docker Hub. Re-pinning the cloud compose so the next deploy picks it up.