### PR TITLE
Sorare: fix sender/receiver price bug; clearer instructions; floor_price tool

### DIFF
--- a/packages/backend/src/adapters/intl/sorare.json
+++ b/packages/backend/src/adapters/intl/sorare.json
@@ -9,7 +9,7 @@
   "featured": true,
   "priority": 100,
   "requiredEnvVars": ["SORARE_EMAIL", "SORARE_PASSWORD"],
-  "instructions": "## Authentication (handled automatically)\n\nSorare uses a custom two-step login the AnythingMCP `LOGIN_TOKEN` engine performs for you:\n\n1. `GET https://api.sorare.com/api/v1/users/{email}` returns the account's bcrypt salt.\n2. Your plain password is hashed locally with `bcrypt.hashSync(password, salt)`.\n3. The hash is sent through Sorare's `signIn` GraphQL mutation; Sorare returns a JWT valid for ~30 days, tagged with the audience claim `anythingmcp` (managed for you).\n4. Every subsequent call adds `Authorization: Bearer <jwt>` and `JWT-AUD: anythingmcp` headers.\n\nThe token is cached in-memory and in the encrypted `connector_auth_cache` table, then proactively re-issued ~24 h before expiry and on any 401. You never need to refresh manually.\n\n## Credentials\n\n- `SORARE_EMAIL` — your Sorare account email.\n- `SORARE_PASSWORD` — your plain account password (never stored or transmitted in plain text after the first login; only the bcrypt hash leaves your server).\n\n## 2FA\n\nIf your account has 2FA enabled, the `signIn` mutation will fail until you provide a fresh `otpAttempt`. For headless/server use we recommend creating a dedicated read-only Sorare account without 2FA. Set `SORARE_PASSWORD` to that account's password.\n\n## Generic GraphQL tools\n\nAlongside the purpose-built tools below, the adapter auto-exposes four generic helpers for arbitrary GraphQL access: `sorare_graphql_schema_url` (returns the SDL URL `https://api.sorare.com/graphql/schema`), `sorare_graphql_query`, `sorare_graphql_mutation`, and `sorare_graphql_subscription`. Use these when you need an operation that isn't covered by a dedicated tool.\n\n## Rate limits\n\nSorare enforces per-IP and per-token rate limits (\"too many requests\" on `429`). Heavy bulk-export workflows should batch and back-off.\n\n## Useful starter prompts\n\n- \"Show me my current Sorare account.\"\n- \"Find the next 5 Lionel Messi rare cards on auction under 0.05 ETH.\"\n- \"List my limited cards by player.\"\n- \"What auctions for Real Madrid players close in the next hour?\"",
+  "instructions": "## Authentication (handled automatically)\n\nSorare uses a custom two-step login the AnythingMCP `LOGIN_TOKEN` engine performs for you:\n\n1. `GET https://api.sorare.com/api/v1/users/{email}` returns the account's bcrypt salt.\n2. Your plain password is hashed locally with `bcrypt.hashSync(password, salt)`.\n3. The hash is sent through Sorare's `signIn` GraphQL mutation; Sorare returns a JWT valid for ~30 days, tagged with the audience claim `anythingmcp` (managed for you).\n4. Every subsequent call adds `Authorization: Bearer <jwt>` and `JWT-AUD: anythingmcp` headers.\n\nThe token is cached in-memory and in the encrypted `connector_auth_cache` table, then proactively re-issued ~24 h before expiry and on any 401. You never need to refresh manually.\n\n## Credentials\n\n- `SORARE_EMAIL` — your Sorare account email.\n- `SORARE_PASSWORD` — your plain account password (never stored or transmitted in plain text after the first login; only the bcrypt hash leaves your server).\n\n## 2FA\n\nIf your account has 2FA enabled, the `signIn` mutation will fail until you provide a fresh `otpAttempt`. For headless/server use we recommend creating a dedicated read-only Sorare account without 2FA. Set `SORARE_PASSWORD` to that account's password.\n\n## Money & pricing conventions — READ THIS FIRST\n\nSorare exposes amounts in **four parallel scales** on every `MonetaryAmount`:\n- `wei` → raw on-chain unit (1 ETH = 10^18 wei). String to avoid precision loss.\n- `eurCents`, `usdCents`, `gbpCents` → **integers in cents, divide by 100 for the currency unit.** Example: `eurCents: 354` means **€3.54**, not €354.\n- These can be `null` when the card is listed only in crypto (no fiat conversion exposed). When you see `eurCents: null`, fall back to `wei` (roughly: `wei * 1e-18 * <ETH/EUR>` for an EUR estimate; the live ETH/EUR rate is not provided by the API).\n\n### TokenOffer sides — easy to get wrong\n\nFor a **single-sale offer** (someone selling a card):\n- `senderSide.anyCards` = the cards being sold (sender = seller, sending the card).\n- `receiverSide.amounts` = the price the buyer pays (receiver = buyer, receiving the card).\n\nIf you query `senderSide.amounts` on a sale offer you'll get **zeros** because the seller isn't sending money. Always read prices from `receiverSide.amounts`.\n\n## When dedicated tools are not enough\n\nThe purpose-built tools below cover the most common workflows. For anything else use the generic helpers:\n- `sorare_graphql_schema` (no args) → compact summary of Query/Mutation + a flat index of every type.\n- `sorare_graphql_schema(type: \"TypeName\")` → just one type's definition.\n- `sorare_graphql_schema(search: \"keyword\")` → every type whose name or a field name matches.\n- `sorare_graphql_query` / `_mutation` / `_subscription` → execute arbitrary documents.\n\n**GraphQL introspection (`__schema` / `__type`) is disabled on Sorare's production endpoint.** Use `sorare_graphql_schema(type: \"…\")` instead.\n\n## Useful field paths the schema search won't surface obviously\n\n- `Player.lowestPriceAnyCard(rarity, inSeason)` → floor card for a player at a rarity. (Wrapped by `sorare_player_floor_price`.)\n- `Player.so5Scores(last, position?)` → recent So5 scores for form analysis. (Wrapped by `sorare_player_recent_scores`.)\n- `tokens.tokenPrices(playerSlug, rarity, first, season?)` → recent sale history for a player+rarity, in fiat + wei. (Wrapped by `sorare_token_prices`.)\n- `tokens.liveSingleSaleOffers(playerSlug?, sport?, first)` → current secondary market. (Wrapped by `sorare_live_sale_offers`.)\n- `currentUser.cards(first, rarities, sport)` → your inventory. NOT `currentUser.football.myCards` (that path doesn't exist).\n- `currentUser.availableBalances` → wallet in wei + EUR + USD + GBP. (Wrapped by `sorare_wallet_balance`.)\n- For free-text player search use the root `searchPlayers(query, pageSize)` then drill via `commonPlayerHits { anyPlayer { ... on Player { ... } } }`. There is no `football.players(search:…)` — that path doesn't exist.\n\n## Sport / season / rarity enum quirks\n\n- `Sport` is upper-snake: `FOOTBALL`, `BASEBALL`, `NBA`.\n- `Rarity` is lowercase: `common`, `limited`, `rare`, `super_rare`, `unique`, `custom_series` (not the upper-snake form).\n- `season` arguments are season **start years**: 2024 means the 2024-25 season.\n- Older-vintage cards (pre-current-season) still score normally in So5 Classic competitions; the vintage mainly matters for the Captain Bonus and for season-eligibility tournaments.\n\n## Rate limits\n\nSorare enforces per-IP and per-token rate limits (`429`). Heavy bulk-export workflows should batch and back-off. Very large GraphQL responses (hundreds of items × deep selection) may also time out — split the request.\n\n## Useful starter prompts\n\n- \"What's my Sorare wallet balance?\" → `sorare_wallet_balance`\n- \"What's the floor price for a Limited Calafiori right now?\" → `sorare_player_floor_price(playerSlug, rarity:\"limited\")`\n- \"What did Messi rare cards sell for in the last month?\" → `sorare_token_prices(playerSlug, rarity:\"rare\", first:30)`\n- \"Show me my Limited cards for Top-5-league players.\" → `sorare_list_my_cards(rarities:[\"limited\"])`\n- \"Is this player in form?\" → `sorare_player_recent_scores(playerSlug, last:10)`\n- \"How am I doing in So5 overall?\" → `sorare_my_trophies_summary(sport:\"FOOTBALL\")`",
   "connector": {
     "name": "Sorare",
     "type": "GRAPHQL",
@@ -83,7 +83,7 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query CardBySlug($slug: String!) { football { card(slug: $slug) { slug name rarity displayRarity backPictureUrl power season { startYear } user { slug } footballPlayer { slug displayName position country { slug } } liveSingleSaleOffer { id endDate status senderSide { wei amounts { eurCents } } } latestEnglishAuction { id endDate } } } }",
+        "path": "query CardBySlug($slug: String!) { football { card(slug: $slug) { slug name rarity displayRarity backPictureUrl power season { startYear } user { slug } footballPlayer { slug displayName position country { slug } } liveSingleSaleOffer { id endDate status receiverSide { amounts { wei eurCents usdCents gbpCents } } } latestEnglishAuction { id endDate currentPrice currency } } } }",
         "queryParams": {
           "slug": "$slug"
         }
@@ -355,6 +355,40 @@
       }
     },
     {
+      "name": "sorare_player_floor_price",
+      "description": "Get the cheapest currently-listed card for a player at a given rarity. Returns the card slug + the live single-sale offer price in wei + EUR/USD/GBP cents. Optionally restrict to in-season cards only. Far cheaper (1 round-trip) than scanning live_sale_offers when you just want 'what does this player's rarity X cost right now?'.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "playerSlug": {
+            "type": "string",
+            "description": "Football player slug (from sorare_search_player)."
+          },
+          "rarity": {
+            "type": "string",
+            "enum": ["common", "limited", "rare", "super_rare", "unique", "custom_series"],
+            "description": "Card rarity (lowercase per Sorare's enum)."
+          },
+          "inSeasonOnly": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, only consider cards eligible for in-season tournaments."
+          }
+        },
+        "required": ["playerSlug", "rarity"],
+        "additionalProperties": false
+      },
+      "endpointMapping": {
+        "method": "query",
+        "path": "query PlayerFloor($playerSlug: String!, $rarity: Rarity!, $inSeasonOnly: Boolean) { players(slugs: [$playerSlug]) { slug displayName ... on Player { lowestPriceAnyCard(rarity: $rarity, inSeason: $inSeasonOnly) { slug name ... on Card { rarity season { startYear } liveSingleSaleOffer { id endDate status receiverSide { amounts { wei eurCents usdCents gbpCents } } } } } } } }",
+        "queryParams": {
+          "playerSlug": "$playerSlug",
+          "rarity": "$rarity",
+          "inSeasonOnly": "$inSeasonOnly"
+        }
+      }
+    },
+    {
       "name": "sorare_live_sale_offers",
       "description": "List currently-live single-sale offers on the secondary market (Sorare's 'transfer market'). Optionally filter by player slug or sport. For rarity / max-price filters use sorare_graphql_query.",
       "parameters": {
@@ -380,7 +414,7 @@
       },
       "endpointMapping": {
         "method": "query",
-        "path": "query LiveSaleOffers($playerSlug: String, $sport: Sport, $limit: Int!) { tokens { liveSingleSaleOffers(playerSlug: $playerSlug, sport: $sport, first: $limit) { nodes { id endDate status senderSide { wei amounts { eurCents usdCents } anyCards { slug name ... on Card { rarity footballPlayer { slug displayName } } } } } } } }",
+        "path": "query LiveSaleOffers($playerSlug: String, $sport: Sport, $limit: Int!) { tokens { liveSingleSaleOffers(playerSlug: $playerSlug, sport: $sport, first: $limit) { nodes { id endDate status senderSide { anyCards { slug name ... on Card { rarity season { startYear } footballPlayer { slug displayName } } } } receiverSide { amounts { wei eurCents usdCents gbpCents } } } } } }",
         "queryParams": {
           "playerSlug": "$playerSlug",
           "sport": "$sport",


### PR DESCRIPTION
## Why

Live audit of a real Claude session (user budget 100€ → buy strategy) revealed three pain points the agent had to discover the hard way.

## Fixes

| Problem | Fix |
|---|---|
| Sale-offer prices came back as zero | \`senderSide.amounts\` returns 0 because sender = seller. Switched live_sale_offers and get_card_by_slug to **receiverSide.amounts** (the price the buyer pays). |
| Agent had to discover \`lowestPriceAnyCard\` by walking the SDL | Added **\`sorare_player_floor_price(playerSlug, rarity, inSeasonOnly)\`** as a dedicated wrapper. |
| Agent burned several turns guessing pricing units / sender side / enum casing | Rewrote adapter instructions to spell out: eurCents-in-cents, sender vs receiver, crypto-only listings = eurCents null, introspection disabled (use \`sorare_graphql_schema(type:…)\`), Sport enum casing, season=start-year, concrete starter-prompt → tool mapping. |

## Live audit results

- \`live_sale_offers\` payload: 1163 B → 1405 B (now carries the prices)
- \`get_card_by_slug\` payload: 581 B → 631 B (now carries auction price + currency)
- New \`sorare_player_floor_price\` returns the floor card + price in one round-trip

17/19 tools answer cleanly; the two remaining are deliberate NOT_FOUND probes against fake IDs for get_lineup / get_auction.

## Test plan

- [x] catalog spec passes
- [x] live audit script run with owner credentials
- [ ] After merge → docker-publish → deploy-cloud