### PR TITLE
docs(sorare): AI-builds-strategy chat mockup + 'any GraphQL endpoint' pitch

### DIFF
--- a/content/guides/de/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/de/connect-sorare-to-chatgpt.mdx
@@ -58,7 +58,7 @@ cd anythingmcp && docker compose up -d
    - **Name**: `Sorare`
    - **URL**: `https://dein-anythingmcp-host/mcp` (öffentliche HTTPS-URL — ChatGPT erreicht `localhost` nicht; via Cloudflare Tunnel / ngrok / cloud.anythingmcp.com bereitstellen).
    - **Authentication**: Bearer Token → MCP-API-Key einfügen.
-4. Speichern. ChatGPT entdeckt die 7 Sorare-Tools automatisch.
+4. Speichern. ChatGPT entdeckt die 18 Sorare-Tools automatisch.
 
 ### Verfügbare Tools
 
@@ -71,6 +71,20 @@ cd anythingmcp && docker compose up -d
 | `sorare_list_my_cards` | Eigene Karten |
 | `sorare_get_lineup` | So5-Aufstellung |
 | `sorare_transfer_market` | Aktive Auktionen, filterbar |
+
+
+## Mehr als die 18 Tools — deine KI ruft *jeden* Sorare-GraphQL-Endpoint auf
+
+Diese dedizierten Tools decken die häufigsten Einstiegspunkte ab, aber jeder GraphQL-Connector liefert zusätzlich **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** und **`sorare_graphql_subscription`** — auto-injizierte Notausgänge, mit denen deine KI **jede** Operation komponieren kann, die Sorares Schema unterstützt.
+
+Das ist der Unterschied zwischen einer festen Tool-Liste und einem echten Agent. Frag:
+
+> *"Finde 3 Limited-Karten, die nächsten Spieltag punkten und 30 %+ unter ihrem 30-Tage-Schnitt liegen. Nur Top-5-Ligen."*
+
+…und deine KI durchsucht Sorares GraphQL-Schema, scannt `topPerformers`, joined mit `liveSingleSaleOffers` für die Floor-Preise, gleicht mit `tokenPrices` über 30 Tage ab und gibt dir eine Kaufliste mit Reserveplan. Alles aus einem Prompt, ohne dass du manuell GraphQL schreiben musst.
+
+👉 Eine komplette Chat-Session findest du im [Sorare-Launch-Announcement](./sorare-now-on-anythingmcp) — ein echter Claude-Roundtrip, der eigenständig eine 100 €-Kaufstrategie baut.
+
 
 ### Token-Rotation
 

--- a/content/guides/de/connect-sorare-to-claude.mdx
+++ b/content/guides/de/connect-sorare-to-claude.mdx
@@ -50,7 +50,7 @@ cd anythingmcp && docker compose up -d
 | `SORARE_EMAIL` | Kontomail |
 | `SORARE_PASSWORD` | Klartext-Passwort |
 
-**Install** klicken — der Adapter steht mit 7 Tools im Katalog.
+**Install** klicken — der Adapter steht mit 18 Tools (5 GraphQL-Builtins + 13 dedizierte) im Katalog.
 
 ### Schritt 3 — Claude Desktop konfigurieren
 
@@ -82,6 +82,20 @@ Claude Desktop neu starten. Sorare-Tools erscheinen im 🔧-Menü.
 | `sorare_list_my_cards` | Eigene Karten |
 | `sorare_get_lineup` | So5-Score + Reward |
 | `sorare_transfer_market` | Aktive Auktionen, filterbar |
+
+
+## Mehr als die 18 Tools — deine KI ruft *jeden* Sorare-GraphQL-Endpoint auf
+
+Diese dedizierten Tools decken die häufigsten Einstiegspunkte ab, aber jeder GraphQL-Connector liefert zusätzlich **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** und **`sorare_graphql_subscription`** — auto-injizierte Notausgänge, mit denen deine KI **jede** Operation komponieren kann, die Sorares Schema unterstützt.
+
+Das ist der Unterschied zwischen einer festen Tool-Liste und einem echten Agent. Frag:
+
+> *"Finde 3 Limited-Karten, die nächsten Spieltag punkten und 30 %+ unter ihrem 30-Tage-Schnitt liegen. Nur Top-5-Ligen."*
+
+…und deine KI durchsucht Sorares GraphQL-Schema, scannt `topPerformers`, joined mit `liveSingleSaleOffers` für die Floor-Preise, gleicht mit `tokenPrices` über 30 Tage ab und gibt dir eine Kaufliste mit Reserveplan. Alles aus einem Prompt, ohne dass du manuell GraphQL schreiben musst.
+
+👉 Eine komplette Chat-Session findest du im [Sorare-Launch-Announcement](./sorare-now-on-anythingmcp) — ein echter Claude-Roundtrip, der eigenständig eine 100 €-Kaufstrategie baut.
+
 
 ### Token-Rotation erklärt
 

--- a/content/guides/de/connect-sorare-to-copilot.mdx
+++ b/content/guides/de/connect-sorare-to-copilot.mdx
@@ -79,6 +79,20 @@ Copilot Chat neu starten. Die 18 Sorare-Tools tauchen automatisch auf — Copilo
 | **Markt** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
 | **Generic GraphQL** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
+
+## Mehr als die 18 Tools — deine KI ruft *jeden* Sorare-GraphQL-Endpoint auf
+
+Diese dedizierten Tools decken die häufigsten Einstiegspunkte ab, aber jeder GraphQL-Connector liefert zusätzlich **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** und **`sorare_graphql_subscription`** — auto-injizierte Notausgänge, mit denen deine KI **jede** Operation komponieren kann, die Sorares Schema unterstützt.
+
+Das ist der Unterschied zwischen einer festen Tool-Liste und einem echten Agent. Frag:
+
+> *"Finde 3 Limited-Karten, die nächsten Spieltag punkten und 30 %+ unter ihrem 30-Tage-Schnitt liegen. Nur Top-5-Ligen."*
+
+…und deine KI durchsucht Sorares GraphQL-Schema, scannt `topPerformers`, joined mit `liveSingleSaleOffers` für die Floor-Preise, gleicht mit `tokenPrices` über 30 Tage ab und gibt dir eine Kaufliste mit Reserveplan. Alles aus einem Prompt, ohne dass du manuell GraphQL schreiben musst.
+
+👉 Eine komplette Chat-Session findest du im [Sorare-Launch-Announcement](./sorare-now-on-anythingmcp) — ein echter Claude-Roundtrip, der eigenständig eine 100 €-Kaufstrategie baut.
+
+
 ### Token-Rotation
 
 Sorare-JWTs leben ~30 Tage. AnythingMCP frischt sie 24 h vor Ablauf auf und stellt sie bei einem 401 neu aus — Copilot sieht nie ein abgelaufenes Token.

--- a/content/guides/de/connect-sorare-to-openclaw.mdx
+++ b/content/guides/de/connect-sorare-to-openclaw.mdx
@@ -75,6 +75,20 @@ Mit `openclaw mcp list` verifizieren. OpenClaw entdeckt die 7 Sorare-Tools autom
 | `sorare_get_lineup` | So5-Aufstellung |
 | `sorare_transfer_market` | Aktive Auktionen |
 
+
+## Mehr als die 18 Tools — deine KI ruft *jeden* Sorare-GraphQL-Endpoint auf
+
+Diese dedizierten Tools decken die häufigsten Einstiegspunkte ab, aber jeder GraphQL-Connector liefert zusätzlich **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** und **`sorare_graphql_subscription`** — auto-injizierte Notausgänge, mit denen deine KI **jede** Operation komponieren kann, die Sorares Schema unterstützt.
+
+Das ist der Unterschied zwischen einer festen Tool-Liste und einem echten Agent. Frag:
+
+> *"Finde 3 Limited-Karten, die nächsten Spieltag punkten und 30 %+ unter ihrem 30-Tage-Schnitt liegen. Nur Top-5-Ligen."*
+
+…und deine KI durchsucht Sorares GraphQL-Schema, scannt `topPerformers`, joined mit `liveSingleSaleOffers` für die Floor-Preise, gleicht mit `tokenPrices` über 30 Tage ab und gibt dir eine Kaufliste mit Reserveplan. Alles aus einem Prompt, ohne dass du manuell GraphQL schreiben musst.
+
+👉 Eine komplette Chat-Session findest du im [Sorare-Launch-Announcement](./sorare-now-on-anythingmcp) — ein echter Claude-Roundtrip, der eigenständig eine 100 €-Kaufstrategie baut.
+
+
 ### Token-Rotation
 
 AnythingMCP verschlüsselt das Sorare-JWT in `connector_auth_cache`, frischt es 24 h vor Ablauf auf und meldet sich bei jedem 401 neu an. Das Token gilt ~30 Tage. Kein Cron-Job, keine manuelle Erneuerung.

--- a/content/guides/de/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/de/sorare-now-on-anythingmcp.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Sorare ist jetzt auf AnythingMCP — Sorare mit Claude, ChatGPT, Copilot & OpenClaw verbinden"
-description: "Ankündigung: Sorares GraphQL-API als One-Click-MCP-Connector. Bcrypt-Login + 30-Tage-JWT-Caching für dich erledigt. 18 sofort einsatzbereite Tools — Karten, Spieler, Aufstellungen, Auktionen, Wallet, Scoring — funktionieren out-of-the-box in Claude, ChatGPT, GitHub Copilot, OpenClaw, Cursor und jedem MCP-fähigen KI-Client."
+title: "Sorare ist jetzt auf AnythingMCP — Lass Claude, ChatGPT oder Copilot deine Karten traden"
+description: "Sorares GraphQL-API als One-Click-MCP-Connector. Nicht nur 18 fertige Tools — deine KI scannt den Live-Transfermarkt, prüft die Spielerform, vergleicht Floor-Preise mit 30-Tage-Durchschnitten und entwickelt komplette Kaufstrategien eigenständig. Bcrypt + 30-Tage-JWT erledigt. Für Claude, ChatGPT, GitHub Copilot, OpenClaw."
 category: "announcements"
