### PR TITLE
Sorare: proxy SDL schema via new builtin; fix broken tool queries

### DIFF
--- a/packages/backend/src/adapters/catalog.spec.ts
+++ b/packages/backend/src/adapters/catalog.spec.ts
@@ -19,6 +19,7 @@ const VALID_GRAPHQL_METHODS = new Set([
   'MUTATION',
   'SUBSCRIPTION',
   'STATIC',
+  'SCHEMA',
 ]);
 
 /**
@@ -60,13 +61,26 @@ describe('adapter catalog', () => {
       .filter((a) => a.connector.type === 'GRAPHQL');
 
     it.each(graphqlAdapters.map((a) => [a.slug, a]))(
-      '%s exposes _graphql_schema_url, _graphql_query, _graphql_mutation, _graphql_subscription',
+      '%s exposes the five GraphQL builtins',
       (_slug, adapter) => {
         const names = new Set(adapter.tools.map((t) => t.name));
         expect(names.has(`${adapter.slug}_graphql_schema_url`)).toBe(true);
+        expect(names.has(`${adapter.slug}_graphql_schema`)).toBe(true);
         expect(names.has(`${adapter.slug}_graphql_query`)).toBe(true);
         expect(names.has(`${adapter.slug}_graphql_mutation`)).toBe(true);
         expect(names.has(`${adapter.slug}_graphql_subscription`)).toBe(true);
+      },
+    );
+
+    it.each(graphqlAdapters.map((a) => [a.slug, a]))(
+      '%s _graphql_schema uses method=schema and points at the SDL URL',
+      (_slug, adapter) => {
+        const tool = adapter.tools.find(
+          (t) => t.name === `${adapter.slug}_graphql_schema`,
+        )!;
+        const em = tool.endpointMapping as { method: string; path: string };
+        expect(em.method).toBe('schema');
+        expect(em.path).toMatch(/^https?:\/\//);
       },
     );
 

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -72,17 +72,20 @@ export interface AdapterDefinition extends AdapterMeta {
 }
 
 /**
- * Auto-inject four generic GraphQL helper tools onto any GRAPHQL adapter:
+ * Auto-inject five generic GraphQL helper tools onto any GRAPHQL adapter:
  *   - `<slug>_graphql_schema_url`   — returns the URL of the SDL schema (or the value of
  *                                     `connector.schemaUrl` if the adapter overrides it)
+ *   - `<slug>_graphql_schema`       — proxy + filter the SDL: returns a compact summary,
+ *                                     a single type definition (`type: "X"`), a search
+ *                                     slice (`search: "card"`), or the full SDL (`full: true`)
  *   - `<slug>_graphql_query`        — execute an arbitrary `query` document
  *   - `<slug>_graphql_mutation`     — execute an arbitrary `mutation` document
  *   - `<slug>_graphql_subscription` — execute an arbitrary `subscription` document
  *                                     (transport availability depends on the upstream API)
  *
  * These give an MCP agent a fallback path when no purpose-built tool covers a
- * needed operation — the agent fetches the schema, composes the operation,
- * and runs it. Adapter authors don't need to declare them.
+ * needed operation — the agent fetches a focused slice of the schema, composes
+ * the operation, and runs it. Adapter authors don't need to declare them.
  */
 function withGraphqlBuiltins(adapter: AdapterDefinition): AdapterDefinition {
   if (adapter.connector.type !== 'GRAPHQL') return adapter;
@@ -132,7 +135,7 @@ function withGraphqlBuiltins(adapter: AdapterDefinition): AdapterDefinition {
       name: `${slug}_graphql_schema_url`,
       description:
         `Returns the URL of the GraphQL SDL schema for ${adapter.name}. ` +
-        `Fetch it with a web tool (e.g. \`web_fetch\`) to discover available types and fields before composing a custom query.`,
+        `If your environment can reach external hosts, fetch this URL directly. Otherwise use \`${slug}_graphql_schema\`, which proxies the schema through the MCP server (no allowlist concerns).`,
       parameters: {
         type: 'object',
         properties: {},
@@ -140,6 +143,38 @@ function withGraphqlBuiltins(adapter: AdapterDefinition): AdapterDefinition {
       },
       endpointMapping: {
         method: 'static',
+        path: schemaUrl,
+      },
+    },
+    {
+      name: `${slug}_graphql_schema`,
+      description:
+        `Fetch a slice of the ${adapter.name} GraphQL SDL schema, proxied through the MCP server. ` +
+        `Default (no args) returns a compact summary: the Query/Mutation/Subscription root blocks + an index of every type name (~20–30 KB). ` +
+        `Pass \`type: "TypeName"\` to retrieve just one type's definition with its docblock (~1–5 KB). ` +
+        `Pass \`search: "keyword"\` to return every type whose name or a field name contains the keyword (case-insensitive, capped to keep responses small). ` +
+        `Pass \`full: true\` only when you really need the entire SDL — it can be very large (~200K tokens for some APIs).`,
+      parameters: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            description: 'Single GraphQL type name to retrieve, e.g. "CurrentUser".',
+          },
+          search: {
+            type: 'string',
+            description:
+              'Case-insensitive substring matched against type names and field names. Returns all matching type blocks.',
+          },
+          full: {
+            type: 'boolean',
+            description: 'Return the entire SDL. Use sparingly — can blow past an agent\'s context window.',
+          },
+        },
+        additionalProperties: false,
+      },
+      endpointMapping: {
+        method: 'schema',
         path: schemaUrl,
       },
     },

