### PR TITLE
docs(sorare): 'no install — use cloud.anythingmcp.com' callout in every guide

### DIFF
--- a/content/guides/de/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/de/connect-sorare-to-chatgpt.mdx
@@ -12,6 +12,8 @@ lang: "de"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
 ## Sorare mit ChatGPT verbinden
 
 ChatGPT unterstützt das **Model Context Protocol** in Custom Connectors und in der Developer-Tools-Oberfläche. Mit AnythingMCP als Brücke zur Sorare-GraphQL-API kannst du Karten, Spieler, Aufstellungen und Transfermarkt direkt aus einer ChatGPT-Konversation abfragen — ohne OAuth-Tanz und ohne Token-Babysitting.

--- a/content/guides/de/connect-sorare-to-claude.mdx
+++ b/content/guides/de/connect-sorare-to-claude.mdx
@@ -12,6 +12,8 @@ lang: "de"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
 ## Sorare mit Claude verbinden
 
 Sorare ist das größte NFT-Fantasy-Football-Spiel mit voller GraphQL-Abdeckung von Karten, Spielern, Aufstellungen und Transfermarkt. Mit AnythingMCP steuerst du alles direkt aus Claude Desktop oder Claude Code in Klartext — ohne SDK-Kleber, ohne manuelle Token-Rotation.

--- a/content/guides/de/connect-sorare-to-copilot.mdx
+++ b/content/guides/de/connect-sorare-to-copilot.mdx
@@ -12,6 +12,8 @@ lang: "de"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
 ## Sorare mit GitHub Copilot verbinden
 
 GitHub Copilot Chat unterstützt jetzt das **Model Context Protocol (MCP)** über die `mcp`-Konfiguration in VS Code und JetBrains. Mit AnythingMCP als Brücke zur Sorare-GraphQL-API kannst du Karten, Spieler, Aufstellungen, den Sekundärmarkt und dein Wallet direkt aus Copilot heraus abfragen — ohne den Editor zu verlassen.