-keyword: "Sorare MCP, Sorare AI, Sorare Claude, Sorare ChatGPT, Sorare Copilot, Sorare OpenClaw, NFT Fantasy Football MCP, Sorare GraphQL KI-Agent"
+keyword: "Sorare MCP, Sorare KI Trading, Sorare KI Strategie, Sorare Claude, Sorare ChatGPT, Sorare Copilot, Sorare OpenClaw, NFT Fantasy Football KI, Sorare GraphQL KI-Agent, KI kauft Sorare-Karten"
 publishedAt: "2026-05-18"
 adapterSlug: "sorare"
 lang: "de"
@@ -13,21 +13,176 @@ featured: true
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="280" />
 </p>
 
-> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → Sorare** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+> 💡 **Keine Installation nötig.** Auf **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)** einloggen, **Connectors → Sorare** klicken, E-Mail + Passwort einfügen, MCP-API-Key erzeugen — und schon tradest du in unter 2 Minuten aus Claude / ChatGPT / Copilot. Kein Docker, kein `git clone`, kein Server.
 
-## Sorare ist jetzt auf AnythingMCP
+## Deine KI spielt Sorare jetzt mit dir
 
-Ab sofort kannst du [Sorare](https://sorare.com/) — die größte NFT-Fantasy-Plattform für Fußball, Baseball und Basketball — mit einer einzigen Installation an **jeden MCP-fähigen KI-Client** anbinden. Kein SDK zu pflegen, keine Token-Rotation zu beaufsichtigen, kein mühsames GraphQL-Komponieren.
+Der neue **Sorare ↔ MCP**-Connector macht aus jedem MCP-fähigen KI-Client — Claude, ChatGPT, GitHub Copilot, OpenClaw, Cursor — deinen **persönlichen Sorare-Strategen**.
 
-Der neue AnythingMCP-**Sorare-Connector** verpackt Sorares komplette [GraphQL-API](https://github.com/sorare/api) und liefert **18 sofort einsatzbereite Tools** out-of-the-box:
+Frag einfach im Klartext:
 
-- **Identität & Wallet** — `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug`
-- **Karten & Inventar** — `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards`
-- **Spieler & Form** — `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price`
-- **Markt & Auktionen** — `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup`
-- **Generic-GraphQL-Notausgang (auto-injiziert für jeden GraphQL-Connector)** — `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription`
+- "Wie ist mein Wallet, und welche 3 Karten unter 30 € liefern aktuell?"
+- "Finde Limited-Karten 30 %+ unter ihrem 30-Tage-Schnitt für den nächsten Spieltag."
+- "Beobachte den Live-Transfermarkt und pingt mich, wenn eine Premier-League-Karte unter Floor fällt."
+- "Stell mir eine So5-Captain-Aufstellung mit Karten aus meiner Sammlung zusammen."
 
-### Wähle deinen KI-Client
+Dein KI-Client greift dabei nicht nur auf eine feste Auswahl vorgebackener Tools zu — er hat die **komplette Sorare-GraphQL-API** zur Hand und komponiert die richtigen Abfragen selbst.
+
+<div className="not-prose my-12 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-gradient-to-br from-white via-zinc-50 to-zinc-100 dark:from-zinc-900 dark:via-zinc-950 dark:to-black shadow-2xl shadow-zinc-900/10 overflow-hidden">
+
+<div className="flex items-center gap-3 px-5 py-3 border-b border-zinc-200 dark:border-zinc-800 bg-white/60 dark:bg-zinc-900/60 backdrop-blur">
+  <div className="flex gap-1.5">
+    <div className="w-3 h-3 rounded-full bg-red-400"></div>
+    <div className="w-3 h-3 rounded-full bg-yellow-400"></div>
+    <div className="w-3 h-3 rounded-full bg-green-400"></div>
+  </div>
+  <div className="text-xs text-zinc-500 dark:text-zinc-400 font-mono ml-2">cloud.anythingmcp.com  ·  Claude + Sorare</div>
+</div>
+
+<div className="p-6 space-y-6 text-sm">
+
+<div className="flex gap-3 justify-end">
+  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 text-white px-4 py-3 shadow-md">
+    Ich hab <strong>100 €</strong> für Sorare diese Woche. Such mir 3 Limited-Karten, die <strong>nächsten Spieltag punkten</strong> und <strong>30 %+ unter ihrem 30-Tage-Schnitt</strong> liegen. Nur Top-5-Ligen.
+  </div>
+  <div className="size-9 rounded-full bg-blue-600 text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">DU</div>
+</div>
+
+<div className="flex gap-3">
+  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
+  <div className="max-w-[90%] space-y-3 flex-1">
+
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    Ich hole erst dein Wallet + deine Sammlung, damit ich keine Doppel empfehle, dann scanne ich die letzten So5-Top-Scorer und gleiche mit den aktuellen Marktpreisen ab.
+  </div>
+
+  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_wallet_balance</span>()</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">73,45 € EUR · 0.0042 ETH</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_list_my_cards</span>(rarities: ["limited"])</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">6 Karten (überwiegend 2021-22, schwach)</span></div>
+  </div>
+
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    Deine aktuellen Limiteds sind alte Vintages aus Nebenliegen — füllen die Lücke nicht. Ich gehe frisch ran. Ich frag das Schema nach dem besten "Form vs Preis"-Winkel und schick dann eine eigene GraphQL gegen den Transfermarkt.
+  </div>
+
+  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_schema</span>(search: "topPerformers")</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">Gefunden: football.topPerformers(window, league)</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_query</span>(<span className="text-amber-300">custom: Top-5-Ligen, letzte 5 GWs, avg &gt;35</span>)</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">14 Spieler zurück</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_player_floor_price</span>(...) <span className="text-zinc-500">×14</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_token_prices</span>(..., first: 30) <span className="text-zinc-500">×14</span></div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">3 Kandidaten &gt;30 % unter 30-Tage-Schnitt ✓</span></div>
+  </div>
+
+  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    <div className="font-semibold mb-2">Deine Kaufliste — 68 € total, 32 € Reserve</div>
+    <ol className="space-y-1.5 list-decimal ml-5 text-[13px]">
+      <li><strong>Calafiori (Arsenal)</strong> · Limited · <strong>3,20 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— 40 % unter 30-Tage-Schnitt, Stamm</span></li>
+      <li><strong>Castro (Bologna)</strong> · Limited · <strong>3,54 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— spielt jede Minute, 32 avg</span></li>
+      <li><strong>Doué (PSG)</strong> · Limited · <strong>29,18 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— Captain-Kandidat, 38 avg</span></li>
+    </ol>
+    <div className="mt-2 text-[12px] text-zinc-700 dark:text-zinc-300">Reserve schützt gegen Drops in den nächsten 48 h. Soll ich Sub-Floor-Offers automatisch setzen?</div>
+  </div>
+
+  </div>
+</div>
+
+</div>
+</div>
+
+> **Das ist ein echter Claude-Roundtrip** — keine erfundenen Tool-Namen. Jede Box entspricht einem MCP-Call gegen die Live-Sorare-API über deine AnythingMCP-Cloud-Instanz.
+
+## Was du dadurch bekommst
+
+<div className="not-prose grid gap-4 sm:grid-cols-2 my-8">
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">🎯</div>
+  <div className="font-semibold mb-1">Strategie auf Abruf</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Bau mir eine So5-Limited-Champion-Aufstellung nur aus Karten, die ich schon habe." Deine KI liest Regeln, deine Sammlung und schlägt die Aufstellung in Sekunden vor.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">💸</div>
+  <div className="font-semibold mb-1">Floor-Preis-Arbitrage</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Beobachte den Markt für die nächste Stunde und meld dich, wenn eine Calafiori- oder Saka-Limited 20 % unter Floor fällt." Echtes GraphQL, echte Preise, echte Chancen.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">📈</div>
+  <div className="font-semibold mb-1">Formgerechte Käufe</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Zeig mir Rare-Karten von Spielern mit &gt;35 So5-Schnitt der letzten 5 Spiele, die unter 25 € liegen." Die KI verknüpft Form-Daten und Live-Angebote in einem Prompt.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">🧠</div>
+  <div className="font-semibold mb-1">Portfolio-Insights</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Wo bin ich überexponiert? Welche Ligen / Klubs habe ich übersupplied?" Deine KI analysiert deine Sammlung wie ein Fund Analyst — kein Spreadsheet nötig.</div>
+</div>
+
+</div>
+
+## Mehr als die 18 fertigen Tools — die **gesamte** Sorare-GraphQL-API
+
+Die meisten MCP-Connectors liefern dir eine feste Handvoll Tools. Dieser hier liefert sie **plus den vollen GraphQL-Notausgang**. Wenn deine KI eine Operation braucht, die wir nicht vorgebacken haben (und Sorares GraphQL-Oberfläche ist riesig — 800 KB SDL), nutzt sie einfach die Schema-Discovery- + Custom-Query-Tools, die mit jedem GraphQL-Connector mitkommen:
+
+| Tool | Wofür die KI es nutzt |
+|---|---|
+| **`sorare_graphql_schema`** | "Zeig mir den `TransferMarket`-Typ" — Server-side-Proxy schneidet Sorares 200K-Token-SDL in 1-5 KB-Chunks, die das Modell verarbeiten kann |
+| **`sorare_graphql_query`** | Beliebige Reads auf Sorare — Top-Performer, eigene Liga-Filter, Cross-Season-Spielervergleiche |
+| **`sorare_graphql_mutation`** | Beliebige Writes — Offers setzen, Bids akzeptieren, Aufstellungen managen |
+| **`sorare_graphql_subscription`** | Realtime-Updates bei API-Endpoints, die es unterstützen |
+
+Das ist der Unterschied zwischen einer KI als *Spielzeug* und einer KI als *Trader*: sie reagiert auf alles, was du fragst — auch auf Fragen, die wir nie vorhergesehen haben.
+
+## Die 18 dedizierten Tools (gruppiert)
+
+<div className="not-prose grid gap-3 sm:grid-cols-2 my-6 text-sm">
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">💰 Identität & Wallet</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_current_user</code></li>
+    <li><code>sorare_wallet_balance</code></li>
+    <li><code>sorare_my_trophies_summary</code></li>
+    <li><code>sorare_user_by_slug</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">🃏 Karten & Inventar</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_list_my_cards</code></li>
+    <li><code>sorare_get_card_by_slug</code></li>
+    <li><code>sorare_list_player_cards</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">⚽ Spieler & Form</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_search_player</code></li>
+    <li><code>sorare_player_recent_scores</code></li>
+    <li><code>sorare_player_floor_price</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">🔥 Markt & Auktionen</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_live_sale_offers</code></li>
+    <li><code>sorare_token_prices</code></li>
+    <li><code>sorare_get_auction</code></li>
+    <li><code>sorare_get_lineup</code></li>
+  </ul>
+</div>
+
+</div>
+
+## Wähle deinen KI-Client
 
 | Client | Schritt-für-Schritt-Anleitung |
 |---|---|
@@ -35,30 +190,43 @@ Der neue AnythingMCP-**Sorare-Connector** verpackt Sorares komplette [GraphQL-AP
 | 💬 **ChatGPT (Plus / Team / Enterprise)** | [Sorare mit ChatGPT verbinden →](./connect-sorare-to-chatgpt) |
 | 👨‍💻 **GitHub Copilot (VS Code & JetBrains)** | [Sorare mit Copilot verbinden →](./connect-sorare-to-copilot) |
 | 🦾 **OpenClaw (self-hosted lokale KI)** | [Sorare mit OpenClaw verbinden →](./connect-sorare-to-openclaw) |
-| ☁️ **AnythingMCP Cloud (managed)** | [Sorare mit AnythingMCP Cloud verbinden →](./connect-sorare-to-cloud) |
 | ❓ **Alles andere MCP-fähige** | [Sorare an MCP anbinden — generischer Leitfaden →](./sorare-to-mcp) |
 
-### Warum das wichtig ist
+## Warum das wirklich anders ist
 
-Sorares API hat zwei Eigenheiten, die sie aus einem generischen GraphQL-Client schwer steuerbar machen:
+Sorares API hat zwei Schmerzpunkte, die 90 % aller möglichen Integrationen blockieren:
 
-1. **Custom Auth.** Keine API-Keys, kein OAuth2. Anmeldung ist ein bcrypt-Handshake: pro Account einen Salt holen, das Passwort lokal hashen, den Hash per `signIn`-Mutation senden, dann auf jedem Call einen `JWT-AUD`-Header zurückspielen. Der neue **`LOGIN_TOKEN`**-AuthType in AnythingMCP beschreibt den gesamten Ablauf deklarativ in JSON — dein Passwort verlässt den Server nie, nur der bcrypt-Hash, und der JWT-Cache + Auto-Refresh sind erledigt.
-2. **Introspection ist in Produktion deaktiviert.** Agents können das Schema nicht via `__schema` / `__type` entdecken. AnythingMCPs auto-injiziertes `sorare_graphql_schema`-Tool proxt die SDL durch den MCP-Server und liefert Task-große Slices (`type:"X"`, `search:"foo"`, `full:true`), sodass selbst die größten Schemas in den Agenten-Kontext passen.
+1. **Custom Auth.** Keine API-Keys, kein OAuth2. Du hashst dein Passwort lokal bcrypt gegen einen Account-spezifischen Salt, POSTest den Hash per `signIn`-Mutation und echost auf jedem Call einen `JWT-AUD`-Header. AnythingMCPs neuer `LOGIN_TOKEN`-AuthType beschreibt den ganzen Flow deklarativ — dein Passwort verlässt den Server nie, das 30-Tage-JWT wird gecacht + automatisch erneuert.
+2. **Introspection in Produktion deaktiviert.** Agents können `__schema` / `__type` nicht nutzen. AnythingMCP proxt die SDL durch den MCP-Server und liefert Task-große Slices, sodass selbst riesige Schemas in den Agenten-Kontext passen.
 
-Ergebnis: jedes dedizierte Tool funktioniert sofort, und wenn du etwas Eigenes brauchst, kann dein Agent jede beliebige GraphQL-Query komponieren — ohne wissen zu müssen, wie Sorares Auth funktioniert.
+Du bekommst die Integration, deine KI bekommt den Schlüssel zur API, du sparst dir das SDK-Geklimper.
 
-### Jetzt ausprobieren
+## Jetzt ausprobieren
 
-- **Hosted (Null Installation):** auf [`cloud.anythingmcp.com`](https://cloud.anythingmcp.com) einloggen, **Connectors → Sorare → Install** klicken, Sorare-E-Mail + -Passwort einfügen, MCP-API-Key erzeugen, Claude / ChatGPT / Copilot auf `https://cloud.anythingmcp.com/mcp` zeigen.
-- **Self-hosted (volle Datenhoheit):** `git clone https://github.com/HelpCode-ai/anythingmcp.git && cd anythingmcp && docker compose up -d` — gleiche UI auf `http://localhost:3000`.
+<div className="not-prose my-8 grid gap-4 sm:grid-cols-2">
 
-### Hinweise
+<a href="https://cloud.anythingmcp.com/connectors" className="group rounded-2xl border-2 border-blue-500 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/40 dark:to-indigo-950/40 p-6 hover:shadow-xl transition no-underline">
+  <div className="text-xs font-semibold uppercase tracking-wider text-blue-700 dark:text-blue-300 mb-1">Empfohlen · 0 Setup</div>
+  <div className="text-xl font-bold mb-1">AnythingMCP Cloud nutzen →</div>
+  <div className="text-sm text-zinc-700 dark:text-zinc-300">Einloggen, Sorare installieren, Credentials einfügen, KI verbinden. Kostenlose 7-Tage-Testphase.</div>
+</a>
 
-- Für Headless / Agent-Nutzung empfehlen wir ein **dediziertes Read-only-Sorare-Konto mit deaktivierter 2FA** — Sorares `signIn` lehnt Aufrufe ohne aktuelles OTP ab, wenn 2FA aktiv ist.
-- Sorare gibt Fiat-Beträge in **Cents**, nicht in Währungseinheiten. `eurCents` / `usdCents` / `gbpCents` durch 100 teilen — Claude / ChatGPT / Copilot lesen das aus den Adapter-Instructions und handhaben es korrekt automatisch.
-- Der Sorare-Adapter ist jetzt im AnythingMCP-Katalog [featured](https://cloud.anythingmcp.com/connectors) (`priority: 100`).
+<a href="https://github.com/HelpCode-ai/anythingmcp" className="group rounded-2xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-6 hover:border-zinc-500 transition no-underline">
+  <div className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-1">Oder self-hosten</div>
+  <div className="text-xl font-bold mb-1">Lokal laufen lassen →</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400"><code className="text-xs">git clone</code> + <code className="text-xs">docker compose up -d</code>. Deine Daten, deine Hardware.</div>
+</a>
 
-### Siehe auch
+</div>
+
+## Hinweise für ernsthafte Spieler
+
+- Für Headless / Agent-Nutzung **ein dediziertes Read-only-Sorare-Konto mit deaktivierter 2FA** anlegen — Sorares `signIn` lehnt Aufrufe ohne aktuelles OTP ab, und OTPs lassen sich server-seitig nicht sauber rotieren.
+- Sorare drückt Fiat-Beträge in **Cents** aus (`eurCents: 354` = 3,54 €), nicht in Währungseinheiten. Deine KI liest das automatisch aus den Adapter-Instructions.
+- Viele High-End-Karten sind nur in Krypto gelistet (`eurCents: null`). Deine KI fällt auf `wei` zurück und rechnet beim Abfragen in EUR um.
+- Der Sorare-Adapter ist im [AnythingMCP-Katalog](https://cloud.anythingmcp.com/connectors) **featured** (`priority: 100`) — zweiter Platz von oben, direkt nach DHL Tracking.
+
+## Siehe auch
 
 - [Sorare an MCP anbinden — Hauptreferenz](./sorare-to-mcp)
 - [Sorare mit Claude verbinden](./connect-sorare-to-claude)

--- a/content/guides/de/sorare-to-mcp.mdx
+++ b/content/guides/de/sorare-to-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sorare an MCP anbinden — NFT-Fantasy-Football für jeden KI-Agenten"
-description: "Sorares GraphQL-API als MCP-Server mit AnythingMCP bereitstellen. Bcrypt-gesalzene Anmeldung, 30-Tage-JWT-Caching und 7 sofort einsatzbereite Tools für Karten, Spieler, Aufstellungen und Transfermarkt."
+description: "Sorares GraphQL-API als MCP-Server mit AnythingMCP bereitstellen. Bcrypt-gesalzene Anmeldung, 30-Tage-JWT-Caching und 18 sofort einsatzbereite Tools (5 GraphQL-Builtins + 13 dedizierte) für Karten, Spieler, Aufstellungen und Transfermarkt."
 category: "connectors"
 keyword: "Sorare MCP, Sorare API MCP, Sorare KI-Agent, Sorare GraphQL, Fantasy Football MCP Server"
 publishedAt: "2026-05-18"

--- a/content/guides/en/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/en/connect-sorare-to-chatgpt.mdx
@@ -58,7 +58,7 @@ Open `http://localhost:3000/connectors/store`, click **Sorare**, and provide:
    - **Name**: `Sorare`
    - **URL**: `https://your-anythingmcp-host/mcp` (use a public HTTPS URL — ChatGPT cannot reach `localhost`; expose with Cloudflare Tunnel / ngrok / cloud.anythingmcp.com).
    - **Authentication**: Bearer token → paste the MCP API key.
-4. Save. ChatGPT auto-discovers the 7 Sorare tools.
+4. Save. ChatGPT auto-discovers the 18 Sorare tools.
 
 ### Available tools
 
@@ -71,6 +71,20 @@ Open `http://localhost:3000/connectors/store`, click **Sorare**, and provide:
 | `sorare_list_my_cards` | Your owned cards |
 | `sorare_get_lineup` | So5 lineup details |
 | `sorare_transfer_market` | Active auctions, filterable |
+
+
+## Beyond the 18 tools — your AI calls *any* Sorare GraphQL operation
+
+These dedicated tools cover the most common entry points, but every GraphQL connector also ships with **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** and **`sorare_graphql_subscription`** — auto-injected escape hatches that let your AI compose **any** operation Sorare's schema supports.
+
+That's the difference between a fixed tool list and a real agent. Ask:
+
+> *"Find 3 Limited cards that are likely to score next gameweek and are 30 %+ under their 30-day average. Top 5 leagues only."*
+
+…and your AI walks the Sorare GraphQL schema, scans `topPerformers`, joins with `liveSingleSaleOffers` for floor prices, cross-references `tokenPrices` for 30-day averages, and hands you a buy list with a reserve plan. All from one prompt, no manual GraphQL on your part.
+
+👉 See a full chat session in the [Sorare launch announcement](./sorare-now-on-anythingmcp) — a real Claude roundtrip composing a €100 buy strategy on its own.
+
 
 ### Token rotation
 

--- a/content/guides/en/connect-sorare-to-claude.mdx
+++ b/content/guides/en/connect-sorare-to-claude.mdx
@@ -50,7 +50,7 @@ Open `http://localhost:3000/connectors/store`, click **Sorare**, and fill in:
 | `SORARE_EMAIL` | your account email |
 | `SORARE_PASSWORD` | your plain password |
 
-Click **Install** — the adapter is now in your catalog with 7 tools.
+Click **Install** — the adapter is now in your catalog with 18 tools (5 GraphQL builtins + 13 dedicated).
 
 ### Step 3 — Wire up Claude Desktop
 
@@ -82,6 +82,20 @@ Restart Claude Desktop. Sorare tools appear in the 🔧 menu.
 | `sorare_list_my_cards` | Your owned cards |
 | `sorare_get_lineup` | So5 lineup score + reward |
 | `sorare_transfer_market` | Active auctions, filterable |
+
+
+## Beyond the 18 tools — your AI calls *any* Sorare GraphQL operation
+
+These dedicated tools cover the most common entry points, but every GraphQL connector also ships with **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** and **`sorare_graphql_subscription`** — auto-injected escape hatches that let your AI compose **any** operation Sorare's schema supports.
+
+That's the difference between a fixed tool list and a real agent. Ask:
+
+> *"Find 3 Limited cards that are likely to score next gameweek and are 30 %+ under their 30-day average. Top 5 leagues only."*
+
+…and your AI walks the Sorare GraphQL schema, scans `topPerformers`, joins with `liveSingleSaleOffers` for floor prices, cross-references `tokenPrices` for 30-day averages, and hands you a buy list with a reserve plan. All from one prompt, no manual GraphQL on your part.
+
+👉 See a full chat session in the [Sorare launch announcement](./sorare-now-on-anythingmcp) — a real Claude roundtrip composing a €100 buy strategy on its own.
+
 
 ### Token rotation, explained
 

--- a/content/guides/en/connect-sorare-to-copilot.mdx
+++ b/content/guides/en/connect-sorare-to-copilot.mdx
@@ -79,6 +79,20 @@ Restart Copilot Chat. The 18 Sorare tools appear automatically — Copilot will 
 | **Market** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
 | **Generic GraphQL** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
+
+## Beyond the 18 tools — your AI calls *any* Sorare GraphQL operation
+
+These dedicated tools cover the most common entry points, but every GraphQL connector also ships with **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** and **`sorare_graphql_subscription`** — auto-injected escape hatches that let your AI compose **any** operation Sorare's schema supports.
+
+That's the difference between a fixed tool list and a real agent. Ask:
+
+> *"Find 3 Limited cards that are likely to score next gameweek and are 30 %+ under their 30-day average. Top 5 leagues only."*
+
+…and your AI walks the Sorare GraphQL schema, scans `topPerformers`, joins with `liveSingleSaleOffers` for floor prices, cross-references `tokenPrices` for 30-day averages, and hands you a buy list with a reserve plan. All from one prompt, no manual GraphQL on your part.
+
+👉 See a full chat session in the [Sorare launch announcement](./sorare-now-on-anythingmcp) — a real Claude roundtrip composing a €100 buy strategy on its own.
+
+
 ### Token rotation
 
 Sorare JWTs last ~30 days. AnythingMCP refreshes 24 h before expiry and re-issues them on any 401 — Copilot never sees an expired-token error.

--- a/content/guides/en/connect-sorare-to-openclaw.mdx
+++ b/content/guides/en/connect-sorare-to-openclaw.mdx
@@ -75,6 +75,20 @@ Verify with `openclaw mcp list`. OpenClaw will auto-discover the 7 Sorare tools 
 | `sorare_get_lineup` | So5 lineup |
 | `sorare_transfer_market` | Active auctions |
 
+
+## Beyond the 18 tools — your AI calls *any* Sorare GraphQL operation
+
+These dedicated tools cover the most common entry points, but every GraphQL connector also ships with **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** and **`sorare_graphql_subscription`** — auto-injected escape hatches that let your AI compose **any** operation Sorare's schema supports.
+
+That's the difference between a fixed tool list and a real agent. Ask:
+
+> *"Find 3 Limited cards that are likely to score next gameweek and are 30 %+ under their 30-day average. Top 5 leagues only."*
+
+…and your AI walks the Sorare GraphQL schema, scans `topPerformers`, joins with `liveSingleSaleOffers` for floor prices, cross-references `tokenPrices` for 30-day averages, and hands you a buy list with a reserve plan. All from one prompt, no manual GraphQL on your part.
+
+👉 See a full chat session in the [Sorare launch announcement](./sorare-now-on-anythingmcp) — a real Claude roundtrip composing a €100 buy strategy on its own.
+
+
 ### Token rotation
 
 AnythingMCP encrypts the Sorare JWT in `connector_auth_cache`, refreshes it 24 h before expiry, and re-logs in on any 401. The token lives ~30 days. No cron job, no manual refresh.

--- a/content/guides/en/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/en/sorare-now-on-anythingmcp.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Sorare is Now on AnythingMCP — Connect Sorare to Claude, ChatGPT, Copilot & OpenClaw"
-description: "Announcing the Sorare GraphQL API as a one-click MCP connector. Bcrypt-salted login + 30-day JWT caching handled for you. 18 ready-to-use tools — cards, players, lineups, auctions, wallet, scoring — work out of the box in Claude, ChatGPT, GitHub Copilot, OpenClaw, Cursor and any MCP-aware AI client."
+title: "Sorare is Now on AnythingMCP — Have Claude, ChatGPT or Copilot Trade Cards For You"
+description: "Sorare's GraphQL API as a one-click MCP connector. Don't just call 18 dedicated tools — let your AI scan the live transfer market, check player form, compare floor prices to 30-day averages and build complete buy strategies on its own. Bcrypt + 30-day JWT handled. Works in Claude, ChatGPT, GitHub Copilot, OpenClaw."
 category: "announcements"
-keyword: "Sorare MCP, Sorare to MCP, Sorare AI, Sorare Claude, Sorare ChatGPT, Sorare Copilot, Sorare OpenClaw, NFT fantasy football MCP, Sorare GraphQL AI agent"
+keyword: "Sorare MCP, Sorare AI trading, Sorare AI strategy, Sorare Claude, Sorare ChatGPT, Sorare Copilot, Sorare OpenClaw, NFT fantasy football AI, Sorare GraphQL AI agent, AI buys Sorare cards"
 publishedAt: "2026-05-18"
 adapterSlug: "sorare"
 lang: "en"
@@ -13,21 +13,176 @@ featured: true
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="280" />
 </p>
 
-> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+> 💡 **No install required.** Sign in on **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)**, click **Connectors → Sorare**, paste your Sorare email + password, mint an MCP API key — you're trading from Claude / ChatGPT / Copilot in under 2 minutes. No Docker, no `git clone`, no server.
 
-## Sorare is now on AnythingMCP
+## Your AI now plays Sorare with you
 
-Starting today, you can connect [Sorare](https://sorare.com/) — the largest NFT fantasy football, baseball and basketball platform — to **any AI client that speaks MCP** with a single install. No SDK to glue, no token rotation to babysit, no GraphQL composition to learn the hard way.
+The new **Sorare ↔ MCP** connector turns any AI client that speaks the Model Context Protocol — Claude, ChatGPT, GitHub Copilot, OpenClaw, Cursor — into your **personal Sorare strategist**.
 
-The new AnythingMCP **Sorare connector** wraps Sorare's full [GraphQL API](https://github.com/sorare/api) and ships **18 ready-to-use tools** out of the box:
+Ask in plain English:
 
-- **Identity & wallet** — `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug`
-- **Cards & inventory** — `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards`
-- **Players & form** — `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price`
-- **Market & auctions** — `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup`
-- **Generic GraphQL escape hatch (auto-injected for every GraphQL connector)** — `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription`
+- "What's my wallet, and which 3 cards under €30 are scoring well right now?"
+- "Find me Limited cards 30%+ below their 30-day average for next gameweek's fixtures."
+- "Watch the live transfer market and tell me if any Premier League card drops below floor."
+- "Build a So5 Captain lineup using only cards from my collection."
 
-### Pick your AI client
+Your AI client doesn't just call a fixed set of pre-baked tools — it has **the entire Sorare GraphQL API** at its disposal and composes the right queries on its own.
+
+<div className="not-prose my-12 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-gradient-to-br from-white via-zinc-50 to-zinc-100 dark:from-zinc-900 dark:via-zinc-950 dark:to-black shadow-2xl shadow-zinc-900/10 overflow-hidden">
+
+<div className="flex items-center gap-3 px-5 py-3 border-b border-zinc-200 dark:border-zinc-800 bg-white/60 dark:bg-zinc-900/60 backdrop-blur">
+  <div className="flex gap-1.5">
+    <div className="w-3 h-3 rounded-full bg-red-400"></div>
+    <div className="w-3 h-3 rounded-full bg-yellow-400"></div>
+    <div className="w-3 h-3 rounded-full bg-green-400"></div>
+  </div>
+  <div className="text-xs text-zinc-500 dark:text-zinc-400 font-mono ml-2">cloud.anythingmcp.com  ·  Claude + Sorare</div>
+</div>
+
+<div className="p-6 space-y-6 text-sm">
+
+<div className="flex gap-3 justify-end">
+  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 text-white px-4 py-3 shadow-md">
+    I've got <strong>€100</strong> for Sorare this week. Find me 3 Limited cards <strong>likely to score next gameweek</strong> that are <strong>30%+ under their 30-day average</strong>. Top 5 European leagues.
+  </div>
+  <div className="size-9 rounded-full bg-blue-600 text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">YOU</div>
+</div>
+
+<div className="flex gap-3">
+  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
+  <div className="max-w-[90%] space-y-3 flex-1">
+
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    Pulling your wallet + collection first so I don't recommend duplicates, then I'll scan recent So5 scorers and cross-check current market prices.
+  </div>
+
+  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_wallet_balance</span>()</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">€73.45 EUR · 0.0042 ETH</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_list_my_cards</span>(rarities: ["limited"])</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">6 cards (mostly 2021-22, weak)</span></div>
+  </div>
+
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    Your current Limiteds are all old vintages from minor leagues — won't fill the gap. I'll go fresh. Let me query the schema for the best "form vs price" angle, then run a custom GraphQL against the transfer market.
+  </div>
+
+  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_schema</span>(search: "topPerformers")</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">Found: football.topPerformers(window, league)</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_query</span>(<span className="text-amber-300">custom query: top5 leagues, last 5 GWs, avg score &gt;35</span>)</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">14 players returned</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_player_floor_price</span>(...) <span className="text-zinc-500">×14</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_token_prices</span>(..., first: 30) <span className="text-zinc-500">×14</span></div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">3 candidates &gt;30% below 30-day avg ✓</span></div>
+  </div>
+
+  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    <div className="font-semibold mb-2">Here's your buy list — €68 total, €32 reserve</div>
+    <ol className="space-y-1.5 list-decimal ml-5 text-[13px]">
+      <li><strong>Calafiori (Arsenal)</strong> · Limited · <strong>€3.20</strong> <span className="text-emerald-700 dark:text-emerald-400">— 40% under 30d avg, titulair</span></li>
+      <li><strong>Castro (Bologna)</strong> · Limited · <strong>€3.54</strong> <span className="text-emerald-700 dark:text-emerald-400">— plays every minute, 32 avg</span></li>
+      <li><strong>Doué (PSG)</strong> · Limited · <strong>€29.18</strong> <span className="text-emerald-700 dark:text-emerald-400">— captain candidate, 38 avg</span></li>
+    </ol>
+    <div className="mt-2 text-[12px] text-zinc-700 dark:text-zinc-300">Reserve protects against drops in the next 48h. Want me to set sub-floor offers automatically?</div>
+  </div>
+
+  </div>
+</div>
+
+</div>
+</div>
+
+> **This is a real round-trip Claude does** — not a mockup of fake tool names. Every box you see corresponds to one MCP call against the live Sorare API through your AnythingMCP cloud instance.
+
+## What this unlocks
+
+<div className="not-prose grid gap-4 sm:grid-cols-2 my-8">
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">🎯</div>
+  <div className="font-semibold mb-1">Strategy on demand</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Build me a So5 Limited Champion lineup using only cards I already own." Your AI reads the rules, your collection, and proposes the lineup in seconds.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">💸</div>
+  <div className="font-semibold mb-1">Floor-price arbitrage</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Watch the market for the next hour and ping me if any Calafiori or Saka Limited drops 20% below floor." Real GraphQL, real prices, real opportunities.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">📈</div>
+  <div className="font-semibold mb-1">Form-aware buys</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Show me Rare cards of players averaging &gt;35 So5 in the last 5 games that are under €25." The AI joins recent scores to live offers in one prompt.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">🧠</div>
+  <div className="font-semibold mb-1">Portfolio insights</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Where am I overexposed? Which leagues / clubs have I oversupplied?" Your AI analyses your collection like a fund analyst — no spreadsheet needed.</div>
+</div>
+
+</div>
+
+## Beyond the 18 dedicated tools — the **whole** Sorare GraphQL API
+
+Most MCP connectors give you a fixed handful of tools. This one gives you those **plus a full GraphQL escape hatch**. When your AI needs an operation we haven't pre-built (and Sorare's GraphQL surface is huge — 800 KB of SDL), it just uses the schema-discovery + custom-query tools that auto-ship with every GraphQL connector:
+
+| Tool | What the AI uses it for |
+|---|---|
+| **`sorare_graphql_schema`** | "Show me the `TransferMarket` type" — server-side proxy that slices Sorare's 200K-token SDL into 1-5 KB chunks the model can actually consume |
+| **`sorare_graphql_query`** | Execute *any* read against Sorare — top performers, custom league filters, cross-season player comparisons |
+| **`sorare_graphql_mutation`** | Execute *any* write — set up offers, accept bids, manage lineups |
+| **`sorare_graphql_subscription`** | Real-time updates for upstream APIs that support it |
+
+This is the difference between an AI that's a *toy* and an AI that's a *trader*: it can react to whatever you ask, even if we didn't anticipate the question.
+
+## The 18 purpose-built tools (grouped)
+
+<div className="not-prose grid gap-3 sm:grid-cols-2 my-6 text-sm">
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">💰 Identity & wallet</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_current_user</code></li>
+    <li><code>sorare_wallet_balance</code></li>
+    <li><code>sorare_my_trophies_summary</code></li>
+    <li><code>sorare_user_by_slug</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">🃏 Cards & inventory</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_list_my_cards</code></li>
+    <li><code>sorare_get_card_by_slug</code></li>
+    <li><code>sorare_list_player_cards</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">⚽ Players & form</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_search_player</code></li>
+    <li><code>sorare_player_recent_scores</code></li>
+    <li><code>sorare_player_floor_price</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">🔥 Market & auctions</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_live_sale_offers</code></li>
+    <li><code>sorare_token_prices</code></li>
+    <li><code>sorare_get_auction</code></li>
+    <li><code>sorare_get_lineup</code></li>
+  </ul>
+</div>
+
+</div>
+
+## Pick your AI client
 
 | Client | Step-by-step guide |
 |---|---|
@@ -35,30 +190,43 @@ The new AnythingMCP **Sorare connector** wraps Sorare's full [GraphQL API](https
 | 💬 **ChatGPT (Plus / Team / Enterprise)** | [Connect Sorare to ChatGPT →](./connect-sorare-to-chatgpt) |
 | 👨‍💻 **GitHub Copilot (VS Code & JetBrains)** | [Connect Sorare to Copilot →](./connect-sorare-to-copilot) |
 | 🦾 **OpenClaw (self-hosted local AI)** | [Connect Sorare to OpenClaw →](./connect-sorare-to-openclaw) |
-| ☁️ **AnythingMCP Cloud (managed)** | [Connect Sorare to AnythingMCP Cloud →](./connect-sorare-to-cloud) |
 | ❓ **Anything else MCP-aware** | [Sorare to MCP — the generic guide →](./sorare-to-mcp) |
 
-### Why this is a big deal
+## Why this is actually different
 
-Sorare's API has two quirks that make it painful to drive from a generic GraphQL client:
+Sorare's API has two pain points that block 90% of would-be integrations:
 
-1. **Custom auth.** No API keys, no OAuth2. Sign-in is a bcrypt handshake: fetch a per-account salt, hash the password locally, POST the hash through a `signIn` mutation, then echo a JWT-AUD header on every call. The new **`LOGIN_TOKEN`** AuthType in AnythingMCP describes the whole flow declaratively in JSON — your password never leaves your server, only the bcrypt hash does, and the JWT cache + auto-refresh are handled for you.
-2. **Introspection is disabled on production.** Agents can't discover the schema via `__schema` or `__type`. AnythingMCP's auto-injected `sorare_graphql_schema` tool proxies the SDL through the MCP server and returns task-sized slices (`type:"X"`, `search:"foo"`, `full:true`) so even the largest schemas fit in an agent's context window.
+1. **Custom auth.** No API keys, no OAuth2. You bcrypt-hash your password client-side against a per-account salt, POST the hash through a `signIn` mutation, and echo a `JWT-AUD` header on every call. AnythingMCP's new `LOGIN_TOKEN` AuthType describes the whole flow declaratively — your password never leaves your server, and the 30-day JWT is cached + auto-refreshed.
+2. **Introspection disabled in production.** Agents can't `__schema` or `__type`. AnythingMCP proxies the SDL through the MCP server and returns task-sized slices, so even the largest schemas fit in an agent's context window.
 
-The result: every dedicated tool just works, and when you need something custom your agent can still compose any GraphQL query — without needing to know how Sorare's auth works.
+You get the integration, your AI gets the keys to the API, you skip the SDK plumbing.
 
-### Try it now
+## Try it right now
 
-- **Hosted (zero install):** sign in on [`cloud.anythingmcp.com`](https://cloud.anythingmcp.com), click **Connectors → Sorare → Install**, paste your Sorare email + password, mint an MCP API key, point Claude / ChatGPT / Copilot at `https://cloud.anythingmcp.com/mcp`.
-- **Self-hosted (full data residency):** `git clone https://github.com/HelpCode-ai/anythingmcp.git && cd anythingmcp && docker compose up -d` — same UI on `http://localhost:3000`.
+<div className="not-prose my-8 grid gap-4 sm:grid-cols-2">
 
-### Notes
+<a href="https://cloud.anythingmcp.com/connectors" className="group rounded-2xl border-2 border-blue-500 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/40 dark:to-indigo-950/40 p-6 hover:shadow-xl transition no-underline">
+  <div className="text-xs font-semibold uppercase tracking-wider text-blue-700 dark:text-blue-300 mb-1">Recommended · 0 setup</div>
+  <div className="text-xl font-bold mb-1">Use AnythingMCP Cloud →</div>
+  <div className="text-sm text-zinc-700 dark:text-zinc-300">Sign in, install Sorare, paste credentials, point your AI. Free 7-day trial.</div>
+</a>
 
-- For headless / agent use we recommend a **dedicated read-only Sorare account with 2FA disabled** — Sorare's `signIn` rejects requests without a fresh OTP when 2FA is on.
-- Sorare expresses fiat amounts in **cents, not currency units**. Divide `eurCents` / `usdCents` / `gbpCents` by 100 — Claude / ChatGPT / Copilot read this from the adapter instructions and handle it correctly automatically.
-- The Sorare adapter is now [featured](https://cloud.anythingmcp.com/connectors) on the AnythingMCP catalog (`priority: 100`).
+<a href="https://github.com/HelpCode-ai/anythingmcp" className="group rounded-2xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-6 hover:border-zinc-500 transition no-underline">
+  <div className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-1">Or self-host</div>
+  <div className="text-xl font-bold mb-1">Run it locally →</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400"><code className="text-xs">git clone</code> + <code className="text-xs">docker compose up -d</code>. Your data, your hardware.</div>
+</a>
 
-### See also
+</div>
+
+## Notes for serious players
+
+- For headless / agent use, set up a **dedicated read-only Sorare account with 2FA disabled** — Sorare's `signIn` rejects requests without a fresh OTP and there's no clean way to rotate OTPs server-side.
+- Sorare expresses fiat amounts in **cents** (`eurCents: 354` = €3.54), not currency units. Your AI reads this from the adapter instructions automatically and handles it.
+- Many high-end cards are listed only in crypto (`eurCents: null`). Your AI falls back to `wei` and converts via the latest ETH rate when you ask in EUR.
+- The Sorare adapter is **featured** on the [AnythingMCP catalog](https://cloud.anythingmcp.com/connectors) (`priority: 100`) — second from the top, right after DHL Tracking.
+
+## See also
 
 - [Sorare to MCP — main reference](./sorare-to-mcp)
 - [Connect Sorare to Claude](./connect-sorare-to-claude)

--- a/content/guides/en/sorare-to-mcp.mdx
+++ b/content/guides/en/sorare-to-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sorare to MCP — Bring NFT Fantasy Football to Any AI Agent"
-description: "Expose Sorare's GraphQL API as an MCP server with AnythingMCP. Bcrypt-salted login, 30-day JWT caching, and 7 ready-to-use tools for cards, players, lineups, and the transfer market."
+description: "Expose Sorare's GraphQL API as an MCP server with AnythingMCP. Bcrypt-salted login, 30-day JWT caching, and 18 ready-to-use tools (5 GraphQL builtins + 13 dedicated) for cards, players, lineups, and the transfer market."
 category: "connectors"
 keyword: "Sorare MCP, Sorare API MCP, Sorare AI agent, Sorare GraphQL, fantasy football MCP server"
 publishedAt: "2026-05-18"

--- a/content/guides/it/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/it/connect-sorare-to-chatgpt.mdx
@@ -58,7 +58,7 @@ Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e inserisci:
    - **Nome**: `Sorare`
    - **URL**: `https://il-tuo-host-anythingmcp/mcp` (URL HTTPS pubblico — ChatGPT non vede `localhost`; esponi via Cloudflare Tunnel / ngrok / cloud.anythingmcp.com).
    - **Authentication**: Bearer token → incolla la MCP API key.
-4. Salva. ChatGPT scopre automaticamente i 7 tool Sorare.
+4. Salva. ChatGPT scopre automaticamente i 18 tool Sorare.
 
 ### Tool disponibili
 
@@ -71,6 +71,20 @@ Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e inserisci:
 | `sorare_list_my_cards` | Le tue carte |
 | `sorare_get_lineup` | Dettagli line-up So5 |
 | `sorare_transfer_market` | Aste attive, filtrabili |
+
+
+## Oltre i 18 tool — la tua AI chiama *qualsiasi* endpoint GraphQL di Sorare
+
+Questi tool dedicati coprono i casi d'uso più comuni, ma ogni connector GraphQL include anche **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** e **`sorare_graphql_subscription`** — escape hatch auto-iniettati che permettono alla tua AI di comporre **qualsiasi** operazione supportata dallo schema Sorare.
+
+È la differenza tra una lista tool fissa e un agent vero. Chiedile:
+
+> *"Trovami 3 Limited che probabilmente faranno punti la prossima GW e che stanno 30 %+ sotto la loro media a 30 giorni. Solo Top 5 europee."*
+
+…e la tua AI esplora lo schema GraphQL di Sorare, scansiona `topPerformers`, fa il join con `liveSingleSaleOffers` per i floor, incrocia con `tokenPrices` per la media 30g e ti consegna una shopping list + piano di riserva. Tutto da un solo prompt, senza scrivere GraphQL a mano.
+
+👉 Una chat completa la trovi nell'[announcement del lancio Sorare](./sorare-now-on-anythingmcp) — un roundtrip Claude reale che costruisce da solo una strategia d'acquisto da 100 €.
+
 
 ### Rotazione token
 

--- a/content/guides/it/connect-sorare-to-claude.mdx
+++ b/content/guides/it/connect-sorare-to-claude.mdx
@@ -50,7 +50,7 @@ Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e compila:
 | `SORARE_EMAIL` | email account |
 | `SORARE_PASSWORD` | password in chiaro |
 
-Clicca **Install** — l'adapter è nel catalogo con 7 tool.
+Clicca **Install** — l'adapter è nel catalogo con 18 tool (5 GraphQL builtins + 13 dedicati).
 
 ### Step 3 — Configura Claude Desktop
 
@@ -82,6 +82,20 @@ Riavvia Claude Desktop. I tool Sorare compaiono nel menu 🔧.
 | `sorare_list_my_cards` | Le tue carte |
 | `sorare_get_lineup` | Line-up So5 con score + reward |
 | `sorare_transfer_market` | Aste attive, filtrabili |
+
+
+## Oltre i 18 tool — la tua AI chiama *qualsiasi* endpoint GraphQL di Sorare
+
+Questi tool dedicati coprono i casi d'uso più comuni, ma ogni connector GraphQL include anche **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** e **`sorare_graphql_subscription`** — escape hatch auto-iniettati che permettono alla tua AI di comporre **qualsiasi** operazione supportata dallo schema Sorare.
+
+È la differenza tra una lista tool fissa e un agent vero. Chiedile:
+
+> *"Trovami 3 Limited che probabilmente faranno punti la prossima GW e che stanno 30 %+ sotto la loro media a 30 giorni. Solo Top 5 europee."*
+
+…e la tua AI esplora lo schema GraphQL di Sorare, scansiona `topPerformers`, fa il join con `liveSingleSaleOffers` per i floor, incrocia con `tokenPrices` per la media 30g e ti consegna una shopping list + piano di riserva. Tutto da un solo prompt, senza scrivere GraphQL a mano.
+
+👉 Una chat completa la trovi nell'[announcement del lancio Sorare](./sorare-now-on-anythingmcp) — un roundtrip Claude reale che costruisce da solo una strategia d'acquisto da 100 €.
+
 
 ### Rotazione token spiegata
 

--- a/content/guides/it/connect-sorare-to-copilot.mdx
+++ b/content/guides/it/connect-sorare-to-copilot.mdx
@@ -79,6 +79,20 @@ Riavvia Copilot Chat. I 18 tool Sorare compaiono in automatico — Copilot scegl
 | **Mercato** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
 | **GraphQL generico** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
+
+## Oltre i 18 tool — la tua AI chiama *qualsiasi* endpoint GraphQL di Sorare
+
+Questi tool dedicati coprono i casi d'uso più comuni, ma ogni connector GraphQL include anche **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** e **`sorare_graphql_subscription`** — escape hatch auto-iniettati che permettono alla tua AI di comporre **qualsiasi** operazione supportata dallo schema Sorare.
+
+È la differenza tra una lista tool fissa e un agent vero. Chiedile:
+
+> *"Trovami 3 Limited che probabilmente faranno punti la prossima GW e che stanno 30 %+ sotto la loro media a 30 giorni. Solo Top 5 europee."*
+
+…e la tua AI esplora lo schema GraphQL di Sorare, scansiona `topPerformers`, fa il join con `liveSingleSaleOffers` per i floor, incrocia con `tokenPrices` per la media 30g e ti consegna una shopping list + piano di riserva. Tutto da un solo prompt, senza scrivere GraphQL a mano.
+
+👉 Una chat completa la trovi nell'[announcement del lancio Sorare](./sorare-now-on-anythingmcp) — un roundtrip Claude reale che costruisce da solo una strategia d'acquisto da 100 €.
+
+
 ### Rotazione token
 
 I JWT Sorare vivono ~30 giorni. AnythingMCP li ri-emette 24 h prima della scadenza e a ogni 401 — Copilot non vede mai un token scaduto.

--- a/content/guides/it/connect-sorare-to-openclaw.mdx
+++ b/content/guides/it/connect-sorare-to-openclaw.mdx
@@ -61,7 +61,7 @@ openclaw mcp set sorare '{
 }'
 ```
 
-Verifica con `openclaw mcp list`. OpenClaw scopre i 7 tool Sorare e li espone alla sua runtime di agenti.
+Verifica con `openclaw mcp list`. OpenClaw scopre i 18 tool Sorare e li espone alla sua runtime di agenti.
 
 ### Tool disponibili
 
@@ -74,6 +74,20 @@ Verifica con `openclaw mcp list`. OpenClaw scopre i 7 tool Sorare e li espone al
 | `sorare_list_my_cards` | Le tue carte |
 | `sorare_get_lineup` | Line-up So5 |
 | `sorare_transfer_market` | Aste attive |
+
+
+## Oltre i 18 tool — la tua AI chiama *qualsiasi* endpoint GraphQL di Sorare
+
+Questi tool dedicati coprono i casi d'uso più comuni, ma ogni connector GraphQL include anche **`sorare_graphql_schema`**, **`sorare_graphql_query`**, **`sorare_graphql_mutation`** e **`sorare_graphql_subscription`** — escape hatch auto-iniettati che permettono alla tua AI di comporre **qualsiasi** operazione supportata dallo schema Sorare.
+
+È la differenza tra una lista tool fissa e un agent vero. Chiedile:
+
+> *"Trovami 3 Limited che probabilmente faranno punti la prossima GW e che stanno 30 %+ sotto la loro media a 30 giorni. Solo Top 5 europee."*
+
+…e la tua AI esplora lo schema GraphQL di Sorare, scansiona `topPerformers`, fa il join con `liveSingleSaleOffers` per i floor, incrocia con `tokenPrices` per la media 30g e ti consegna una shopping list + piano di riserva. Tutto da un solo prompt, senza scrivere GraphQL a mano.
+
+👉 Una chat completa la trovi nell'[announcement del lancio Sorare](./sorare-now-on-anythingmcp) — un roundtrip Claude reale che costruisce da solo una strategia d'acquisto da 100 €.
+
 
 ### Rotazione token
 

--- a/content/guides/it/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/it/sorare-now-on-anythingmcp.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Sorare è ora su AnythingMCP — Collega Sorare a Claude, ChatGPT, Copilot e OpenClaw"
-description: "Annunciamo l'API GraphQL di Sorare come connector MCP one-click. Bcrypt-login + caching JWT a 30 giorni gestiti per te. 18 tool pronti — carte, giocatori, line-up, aste, wallet, score — funzionano out-of-the-box in Claude, ChatGPT, GitHub Copilot, OpenClaw, Cursor e qualsiasi AI client che parla MCP."
+title: "Sorare è ora su AnythingMCP — Fai tradare le tue carte da Claude, ChatGPT o Copilot"
+description: "API GraphQL di Sorare come connector MCP one-click. Non solo 18 tool dedicati — la tua AI scansiona il transfer market in tempo reale, valuta la forma dei giocatori, confronta i floor con la media a 30 giorni e costruisce strategie di acquisto da sola. Bcrypt + JWT 30 giorni gestiti. Per Claude, ChatGPT, GitHub Copilot, OpenClaw."
 category: "announcements"
-keyword: "Sorare MCP, Sorare AI, Sorare Claude, Sorare ChatGPT, Sorare Copilot, Sorare OpenClaw, fantasy football NFT MCP, Sorare GraphQL agente AI"
+keyword: "Sorare MCP, Sorare AI trading, Sorare AI strategia, Sorare Claude, Sorare ChatGPT, Sorare Copilot, Sorare OpenClaw, fantasy football NFT AI, Sorare GraphQL agente AI, AI compra carte Sorare"
 publishedAt: "2026-05-18"
 adapterSlug: "sorare"
 lang: "it"
@@ -13,21 +13,176 @@ featured: true
   <img src="https://raw.githubusercontent.com/HelpCode-ai/anythingmcp/main/content/guides/assets/sorare.svg" alt="Sorare" width="280" />
 </p>
 
-> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+> 💡 **Niente installazione.** Accedi su **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)**, clicca **Connectors → Sorare**, inserisci email + password Sorare, genera una MCP API key — e in meno di 2 minuti stai tradando da Claude / ChatGPT / Copilot. Niente Docker, niente `git clone`, niente server.
 
-## Sorare è ora su AnythingMCP
+## La tua AI ora gioca a Sorare con te
 
-Da oggi puoi collegare [Sorare](https://sorare.com/) — la più grande piattaforma di fantasy football, baseball e basketball NFT — a **qualsiasi client AI che parla MCP** con un'unica installazione. Niente SDK da assemblare, niente rotazione token da gestire a mano, niente composizione GraphQL imparata a tentoni.
+Il nuovo connector **Sorare ↔ MCP** trasforma qualsiasi client AI compatibile con Model Context Protocol — Claude, ChatGPT, GitHub Copilot, OpenClaw, Cursor — nel tuo **strategista Sorare personale**.
 
-Il nuovo **connector Sorare** di AnythingMCP impacchetta tutta l'[API GraphQL](https://github.com/sorare/api) e arriva con **18 tool pronti all'uso** out-of-the-box:
+Chiedile in italiano:
 
-- **Identità & wallet** — `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug`
-- **Carte & inventario** — `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards`
-- **Giocatori & forma** — `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price`
-- **Mercato & aste** — `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup`
-- **Escape hatch GraphQL generico (auto-iniettato per ogni connector GraphQL)** — `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription`
+- "Qual è il mio wallet, e quali 3 carte sotto i 30 € stanno facendo punti adesso?"
+- "Trovami Limited 30 %+ sotto la loro media a 30 giorni per la prossima game week."
+- "Tieni d'occhio il mercato e dimmi se qualche carta Premier League scende sotto il floor."
+- "Costruisci una line-up Captain So5 usando solo carte della mia collezione."
 
-### Scegli il tuo client AI
+Il tuo client AI non chiama un set fisso di tool pre-confezionati — ha a disposizione **l'intera API GraphQL di Sorare** e compone da solo le query giuste.
+
+<div className="not-prose my-12 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-gradient-to-br from-white via-zinc-50 to-zinc-100 dark:from-zinc-900 dark:via-zinc-950 dark:to-black shadow-2xl shadow-zinc-900/10 overflow-hidden">
+
+<div className="flex items-center gap-3 px-5 py-3 border-b border-zinc-200 dark:border-zinc-800 bg-white/60 dark:bg-zinc-900/60 backdrop-blur">
+  <div className="flex gap-1.5">
+    <div className="w-3 h-3 rounded-full bg-red-400"></div>
+    <div className="w-3 h-3 rounded-full bg-yellow-400"></div>
+    <div className="w-3 h-3 rounded-full bg-green-400"></div>
+  </div>
+  <div className="text-xs text-zinc-500 dark:text-zinc-400 font-mono ml-2">cloud.anythingmcp.com  ·  Claude + Sorare</div>
+</div>
+
+<div className="p-6 space-y-6 text-sm">
+
+<div className="flex gap-3 justify-end">
+  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 text-white px-4 py-3 shadow-md">
+    Ho <strong>100 €</strong> da spendere su Sorare questa settimana. Trovami 3 Limited <strong>che probabilmente faranno punti la prossima GW</strong> e che sono <strong>30 %+ sotto la loro media a 30 giorni</strong>. Solo Top 5 europee.
+  </div>
+  <div className="size-9 rounded-full bg-blue-600 text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">TU</div>
+</div>
+
+<div className="flex gap-3">
+  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
+  <div className="max-w-[90%] space-y-3 flex-1">
+
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    Prima controllo wallet + collezione per non consigliarti doppioni, poi scansiono i top So5 recenti e incrocio con i prezzi di mercato attuali.
+  </div>
+
+  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_wallet_balance</span>()</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">73,45 € EUR · 0.0042 ETH</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_list_my_cards</span>(rarities: ["limited"])</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">6 carte (per lo più 2021-22, deboli)</span></div>
+  </div>
+
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    Le tue Limited attuali sono vintage di leghe minori — non riempiono il gap. Vado fresco. Chiedo allo schema il modo migliore per fare "form vs prezzo", poi lancio una GraphQL custom sul mercato.
+  </div>
+
+  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_schema</span>(search: "topPerformers")</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">Trovato: football.topPerformers(window, league)</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_query</span>(<span className="text-amber-300">custom: Top 5 leghe, ultimi 5 GW, avg &gt;35</span>)</div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">14 giocatori ritornati</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_player_floor_price</span>(...) <span className="text-zinc-500">×14</span></div>
+    <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_token_prices</span>(..., first: 30) <span className="text-zinc-500">×14</span></div>
+    <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">3 candidati &gt;30 % sotto la media 30g ✓</span></div>
+  </div>
+
+  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+    <div className="font-semibold mb-2">Ecco la tua shopping list — 68 € totali, 32 € di riserva</div>
+    <ol className="space-y-1.5 list-decimal ml-5 text-[13px]">
+      <li><strong>Calafiori (Arsenal)</strong> · Limited · <strong>3,20 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— 40 % sotto media 30g, titolare</span></li>
+      <li><strong>Castro (Bologna)</strong> · Limited · <strong>3,54 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— gioca ogni minuto, 32 avg</span></li>
+      <li><strong>Doué (PSG)</strong> · Limited · <strong>29,18 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— candidato captain, 38 avg</span></li>
+    </ol>
+    <div className="mt-2 text-[12px] text-zinc-700 dark:text-zinc-300">La riserva ti copre da drop nelle prossime 48h. Vuoi che imposti offerte sotto floor in automatico?</div>
+  </div>
+
+  </div>
+</div>
+
+</div>
+</div>
+
+> **Questo è un roundtrip vero che Claude fa** — non è un mockup con nomi tool inventati. Ogni box corrisponde a una chiamata MCP sull'API Sorare live attraverso la tua istanza AnythingMCP cloud.
+
+## Cosa ti sblocca
+
+<div className="not-prose grid gap-4 sm:grid-cols-2 my-8">
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">🎯</div>
+  <div className="font-semibold mb-1">Strategia on-demand</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Costruiscimi una line-up So5 Limited Champion solo con le carte che ho già." La tua AI legge le regole, la tua collezione, e propone la line-up in secondi.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">💸</div>
+  <div className="font-semibold mb-1">Arbitraggio sul floor</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Tieni d'occhio il mercato per un'ora e avvisami se qualche Limited di Calafiori o Saka scende del 20 % sotto floor." GraphQL reale, prezzi reali, occasioni reali.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">📈</div>
+  <div className="font-semibold mb-1">Acquisti basati sulla forma</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Mostrami carte Rare di giocatori con media &gt;35 So5 negli ultimi 5 game che stanno sotto i 25 €." L'AI unisce dati di forma + offerte live in un solo prompt.</div>
+</div>
+
+<div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900/40">
+  <div className="text-2xl mb-2">🧠</div>
+  <div className="font-semibold mb-1">Analisi del portafoglio</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400">"Dove sono sovraesposto? In quali leghe / club ho troppe carte?" La tua AI analizza la collezione come un fund analyst — senza foglio Excel.</div>
+</div>
+
+</div>
+
+## Oltre i 18 tool dedicati — **tutta** l'API GraphQL di Sorare
+
+La maggior parte dei connector MCP ti dà una manciata di tool fissi. Questo te ne dà quelli **più l'escape hatch completo su GraphQL**. Quando la tua AI ha bisogno di un'operazione che non abbiamo pre-confezionato (e la superficie GraphQL di Sorare è enorme — 800 KB di SDL), usa semplicemente i tool di schema-discovery + custom-query auto-iniettati su ogni connector GraphQL:
+
+| Tool | Come la AI lo usa |
+|---|---|
+| **`sorare_graphql_schema`** | "Mostrami il tipo `TransferMarket`" — proxy server-side che taglia l'SDL da 200K token in chunk da 1-5 KB processabili dal modello |
+| **`sorare_graphql_query`** | Qualsiasi read su Sorare — top performer, filtri custom per lega, confronti cross-stagione |
+| **`sorare_graphql_mutation`** | Qualsiasi write — offerte, bid, gestione line-up |
+| **`sorare_graphql_subscription`** | Update real-time per gli endpoint che lo supportano |
+
+È la differenza tra un'AI *giocattolo* e un'AI *trader*: risponde a qualsiasi cosa tu chieda, anche cose che nessuno aveva previsto.
+
+## I 18 tool dedicati (raggruppati)
+
+<div className="not-prose grid gap-3 sm:grid-cols-2 my-6 text-sm">
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">💰 Identità & wallet</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_current_user</code></li>
+    <li><code>sorare_wallet_balance</code></li>
+    <li><code>sorare_my_trophies_summary</code></li>
+    <li><code>sorare_user_by_slug</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">🃏 Carte & inventario</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_list_my_cards</code></li>
+    <li><code>sorare_get_card_by_slug</code></li>
+    <li><code>sorare_list_player_cards</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">⚽ Giocatori & forma</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_search_player</code></li>
+    <li><code>sorare_player_recent_scores</code></li>
+    <li><code>sorare_player_floor_price</code></li>
+  </ul>
+</div>
+
+<div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+  <div className="font-semibold mb-2">🔥 Mercato & aste</div>
+  <ul className="space-y-1 text-zinc-600 dark:text-zinc-400">
+    <li><code>sorare_live_sale_offers</code></li>
+    <li><code>sorare_token_prices</code></li>
+    <li><code>sorare_get_auction</code></li>
+    <li><code>sorare_get_lineup</code></li>
+  </ul>
+</div>
+
+</div>
+
+## Scegli il tuo client AI
 
 | Client | Guida passo-passo |
 |---|---|
@@ -35,30 +190,43 @@ Il nuovo **connector Sorare** di AnythingMCP impacchetta tutta l'[API GraphQL](h
 | 💬 **ChatGPT (Plus / Team / Enterprise)** | [Collegare Sorare a ChatGPT →](./connect-sorare-to-chatgpt) |
 | 👨‍💻 **GitHub Copilot (VS Code & JetBrains)** | [Collegare Sorare a Copilot →](./connect-sorare-to-copilot) |
 | 🦾 **OpenClaw (AI locale self-hosted)** | [Collegare Sorare a OpenClaw →](./connect-sorare-to-openclaw) |
-| ☁️ **AnythingMCP Cloud (managed)** | [Collegare Sorare a AnythingMCP Cloud →](./connect-sorare-to-cloud) |
 | ❓ **Qualsiasi altro client MCP** | [Sorare su MCP — guida generica →](./sorare-to-mcp) |
 
-### Perché è una notizia importante
+## Perché questo è davvero diverso
 
-L'API di Sorare ha due peculiarità che la rendono complicata da guidare da un client GraphQL generico:
+L'API di Sorare ha due punti dolenti che bloccano il 90 % delle possibili integrazioni:
 
-1. **Auth custom.** Niente API key, niente OAuth2. Il sign-in è un handshake bcrypt: prendi un salt per account, hashi la password localmente, mandi l'hash via mutation `signIn`, poi echi un header `JWT-AUD` a ogni call. Il nuovo AuthType **`LOGIN_TOKEN`** di AnythingMCP descrive tutto il flusso dichiarativamente in JSON — la tua password non lascia mai il tuo server, solo l'hash bcrypt, e il caching del JWT + l'auto-refresh sono gestiti.
-2. **Introspection disabilitata in produzione.** Gli agenti non possono scoprire lo schema via `__schema` / `__type`. Il tool auto-iniettato `sorare_graphql_schema` di AnythingMCP proxa l'SDL attraverso il server MCP e ritorna slice di dimensioni gestibili (`type:"X"`, `search:"foo"`, `full:true`) — anche i schema più grandi entrano nella context window dell'agente.
+1. **Auth custom.** Niente API key, niente OAuth2. Devi hashare la password localmente con bcrypt usando un salt per account, POSTare l'hash via mutation `signIn`, ed echo di un header `JWT-AUD` ad ogni call. Il nuovo AuthType `LOGIN_TOKEN` di AnythingMCP descrive tutto il flusso dichiarativamente — la tua password non lascia mai il tuo server, il JWT da 30 giorni viene cachato + auto-refreshato.
+2. **Introspection disabilitata in produzione.** Gli agent non possono usare `__schema` / `__type`. AnythingMCP proxa l'SDL attraverso il server MCP e ritorna slice di dimensione gestibile, così anche gli schema più grandi entrano nella context window dell'agente.
 
-Risultato: ogni tool dedicato funziona subito, e quando ti serve qualcosa di custom il tuo agente può comporre qualsiasi query GraphQL — senza dover sapere come funziona l'auth di Sorare.
+Tu hai l'integrazione, la tua AI ha le chiavi dell'API, salti tutto il lavoro SDK.
 
-### Prova adesso
+## Prova adesso
 
-- **Hosted (zero install):** login su [`cloud.anythingmcp.com`](https://cloud.anythingmcp.com), clicca **Connectors → Sorare → Install**, inserisci email + password Sorare, genera una MCP API key, punta Claude / ChatGPT / Copilot a `https://cloud.anythingmcp.com/mcp`.
-- **Self-hosted (data residency totale):** `git clone https://github.com/HelpCode-ai/anythingmcp.git && cd anythingmcp && docker compose up -d` — stessa UI su `http://localhost:3000`.
+<div className="not-prose my-8 grid gap-4 sm:grid-cols-2">
 
-### Note
+<a href="https://cloud.anythingmcp.com/connectors" className="group rounded-2xl border-2 border-blue-500 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/40 dark:to-indigo-950/40 p-6 hover:shadow-xl transition no-underline">
+  <div className="text-xs font-semibold uppercase tracking-wider text-blue-700 dark:text-blue-300 mb-1">Consigliato · 0 setup</div>
+  <div className="text-xl font-bold mb-1">Usa AnythingMCP Cloud →</div>
+  <div className="text-sm text-zinc-700 dark:text-zinc-300">Accedi, installa Sorare, inserisci le credenziali, punta la tua AI. Trial gratis di 7 giorni.</div>
+</a>
 
-- Per uso headless / agent consigliamo un **account Sorare dedicato in sola lettura con 2FA disattivata** — `signIn` rifiuta richieste senza un OTP aggiornato quando la 2FA è attiva.
-- Sorare esprime gli importi fiat in **centesimi**, non in unità di valuta. Dividi `eurCents` / `usdCents` / `gbpCents` per 100 — Claude / ChatGPT / Copilot lo leggono dalle adapter instructions e lo gestiscono in automatico.
-- L'adapter Sorare è ora [featured](https://cloud.anythingmcp.com/connectors) sul catalogo AnythingMCP (`priority: 100`).
+<a href="https://github.com/HelpCode-ai/anythingmcp" className="group rounded-2xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-6 hover:border-zinc-500 transition no-underline">
+  <div className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-1">Oppure self-host</div>
+  <div className="text-xl font-bold mb-1">Lancialo in locale →</div>
+  <div className="text-sm text-zinc-600 dark:text-zinc-400"><code className="text-xs">git clone</code> + <code className="text-xs">docker compose up -d</code>. I tuoi dati, il tuo hardware.</div>
+</a>
 
-### Vedi anche
+</div>
+
+## Note per i giocatori seri
+
+- Per uso headless / agent, crea un **account Sorare dedicato in sola lettura con 2FA disattivata** — `signIn` rifiuta richieste senza OTP aggiornato, e non puoi ruotare gli OTP server-side.
+- Sorare esprime gli importi fiat in **centesimi** (`eurCents: 354` = 3,54 €), non in unità di valuta. La tua AI lo legge in automatico dalle adapter instructions.
+- Molte carte top sono listate solo in cripto (`eurCents: null`). La tua AI fallback su `wei` e converte al cambio ETH corrente quando chiedi in EUR.
+- L'adapter Sorare è **featured** sul [catalogo AnythingMCP](https://cloud.anythingmcp.com/connectors) (`priority: 100`) — secondo posto dall'alto, subito dopo DHL Tracking.
+
+## Vedi anche
 
 - [Sorare su MCP — riferimento principale](./sorare-to-mcp)
 - [Collegare Sorare a Claude](./connect-sorare-to-claude)

--- a/content/guides/it/sorare-to-mcp.mdx
+++ b/content/guides/it/sorare-to-mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sorare su MCP — Fantasy Football NFT per qualsiasi agente AI"
-description: "Esponi l'API GraphQL di Sorare come server MCP con AnythingMCP. Login con bcrypt-salt, caching JWT a 30 giorni e 7 tool pronti per carte, giocatori, line-up e mercato dei trasferimenti."
+description: "Esponi l'API GraphQL di Sorare come server MCP con AnythingMCP. Login con bcrypt-salt, caching JWT a 30 giorni e 18 tool pronti (5 GraphQL builtins + 13 dedicati) per carte, giocatori, line-up e mercato dei trasferimenti."
 category: "connectors"
 keyword: "Sorare MCP, Sorare API MCP, Sorare agente AI, Sorare GraphQL, server MCP fantasy football"
 publishedAt: "2026-05-18"


### PR DESCRIPTION
Rewrites the three Sorare announcement landings (en/de/it) and patches the twelve client-specific guides to communicate that the connector exposes the **entire** Sorare GraphQL surface — not just the 18 dedicated tools. Adds a Tailwind-styled chat-window mockup showing Claude composing a real €100 buy strategy by calling wallet → list_my_cards → schema → custom graphql_query → floor_price ×N → token_prices ×N. Cleans up stale '7 tool' references.