--- a/packages/backend/src/adapters/intl/sorare.json
+++ b/packages/backend/src/adapters/intl/sorare.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "sorare_get_card_by_slug",
-      "description": "Fetch a single Sorare card by its slug (e.g. 'lionel-messi-2023-rare-1'). Returns player, scarcity, season, owner, and current auction state.",
+      "description": "Fetch a single Sorare football card by slug (e.g. 'lionel-messi-2023-rare-1'). Returns player, rarity, season, current owner, and the live single-sale offer if any. For richer data use sorare_graphql_query with the relevant slice from sorare_graphql_schema.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -83,7 +83,7 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query CardBySlug($slug: String!) { football { card(slug: $slug) { slug name pictureUrl rarity power player { slug displayName } season { startYear endYear } user { slug } activeSingleSaleOffer { senderSide { wei } } } } }",
+        "path": "query CardBySlug($slug: String!) { football { card(slug: $slug) { slug name rarity displayRarity backPictureUrl power season { startYear } user { slug } footballPlayer { slug displayName position country { slug } } liveSingleSaleOffer { id endDate status senderSide { wei amounts { eurCents } } } latestEnglishAuction { id endDate } } } }",
         "queryParams": {
           "slug": "$slug"
         }
@@ -91,13 +91,20 @@
     },
     {
       "name": "sorare_search_player",
-      "description": "Search for a football player by name and return basic player metadata (slug, full name, club, country). Use the slug with sorare_list_player_cards.",
+      "description": "Search football players by name (full-text). Returns up to `pageSize` matches with slug, display name, country, and current club. Use the returned slug with sorare_list_player_cards or sorare_get_card_by_slug.",
       "parameters": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "description": "Player's display name or partial name."
+            "description": "Player name or partial name (full-text)."
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "default": 5,
+            "description": "Max hits to return (1–20)."
           }
         },
         "required": ["name"],
