### PR TITLE
License: always-visible activation field + auto-activation from pricing redirect

### DIFF
--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { auth, license, server } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
+import { buildPricingUrl } from '@/lib/marketing';
 import { LogoIcon } from '@/components/nav-bar';
 
 type SetupStep = 'auth' | 'verify-email' | 'license-choice' | 'license-email-sent' | 'license-key' | 'trial-activated';
@@ -494,7 +495,7 @@ function LoginForm() {
           <p className="text-sm text-[var(--muted-foreground)] mb-4">
             Purchase a license at{' '}
             <a
-              href="https://anythingmcp.com/pricing"
+              href={buildPricingUrl()}
               target="_blank"
               rel="noopener noreferrer"
               className="text-[var(--brand)] hover:underline font-medium"

--- a/packages/frontend/src/app/settings/license/activate/page.tsx
+++ b/packages/frontend/src/app/settings/license/activate/page.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { Suspense, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useAuth } from '@/lib/auth-context';
+import { license } from '@/lib/api';
+import { LogoIcon } from '@/components/nav-bar';
+
+const KEY_RE = /^AMCP-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}$/;
+
+type Phase = 'loading' | 'activating' | 'success' | 'error' | 'invalid';
+
+function LicenseActivateInner() {
+  const { token, user, isLoading } = useAuth();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const rawKey = searchParams.get('key') || '';
+  const key = rawKey.toUpperCase();
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [message, setMessage] = useState('');
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (isLoading || ran.current) return;
+
+    if (!key) {
+      setPhase('invalid');
+      setMessage('No license key was provided in the URL.');
+      ran.current = true;
+      return;
+    }
+
+    if (!KEY_RE.test(key)) {
+      setPhase('invalid');
+      setMessage('The license key in the URL is malformed.');
+      ran.current = true;
+      return;
+    }
+
+    if (!token || !user) {
+      const next = `/settings/license/activate?key=${encodeURIComponent(key)}`;
+      router.replace(`/login?redirect=${encodeURIComponent(next)}`);
+      ran.current = true;
+      return;
+    }
+
+    if (user.role !== 'ADMIN') {
+      setPhase('error');
+      setMessage('Only administrators can activate a license key. Ask your admin to sign in.');
+      ran.current = true;
+      return;
+    }
+
+    ran.current = true;
+    setPhase('activating');
+    license.setKey(key, token)
+      .then((res) => {
+        setPhase('success');
+        setMessage(res.message || 'License activated successfully.');
+        setTimeout(() => router.replace('/settings/license'), 1500);
+      })
+      .catch((err: any) => {
+        setPhase('error');
+        setMessage(err?.message || 'Failed to activate license.');
+      });
+  }, [key, token, user, isLoading, router]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--background)] px-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-6">
+          <div className="flex justify-center mb-3">
+            <LogoIcon size={48} />
+          </div>
+          <h1 className="text-xl font-bold">License Activation</h1>
+        </div>
+
+        <div className="border border-[var(--border)] rounded-lg p-6 bg-[var(--card)] text-sm">
+          {phase === 'loading' || phase === 'activating' ? (
+            <p className="text-center text-[var(--muted-foreground)]">
+              {phase === 'loading' ? 'Preparing…' : 'Activating your license…'}
+            </p>
+          ) : null}
+
+          {phase === 'success' && (
+            <div className="text-center">
+              <p className="text-emerald-600 font-medium mb-2">{message}</p>
+              <p className="text-[var(--muted-foreground)] text-xs">Redirecting to settings…</p>
+            </div>
+          )}
+
+          {(phase === 'error' || phase === 'invalid') && (
+            <div className="space-y-3">
+              <p className="text-[var(--destructive-text)]">{message}</p>
+              {key && phase === 'error' && (
+                <p className="text-xs text-[var(--muted-foreground)] break-all">
+                  Key: <span className="font-mono">{key}</span>
+                </p>
+              )}
+              <Link
+                href="/settings/license"
+                className="inline-block bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90"
+              >
+                Go to License Settings
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function LicenseActivatePage() {
+  return (
+    <Suspense>
+      <LicenseActivateInner />
+    </Suspense>
+  );
+}

--- a/packages/frontend/src/app/settings/license/page.tsx
+++ b/packages/frontend/src/app/settings/license/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
 import { license } from '@/lib/api';
+import { buildPricingUrl } from '@/lib/marketing';
 
 interface LicenseStatus {
   plan: string | null;
@@ -258,16 +259,15 @@ export default function LicenseSettingsPage() {
         </section>
       )}
 
-      {/* Change License Key */}
-      {(!isCloud || status?.status === 'expired' || (status?.plan === 'trial' && status?.trialDaysLeft !== undefined && status?.trialDaysLeft <= 0)) && (
-        <section className="border border-[var(--border)] rounded-lg p-5 bg-[var(--card)]">
+      {/* Change License Key — always available so admins can activate a purchased key any time */}
+      <section className="border border-[var(--border)] rounded-lg p-5 bg-[var(--card)]">
           <h2 className="text-sm font-semibold mb-4">
-            {status?.plan ? 'Change License Key' : 'Activate License Key'}
+            {status?.plan && status.plan !== 'trial' ? 'Change License Key' : 'Activate License Key'}
           </h2>
           <p className="text-sm text-[var(--muted-foreground)] mb-4">
             Purchase a license at{' '}
             <a
-              href="https://anythingmcp.com/pricing"
+              href={buildPricingUrl()}
               target="_blank"
               rel="noopener noreferrer"
               className="text-[var(--brand)] hover:underline font-medium"
@@ -293,7 +293,6 @@ export default function LicenseSettingsPage() {
             </button>
           </div>
         </section>
-      )}
 
       {/* Upgrade Plan (Cloud mode) */}
       {isCloud && status?.plan === 'trial' && (
@@ -303,7 +302,7 @@ export default function LicenseSettingsPage() {
             Upgrade to a paid plan to continue using AnythingMCP Cloud after your trial ends.
           </p>
           <a
-            href="https://anythingmcp.com/pricing"
+            href={buildPricingUrl()}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90"

--- a/packages/frontend/src/components/license-wall.tsx
+++ b/packages/frontend/src/components/license-wall.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { license } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
+import { buildPricingUrl } from '@/lib/marketing';
 import { LogoIcon } from '@/components/nav-bar';
 
 export function LicenseWall() {
@@ -47,7 +48,7 @@ export function LicenseWall() {
 
         <div className="space-y-3">
           <a
-            href="https://anythingmcp.com/pricing"
+            href={buildPricingUrl()}
             target="_blank"
             rel="noopener noreferrer"
             className="block w-full bg-[var(--brand)] text-white px-4 py-2.5 rounded-md text-sm font-medium hover:brightness-90 text-center"

--- a/packages/frontend/src/components/trial-banner.tsx
+++ b/packages/frontend/src/components/trial-banner.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { license } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
+import { buildPricingUrl } from '@/lib/marketing';
 
 export function TrialBanner() {
   const { token } = useAuth();
@@ -41,7 +42,7 @@ export function TrialBanner() {
       </span>
       {' '}
       <a
-        href="https://anythingmcp.com/pricing"
+        href={buildPricingUrl()}
         target="_blank"
         rel="noopener noreferrer"
         className="underline font-medium hover:no-underline"

--- a/packages/frontend/src/lib/marketing.ts
+++ b/packages/frontend/src/lib/marketing.ts
@@ -1,0 +1,17 @@
+const DEFAULT_MARKETING_URL = 'https://anythingmcp.com';
+
+export function getMarketingUrl(): string {
+  if (typeof process !== 'undefined') {
+    const env = (process as { env?: Record<string, string | undefined> }).env;
+    const fromEnv = env?.NEXT_PUBLIC_MARKETING_URL;
+    if (fromEnv) return fromEnv.replace(/\/$/, '');
+  }
+  return DEFAULT_MARKETING_URL;
+}
+
+export function buildPricingUrl(returnPath = '/settings/license/activate'): string {
+  const base = `${getMarketingUrl()}/pricing`;
+  if (typeof window === 'undefined') return base;
+  const returnUrl = `${window.location.origin}${returnPath}`;
+  return `${base}?return_url=${encodeURIComponent(returnUrl)}`;
+}


### PR DESCRIPTION
## Summary

Closes the cross-domain license-handoff gap between the cloud frontend and `anythingmcp.com/pricing`:

- **Always-visible activation field**: the "Activate License Key" section on `/settings/license` was hidden during an active cloud trial. Admins now see it at all times so a purchased key can be pasted immediately.
- **`buildPricingUrl()` helper**: every `Upgrade Plan` / `View Plans` / `Upgrade now` link now appends `?return_url=<cloud-origin>/settings/license/activate`. Driven by `NEXT_PUBLIC_MARKETING_URL` (default `https://anythingmcp.com`).
- **New `/settings/license/activate` callback page**: reads `?key=AMCP-XXXX-XXXX-XXXX-XXXX`, validates the format, calls `PUT /api/license/key` when an admin is signed in, otherwise sends the visitor through `/login?redirect=...` and resumes after sign-in. On success, redirects to `/settings/license`.

The marketing-site half of the flow lives in [anythingmcp-website#57](https://github.com/HelpCode-ai/anythingmcp-website/pull/57) — together they turn the post-checkout email-and-paste loop into a one-click redirect.

## Why

Reported by a customer who purchased a license and could not find a place to redeem it in the cloud UI: during an active trial the field was hidden, and the only path was to wait, copy-paste from email, or already know the deep URL.

## Test plan

- [ ] Sign in as admin on a cloud instance with an active trial → `/settings/license` shows the "Activate License Key" section
- [ ] Click "Upgrade Plan" / "View Plans" / the trial-banner CTA → opens `anythingmcp.com/pricing?return_url=...` with the cloud origin URL-encoded in the query
- [ ] Visit `/settings/license/activate?key=AMCP-XXXX-XXXX-XXXX-XXXX` while signed in as admin → key is activated and the page redirects to `/settings/license`
- [ ] Same URL while signed out → bounces through `/login?redirect=…` and resumes activation after sign-in
- [ ] Same URL while signed in as non-admin → shows error message instead of attempting the call
- [ ] Malformed key in URL → shows "license key in the URL is malformed" message without hitting the API