--- a/content/guides/de/connect-sorare-to-openclaw.mdx
+++ b/content/guides/de/connect-sorare-to-openclaw.mdx
@@ -12,6 +12,8 @@ lang: "de"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
 ## Sorare mit OpenClaw verbinden
 
 [OpenClaw](https://openclaw.ai/) ist ein Open-Source-KI-Assistent, der lokal läuft und MCP-Server über sein CLI einbindet. Kombiniert mit AnythingMCP erhältst du ein End-to-End-privates Setup, um Sorare von deinem eigenen Rechner aus abzufragen — Passwort und JWT verlassen dein Netzwerk nie.

--- a/content/guides/de/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/de/sorare-now-on-anythingmcp.mdx
@@ -13,6 +13,8 @@ featured: true
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="280" />
 </p>
 
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
 ## Sorare ist jetzt auf AnythingMCP
 
 Ab sofort kannst du [Sorare](https://sorare.com/) — die größte NFT-Fantasy-Plattform für Fußball, Baseball und Basketball — mit einer einzigen Installation an **jeden MCP-fähigen KI-Client** anbinden. Kein SDK zu pflegen, keine Token-Rotation zu beaufsichtigen, kein mühsames GraphQL-Komponieren.

--- a/content/guides/de/sorare-to-mcp.mdx
+++ b/content/guides/de/sorare-to-mcp.mdx
@@ -12,6 +12,8 @@ lang: "de"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
 ## Sorare im Model Context Protocol
 
 [Sorare](https://sorare.com/) ist das größte lizenzierte NFT-Fantasy-Sportspiel und bietet eine vollständige GraphQL-Schnittstelle für Spieler, Karten, Auktionen und So5-Aufstellungen. AnythingMCP verpackt diese GraphQL-API als **MCP-Server**, sodass jeder Agent — Claude, ChatGPT, OpenClaw, Cursor oder eigene Implementierungen — Sorare-Daten in natürlicher Sprache lesen und nutzen kann.

--- a/content/guides/en/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/en/connect-sorare-to-chatgpt.mdx
@@ -12,6 +12,8 @@ lang: "en"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 ## Connect Sorare to ChatGPT
 
 ChatGPT supports the **Model Context Protocol** in custom connectors and in the Developer tools surface. With AnythingMCP exposing Sorare's GraphQL API as MCP tools, you can query cards, players, lineups, and the transfer market from a ChatGPT conversation — without OAuth ceremonies or token babysitting.

--- a/content/guides/en/connect-sorare-to-claude.mdx
+++ b/content/guides/en/connect-sorare-to-claude.mdx
@@ -12,6 +12,8 @@ lang: "en"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 ## Connect Sorare to Claude
 
 Sorare is the largest NFT fantasy football game, with full GraphQL coverage over cards, players, lineups, and the transfer market. With AnythingMCP, you can drive all of it from Claude Desktop or Claude Code in plain English — no SDK to glue, no token rotation to babysit.

--- a/content/guides/en/connect-sorare-to-copilot.mdx
+++ b/content/guides/en/connect-sorare-to-copilot.mdx
@@ -12,6 +12,8 @@ lang: "en"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 ## Connect Sorare to GitHub Copilot
 
 GitHub Copilot Chat now supports the **Model Context Protocol (MCP)** through its `mcp` configuration in VS Code and JetBrains. With AnythingMCP exposing Sorare's full GraphQL API as a managed MCP server, you can query cards, players, lineups, the secondary market and your wallet directly from Copilot — without leaving your editor.

--- a/content/guides/en/connect-sorare-to-openclaw.mdx
+++ b/content/guides/en/connect-sorare-to-openclaw.mdx
@@ -12,6 +12,8 @@ lang: "en"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 ## Connect Sorare to OpenClaw
 
 [OpenClaw](https://openclaw.ai/) is an open-source personal AI assistant that runs locally and supports MCP servers via its CLI. Combine it with AnythingMCP and you have a self-hosted, end-to-end private setup for querying Sorare from your own machine — your password and the issued JWT never leave your network.

--- a/content/guides/en/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/en/sorare-now-on-anythingmcp.mdx
@@ -13,6 +13,8 @@ featured: true
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="280" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 ## Sorare is now on AnythingMCP
 
 Starting today, you can connect [Sorare](https://sorare.com/) — the largest NFT fantasy football, baseball and basketball platform — to **any AI client that speaks MCP** with a single install. No SDK to glue, no token rotation to babysit, no GraphQL composition to learn the hard way.

--- a/content/guides/en/sorare-to-mcp.mdx
+++ b/content/guides/en/sorare-to-mcp.mdx
@@ -12,6 +12,8 @@ lang: "en"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 ## Sorare on the Model Context Protocol
 
 [Sorare](https://sorare.com/) is the largest licensed NFT fantasy sports game, with full GraphQL coverage over players, cards, auctions, and So5 lineups. AnythingMCP wraps that GraphQL API as an **MCP server** so any agent — Claude, ChatGPT, OpenClaw, Cursor, your own — can read and act on Sorare data with natural language.

--- a/content/guides/it/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/it/connect-sorare-to-chatgpt.mdx
@@ -12,6 +12,8 @@ lang: "it"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
 ## Collegare Sorare a ChatGPT
 
 ChatGPT supporta il **Model Context Protocol** nei custom connector e nell'area Developer Tools. Con AnythingMCP che espone l'API GraphQL di Sorare come tool MCP, interroghi carte, giocatori, line-up e mercato direttamente da una conversazione ChatGPT — senza riti OAuth né babysitting dei token.

--- a/content/guides/it/connect-sorare-to-claude.mdx
+++ b/content/guides/it/connect-sorare-to-claude.mdx
@@ -12,6 +12,8 @@ lang: "it"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
 ## Collegare Sorare a Claude
 
 Sorare è il più grande gioco di fantasy football NFT, con copertura GraphQL completa su carte, giocatori, line-up e mercato dei trasferimenti. Con AnythingMCP guidi tutto da Claude Desktop o Claude Code in italiano — senza incollare SDK e senza dover rinfrescare token a mano.

--- a/content/guides/it/connect-sorare-to-copilot.mdx
+++ b/content/guides/it/connect-sorare-to-copilot.mdx
@@ -12,6 +12,8 @@ lang: "it"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
 ## Collegare Sorare a GitHub Copilot
 
 GitHub Copilot Chat ora supporta il **Model Context Protocol (MCP)** tramite la configurazione `mcp` in VS Code e JetBrains. Con AnythingMCP che espone l'API GraphQL completa di Sorare come server MCP gestito, puoi interrogare carte, giocatori, line-up, mercato secondario e il tuo wallet direttamente da Copilot — senza uscire dall'editor.

--- a/content/guides/it/connect-sorare-to-openclaw.mdx
+++ b/content/guides/it/connect-sorare-to-openclaw.mdx
@@ -12,6 +12,8 @@ lang: "it"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
 ## Collegare Sorare a OpenClaw
 
 [OpenClaw](https://openclaw.ai/) è un assistente AI personale open-source che gira in locale e supporta server MCP tramite il suo CLI. In combinazione con AnythingMCP ottieni un setup end-to-end privato e self-hosted per interrogare Sorare dalla tua macchina — password e JWT non escono mai dalla tua rete.

--- a/content/guides/it/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/it/sorare-now-on-anythingmcp.mdx
@@ -13,6 +13,8 @@ featured: true
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="280" />
 </p>
 
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
 ## Sorare è ora su AnythingMCP
 
 Da oggi puoi collegare [Sorare](https://sorare.com/) — la più grande piattaforma di fantasy football, baseball e basketball NFT — a **qualsiasi client AI che parla MCP** con un'unica installazione. Niente SDK da assemblare, niente rotazione token da gestire a mano, niente composizione GraphQL imparata a tentoni.

--- a/content/guides/it/sorare-to-mcp.mdx
+++ b/content/guides/it/sorare-to-mcp.mdx
@@ -12,6 +12,8 @@ lang: "it"
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
 ## Sorare nel Model Context Protocol
 
 [Sorare](https://sorare.com/) è il più grande gioco di fantasy football NFT su licenza, con piena copertura GraphQL su giocatori, carte, aste e line-up So5. AnythingMCP impacchetta l'API GraphQL come **server MCP**: qualsiasi agente — Claude, ChatGPT, OpenClaw, Cursor o uno tuo — può leggere e agire sui dati Sorare in linguaggio naturale.

--- a/docs/guides/connect-sorare-to-chatgpt.md
+++ b/docs/guides/connect-sorare-to-chatgpt.md
@@ -2,6 +2,8 @@
   <img src="../assets/icons/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 # Connect Sorare to ChatGPT — fantasy football tools inside GPT
 
 **Keywords:** connect sorare to chatgpt · sorare chatgpt · sorare gpt · sorare openai · sorare chatgpt connector · sorare chatgpt mcp · fantasy football chatgpt · sorare ai chatgpt

--- a/docs/guides/connect-sorare-to-claude.md
+++ b/docs/guides/connect-sorare-to-claude.md
@@ -2,6 +2,8 @@
   <img src="../assets/icons/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 # Connect Sorare to Claude — NFT fantasy football inside Claude Desktop & Claude Code
 
 **Keywords:** connect sorare to claude · sorare claude desktop · sorare claude code · sorare claude mcp · sorare ai claude · sorare anthropic · fantasy football claude · sorare claude integration

--- a/docs/guides/connect-sorare-to-copilot.md
+++ b/docs/guides/connect-sorare-to-copilot.md
@@ -2,6 +2,8 @@
   <img src="../assets/icons/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 # Connect Sorare to GitHub Copilot — NFT fantasy football inside Copilot Chat
 
 **Keywords:** connect sorare to copilot · sorare github copilot · sorare copilot mcp · sorare copilot chat · sorare vs code · sorare jetbrains · fantasy football copilot · NFT fantasy copilot

--- a/docs/guides/connect-sorare-to-openclaw.md
+++ b/docs/guides/connect-sorare-to-openclaw.md
@@ -2,6 +2,8 @@
   <img src="../assets/icons/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 # Connect Sorare to OpenClaw — self-hosted AI assistant + NFT fantasy football
 
 **Keywords:** connect sorare to openclaw · sorare openclaw · sorare openclaw mcp · sorare self-hosted ai · openclaw mcp connector · openclaw graphql · sorare local ai · fantasy football openclaw

--- a/docs/guides/sorare-to-mcp.md
+++ b/docs/guides/sorare-to-mcp.md
@@ -2,6 +2,8 @@
   <img src="../assets/icons/sorare.svg" alt="Sorare" width="220" />
 </p>
 
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
 # Sorare to MCP — Connect Sorare GraphQL API to any AI agent
 
 **Keywords:** sorare mcp · sorare to mcp · sorare graphql mcp · sorare api mcp · sorare model context protocol · sorare ai · sorare ai agent · connect sorare api · sorare bcrypt auth · sorare jwt 30 days · fantasy football mcp · nft fantasy mcp


### PR DESCRIPTION
Adds a one-line callout right under the centred logo banner of every Sorare guide that surfaces the managed-cloud option above the local-install steps:

> 💡 **No install? Use cloud.anythingmcp.com directly.** Sign in, click Connectors → Sorare, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run.

Why: the guides currently lead with a docker-compose section, which buries the easier path for readers who don't want to self-host. The callout makes the cloud path the first thing they see, with the direct link and exact UI navigation.

Affects 23 files (5 `docs/guides/*.md` + 6 MDX × 3 locales). Skips the cloud-specific guide (already cloud-only). Localised EN / DE / IT.

Docs-only; no code, no Docker, no deploy needed.