### PR TITLE
docs(sorare): GitHub-indexed guides + feature Sorare in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,17 @@ cd anythingmcp && ./setup.sh
 
 ## Pre-configured MCP connectors
 
-AnythingMCP ships with **36+ ready-to-use adapters** — DACH-rooted but reaching the UK, India, Brasil, Nigeria and Japan. Provide your API credentials at import time and the tools become available immediately. Each adapter has its own setup guide on [anythingmcp.com](https://anythingmcp.com/guides) (English, German, Italian).
+AnythingMCP ships with **37+ ready-to-use adapters** — DACH-rooted but reaching the UK, India, Brasil, Nigeria, Japan and the global gaming web3 space. Provide your API credentials at import time and the tools become available immediately. Each adapter has its own setup guide on [anythingmcp.com](https://anythingmcp.com/guides) (English, German, Italian).
 
 > 📍 **Catalog heads-up.** The starting set leans DACH (Germany / Austria / Switzerland) because that's where this was built in production first, with first-wave international coverage now landing across 🇬🇧 UK, 🇮🇳 India, 🇧🇷 Brasil, 🇳🇬 Nigeria and 🇯🇵 Japan. US/APAC SaaS adapters are very welcome as community PRs — there's a [good-first-issue](https://github.com/HelpCode-ai/anythingmcp/issues/150) walking you through adding one in ~30 minutes (single JSON file).
+
+### 🎮 Gaming & Web3 — featured
+
+| Connector | Description | Guides |
+|---|---|---|
+| **Sorare Fantasy Football** ⚽🌍 | NFT fantasy football, baseball & basketball — 18 tools over cards, players, So5 lineups, wallet, scoring history and the live transfer market. Bcrypt-salted login + 30-day JWT caching handled for you. | [Sorare → MCP](docs/guides/sorare-to-mcp.md) · [Claude](docs/guides/connect-sorare-to-claude.md) · [ChatGPT](docs/guides/connect-sorare-to-chatgpt.md) · [OpenClaw](docs/guides/connect-sorare-to-openclaw.md) · [Cloud](docs/guides/connect-sorare-to-cloud.md) |
+
+Sorare is also the reference implementation of AnythingMCP's new **`LOGIN_TOKEN`** AuthType — a declarative spec for any API that requires a custom bcrypt-style sign-in handshake before issuing a long-lived bearer. Reuse the pattern for any other crypto / fintech / gaming API with non-OAuth auth: see [`docs/connectors/login-token-auth.md`](docs/connectors/login-token-auth.md).
 
 ### 📦 Logistics &amp; shipping
 
@@ -300,6 +308,11 @@ AnythingMCP works with any MCP-compatible client. Pick yours:
 | **GraphQL** | GraphQL endpoints with introspection | [Guide →](docs/connectors/graphql.md) |
 | **Database** | PostgreSQL, MySQL, MariaDB, MSSQL, Oracle, MongoDB, SQLite | [Guide →](docs/connectors/database.md) |
 | **MCP Bridge** | Aggregate multiple MCP servers into one | [Guide →](docs/connectors/mcp-bridge.md) |
+| **LOGIN_TOKEN auth** | APIs that POST credentials → return long-lived bearer (bcrypt-salted handshakes, Sorare-style) | [Guide →](docs/connectors/login-token-auth.md) |
+
+### Featured adapter walkthroughs
+
+- 🎮 **Sorare Fantasy Football** — [Sorare → MCP](docs/guides/sorare-to-mcp.md) · [Connect Sorare to Claude](docs/guides/connect-sorare-to-claude.md) · [Connect Sorare to ChatGPT](docs/guides/connect-sorare-to-chatgpt.md) · [Connect Sorare to OpenClaw](docs/guides/connect-sorare-to-openclaw.md) · [Connect Sorare to AnythingMCP Cloud](docs/guides/connect-sorare-to-cloud.md)
 
 ---
 

--- a/docs/guides/connect-sorare-to-chatgpt.md
+++ b/docs/guides/connect-sorare-to-chatgpt.md
@@ -1,0 +1,105 @@
+# Connect Sorare to ChatGPT — fantasy football tools inside GPT
+
+**Keywords:** connect sorare to chatgpt · sorare chatgpt · sorare gpt · sorare openai · sorare chatgpt connector · sorare chatgpt mcp · fantasy football chatgpt · sorare ai chatgpt
+
+> Add the [Sorare GraphQL API](https://github.com/sorare/api) to **ChatGPT** as a custom MCP (Model Context Protocol) connector using [AnythingMCP](https://github.com/HelpCode-ai/anythingmcp). bcrypt login, 30-day JWT caching and 18 dedicated tools are handled for you.
+
+Other guides in this directory:
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [Connect Sorare to Claude](./connect-sorare-to-claude.md)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw.md)
+- [Connect Sorare to AnythingMCP Cloud](./connect-sorare-to-cloud.md)
+
+---
+
+## What you can ask ChatGPT after this is wired up
+
+- "Pull my current Sorare lineup and tell me where I'm weakest this game week."
+- "List every Rare Vinícius Júnior card minted in season 2024."
+- "What is the floor price for Limited Bukayo Saka right now? Is that a good buy?"
+- "Find auctions for Liverpool players ending in the next 90 minutes."
+- "How am I doing in So5 this season — show podium finishes and total monetary rewards."
+
+ChatGPT picks the right Sorare MCP tool for each prompt — `sorare_get_lineup`, `sorare_token_prices`, `sorare_player_floor_price`, `sorare_live_sale_offers`, `sorare_my_trophies_summary`.
+
+---
+
+## Prerequisites
+
+- ChatGPT **Plus**, **Team**, or **Enterprise** (custom connectors are gated to paid tiers).
+- A Sorare account (https://sorare.com). **2FA off** for headless use — recommended to create a dedicated read-only Sorare account for this purpose.
+- AnythingMCP either local (`./setup.sh && docker compose up -d`) or on [`cloud.anythingmcp.com`](https://cloud.anythingmcp.com).
+- **Important:** ChatGPT can only reach **public HTTPS** URLs. If you run AnythingMCP locally, you need to expose it through Cloudflare Tunnel, ngrok or a reverse proxy. The simpler path is to use `cloud.anythingmcp.com`.
+
+---
+
+## Step 1 — Install the Sorare adapter
+
+Same flow as any other client: open `https://cloud.anythingmcp.com/connectors` (or `http://localhost:3000/connectors/store` locally), pick **Sorare**, paste:
+
+| Field | Value |
+|---|---|
+| `SORARE_EMAIL` | Sorare account email |
+| `SORARE_PASSWORD` | Plain password (hashed locally with bcrypt before login) |
+
+There is no AUD field to fill — the adapter hardcodes the JWT audience to `anythingmcp`.
+
+Mint an MCP API key under **Profile → MCP API Keys → New Key**.
+
+---
+
+## Step 2 — Add the connector inside ChatGPT
+
+1. In ChatGPT, open **Settings → Connectors → Add custom connector**.
+2. Fill in:
+   - **Name:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp` (or your tunneled host if you self-host).
+   - **Authentication:** Bearer token → paste the MCP API key.
+3. Save. ChatGPT auto-discovers the 18 Sorare tools.
+
+---
+
+## The 18 tools you get
+
+Same set as for Claude. Quick groups:
+
+- **Identity / wallet:** `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug`
+- **Cards:** `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards`
+- **Players:** `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price`
+- **Market:** `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup`
+- **Generic GraphQL escape hatch:** `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription`
+
+Full reference and field-path notes: [`sorare-to-mcp.md`](./sorare-to-mcp.md).
+
+---
+
+## Token rotation
+
+JWTs live ~30 days. AnythingMCP refreshes 24 h before expiry and re-logs in on any 401. ChatGPT calls never see a stale-token error.
+
+---
+
+## FAQ
+
+**ChatGPT says "connector unreachable" or the connector silently has no tools.**
+ChatGPT can't see `localhost` or private IPs. Either deploy to `cloud.anythingmcp.com` or expose your local instance with Cloudflare Tunnel / ngrok.
+
+**Do I need ChatGPT Enterprise?**
+No — custom connectors are available on Plus, Team and Enterprise.
+
+**Can I make the connector read-only?**
+Yes. Either drop `sorare_graphql_mutation` from the tool set in your MCP server config, or — for finer control — assign the connector a Role in AnythingMCP that whitelists only `sorare_get_*` / `sorare_list_*` / `sorare_current_user` / `sorare_wallet_balance` / `sorare_token_prices` etc.
+
+**Why does the adapter ask for my Sorare password instead of an API token?**
+Sorare doesn't issue API tokens. The only auth is the bcrypt + `signIn` flow described in the [Sorare API repo](https://github.com/sorare/api). AnythingMCP encrypts the password at rest (AES-256-GCM) and only the bcrypt hash crosses the wire on first sign-in.
+
+---
+
+## Links
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [AnythingMCP repo](https://github.com/HelpCode-ai/anythingmcp)
+- [AnythingMCP cloud](https://cloud.anythingmcp.com)
+- [Sorare API official repo](https://github.com/sorare/api)
+- [LOGIN_TOKEN auth reference](../connectors/login-token-auth.md)

--- a/docs/guides/connect-sorare-to-claude.md
+++ b/docs/guides/connect-sorare-to-claude.md
@@ -1,0 +1,142 @@
+# Connect Sorare to Claude — NFT fantasy football inside Claude Desktop & Claude Code
+
+**Keywords:** connect sorare to claude · sorare claude desktop · sorare claude code · sorare claude mcp · sorare ai claude · sorare anthropic · fantasy football claude · sorare claude integration
+
+> Step-by-step guide to add the [Sorare GraphQL API](https://github.com/sorare/api) to **Claude Desktop** or **Claude Code** as an MCP (Model Context Protocol) server. Uses [AnythingMCP](https://github.com/HelpCode-ai/anythingmcp), which handles Sorare's bcrypt-salted login and 30-day JWT caching for you.
+
+Other guides in this directory:
+
+- [Sorare to MCP — the main hub](./sorare-to-mcp.md)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt.md)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw.md)
+- [Connect Sorare to AnythingMCP Cloud](./connect-sorare-to-cloud.md)
+
+---
+
+## What you can ask Claude after this is wired up
+
+- "What's my Sorare wallet balance and how many Limited cards do I own?"
+- "What did Limited Calafiori cards sell for in the last 30 days?"
+- "Find me cheap Rare midfielders in the top 5 European leagues."
+- "How am I doing in So5 this season?"
+- "Show me my last So5 lineup."
+
+Each of these maps to one or two MCP tool calls against the Sorare adapter — no manual GraphQL composition required.
+
+---
+
+## Prerequisites
+
+- A Sorare account (https://sorare.com). For headless use we strongly recommend a **dedicated read-only account with 2FA disabled** — the `signIn` mutation refuses requests without a fresh OTP and there's no clean way to rotate OTPs from a server.
+- Claude Desktop **or** Claude Code installed.
+- Either:
+  - AnythingMCP running locally (`git clone … && ./setup.sh && docker compose up -d`), **or**
+  - An account on [`cloud.anythingmcp.com`](https://cloud.anythingmcp.com) — Sorare is in the catalog.
+
+---
+
+## Step 1 — Install the Sorare adapter
+
+### Local
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && ./setup.sh && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **Sorare**, fill in:
+
+| Field | Value |
+|---|---|
+| `SORARE_EMAIL` | your Sorare account email |
+| `SORARE_PASSWORD` | your plain password (never stored unencrypted; only the bcrypt hash leaves your server) |
+
+Note: there is **no AUD field** — the adapter hardcodes the JWT audience to `anythingmcp`.
+
+### Cloud
+
+Sign in at `https://cloud.anythingmcp.com/connectors`, click **Sorare**, same two fields.
+
+In both cases, mint an MCP API key under **Profile → MCP API Keys → New Key**.
+
+---
+
+## Step 2 — Wire it into Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%AppData%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "sorare": {
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+For cloud, swap the URL for `https://cloud.anythingmcp.com/mcp`.
+
+Restart Claude Desktop. The Sorare tools appear in the 🔧 menu — 18 of them in this release.
+
+---
+
+## Step 3 — Wire it into Claude Code
+
+In Claude Code, add the MCP server via the CLI or `~/.config/claude-code/mcp.json`:
+
+```bash
+claude mcp add sorare \
+  --transport http \
+  --url http://localhost:4000/mcp \
+  --header "Authorization: Bearer YOUR_MCP_API_KEY"
+```
+
+Verify with `claude mcp list`. Sorare tools become available in any Claude Code session.
+
+---
+
+## The 18 tools, grouped
+
+- **Identity / wallet:** `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug`
+- **Cards / inventory:** `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards`
+- **Players / form:** `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price`
+- **Market:** `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup`
+- **Generic GraphQL escape hatch:** `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription`
+
+Full reference: [`sorare-to-mcp.md`](./sorare-to-mcp.md).
+
+---
+
+## Token rotation, explained for Claude users
+
+Sorare JWTs last ~30 days. AnythingMCP encrypts yours at rest (AES-256-GCM), **re-issues it 24 h before expiry**, and re-logs in on any 401 — without your password ever being re-read from disk (the bcrypt hash is recomputed from the freshly fetched salt). Claude never sees an expired-token error.
+
+---
+
+## FAQ
+
+**Does AnythingMCP store my Sorare password in plain text?**
+No. The password is encrypted in `authConfig` with AES-256-GCM. The bcrypt hash is what crosses the wire — only on `signIn`, only on first use or after the cached JWT expires.
+
+**Can I use a Sorare account with 2FA?**
+The `signIn` mutation requires a fresh `otpAttempt` when 2FA is on, and there's no clean way to automate it. Use a dedicated read-only account without 2FA.
+
+**Does this work for Claude Code too?**
+Yes — same MCP endpoint and Bearer header. See Step 3.
+
+**Why does the wallet show prices in `eurCents`?**
+Sorare expresses fiat amounts as integer cents. Divide by 100 for the currency unit (`354` → €3.54). This is documented in the adapter `instructions` block so Claude reads it automatically before composing prompts.
+
+---
+
+## Links
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [AnythingMCP repo](https://github.com/HelpCode-ai/anythingmcp)
+- [AnythingMCP cloud](https://cloud.anythingmcp.com)
+- [Sorare API official repo](https://github.com/sorare/api)
+- [LOGIN_TOKEN auth reference](../connectors/login-token-auth.md)

--- a/docs/guides/connect-sorare-to-cloud.md
+++ b/docs/guides/connect-sorare-to-cloud.md
@@ -1,0 +1,127 @@
+# Connect Sorare to AnythingMCP Cloud — managed MCP server for the Sorare GraphQL API
+
+**Keywords:** connect sorare to cloud · sorare cloud mcp · sorare anythingmcp cloud · sorare managed mcp · sorare hosted mcp · sorare api saas · sorare claude cloud · sorare chatgpt cloud · sorare opencloud
+
+> Use [`cloud.anythingmcp.com`](https://cloud.anythingmcp.com) as a **managed** MCP server for the [Sorare GraphQL API](https://github.com/sorare/api). Zero infrastructure on your side — sign up, install the adapter from the catalog, paste your Sorare email + password, mint an MCP API key, point any AI client at the cloud endpoint. The same bcrypt + 30-day JWT handling is baked in.
+
+Other guides in this directory:
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [Connect Sorare to Claude](./connect-sorare-to-claude.md)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt.md)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw.md)
+
+---
+
+## Why the cloud path
+
+| | Self-hosted | AnythingMCP Cloud |
+|---|---|---|
+| Setup | `git clone` + Docker + Postgres + Redis | sign up, paste credentials |
+| ChatGPT can reach it | only via Cloudflare Tunnel / ngrok | yes, native HTTPS |
+| Updates | `docker compose pull && up -d` | automatic, deployed on every merge to `main` |
+| Where the Sorare JWT lives | encrypted in your local Postgres | encrypted in the managed Postgres (AES-256-GCM) |
+| Cost | hosting only | managed pricing |
+
+Pick the cloud if you want ChatGPT / Claude / OpenClaw to "just work" from any device, without exposing localhost to the internet. Pick self-hosted if you want the JWT and the bcrypt hash to never leave your hardware (see the [OpenClaw guide](./connect-sorare-to-openclaw.md) for a fully-local setup).
+
+---
+
+## Step 1 — Sign in on `cloud.anythingmcp.com`
+
+1. Go to [`https://cloud.anythingmcp.com`](https://cloud.anythingmcp.com).
+2. Register or sign in. The first user in an organisation becomes the admin.
+
+---
+
+## Step 2 — Install the Sorare adapter from the catalog
+
+1. Open `https://cloud.anythingmcp.com/connectors`.
+2. Click **Add connector → from catalog → Sorare Fantasy Football** (it's in the **Featured** rail because the adapter is marked `featured: true, priority: 100`).
+3. Fill in:
+
+| Field | Value |
+|---|---|
+| `SORARE_EMAIL` | your Sorare account email |
+| `SORARE_PASSWORD` | your plain password (encrypted at rest with AES-256-GCM; only the bcrypt hash leaves the server) |
+
+There is **no AUD field** — the adapter hardcodes the JWT audience to `anythingmcp` so you don't pick one.
+
+4. Click **Install**. The 18 Sorare tools are now wired up.
+
+> 💡 For headless / agent use we strongly recommend a **dedicated read-only Sorare account with 2FA disabled**. The `signIn` mutation refuses requests without a fresh OTP and there's no clean way to rotate OTPs from a server.
+
+---
+
+## Step 3 — Mint an MCP API key and pick your client
+
+Under **Profile → MCP API Keys → New Key**, generate a key labeled by client (`claude-desktop`, `chatgpt-team`, `openclaw-laptop`, …).
+
+The cloud MCP endpoint is:
+
+```
+https://cloud.anythingmcp.com/mcp
+```
+
+With the header:
+
+```
+Authorization: Bearer YOUR_MCP_API_KEY
+```
+
+### Hooking it up to clients
+
+- **Claude Desktop / Claude Code** → see [`connect-sorare-to-claude.md`](./connect-sorare-to-claude.md). Swap the local `http://localhost:4000/mcp` URL for the cloud URL.
+- **ChatGPT** → see [`connect-sorare-to-chatgpt.md`](./connect-sorare-to-chatgpt.md). The cloud URL is already public HTTPS, so no Cloudflare Tunnel needed.
+- **OpenClaw** → see [`connect-sorare-to-openclaw.md`](./connect-sorare-to-openclaw.md). Replace the localhost URL in the `openclaw mcp set` payload.
+
+---
+
+## The 18 tools you get
+
+| Group | Tools |
+|---|---|
+| **Identity / wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Cards** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Players** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Market** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **Generic GraphQL escape hatch** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
+
+Full field reference and pricing conventions: [`sorare-to-mcp.md`](./sorare-to-mcp.md).
+
+---
+
+## What's hosted vs what's local
+
+- **Hosted in the cloud:** the bcrypt-hashed login flow, the JWT cache, the GraphQL schema cache, the per-tool routing.
+- **Stays at the upstream:** the actual GraphQL execution hits `https://api.sorare.com/graphql` from the cloud server (not from your client).
+- **Your client never gets your Sorare password.** It only gets MCP tool responses.
+
+---
+
+## FAQ
+
+**How is my Sorare password protected on the cloud?**
+Encrypted at rest in the `authConfig` blob using AES-256-GCM with a server-side `ENCRYPTION_KEY` env var. Only the bcrypt hash crosses the wire on `signIn`, never the plain password.
+
+**Can I rotate my MCP API keys without breaking the Sorare auth?**
+Yes — MCP API keys and Sorare credentials are separate. Revoke an MCP key from **Profile → MCP API Keys** without touching the adapter.
+
+**Does the cloud cache the same JWT across all my MCP keys?**
+Yes. The JWT lives once per connector in the encrypted `connector_auth_cache` table; all your MCP keys reuse it. Re-issued 24 h before expiry and on any 401.
+
+**Can I uninstall the adapter and start over?**
+Yes. **Connectors → Sorare → Uninstall** wipes the encrypted credentials and the cached JWT. You can reinstall any time.
+
+**Is the cloud version of the catalog kept in sync with the open-source repo?**
+Yes — the `deploy-cloud.yml` GitHub Actions workflow rebuilds the image from `main` on every merge and rolls it out to the droplet. Sorare's 18-tool surface is identical on cloud and self-hosted.
+
+---
+
+## Links
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [AnythingMCP repo](https://github.com/HelpCode-ai/anythingmcp)
+- [AnythingMCP cloud](https://cloud.anythingmcp.com)
+- [Sorare API official repo](https://github.com/sorare/api)
+- [LOGIN_TOKEN auth reference](../connectors/login-token-auth.md)

--- a/docs/guides/connect-sorare-to-openclaw.md
+++ b/docs/guides/connect-sorare-to-openclaw.md
@@ -1,0 +1,113 @@
+# Connect Sorare to OpenClaw — self-hosted AI assistant + NFT fantasy football
+
+**Keywords:** connect sorare to openclaw · sorare openclaw · sorare openclaw mcp · sorare self-hosted ai · openclaw mcp connector · openclaw graphql · sorare local ai · fantasy football openclaw
+
+> Add the [Sorare GraphQL API](https://github.com/sorare/api) to **[OpenClaw](https://openclaw.ai/)** — the open-source local AI assistant — via an MCP (Model Context Protocol) server published by [AnythingMCP](https://github.com/HelpCode-ai/anythingmcp). End-to-end private: your password and the issued JWT never leave your network.
+
+Other guides in this directory:
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [Connect Sorare to Claude](./connect-sorare-to-claude.md)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt.md)
+- [Connect Sorare to AnythingMCP Cloud](./connect-sorare-to-cloud.md)
+
+---
+
+## Why OpenClaw + Sorare + AnythingMCP
+
+- **OpenClaw** runs locally. It supports streamable-HTTP MCP servers via `openclaw mcp set` ([CLI reference](https://docs.openclaw.ai/cli/mcp.md)).
+- **AnythingMCP** wraps Sorare's GraphQL API as an MCP server. The bcrypt + 30-day-JWT handshake the Sorare API requires is fully managed.
+- Run both on your machine and your Sorare credentials, the bcrypt hash, and the JWT all stay on your hardware. No SaaS dependency, no public exposure required.
+
+---
+
+## Prerequisites
+
+- OpenClaw installed (`brew install openclaw` or follow [docs.openclaw.ai/getting-started](https://docs.openclaw.ai/getting-started)).
+- AnythingMCP running locally: `git clone … && ./setup.sh && docker compose up -d`.
+- A Sorare account (https://sorare.com). For headless / agent use, create a dedicated **read-only account with 2FA disabled**.
+
+---
+
+## Step 1 — Install the Sorare adapter
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && ./setup.sh && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **Sorare**, and fill in `SORARE_EMAIL` + `SORARE_PASSWORD`. There is no AUD field (it's hardcoded to `anythingmcp`).
+
+Mint an MCP API key under **Profile → MCP API Keys → New Key**.
+
+---
+
+## Step 2 — Register the MCP server in OpenClaw
+
+OpenClaw stores MCP servers under the `mcp.servers` key in its config. Add Sorare with the CLI:
+
+```bash
+openclaw mcp set sorare '{
+  "url": "http://localhost:4000/mcp",
+  "transport": "streamable-http",
+  "connectionTimeoutMs": 10000,
+  "headers": {
+    "Authorization": "Bearer YOUR_MCP_API_KEY"
+  }
+}'
+```
+
+Verify the registration:
+
+```bash
+openclaw mcp list
+```
+
+OpenClaw auto-discovers the 18 Sorare tools and makes them available to its agent runtime immediately. No restart needed.
+
+---
+
+## The 18 tools you get
+
+Same set as for Claude and ChatGPT. Quick groups:
+
+- **Identity / wallet:** `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug`
+- **Cards:** `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards`
+- **Players:** `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price`
+- **Market:** `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup`
+- **Generic GraphQL escape hatch:** `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription`
+
+Field reference and pricing-convention notes (eurCents-in-cents, sender vs receiver side, crypto-only listings): [`sorare-to-mcp.md`](./sorare-to-mcp.md).
+
+---
+
+## Token rotation
+
+AnythingMCP encrypts the Sorare JWT in `connector_auth_cache` (AES-256-GCM), refreshes it 24 h before expiry, and re-logs in on any 401. The token lives ~30 days. No cron, no manual refresh.
+
+---
+
+## FAQ
+
+**Does OpenClaw need to be on the same machine as AnythingMCP?**
+No. `http://localhost:4000/mcp` is just the default. Any reachable URL works — TLS + Bearer auth strongly recommended for cross-host setups.
+
+**Where is the MCP server config stored on disk?**
+Under `mcp.servers` in OpenClaw's global config — managed via `openclaw mcp set / list / remove`. See [docs.openclaw.ai/cli/mcp.md](https://docs.openclaw.ai/cli/mcp.md).
+
+**Can I run multiple AnythingMCP adapters behind one OpenClaw entry?**
+Yes. Every adapter you install in AnythingMCP becomes a tool on the same `/mcp` endpoint. One OpenClaw `mcp.servers.sorare` entry exposes all 18 Sorare tools at once.
+
+**Can I keep my Sorare password off disk entirely?**
+Set `SORARE_PASSWORD` via environment variable at install time and choose "do not persist credentials" if your AnythingMCP build supports it. Otherwise the password is encrypted at rest with AES-256-GCM in the `authConfig` blob (never written in plaintext anywhere).
+
+---
+
+## Links
+
+- [Sorare to MCP — main hub](./sorare-to-mcp.md)
+- [AnythingMCP repo](https://github.com/HelpCode-ai/anythingmcp)
+- [OpenClaw docs](https://docs.openclaw.ai)
+- [OpenClaw MCP CLI reference](https://docs.openclaw.ai/cli/mcp.md)
+- [Sorare API official repo](https://github.com/sorare/api)
+- [LOGIN_TOKEN auth reference](../connectors/login-token-auth.md)

--- a/docs/guides/sorare-to-mcp.md
+++ b/docs/guides/sorare-to-mcp.md
@@ -1,0 +1,141 @@
+# Sorare to MCP — Connect Sorare GraphQL API to any AI agent
+
+**Keywords:** sorare mcp · sorare to mcp · sorare graphql mcp · sorare api mcp · sorare model context protocol · sorare ai · sorare ai agent · connect sorare api · sorare bcrypt auth · sorare jwt 30 days · fantasy football mcp · nft fantasy mcp
+
+> The official [Sorare GraphQL API](https://github.com/sorare/api) wrapped as an **MCP (Model Context Protocol) server** by [AnythingMCP](https://github.com/HelpCode-ai/anythingmcp). Bcrypt-salted login, 30-day JWT caching, and **18 ready-to-use tools** for cards, players, lineups, auctions, wallet, scoring history and the transfer market. Drop-in for Claude, ChatGPT, OpenClaw, Cursor, Codex and any other MCP-aware client.
+
+Other companion guides in this directory:
+
+- [Connect Sorare to Claude](./connect-sorare-to-claude.md)
+- [Connect Sorare to ChatGPT](./connect-sorare-to-chatgpt.md)
+- [Connect Sorare to OpenClaw](./connect-sorare-to-openclaw.md)
+- [Connect Sorare to AnythingMCP Cloud](./connect-sorare-to-cloud.md)
+
+---
+
+## What "Sorare to MCP" means
+
+[Sorare](https://sorare.com/) is the largest licensed NFT fantasy football, baseball and basketball game. Its [GraphQL API](https://api.sorare.com/graphql) covers everything you can see in the web app — cards, players, the secondary-market transfer offers, So5 lineups, score history, your wallet — but it has two quirks that make it hard to drive from a generic GraphQL client:
+
+1. **Custom auth.** Sorare doesn't issue plain API keys or OAuth2. Sign-in is a bcrypt handshake: fetch a per-account salt from `GET /api/v1/users/{email}`, hash your password locally with `bcrypt.hashSync(password, salt)`, then POST the hash through a `signIn` GraphQL mutation. You get back a JWT good for ~30 days plus an `aud` claim you have to echo on every call as the `JWT-AUD` header.
+2. **Introspection is disabled on production.** You can't query `__schema` or `__type`; the only way to discover types is to fetch the SDL at `https://api.sorare.com/graphql/schema` (816 KB).
+
+The Sorare MCP adapter handles both transparently:
+
+- The new `LOGIN_TOKEN` AuthType in AnythingMCP runs salt-fetch → bcrypt → `signIn` for you, caches the JWT in-memory + in an AES-256-GCM-encrypted DB row, refreshes it 24 h before expiry, and re-issues it transparently on any 401.
+- The auto-injected `sorare_graphql_schema` tool **proxies the SDL through the MCP server** and returns task-sized slices — no allowlist concerns, no 200 K-token blow-up. Pass `type: "CurrentUser"` to retrieve one type, `search: "auction"` to find every type whose name or fields contain the term, or `full: true` for the entire SDL.
+
+The whole flow is one MCP tool call from the agent's point of view — `sorare_current_user` or `sorare_wallet_balance` just works, no auth ceremony.
+
+---
+
+## Quick start (60 seconds)
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && ./setup.sh
+docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **Sorare**, paste your `SORARE_EMAIL` and `SORARE_PASSWORD` (no AUD field — it's hardcoded to `anythingmcp`). Mint an MCP API key from **Profile → MCP API Keys**. Point any MCP client at `http://localhost:4000/mcp` with `Authorization: Bearer <your-key>`.
+
+If you prefer SaaS, sign up on `https://cloud.anythingmcp.com` — Sorare is in the catalog there too, with no install step on your side.
+
+---
+
+## The 18 tools the adapter exposes
+
+### Identity & wallet
+
+| Tool | What it returns |
+|---|---|
+| `sorare_current_user` | Authenticated profile (slug, email, nickname) |
+| `sorare_wallet_balance` | Available balances in wei + EUR + USD + GBP — read **cents, divide by 100** |
+| `sorare_my_trophies_summary` | finalRankings, podiumRankings, cardRewards, lifetime monetary reward |
+| `sorare_user_by_slug` | Any other user's public profile + verified badge |
+
+### Cards & inventory
+
+| Tool | What it returns |
+|---|---|
+| `sorare_list_my_cards` | Your owned cards filterable by rarity (default 20) |
+| `sorare_get_card_by_slug` | One card with player, season, owner, live sale offer **and the price the buyer pays** |
+| `sorare_list_player_cards` | Recent cards minted for a given player slug |
+
+### Players & form
+
+| Tool | What it returns |
+|---|---|
+| `sorare_search_player` | Full-text player search → slug, name, club, country (use slugs in other tools) |
+| `sorare_player_recent_scores` | Last N So5 scores for form/in-form analysis |
+| `sorare_player_floor_price` | The cheapest card listed for a player at a chosen rarity — single round-trip |
+
+### Market & auctions
+
+| Tool | What it returns |
+|---|---|
+| `sorare_live_sale_offers` | Live secondary-market offers — fixed in this release to read `receiverSide.amounts` so prices are real, not zero |
+| `sorare_token_prices` | Historical sale prices for a player + rarity over a window |
+| `sorare_get_auction` | One specific auction by id |
+| `sorare_get_lineup` | One So5 lineup by id |
+
+### Generic GraphQL helpers (auto-injected on every GraphQL adapter)
+
+| Tool | What it returns |
+|---|---|
+| `sorare_graphql_schema_url` | The literal URL of the SDL — `https://api.sorare.com/graphql/schema` |
+| `sorare_graphql_schema` | Proxied + filtered SDL: default summary, `type:` slice, `search:` slice, or `full:true` |
+| `sorare_graphql_query` | Execute an arbitrary GraphQL query |
+| `sorare_graphql_mutation` | Execute an arbitrary GraphQL mutation |
+| `sorare_graphql_subscription` | Execute an arbitrary GraphQL subscription (transport-dependent) |
+
+---
+
+## Sorare pricing & API gotchas (so your agent gets it right the first time)
+
+These are baked into the adapter's `instructions` block so the model sees them automatically, but worth surfacing here for humans skimming the repo:
+
+- `eurCents` / `usdCents` / `gbpCents` are **integers in cents**. `354` means **€3.54**, not €354.
+- On a **single-sale offer**, `senderSide` = the seller (sending the card) and `receiverSide` = the buyer (paying the price). Reading `senderSide.amounts` gives **zero** because the seller isn't sending money. Always read prices from `receiverSide.amounts`.
+- Cards listed only in crypto have `eurCents: null`. Fall back to `wei` (1 ETH = 10¹⁸ wei).
+- **Sport** enum is upper-snake (`FOOTBALL`, `BASEBALL`, `NBA`). **Rarity** enum is lowercase (`common`, `limited`, `rare`, `super_rare`, `unique`, `custom_series`). **Season** is the start year (`2024` = the 2024-25 season).
+- Older vintage cards still score normally in So5 Classic; vintage mainly affects the Captain Bonus and season-eligibility tournaments.
+
+---
+
+## Example workflows
+
+**"What's my Sorare wallet worth?"**
+→ `sorare_wallet_balance` → divide `eurCents` by 100.
+
+**"What does a Limited Calafiori card cost right now?"**
+→ `sorare_player_floor_price(playerSlug: "riccardo-calafiori", rarity: "limited")`.
+
+**"Should I buy this card at €X?"**
+→ `sorare_token_prices(playerSlug, rarity: "limited", first: 30)` for recent sale history + `sorare_player_recent_scores(playerSlug, last: 10)` for form.
+
+**"Find me cheap rare Premier League midfielders."**
+→ `sorare_graphql_query` with `football.allCards(rarities: [rare], inActiveCompetitions: ["premier-league"], first: 20)` plus the schema slice from `sorare_graphql_schema(type: "FootballRoot")` to compose the right arguments.
+
+---
+
+## How it compares to writing your own Sorare client
+
+| | Hand-rolled | AnythingMCP Sorare adapter |
+|---|---|---|
+| Login + bcrypt + salt fetch | ~80 LOC + tests | 0 (declarative `LOGIN_TOKEN` auth) |
+| Token storage + 30-day refresh | DB + cron | 0 (built in) |
+| Schema discovery (introspection blocked) | Manual SDL parsing | `sorare_graphql_schema(type:…)` |
+| Per-call header injection (`JWT-AUD`) | Custom interceptor | 0 (auto) |
+| Multi-client (Claude + ChatGPT + …) | Re-implement per client | One MCP endpoint, every client uses it |
+
+---
+
+## Links
+
+- AnythingMCP repo: https://github.com/HelpCode-ai/anythingmcp
+- AnythingMCP cloud: https://cloud.anythingmcp.com
+- Sorare API docs (official): https://github.com/sorare/api
+- Sorare SDL (raw): https://api.sorare.com/graphql/schema
+- LOGIN_TOKEN auth reference: [../connectors/login-token-auth.md](../connectors/login-token-auth.md)
+- Tool definition format: [../tool-definition.md](../tool-definition.md)


### PR DESCRIPTION
## What

Five new Markdown guides under \`docs/guides/\` with SEO-rich filenames and H1s so GitHub Search surfaces them for the most common Sorare ↔ MCP queries:

| File | Targets the query |
|---|---|
| \`docs/guides/sorare-to-mcp.md\` | sorare to mcp · sorare mcp · sorare graphql mcp |
| \`docs/guides/connect-sorare-to-claude.md\` | connect sorare to claude · sorare claude mcp |
| \`docs/guides/connect-sorare-to-chatgpt.md\` | connect sorare to chatgpt · sorare chatgpt connector |
| \`docs/guides/connect-sorare-to-openclaw.md\` | connect sorare to openclaw · sorare openclaw mcp |
| \`docs/guides/connect-sorare-to-cloud.md\` | connect sorare to cloud · sorare anythingmcp cloud · sorare managed mcp |

Each guide cross-links to the other four and points back to the adapter JSON, the LOGIN_TOKEN auth reference, and the Sorare API repo. Content bakes in everything the live chat-audit surfaced: eurCents-in-cents convention, sender vs receiver semantics on TokenOffer, crypto-only listings, introspection disabled → use \`sorare_graphql_schema(type:…)\`, sport / rarity / season enum casing.

## README changes

- Adapter count bumped 36 → 37 in the catalog intro.
- New **🎮 Gaming & Web3 — featured** rail above the existing regional categories, featuring Sorare with links to all five guides and a callout that Sorare is the reference implementation of AnythingMCP's new \`LOGIN_TOKEN\` AuthType (reusable for any non-OAuth API).
- LOGIN_TOKEN row added to the connector-types table.
- **Featured adapter walkthroughs** sub-section under "Connector guides" linking the five Sorare guides for in-repo discoverability.

## Why this layout

GitHub's Search ranks files higher when:
1. The filename matches the query terms verbatim (these do).
2. The first H1 matches the query terms verbatim (these do).
3. The file lives at a stable indexed path (\`docs/\` is well indexed).
4. The README links to it (now does).

Docs-only change — no code, no tests, no deploy needed.