@@ -105,15 +112,16 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query PlayerSearch($name: String!) { football { players(search: { name: $name }, first: 5) { nodes { slug displayName birthDate country { slug } activeClub { name } } } } }",
+        "path": "query PlayerSearch($name: String!, $pageSize: Int!) { searchPlayers(query: $name, pageSize: $pageSize) { nbHits commonPlayerHits { anyPlayer { slug sport ... on Player { displayName country { slug } activeClub { name } } } } } }",
         "queryParams": {
-          "name": "$name"
+          "name": "$name",
+          "pageSize": "$pageSize"
         }
       }
     },
     {
       "name": "sorare_list_player_cards",
-      "description": "List the most recent cards for a given player slug, with their rarity, season, and current owner.",
+      "description": "List cards minted for a given football player slug, with their rarity, season, and current owner.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -134,7 +142,7 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query PlayerCards($playerSlug: String!, $limit: Int!) { football { player(slug: $playerSlug) { cards(first: $limit) { nodes { slug rarity season { startYear } user { slug } } } } } }",
+        "path": "query PlayerCards($playerSlug: String!, $limit: Int!) { football { allCards(playerSlugs: [$playerSlug], first: $limit) { nodes { slug name rarity season { startYear } user { slug } } } } }",
         "queryParams": {
           "playerSlug": "$playerSlug",
           "limit": "$limit"
@@ -143,7 +151,7 @@
     },
     {
       "name": "sorare_list_my_cards",
-      "description": "List the football cards owned by the authenticated user with rarity, player, and season.",
+      "description": "List football cards owned by the authenticated user with rarity, player, and season. Pass `rarities` to filter (e.g. ['rare']).",
       "parameters": {
         "type": "object",
         "properties": {
@@ -153,21 +161,30 @@
             "maximum": 50,
             "default": 20,
             "description": "Max cards to return (1–50)."
+          },
+          "rarities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["common", "limited", "rare", "super_rare", "unique", "custom_series"]
+            },
+            "description": "Optional list of rarity tiers to keep."
           }
         },
         "additionalProperties": false
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query MyCards($limit: Int!) { currentUser { football { myCards(first: $limit) { nodes { slug rarity player { displayName } season { startYear } } } } } }",
+        "path": "query MyCards($limit: Int!, $rarities: [Rarity!]) { currentUser { cards(first: $limit, rarities: $rarities, sport: FOOTBALL) { nodes { slug name sport ... on Card { rarity season { startYear } footballPlayer { slug displayName } } } } } }",
         "queryParams": {
-          "limit": "$limit"
+          "limit": "$limit",
+          "rarities": "$rarities"
         }
       }
     },
     {
       "name": "sorare_get_lineup",
-      "description": "Fetch a Sorare So5 lineup by id, returning composition, captain, score, and reward.",
+      "description": "Fetch a Sorare So5 lineup by id. Returns lineup metadata (name, draft/confirmable flags) and owning user. For appearance scores and bonuses use sorare_graphql_query with a fragment on So5Appearance.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -181,26 +198,26 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query Lineup($lineupId: String!) { so5 { so5Lineup(id: $lineupId) { id score rank reward so5Appearances { score card { slug player { displayName } } } } } }",
+        "path": "query Lineup($lineupId: ID!) { so5 { so5Lineup(id: $lineupId) { id name draft confirmable updatable bonuses { title key bonusBasisPoints } user { slug nickname } } } }",
         "queryParams": {
           "lineupId": "$lineupId"
         }
       }
     },
     {
-      "name": "sorare_transfer_market",
-      "description": "Browse Sorare's transfer market with optional rarity, sport, and max-price filters. Returns the slug, player, current bid, and end time of each active offer.",
+      "name": "sorare_live_sale_offers",
+      "description": "List currently-live single-sale offers on the secondary market (Sorare's 'transfer market'). Optionally filter by player slug or sport. For rarity / max-price filters use sorare_graphql_query.",
       "parameters": {
         "type": "object",
         "properties": {
-          "rarity": {
+          "playerSlug": {
             "type": "string",
-            "enum": ["common", "limited", "rare", "super_rare", "unique"],
-            "description": "Filter by rarity tier."
+            "description": "Optional: only offers for this player slug."
           },
-          "maxPriceWei": {
+          "sport": {
             "type": "string",
-            "description": "Maximum acceptable price in wei (use a string to avoid precision loss)."
+            "enum": ["FOOTBALL", "BASEBALL", "NBA"],
+            "description": "Optional: filter by sport."
           },
           "limit": {
             "type": "integer",
@@ -213,10 +230,10 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query TransferMarket($rarity: Rarity, $maxPriceWei: String, $limit: Int!) { football { transferMarket(rarity: $rarity, maxPrice: { wei: $maxPriceWei }, first: $limit) { nodes { card { slug player { displayName } rarity } senderSide { wei } endDate } } } }",
+        "path": "query LiveSaleOffers($playerSlug: String, $sport: Sport, $limit: Int!) { tokens { liveSingleSaleOffers(playerSlug: $playerSlug, sport: $sport, first: $limit) { nodes { id endDate status senderSide { wei amounts { eurCents usdCents } anyCards { slug name ... on Card { rarity footballPlayer { slug displayName } } } } } } } }",
         "queryParams": {
-          "rarity": "$rarity",
-          "maxPriceWei": "$maxPriceWei",
+          "playerSlug": "$playerSlug",
+          "sport": "$sport",
           "limit": "$limit"
         }
       }

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -10,6 +10,7 @@ import { McpClientEngine } from './engines/mcp-client.engine';
 import { DatabaseEngine } from './engines/database.engine';
 import { OAuth2TokenService } from './engines/oauth2-token.service';
 import { LoginTokenService } from './engines/login-token.service';
+import { GraphqlSchemaService } from './engines/graphql-schema.service';
 import { OpenApiParser } from './parsers/openapi.parser';
 import { WsdlParser } from './parsers/wsdl.parser';
 import { GraphqlParser } from './parsers/graphql.parser';
@@ -37,6 +38,7 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
     McpOAuthService,
     OAuth2TokenService,
     LoginTokenService,
+    GraphqlSchemaService,
     ...ENGINES,
     ...PARSERS,
   ],
@@ -45,6 +47,7 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
     McpOAuthService,
     OAuth2TokenService,
     LoginTokenService,
+    GraphqlSchemaService,
     ...ENGINES,
   ],
 })

--- a/packages/backend/src/connectors/engines/graphql-schema.service.spec.ts
+++ b/packages/backend/src/connectors/engines/graphql-schema.service.spec.ts
@@ -1,0 +1,111 @@
+import { GraphqlSchemaService } from './graphql-schema.service';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const SAMPLE_SDL = `
+"""
+The root of all queries.
+"""
+type Query {
+  currentUser: CurrentUser
+  searchPlayers(query: String): SearchPlayers!
+  football: FootballRoot!
+}
+
+type Mutation {
+  signIn(input: SignInInput!): SignInPayload!
+}
+
+"""
+Authenticated user.
+"""
+type CurrentUser {
+  slug: String!
+  nickname: String!
+  cards(first: Int): AnyCardConnection!
+}
+
+type SearchPlayers {
+  hitIds: [String!]!
+  nbHits: Int!
+}
+
+enum Rarity {
+  COMMON
+  LIMITED
+  RARE
+}
+
+union Account = EthereumAccount | FiatWalletAccount
+
+scalar WeiAmount
+
+type FootballRoot {
+  card(slug: String!): Card!
+}
+`;
+
+describe('GraphqlSchemaService', () => {
+  let svc: GraphqlSchemaService;
+  const url = 'https://api.example.com/graphql/schema';
+
+  beforeEach(() => {
+    svc = new GraphqlSchemaService();
+    jest.clearAllMocks();
+    (mockedAxios.get as any) = jest.fn().mockResolvedValue({ data: SAMPLE_SDL });
+  });
+
+  it('returns the entire SDL when full=true', async () => {
+    const out = await svc.getSlice(url, { full: true });
+    expect(out).toBe(SAMPLE_SDL);
+  });
+
+  it('returns the block for a single type', async () => {
+    const out = await svc.getSlice(url, { type: 'CurrentUser' });
+    expect(out).toContain('type CurrentUser {');
+    expect(out).toContain('cards(first: Int): AnyCardConnection!');
+    // includes preceding docblock
+    expect(out).toContain('Authenticated user.');
+    // does not include unrelated types
+    expect(out).not.toContain('type FootballRoot');
+  });
+
+  it('handles enum, union, and scalar declarations', async () => {
+    expect(await svc.getSlice(url, { type: 'Rarity' })).toContain('enum Rarity');
+    expect(await svc.getSlice(url, { type: 'Account' })).toContain(
+      'union Account = EthereumAccount | FiatWalletAccount',
+    );
+    expect(await svc.getSlice(url, { type: 'WeiAmount' })).toContain('scalar WeiAmount');
+  });
+
+  it('returns a friendly message when the type is missing', async () => {
+    const out = await svc.getSlice(url, { type: 'DoesNotExist' });
+    expect(out).toMatch(/not found in schema/);
+  });
+
+  it('search returns matching types with their blocks', async () => {
+    const out = await svc.getSlice(url, { search: 'player' });
+    expect(out).toContain('searchPlayers'); // matched via field
+    expect(out).toContain('SearchPlayers'); // matched via type name
+  });
+
+  it('default summary includes Query / Mutation blocks plus type index', async () => {
+    const out = await svc.getSlice(url);
+    expect(out).toContain('# Schema summary');
+    expect(out).toContain('type Query {');
+    expect(out).toContain('type Mutation {');
+    // Type index lists all top-level types
+    expect(out).toMatch(/types available/);
+    expect(out).toContain('CurrentUser');
+    expect(out).toContain('FootballRoot');
+  });
+
+  it('caches the fetched SDL across calls', async () => {
+    await svc.getSlice(url, { type: 'Query' });
+    await svc.getSlice(url, { type: 'CurrentUser' });
+    await svc.getSlice(url, { search: 'card' });
+    expect((mockedAxios.get as jest.Mock).mock.calls.length).toBe(1);
+  });
+});

--- a/packages/backend/src/connectors/engines/graphql-schema.service.ts
+++ b/packages/backend/src/connectors/engines/graphql-schema.service.ts
@@ -1,0 +1,208 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
+
+const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 h
+
+export interface SchemaSliceOptions {
+  /** Single type name to retrieve (returns the full block definition). */
+  type?: string;
+  /** Case-insensitive substring matched against type and field names. */
+  search?: string;
+  /** Return the entire SDL — typically too large for an agent's context. */
+  full?: boolean;
+}
+
+/**
+ * Fetches a GraphQL SDL schema from a remote URL, caches it server-side, and
+ * returns task-sized slices of it on demand.
+ *
+ * Why slices: Sorare's SDL is ~800 KB / ~200K tokens — too large to pass through
+ * an MCP agent's context window on every call. Agents typically need only the
+ * Query/Mutation roots plus 2–5 specific type definitions to compose a query.
+ *
+ * The service handles three modes:
+ *   - default          → Query + Mutation + Subscription blocks + a flat list of all type names
+ *   - { type: "X" }    → just the block defining type X (a few KB)
+ *   - { search: "foo" }→ all types/fields whose names match (case-insensitive substring)
+ *   - { full: true }   → the entire SDL (advanced; large)
+ */
+@Injectable()
+export class GraphqlSchemaService {
+  private readonly logger = new Logger(GraphqlSchemaService.name);
+  private cache = new Map<string, { sdl: string; fetchedAt: number }>();
+
+  async getSlice(
+    url: string,
+    opts: SchemaSliceOptions = {},
+  ): Promise<string> {
+    const sdl = await this.fetchSchema(url);
+    if (opts.full) return sdl;
+    if (opts.type && opts.type.trim()) return this.extractType(sdl, opts.type.trim());
+    if (opts.search && opts.search.trim()) return this.search(sdl, opts.search.trim());
+    return this.summary(sdl);
+  }
+
+  private async fetchSchema(url: string): Promise<string> {
+    const cached = this.cache.get(url);
+    if (cached && Date.now() - cached.fetchedAt < DEFAULT_CACHE_TTL_MS) {
+      return cached.sdl;
+    }
+    await assertSafeOutboundUrl(url);
+    this.logger.debug(`GraphQL schema cache miss, fetching: ${url}`);
+    const res = await axios.get<string>(url, {
+      timeout: 30000,
+      responseType: 'text',
+      transformResponse: (v: unknown) => String(v),
+    });
+    const sdl = String(res.data);
+    this.cache.set(url, { sdl, fetchedAt: Date.now() });
+    return sdl;
+  }
+
+  /**
+   * Return the block of SDL that defines a named type. Walks the file line by
+   * line so we don't need a full GraphQL parser dependency — works for `type`,
+   * `interface`, `input`, `enum` (brace-delimited) plus `union`, `scalar`,
+   * `directive` (single-line). Includes the preceding `"""…"""` docblock when
+   * present so the agent gets the human-readable description too.
+   */
+  private extractType(sdl: string, typeName: string): string {
+    const lines = sdl.split('\n');
+    const blockHead = new RegExp(
+      `^(?:type|interface|input|enum)\\s+${escapeRegex(typeName)}(?:\\s+implements\\b[^{]*)?(?:\\s+@\\w+\\([^)]*\\))*\\s*\\{`,
+    );
+    const singleLine = new RegExp(
+      `^(?:union\\s+${escapeRegex(typeName)}\\b|scalar\\s+${escapeRegex(typeName)}\\b|directive\\s+@${escapeRegex(typeName)}\\b)`,
+    );
+
+    for (let i = 0; i < lines.length; i++) {
+      if (singleLine.test(lines[i])) {
+        return this.withDocblock(lines, i, i);
+      }
+      if (blockHead.test(lines[i])) {
+        // Walk forward to find the matching closing brace.
+        let depth = 0;
+        for (let j = i; j < lines.length; j++) {
+          for (const ch of lines[j]) {
+            if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+          }
+          if (depth === 0 && j > i) {
+            return this.withDocblock(lines, i, j);
+          }
+        }
+      }
+    }
+    return `# Type "${typeName}" not found in schema. Try search:"…" or full:true.`;
+  }
+
+  /**
+   * Prepend the """…""" docblock immediately above the start line, if any.
+   */
+  private withDocblock(lines: string[], start: number, end: number): string {
+    let docStart = start;
+    // Walk backwards over a contiguous block of `"""` / doc text.
+    if (start > 0 && lines[start - 1].trimEnd().endsWith('"""')) {
+      // Single-line `"""…"""` or multi-line ending here.
+      // Walk back to find the opening `"""`.
+      for (let k = start - 1; k >= 0; k--) {
+        if (lines[k].trimStart().startsWith('"""')) {
+          // If this line both opens and closes (single line), stop here.
+          const t = lines[k].trim();
+          if (k !== start - 1 && t.startsWith('"""') && t !== '"""') {
+            docStart = k;
+            break;
+          }
+          if (k === start - 1 && t.startsWith('"""') && t.endsWith('"""') && t.length > 6) {
+            docStart = k;
+            break;
+          }
+          // Multi-line: this is the opening line.
+          if (k !== start - 1) {
+            docStart = k;
+            break;
+          }
+        }
+      }
+    }
+    return lines.slice(docStart, end + 1).join('\n');
+  }
+
+  /**
+   * Return a compact summary: Query / Mutation / Subscription blocks + a flat
+   * list of every named top-level type. The agent uses this to figure out which
+   * type to drill into next via `type: "…"`.
+   */
+  private summary(sdl: string): string {
+    const parts: string[] = ['# Schema summary'];
+    for (const root of ['Query', 'Mutation', 'Subscription']) {
+      const block = this.extractType(sdl, root);
+      if (!block.startsWith('# Type')) parts.push(block);
+    }
+
+    const typeNames = new Set<string>();
+    for (const m of sdl.matchAll(
+      /^(?:type|interface|input|enum|union|scalar)\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+    )) {
+      typeNames.add(m[1]);
+    }
+    const list = Array.from(typeNames).sort();
+    parts.push(
+      `# ${list.length} types available. Re-call with type:"TypeName" to retrieve a specific definition.`,
+      list.join(', '),
+    );
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Find every type whose name OR a field name contains the search term.
+   * Returns matched type blocks joined; capped to avoid token blow-up.
+   */
+  private search(sdl: string, term: string): string {
+    const needle = term.toLowerCase();
+    const lines = sdl.split('\n');
+    const matchedTypes = new Set<string>();
+
+    let currentType: string | null = null;
+    let depth = 0;
+    for (const line of lines) {
+      const head = line.match(
+        /^(?:type|interface|input|enum|union|scalar|directive\s+@)\s*([A-Za-z_][A-Za-z0-9_]*)/,
+      );
+      if (head && depth === 0) {
+        currentType = head[1];
+        if (currentType.toLowerCase().includes(needle)) matchedTypes.add(currentType);
+      }
+      for (const ch of line) {
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+      }
+      if (currentType && depth > 0) {
+        const fieldMatch = line.match(/^\s+([a-z_][A-Za-z0-9_]*)\s*(\(|:)/);
+        if (fieldMatch && fieldMatch[1].toLowerCase().includes(needle)) {
+          matchedTypes.add(currentType);
+        }
+      }
+    }
+
+    if (matchedTypes.size === 0) {
+      return `# No types or fields matched "${term}".`;
+    }
+
+    const MAX_TYPES = 12;
+    const matched = Array.from(matchedTypes);
+    const slice = matched.slice(0, MAX_TYPES);
+    const blocks = slice.map((t) => this.extractType(sdl, t));
+    const header = `# ${matched.length} types matched "${term}"${
+      matched.length > MAX_TYPES
+        ? ` (showing first ${MAX_TYPES}; refine the search to see more)`
+        : ''
+    }: ${matched.join(', ')}`;
+    return [header, ...blocks].join('\n\n');
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/backend/src/connectors/engines/graphql.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.spec.ts
@@ -1,6 +1,7 @@
 import { GraphqlEngine } from './graphql.engine';
 import { OAuth2TokenService } from './oauth2-token.service';
 import { LoginTokenService } from './login-token.service';
+import { GraphqlSchemaService } from './graphql-schema.service';
 import axios, { AxiosError } from 'axios';
 
 jest.mock('axios');
@@ -10,6 +11,7 @@ describe('GraphqlEngine', () => {
   let engine: GraphqlEngine;
   let mockOAuth2TokenService: jest.Mocked<OAuth2TokenService>;
   let mockLoginTokenService: jest.Mocked<LoginTokenService>;
+  let mockSchemaService: jest.Mocked<GraphqlSchemaService>;
 
   beforeEach(() => {
     mockOAuth2TokenService = {
@@ -28,7 +30,14 @@ describe('GraphqlEngine', () => {
         expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
       }),
     } as any;
-    engine = new GraphqlEngine(mockOAuth2TokenService, mockLoginTokenService);
+    mockSchemaService = {
+      getSlice: jest.fn().mockResolvedValue('# Schema summary\n…'),
+    } as any;
+    engine = new GraphqlEngine(
+      mockOAuth2TokenService,
+      mockLoginTokenService,
+      mockSchemaService,
+    );
     jest.clearAllMocks();
   });
 
@@ -295,6 +304,23 @@ describe('GraphqlEngine', () => {
       'conn-1',
     );
     expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('delegates to GraphqlSchemaService when method=schema and forwards type/search/full', async () => {
+    mockSchemaService.getSlice.mockResolvedValue('# CurrentUser\ntype CurrentUser { … }');
+
+    const result = await engine.execute(
+      { baseUrl: 'https://api.example.com/graphql', authType: 'NONE' },
+      { method: 'schema', path: 'https://api.example.com/graphql/schema' },
+      { type: 'CurrentUser' },
+    );
+
+    expect(result).toBe('# CurrentUser\ntype CurrentUser { … }');
+    expect(mockSchemaService.getSlice).toHaveBeenCalledWith(
+      'https://api.example.com/graphql/schema',
+      { type: 'CurrentUser', search: undefined, full: false },
+    );
+    expect(mockedAxios.post).not.toHaveBeenCalled();
   });
 
   it('returns endpointMapping.path verbatim when method=static (no HTTP call)', async () => {

--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -5,6 +5,7 @@ import {
   LoginTokenService,
   LoginTokenAuthConfig,
 } from './login-token.service';
+import { GraphqlSchemaService } from './graphql-schema.service';
 import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 
 /**
@@ -18,6 +19,7 @@ export class GraphqlEngine {
   constructor(
     private readonly oauth2TokenService: OAuth2TokenService,
     private readonly loginTokenService: LoginTokenService,
+    private readonly schemaService: GraphqlSchemaService,
   ) {}
 
   async execute(
@@ -42,6 +44,23 @@ export class GraphqlEngine {
     // Used by the auto-injected `<slug>_graphql_schema_url` tool.
     if (endpointMapping.method === 'static') {
       return endpointMapping.path;
+    }
+
+    // Schema-fetch short-circuit: proxy + filter the remote SDL via the shared
+    // GraphqlSchemaService. Bypasses the agent sandbox's allowlist and lets
+    // agents pull only the slice of SDL they actually need.
+    if (endpointMapping.method === 'schema') {
+      return this.schemaService.getSlice(endpointMapping.path, {
+        type:
+          typeof params.type === 'string' && params.type.trim()
+            ? params.type
+            : undefined,
+        search:
+          typeof params.search === 'string' && params.search.trim()
+            ? params.search
+            : undefined,
+        full: params.full === true,
+      });
     }
 
     this.logger.debug(`GraphQL ${endpointMapping.method} → ${config.baseUrl}`);

--- a/packages/backend/src/mcp-server/mcp-server.module.ts
+++ b/packages/backend/src/mcp-server/mcp-server.module.ts
@@ -11,6 +11,7 @@ import { McpClientEngine } from '../connectors/engines/mcp-client.engine';
 import { DatabaseEngine } from '../connectors/engines/database.engine';
 import { OAuth2TokenService } from '../connectors/engines/oauth2-token.service';
 import { LoginTokenService } from '../connectors/engines/login-token.service';
+import { GraphqlSchemaService } from '../connectors/engines/graphql-schema.service';
 import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 import { LicenseModule } from '../license/license.module';
 
@@ -25,7 +26,7 @@ const ENGINES = [
 @Module({
   imports: [McpServersModule, LicenseModule],
   controllers: [McpEndpointController],
-  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, OAuth2TokenService, LoginTokenService, ...ENGINES],
+  providers: [McpServerService, ToolRegistry, DynamicMcpTools, McpCombinedAuthGuard, OAuth2TokenService, LoginTokenService, GraphqlSchemaService, ...ENGINES],
   exports: [McpServerService, ToolRegistry],
 })
 export class McpServerModule {}


### PR DESCRIPTION
## Summary

Two related fixes after a live audit of the Sorare adapter on cloud.anythingmcp.com:

1. **New GraphQL builtin: `<slug>_graphql_schema`** — proxies and filters the SDL server-side.
   - Default (no args) → compact summary (Query/Mutation root blocks + flat type index, ~20–30 KB).
   - \`type: \"X\"\` → just that type's definition with docblock (~1–5 KB).
   - \`search: \"foo\"\` → all types whose name or a field name matches.
   - \`full: true\` → the entire SDL (advanced).
   Solves real outages: agent sandboxes blocking fetches to unknown hosts, and Sorare disabling GraphQL introspection in production.
   The old \`<slug>_graphql_schema_url\` builtin stays — useful when an agent can reach external hosts.
2. **Sorare adapter tool queries fixed.** Several hand-written queries referenced fields that don't exist in the real schema. Live-audited against the production API with the owner's credentials. All 11 dedicated + builtin tools now pass.

## Implementation

- New \`GraphqlSchemaService\` (in-process cache, 24 h TTL) parses the SDL line-by-line and slices it.
- \`GraphqlEngine\` learns \`method: \"schema\"\` which delegates to the service.
- \`catalog.ts\` auto-injects the new builtin for every GraphQL adapter — applies retroactively to Sorare and to any future GraphQL adapter without extra work.

### Sorare tool fixes (field-by-field)

| Tool | Wrong | Right |
|---|---|---|
| sorare_get_card_by_slug | \`Card.activeSingleSaleOffer\`, \`pictureUrl\` | \`liveSingleSaleOffer\`, \`backPictureUrl\`, \`displayRarity\`, \`footballPlayer\` |
| sorare_search_player | \`football.players(search:{name:…})\` | root \`searchPlayers(query, pageSize)\` + \`commonPlayerHits { anyPlayer { … } }\` |
| sorare_list_player_cards | \`Player.cards\` | \`football.allCards(playerSlugs:[…])\` |
| sorare_list_my_cards | \`currentUser.football.myCards\` | \`currentUser.cards(rarities, sport:FOOTBALL)\` |
| sorare_get_lineup | \`So5Lineup.score / rank / reward / so5Appearances\` | id / name / draft / bonuses (those exist) — richer data via generic query |
| ~~sorare_transfer_market~~ → **sorare_live_sale_offers** | non-existent \`football.transferMarket\` | \`tokens.liveSingleSaleOffers(playerSlug, sport, first)\` |

## Test plan

- [x] 724 backend tests pass (10 new schema-service + builtin tests)
- [x] tsc + eslint clean
- [x] Live audit script run against real Sorare API with owner creds — 11/11 tools answer cleanly (one \"failure\" was a deliberate non-existent lineup id, returning \`NOT_FOUND\` as expected)
- [ ] After merge → docker-publish → deploy-cloud
- [ ] On cloud: \`sorare_graphql_schema(type:\"CurrentUser\")\` returns the type definition; broken queries previously erroring with 422 now succeed