### PR TITLE
docs(sorare): no-code primary flow (claude.ai connectors, ChatGPT UI, Copilot palette) + chat bubble fix

### DIFF
--- a/content/guides/de/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/de/connect-sorare-to-chatgpt.mdx
@@ -36,41 +36,52 @@ ChatGPT unterstützt das **Model Context Protocol** in Custom Connectors und in 
 1. Bei https://sorare.com einloggen.
 2. (Optional) dediziertes Read-only-Konto ohne 2FA anlegen.
 
-### Schritt 2 — Sorare-Adapter installieren
+### Schritt 2 — Sorare-Adapter auf cloud.anythingmcp.com installieren (kein Code)
+
+1. Auf **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)** einloggen.
+2. **Connectors → Sorare → Install** öffnen.
+3. Einfügen:
+   - `SORARE_EMAIL` — deine Sorare-Kontomail
+   - `SORARE_PASSWORD` — Klartext-Passwort (wird vor dem Login lokal bcrypt-gehasht; nie unverschlüsselt gespeichert)
+4. MCP-API-Key erzeugen unter **Profile → MCP API Keys → New Key**. Kopieren.
+
+Es gibt kein AUD-Feld — der Adapter setzt den JWT-Audience-Claim fest auf `anythingmcp`.
+
+### Schritt 3 — Connector in ChatGPT einfügen (kein Code, 4 Klicks)
+
+1. In ChatGPT **Einstellungen → Connectors → Custom Connector hinzufügen** öffnen.
+2. Eintragen:
+   - **Name:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer Token → MCP-API-Key aus Schritt 2 einfügen
+3. **Speichern** klicken.
+4. ChatGPT entdeckt automatisch alle 18 Sorare-Tools und zeigt sie in der Connector-Liste.
+
+Fertig — los geht's. ChatGPT kann nur **öffentliche HTTPS-URLs** erreichen, und genau das ist `cloud.anythingmcp.com`.
+
+<details>
+<summary><strong>Fortgeschritten: AnythingMCP selbst hosten und für ChatGPT exponieren</strong></summary>
+
+Wenn du AnythingMCP lieber auf eigener Hardware betreibst, brauchst du trotzdem eine öffentliche HTTPS-URL, damit ChatGPT die Instanz erreicht.
 
 ```bash
 git clone https://github.com/HelpCode-ai/anythingmcp.git
 cd anythingmcp && docker compose up -d
 ```
 
-`http://localhost:3000/connectors/store` öffnen, **Sorare** klicken, ausfüllen:
+`http://localhost:3000/connectors/store` öffnen, Sorare installieren, Key erzeugen, dann Port 4000 via Cloudflare Tunnel, ngrok oder eigenem TLS-Reverse-Proxy exponieren. Diese HTTPS-URL im ChatGPT-Connector-Formular statt `cloud.anythingmcp.com` verwenden.
 
-| Feld | Wert |
+</details>
+
+### Verfügbare Tools (18 insgesamt)
+
+| Gruppe | Tools |
 |---|---|
-| `SORARE_EMAIL` | Kontomail |
-| `SORARE_PASSWORD` | Klartext-Passwort |
-
-### Schritt 3 — MCP-Connector in ChatGPT hinzufügen
-
-1. In AnythingMCP MCP-API-Key erzeugen: **Profile → MCP API Keys → New Key**.
-2. In ChatGPT: **Einstellungen → Connectors → Custom Connector hinzufügen**.
-3. Eintragen:
-   - **Name**: `Sorare`
-   - **URL**: `https://dein-anythingmcp-host/mcp` (öffentliche HTTPS-URL — ChatGPT erreicht `localhost` nicht; via Cloudflare Tunnel / ngrok / cloud.anythingmcp.com bereitstellen).
-   - **Authentication**: Bearer Token → MCP-API-Key einfügen.
-4. Speichern. ChatGPT entdeckt die 18 Sorare-Tools automatisch.
-
-### Verfügbare Tools
-
-| Tool | Beschreibung |
-|---|---|
-| `sorare_current_user` | Sorare-Profil |
-| `sorare_get_card_by_slug` | Karten-Metadaten + Besitzer + Auktion |
-| `sorare_search_player` | Spielersuche |
-| `sorare_list_player_cards` | Aktuelle Karten zu einem Spieler |
-| `sorare_list_my_cards` | Eigene Karten |
-| `sorare_get_lineup` | So5-Aufstellung |
-| `sorare_transfer_market` | Aktive Auktionen, filterbar |
+| **Identität / Wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Karten / Inventar** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Spieler / Form** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Markt & Auktionen** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **Generic GraphQL Notausgang** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
 
 ## Mehr als die 18 Tools — deine KI ruft *jeden* Sorare-GraphQL-Endpoint auf

--- a/content/guides/de/connect-sorare-to-claude.mdx
+++ b/content/guides/de/connect-sorare-to-claude.mdx
@@ -52,15 +52,32 @@ cd anythingmcp && docker compose up -d
 
 **Install** klicken — der Adapter steht mit 18 Tools (5 GraphQL-Builtins + 13 dedizierte) im Katalog.
 
-### Schritt 3 — Claude Desktop konfigurieren
+### Schritt 3 — Connector in Claude einfügen (kein Code, 4 Klicks)
 
-MCP-API-Key unter **Profile → MCP API Keys** erzeugen, dann in `~/Library/Application Support/Claude/claude_desktop_config.json`:
+Das ist der empfohlene Weg — funktioniert in der **claude.ai Web-App** ohne eine einzige Config-Datei.
+
+1. Öffne **[claude.ai/customize/connectors](https://claude.ai/customize/connectors)**.
+2. Klicke **"Add custom connector"**.
+3. Fülle aus:
+   - **Name:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer Token → MCP-API-Key einfügen (aus AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. **Connect** klicken zum Autorisieren.
+
+Fertig. Alle 18 Sorare-Tools erscheinen sofort im Chat — einfach Prompts schreiben. Token-Cache, Refresh und bcrypt-Anmeldung passieren server-seitig; du siehst davon nie etwas.
+
+<details>
+<summary><strong>Fortgeschritten: Claude Desktop / Claude Code (JSON / CLI)</strong></summary>
+
+Für die **Desktop-Apps** greift die Web-UI nicht — du editierst stattdessen eine lokale Config-Datei.
+
+**Claude Desktop** — bearbeite `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) oder `%AppData%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
   "mcpServers": {
     "sorare": {
-      "url": "http://localhost:4000/mcp",
+      "url": "https://cloud.anythingmcp.com/mcp",
       "headers": {
         "Authorization": "Bearer DEIN_MCP_API_KEY"
       }
@@ -71,17 +88,28 @@ MCP-API-Key unter **Profile → MCP API Keys** erzeugen, dann in `~/Library/Appl
 
 Claude Desktop neu starten. Sorare-Tools erscheinen im 🔧-Menü.
 
-### Verfügbare Tools
+**Claude Code** — ein CLI-Befehl:
 
-| Tool | Beschreibung |
+```bash
+claude mcp add sorare \
+  --transport http \
+  --url https://cloud.anythingmcp.com/mcp \
+  --header "Authorization: Bearer DEIN_MCP_API_KEY"
+```
+
+Mit `claude mcp list` verifizieren.
+
+</details>
+
+### Verfügbare Tools (18 insgesamt)
+
+| Gruppe | Tools |
 |---|---|
-| `sorare_current_user` | Eigenes Profil |
-| `sorare_get_card_by_slug` | Kartendetails per Slug |
-| `sorare_search_player` | Spielersuche nach Name |
-| `sorare_list_player_cards` | Aktuelle Karten zu einem Spieler |
-| `sorare_list_my_cards` | Eigene Karten |
-| `sorare_get_lineup` | So5-Score + Reward |
-| `sorare_transfer_market` | Aktive Auktionen, filterbar |
+| **Identität / Wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Karten / Inventar** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Spieler / Form** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Markt & Auktionen** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **Generic GraphQL Notausgang** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
 
 ## Mehr als die 18 Tools — deine KI ruft *jeden* Sorare-GraphQL-Endpoint auf

--- a/content/guides/de/connect-sorare-to-copilot.mdx
+++ b/content/guides/de/connect-sorare-to-copilot.mdx
@@ -31,31 +31,42 @@ GitHub Copilot Chat unterstützt jetzt das **Model Context Protocol (MCP)** übe
 - AnythingMCP lokal oder auf cloud.anythingmcp.com (3-Minuten-Setup).
 - GitHub Copilot Chat mit MCP-Support (VS Code Insiders ≥ 1.95 oder JetBrains-Plugin mit MCP).
 
-### Schritt 1 — Sorare-Adapter installieren
+### Schritt 1 — Sorare-Adapter auf cloud.anythingmcp.com installieren (kein Code)
 
-```bash
-git clone https://github.com/HelpCode-ai/anythingmcp.git
-cd anythingmcp && docker compose up -d
-```
+1. Auf **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)** einloggen.
+2. **Connectors → Sorare → Install** öffnen.
+3. Einfügen:
+   - `SORARE_EMAIL` — deine Sorare-Kontomail
+   - `SORARE_PASSWORD` — Klartext-Passwort (wird vor dem Login lokal bcrypt-gehasht; nie unverschlüsselt gespeichert)
+4. MCP-API-Key erzeugen unter **Profile → MCP API Keys → New Key**. Kopieren.
 
-Öffne `http://localhost:3000/connectors/store`, klicke **Sorare** und trage ein:
+Es gibt kein AUD-Feld — der Adapter setzt den JWT-Audience-Claim fest auf `anythingmcp`.
 
-| Feld | Wert |
-|---|---|
-| `SORARE_EMAIL` | Kontomail |
-| `SORARE_PASSWORD` | Klartext-Passwort (vor Login lokal bcrypt-gehasht) |
+### Schritt 2 — Sorare in Copilot einfügen (kein Code, Command Palette)
 
-Erstelle einen MCP-API-Key unter **Profile → MCP API Keys**.
+In VS Code (Insiders ≥ 1.95, oder Stable mit MCP-Support):
 
-### Schritt 2 — Sorare in Copilots MCP-Server einfügen
+1. **Cmd/Ctrl + Shift + P** öffnet die Command Palette.
+2. **`MCP: Add Server`** tippen und die HTTP-Option wählen.
+3. Eintragen:
+   - **Server URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authorization Header:** `Bearer DEIN_MCP_API_KEY` (aus Schritt 1)
+4. Server `sorare` nennen und bestätigen.
 
-In VS Code: Einstellungen → suche **Copilot: MCP servers** → ergänze:
+VS Code startet Copilot Chat automatisch neu. Alle 18 Sorare-Tools tauchen im Copilot-Tool-Picker auf — los geht's.
+
+> **JetBrains?** Gleicher Flow — Copilot-Panel öffnen → MCP servers → Add server → URL + Bearer Token einfügen.
+
+<details>
+<summary><strong>Fortgeschritten: <code>settings.json</code> manuell editieren</strong></summary>
+
+Wenn du die Config-Datei direkt bearbeiten willst, öffne `settings.json` (Cmd/Ctrl + Shift + P → "Preferences: Open User Settings (JSON)") und ergänze:
 
 ```json
 {
   "mcp.servers": {
     "sorare": {
-      "url": "http://localhost:4000/mcp",
+      "url": "https://cloud.anythingmcp.com/mcp",
       "transport": "http",
       "headers": {
         "Authorization": "Bearer DEIN_MCP_API_KEY"
@@ -65,9 +76,9 @@ In VS Code: Einstellungen → suche **Copilot: MCP servers** → ergänze:
 }
 ```
 
-Für Cloud: ersetze die URL durch `https://cloud.anythingmcp.com/mcp`.
-
 Copilot Chat neu starten. Die 18 Sorare-Tools tauchen automatisch auf — Copilot wählt das passende Tool je nach Prompt.
+
+</details>
 
 ### Verfügbare Tools (18)
 

--- a/content/guides/de/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/de/sorare-now-on-anythingmcp.mdx
@@ -42,32 +42,32 @@ Dein KI-Client greift dabei nicht nur auf eine feste Auswahl vorgebackener Tools
 <div className="p-6 space-y-6 text-sm">
 
 <div className="flex gap-3 justify-end">
-  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 text-white px-4 py-3 shadow-md">
-    Ich hab <strong>100 €</strong> für Sorare diese Woche. Such mir 3 Limited-Karten, die <strong>nächsten Spieltag punkten</strong> und <strong>30 %+ unter ihrem 30-Tage-Schnitt</strong> liegen. Nur Top-5-Ligen.
+  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 px-4 py-3 shadow-md" style={{color: '#ffffff'}}>
+    <span style={{color: '#ffffff'}}>Ich hab <strong style={{color: '#ffffff'}}>100 €</strong> für Sorare diese Woche. Such mir 3 Limited-Karten, die <strong style={{color: '#ffffff'}}>nächsten Spieltag punkten</strong> und <strong style={{color: '#ffffff'}}>30 %+ unter ihrem 30-Tage-Schnitt</strong> liegen. Nur Top-5-Ligen.</span>
   </div>
-  <div className="size-9 rounded-full bg-blue-600 text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">DU</div>
+  <div className="size-9 rounded-full bg-blue-600 !text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">DU</div>
 </div>
 
 <div className="flex gap-3">
-  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
+  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 !text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
   <div className="max-w-[90%] space-y-3 flex-1">
 
-  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     Ich hole erst dein Wallet + deine Sammlung, damit ich keine Doppel empfehle, dann scanne ich die letzten So5-Top-Scorer und gleiche mit den aktuellen Marktpreisen ab.
   </div>
 
-  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+  <div className="rounded-xl bg-zinc-950 !text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_wallet_balance</span>()</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">73,45 € EUR · 0.0042 ETH</span></div>
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_list_my_cards</span>(rarities: ["limited"])</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">6 Karten (überwiegend 2021-22, schwach)</span></div>
   </div>
 
-  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     Deine aktuellen Limiteds sind alte Vintages aus Nebenliegen — füllen die Lücke nicht. Ich gehe frisch ran. Ich frag das Schema nach dem besten "Form vs Preis"-Winkel und schick dann eine eigene GraphQL gegen den Transfermarkt.
   </div>
 
-  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+  <div className="rounded-xl bg-zinc-950 !text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_schema</span>(search: "topPerformers")</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">Gefunden: football.topPerformers(window, league)</span></div>
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_query</span>(<span className="text-amber-300">custom: Top-5-Ligen, letzte 5 GWs, avg &gt;35</span>)</div>
@@ -77,7 +77,7 @@ Dein KI-Client greift dabei nicht nur auf eine feste Auswahl vorgebackener Tools
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">3 Kandidaten &gt;30 % unter 30-Tage-Schnitt ✓</span></div>
   </div>
 
-  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     <div className="font-semibold mb-2">Deine Kaufliste — 68 € total, 32 € Reserve</div>
     <ol className="space-y-1.5 list-decimal ml-5 text-[13px]">
       <li><strong>Calafiori (Arsenal)</strong> · Limited · <strong>3,20 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— 40 % unter 30-Tage-Schnitt, Stamm</span></li>

--- a/content/guides/en/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/en/connect-sorare-to-chatgpt.mdx
@@ -36,41 +36,52 @@ ChatGPT supports the **Model Context Protocol** in custom connectors and in the 
 1. Sign in to https://sorare.com.
 2. (Optional) create a dedicated read-only Sorare account for MCP and disable 2FA on it.
 
-### Step 2 — Install the Sorare adapter
+### Step 2 — Install the Sorare adapter on cloud.anythingmcp.com (no code)
+
+1. Sign in on **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)**.
+2. Open **Connectors → Sorare → Install**.
+3. Paste:
+   - `SORARE_EMAIL` — your Sorare account email
+   - `SORARE_PASSWORD` — your plain password (bcrypt-hashed locally before login; never stored unencrypted)
+4. Mint an MCP API key under **Profile → MCP API Keys → New Key**. Copy it.
+
+There is no AUD field — the adapter hardcodes the JWT audience to `anythingmcp`.
+
+### Step 3 — Add the connector in ChatGPT (no code, 4 clicks)
+
+1. In ChatGPT, open **Settings → Connectors → Add custom connector**.
+2. Fill in:
+   - **Name:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → paste the MCP API key from Step 2
+3. Click **Save**.
+4. ChatGPT auto-discovers all 18 Sorare tools and they appear in the connector list.
+
+That's it — start prompting. ChatGPT can only reach **public HTTPS** URLs, which is exactly what `cloud.anythingmcp.com` is.
+
+<details>
+<summary><strong>Advanced: self-host AnythingMCP and expose it to ChatGPT</strong></summary>
+
+If you'd rather run AnythingMCP on your own hardware, you still need a public HTTPS URL so ChatGPT can reach it.
 
 ```bash
 git clone https://github.com/HelpCode-ai/anythingmcp.git
 cd anythingmcp && docker compose up -d
 ```
 
-Open `http://localhost:3000/connectors/store`, click **Sorare**, and provide:
+Open `http://localhost:3000/connectors/store`, install Sorare, mint a key, then expose port 4000 via Cloudflare Tunnel, ngrok or any reverse proxy with TLS. Use that HTTPS URL in the ChatGPT connector form instead of `cloud.anythingmcp.com`.
 
-| Field | Value |
+</details>
+
+### Available tools (18 total)
+
+| Group | Tools |
 |---|---|
-| `SORARE_EMAIL` | account email |
-| `SORARE_PASSWORD` | plain password |
-
-### Step 3 — Add the MCP connector in ChatGPT
-
-1. Mint an MCP API key in AnythingMCP: **Profile → MCP API Keys → New Key**.
-2. In ChatGPT, open **Settings → Connectors → Add custom connector**.
-3. Fill in:
-   - **Name**: `Sorare`
-   - **URL**: `https://your-anythingmcp-host/mcp` (use a public HTTPS URL — ChatGPT cannot reach `localhost`; expose with Cloudflare Tunnel / ngrok / cloud.anythingmcp.com).
-   - **Authentication**: Bearer token → paste the MCP API key.
-4. Save. ChatGPT auto-discovers the 18 Sorare tools.
-
-### Available tools
-
-| Tool | Description |
-|---|---|
-| `sorare_current_user` | Your Sorare profile |
-| `sorare_get_card_by_slug` | Card metadata + owner + auction |
-| `sorare_search_player` | Players by name |
-| `sorare_list_player_cards` | Recent cards for a player |
-| `sorare_list_my_cards` | Your owned cards |
-| `sorare_get_lineup` | So5 lineup details |
-| `sorare_transfer_market` | Active auctions, filterable |
+| **Identity / wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Cards / inventory** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Players / form** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Market & auctions** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **Generic GraphQL escape hatch** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
 
 ## Beyond the 18 tools — your AI calls *any* Sorare GraphQL operation

--- a/content/guides/en/connect-sorare-to-claude.mdx
+++ b/content/guides/en/connect-sorare-to-claude.mdx
@@ -52,15 +52,32 @@ Open `http://localhost:3000/connectors/store`, click **Sorare**, and fill in:
 
 Click **Install** — the adapter is now in your catalog with 18 tools (5 GraphQL builtins + 13 dedicated).
 
-### Step 3 — Wire up Claude Desktop
+### Step 3 — Add the connector in Claude (no code, 4 clicks)
 
-Mint an MCP API key in **Profile → MCP API Keys**, then add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+This is the recommended path — works on **claude.ai web** without touching any config file.
+
+1. Open **[claude.ai/customize/connectors](https://claude.ai/customize/connectors)**.
+2. Click **"Add custom connector"**.
+3. Fill in:
+   - **Name:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → paste your MCP API key (from AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Click **Connect** to authorize.
+
+That's it. All 18 Sorare tools appear in your chat — start typing prompts. The token cache, refresh and bcrypt sign-in are all handled server-side; you never see them.
+
+<details>
+<summary><strong>Advanced: Claude Desktop / Claude Code (JSON / CLI)</strong></summary>
+
+For the **desktop apps**, the web UI doesn't apply — you edit a local config file instead.
+
+**Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%AppData%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
   "mcpServers": {
     "sorare": {
-      "url": "http://localhost:4000/mcp",
+      "url": "https://cloud.anythingmcp.com/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_MCP_API_KEY"
       }
@@ -71,17 +88,28 @@ Mint an MCP API key in **Profile → MCP API Keys**, then add to `~/Library/Appl
 
 Restart Claude Desktop. Sorare tools appear in the 🔧 menu.
 
-### Available tools
+**Claude Code** — one CLI command:
 
-| Tool | Description |
+```bash
+claude mcp add sorare \
+  --transport http \
+  --url https://cloud.anythingmcp.com/mcp \
+  --header "Authorization: Bearer YOUR_MCP_API_KEY"
+```
+
+Verify with `claude mcp list`.
+
+</details>
+
+### Available tools (18 total)
+
+| Group | Tools |
 |---|---|
-| `sorare_current_user` | Get your authenticated profile |
-| `sorare_get_card_by_slug` | Card details by slug |
-| `sorare_search_player` | Search players by name |
-| `sorare_list_player_cards` | Recent cards for a player |
-| `sorare_list_my_cards` | Your owned cards |
-| `sorare_get_lineup` | So5 lineup score + reward |
-| `sorare_transfer_market` | Active auctions, filterable |
+| **Identity / wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Cards / inventory** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Players / form** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Market & auctions** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **Generic GraphQL escape hatch** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
 
 ## Beyond the 18 tools — your AI calls *any* Sorare GraphQL operation

--- a/content/guides/en/connect-sorare-to-copilot.mdx
+++ b/content/guides/en/connect-sorare-to-copilot.mdx
@@ -31,31 +31,42 @@ GitHub Copilot Chat now supports the **Model Context Protocol (MCP)** through it
 - AnythingMCP running locally or available on cloud.anythingmcp.com (3-minute setup).
 - GitHub Copilot Chat with MCP enabled (VS Code Insiders ≥ 1.95 or JetBrains plugin with MCP support).
 
-### Step 1 — Install the Sorare adapter
+### Step 1 — Install the Sorare adapter on cloud.anythingmcp.com (no code)
 
-```bash
-git clone https://github.com/HelpCode-ai/anythingmcp.git
-cd anythingmcp && docker compose up -d
-```
+1. Sign in on **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)**.
+2. Open **Connectors → Sorare → Install**.
+3. Paste:
+   - `SORARE_EMAIL` — your Sorare account email
+   - `SORARE_PASSWORD` — your plain password (bcrypt-hashed locally before login; never stored unencrypted)
+4. Mint an MCP API key under **Profile → MCP API Keys → New Key**. Copy it.
 
-Open `http://localhost:3000/connectors/store`, click **Sorare**, and provide:
+There is no AUD field — the adapter hardcodes the JWT audience to `anythingmcp`.
 
-| Field | Value |
-|---|---|
-| `SORARE_EMAIL` | account email |
-| `SORARE_PASSWORD` | plain password (bcrypt-hashed locally before login) |
+### Step 2 — Add Sorare to Copilot (no code, command palette)
 
-Mint an MCP API key in **Profile → MCP API Keys**.
+In VS Code (Insiders ≥ 1.95, or stable with MCP support):
 
-### Step 2 — Add Sorare to Copilot's MCP servers
+1. **Cmd/Ctrl + Shift + P** to open the Command Palette.
+2. Type **`MCP: Add Server`** and pick the HTTP option.
+3. Paste:
+   - **Server URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authorization header:** `Bearer YOUR_MCP_API_KEY` (the one from Step 1)
+4. Name the server `sorare` and confirm.
 
-In VS Code, open settings → search for **Copilot: MCP servers** → add:
+VS Code restarts Copilot Chat automatically. All 18 Sorare tools appear in the Copilot tool picker — start typing prompts.
+
+> **JetBrains?** Same flow — open the Copilot panel → MCP servers → Add server → paste the URL + Bearer token.
+
+<details>
+<summary><strong>Advanced: edit <code>settings.json</code> manually</strong></summary>
+
+If you'd rather edit the config file directly, open `settings.json` (Cmd/Ctrl + Shift + P → "Preferences: Open User Settings (JSON)") and add:
 
 ```json
 {
   "mcp.servers": {
     "sorare": {
-      "url": "http://localhost:4000/mcp",
+      "url": "https://cloud.anythingmcp.com/mcp",
       "transport": "http",
       "headers": {
         "Authorization": "Bearer YOUR_MCP_API_KEY"
@@ -65,9 +76,9 @@ In VS Code, open settings → search for **Copilot: MCP servers** → add:
 }
 ```
 
-For cloud, swap the URL for `https://cloud.anythingmcp.com/mcp`.
+Restart Copilot Chat. The 18 Sorare tools appear automatically — Copilot picks the right one based on your prompt.
 
-Restart Copilot Chat. The 18 Sorare tools appear automatically — Copilot will pick the right one based on your prompt.
+</details>
 
 ### Available tools (18)
 

--- a/content/guides/en/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/en/sorare-now-on-anythingmcp.mdx
@@ -42,32 +42,32 @@ Your AI client doesn't just call a fixed set of pre-baked tools — it has **the
 <div className="p-6 space-y-6 text-sm">
 
 <div className="flex gap-3 justify-end">
-  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 text-white px-4 py-3 shadow-md">
-    I've got <strong>€100</strong> for Sorare this week. Find me 3 Limited cards <strong>likely to score next gameweek</strong> that are <strong>30%+ under their 30-day average</strong>. Top 5 European leagues.
+  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 px-4 py-3 shadow-md" style={{color: '#ffffff'}}>
+    <span style={{color: '#ffffff'}}>I've got <strong style={{color: '#ffffff'}}>€100</strong> for Sorare this week. Find me 3 Limited cards <strong style={{color: '#ffffff'}}>likely to score next gameweek</strong> that are <strong style={{color: '#ffffff'}}>30%+ under their 30-day average</strong>. Top 5 European leagues.</span>
   </div>
-  <div className="size-9 rounded-full bg-blue-600 text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">YOU</div>
+  <div className="size-9 rounded-full bg-blue-600 !text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">YOU</div>
 </div>
 
 <div className="flex gap-3">
-  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
+  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 !text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
   <div className="max-w-[90%] space-y-3 flex-1">
 
-  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     Pulling your wallet + collection first so I don't recommend duplicates, then I'll scan recent So5 scorers and cross-check current market prices.
   </div>
 
-  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+  <div className="rounded-xl bg-zinc-950 !text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_wallet_balance</span>()</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">€73.45 EUR · 0.0042 ETH</span></div>
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_list_my_cards</span>(rarities: ["limited"])</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">6 cards (mostly 2021-22, weak)</span></div>
   </div>
 
-  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     Your current Limiteds are all old vintages from minor leagues — won't fill the gap. I'll go fresh. Let me query the schema for the best "form vs price" angle, then run a custom GraphQL against the transfer market.
   </div>
 
-  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+  <div className="rounded-xl bg-zinc-950 !text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_schema</span>(search: "topPerformers")</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">Found: football.topPerformers(window, league)</span></div>
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_query</span>(<span className="text-amber-300">custom query: top5 leagues, last 5 GWs, avg score &gt;35</span>)</div>
@@ -77,7 +77,7 @@ Your AI client doesn't just call a fixed set of pre-baked tools — it has **the
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">3 candidates &gt;30% below 30-day avg ✓</span></div>
   </div>
 
-  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     <div className="font-semibold mb-2">Here's your buy list — €68 total, €32 reserve</div>
     <ol className="space-y-1.5 list-decimal ml-5 text-[13px]">
       <li><strong>Calafiori (Arsenal)</strong> · Limited · <strong>€3.20</strong> <span className="text-emerald-700 dark:text-emerald-400">— 40% under 30d avg, titulair</span></li>

--- a/content/guides/it/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/it/connect-sorare-to-chatgpt.mdx
@@ -36,41 +36,52 @@ ChatGPT supporta il **Model Context Protocol** nei custom connector e nell'area 
 1. Login su https://sorare.com.
 2. (Opzionale) crea un account Sorare dedicato in sola lettura e disattiva la 2FA.
 
-### Step 2 — Installa l'adapter Sorare
+### Step 2 — Installa l'adapter Sorare su cloud.anythingmcp.com (no code)
+
+1. Accedi su **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)**.
+2. Apri **Connectors → Sorare → Install**.
+3. Inserisci:
+   - `SORARE_EMAIL` — email del tuo account Sorare
+   - `SORARE_PASSWORD` — password in chiaro (hashata bcrypt localmente prima del login; non viene mai salvata in chiaro)
+4. Genera una MCP API key in **Profile → MCP API Keys → New Key**. Copiala.
+
+Non c'è un campo AUD — l'adapter fissa l'audience del JWT a `anythingmcp`.
+
+### Step 3 — Aggiungi il connector in ChatGPT (no code, 4 clic)
+
+1. In ChatGPT apri **Impostazioni → Connectors → Aggiungi custom connector**.
+2. Compila:
+   - **Nome:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → incolla la MCP API key dallo Step 2
+3. Clicca **Salva**.
+4. ChatGPT scopre automaticamente tutti e 18 i tool Sorare e li mostra nell'elenco connector.
+
+Fatto — vai con i prompt. ChatGPT può raggiungere solo URL **HTTPS pubblici**, ed è esattamente quello che è `cloud.anythingmcp.com`.
+
+<details>
+<summary><strong>Avanzato: self-host AnythingMCP esposto a ChatGPT</strong></summary>
+
+Se vuoi far girare AnythingMCP sul tuo hardware, ti serve comunque un URL HTTPS pubblico perché ChatGPT lo raggiunga.
 
 ```bash
 git clone https://github.com/HelpCode-ai/anythingmcp.git
 cd anythingmcp && docker compose up -d
 ```
 
-Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e inserisci:
+Apri `http://localhost:3000/connectors/store`, installa Sorare, genera la key, poi esponi la porta 4000 via Cloudflare Tunnel, ngrok o un reverse proxy con TLS. Usa quell'URL HTTPS nel form del connector ChatGPT invece di `cloud.anythingmcp.com`.
 
-| Campo | Valore |
+</details>
+
+### Tool disponibili (18 totali)
+
+| Gruppo | Tool |
 |---|---|
-| `SORARE_EMAIL` | email account |
-| `SORARE_PASSWORD` | password in chiaro |
-
-### Step 3 — Aggiungi il connector MCP a ChatGPT
-
-1. In AnythingMCP genera una MCP API key: **Profile → MCP API Keys → New Key**.
-2. In ChatGPT: **Impostazioni → Connectors → Aggiungi custom connector**.
-3. Compila:
-   - **Nome**: `Sorare`
-   - **URL**: `https://il-tuo-host-anythingmcp/mcp` (URL HTTPS pubblico — ChatGPT non vede `localhost`; esponi via Cloudflare Tunnel / ngrok / cloud.anythingmcp.com).
-   - **Authentication**: Bearer token → incolla la MCP API key.
-4. Salva. ChatGPT scopre automaticamente i 18 tool Sorare.
-
-### Tool disponibili
-
-| Tool | Descrizione |
-|---|---|
-| `sorare_current_user` | Profilo Sorare |
-| `sorare_get_card_by_slug` | Metadata carta + proprietario + asta |
-| `sorare_search_player` | Ricerca giocatori |
-| `sorare_list_player_cards` | Carte recenti di un giocatore |
-| `sorare_list_my_cards` | Le tue carte |
-| `sorare_get_lineup` | Dettagli line-up So5 |
-| `sorare_transfer_market` | Aste attive, filtrabili |
+| **Identità / wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Carte / inventario** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Giocatori / forma** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Mercato & aste** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **GraphQL escape hatch** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
 
 ## Oltre i 18 tool — la tua AI chiama *qualsiasi* endpoint GraphQL di Sorare

--- a/content/guides/it/connect-sorare-to-claude.mdx
+++ b/content/guides/it/connect-sorare-to-claude.mdx
@@ -52,15 +52,32 @@ Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e compila:
 
 Clicca **Install** — l'adapter è nel catalogo con 18 tool (5 GraphQL builtins + 13 dedicati).
 
-### Step 3 — Configura Claude Desktop
+### Step 3 — Aggiungi il connector in Claude (no code, 4 clic)
 
-Crea una MCP API key in **Profile → MCP API Keys**, poi aggiungi a `~/Library/Application Support/Claude/claude_desktop_config.json`:
+Questo è il percorso consigliato — funziona nella **web app claude.ai** senza toccare nessun file di configurazione.
+
+1. Apri **[claude.ai/customize/connectors](https://claude.ai/customize/connectors)**.
+2. Clicca **"Add custom connector"**.
+3. Compila:
+   - **Name:** `Sorare`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → incolla la tua MCP API key (da AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Clicca **Connect** per autorizzare.
+
+Fatto. Tutti e 18 i tool Sorare appaiono subito in chat — inizia a scrivere prompt. Cache del token, refresh e login bcrypt sono gestiti server-side; non li vedi mai.
+
+<details>
+<summary><strong>Avanzato: Claude Desktop / Claude Code (JSON / CLI)</strong></summary>
+
+Per le **app desktop** la UI web non si applica — modifichi un file di configurazione locale.
+
+**Claude Desktop** — edita `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o `%AppData%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
   "mcpServers": {
     "sorare": {
-      "url": "http://localhost:4000/mcp",
+      "url": "https://cloud.anythingmcp.com/mcp",
       "headers": {
         "Authorization": "Bearer LA_TUA_MCP_API_KEY"
       }
@@ -71,17 +88,28 @@ Crea una MCP API key in **Profile → MCP API Keys**, poi aggiungi a `~/Library/
 
 Riavvia Claude Desktop. I tool Sorare compaiono nel menu 🔧.
 
-### Tool disponibili
+**Claude Code** — un comando CLI:
 
-| Tool | Descrizione |
+```bash
+claude mcp add sorare \
+  --transport http \
+  --url https://cloud.anythingmcp.com/mcp \
+  --header "Authorization: Bearer LA_TUA_MCP_API_KEY"
+```
+
+Verifica con `claude mcp list`.
+
+</details>
+
+### Tool disponibili (18 totali)
+
+| Gruppo | Tool |
 |---|---|
-| `sorare_current_user` | Profilo autenticato |
-| `sorare_get_card_by_slug` | Dettagli carta per slug |
-| `sorare_search_player` | Ricerca giocatori per nome |
-| `sorare_list_player_cards` | Carte recenti di un giocatore |
-| `sorare_list_my_cards` | Le tue carte |
-| `sorare_get_lineup` | Line-up So5 con score + reward |
-| `sorare_transfer_market` | Aste attive, filtrabili |
+| **Identità / wallet** | `sorare_current_user`, `sorare_wallet_balance`, `sorare_my_trophies_summary`, `sorare_user_by_slug` |
+| **Carte / inventario** | `sorare_list_my_cards`, `sorare_get_card_by_slug`, `sorare_list_player_cards` |
+| **Giocatori / forma** | `sorare_search_player`, `sorare_player_recent_scores`, `sorare_player_floor_price` |
+| **Mercato & aste** | `sorare_live_sale_offers`, `sorare_token_prices`, `sorare_get_auction`, `sorare_get_lineup` |
+| **GraphQL escape hatch** | `sorare_graphql_schema_url`, `sorare_graphql_schema`, `sorare_graphql_query`, `sorare_graphql_mutation`, `sorare_graphql_subscription` |
 
 
 ## Oltre i 18 tool — la tua AI chiama *qualsiasi* endpoint GraphQL di Sorare

--- a/content/guides/it/connect-sorare-to-copilot.mdx
+++ b/content/guides/it/connect-sorare-to-copilot.mdx
@@ -31,31 +31,42 @@ GitHub Copilot Chat ora supporta il **Model Context Protocol (MCP)** tramite la 
 - AnythingMCP in locale o su cloud.anythingmcp.com (setup di 3 minuti).
 - GitHub Copilot Chat con MCP abilitato (VS Code Insiders ≥ 1.95 o plugin JetBrains con MCP).
 
-### Step 1 — Installa l'adapter Sorare
+### Step 1 — Installa l'adapter Sorare su cloud.anythingmcp.com (no code)
 
-```bash
-git clone https://github.com/HelpCode-ai/anythingmcp.git
-cd anythingmcp && docker compose up -d
-```
+1. Accedi su **[cloud.anythingmcp.com](https://cloud.anythingmcp.com)**.
+2. Apri **Connectors → Sorare → Install**.
+3. Inserisci:
+   - `SORARE_EMAIL` — email del tuo account Sorare
+   - `SORARE_PASSWORD` — password in chiaro (hashata bcrypt localmente prima del login; non viene mai salvata in chiaro)
+4. Genera una MCP API key in **Profile → MCP API Keys → New Key**. Copiala.
 
-Apri `http://localhost:3000/connectors/store`, clicca **Sorare** e inserisci:
+Non c'è un campo AUD — l'adapter fissa l'audience del JWT a `anythingmcp`.
 
-| Campo | Valore |
-|---|---|
-| `SORARE_EMAIL` | email account |
-| `SORARE_PASSWORD` | password in chiaro (hashata bcrypt localmente prima del login) |
+### Step 2 — Aggiungi Sorare a Copilot (no code, Command Palette)
 
-Genera una MCP API key in **Profile → MCP API Keys**.
+In VS Code (Insiders ≥ 1.95, o Stable con supporto MCP):
 
-### Step 2 — Aggiungi Sorare ai server MCP di Copilot
+1. **Cmd/Ctrl + Shift + P** per aprire la Command Palette.
+2. Scrivi **`MCP: Add Server`** e seleziona l'opzione HTTP.
+3. Inserisci:
+   - **Server URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authorization header:** `Bearer LA_TUA_MCP_API_KEY` (dallo Step 1)
+4. Chiama il server `sorare` e conferma.
 
-In VS Code: Impostazioni → cerca **Copilot: MCP servers** → aggiungi:
+VS Code riavvia Copilot Chat in automatico. Tutti e 18 i tool Sorare appaiono nel picker tool di Copilot — vai con i prompt.
+
+> **JetBrains?** Stesso flusso — apri il pannello Copilot → MCP servers → Add server → incolla URL + Bearer token.
+
+<details>
+<summary><strong>Avanzato: editing manuale di <code>settings.json</code></strong></summary>
+
+Se preferisci editare direttamente il file di config, apri `settings.json` (Cmd/Ctrl + Shift + P → "Preferences: Open User Settings (JSON)") e aggiungi:
 
 ```json
 {
   "mcp.servers": {
     "sorare": {
-      "url": "http://localhost:4000/mcp",
+      "url": "https://cloud.anythingmcp.com/mcp",
       "transport": "http",
       "headers": {
         "Authorization": "Bearer LA_TUA_MCP_API_KEY"
@@ -65,9 +76,9 @@ In VS Code: Impostazioni → cerca **Copilot: MCP servers** → aggiungi:
 }
 ```
 
-Per cloud: sostituisci l'URL con `https://cloud.anythingmcp.com/mcp`.
-
 Riavvia Copilot Chat. I 18 tool Sorare compaiono in automatico — Copilot sceglie il tool giusto in base al prompt.
+
+</details>
 
 ### Tool disponibili (18)
 

--- a/content/guides/it/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/it/sorare-now-on-anythingmcp.mdx
@@ -42,32 +42,32 @@ Il tuo client AI non chiama un set fisso di tool pre-confezionati — ha a dispo
 <div className="p-6 space-y-6 text-sm">
 
 <div className="flex gap-3 justify-end">
-  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 text-white px-4 py-3 shadow-md">
-    Ho <strong>100 €</strong> da spendere su Sorare questa settimana. Trovami 3 Limited <strong>che probabilmente faranno punti la prossima GW</strong> e che sono <strong>30 %+ sotto la loro media a 30 giorni</strong>. Solo Top 5 europee.
+  <div className="max-w-[85%] rounded-2xl rounded-tr-md bg-blue-600 px-4 py-3 shadow-md" style={{color: '#ffffff'}}>
+    <span style={{color: '#ffffff'}}>Ho <strong style={{color: '#ffffff'}}>100 €</strong> da spendere su Sorare questa settimana. Trovami 3 Limited <strong style={{color: '#ffffff'}}>che probabilmente faranno punti la prossima GW</strong> e che sono <strong style={{color: '#ffffff'}}>30 %+ sotto la loro media a 30 giorni</strong>. Solo Top 5 europee.</span>
   </div>
-  <div className="size-9 rounded-full bg-blue-600 text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">TU</div>
+  <div className="size-9 rounded-full bg-blue-600 !text-white grid place-items-center font-semibold text-xs flex-shrink-0 shadow">TU</div>
 </div>
 
 <div className="flex gap-3">
-  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
+  <div className="size-9 rounded-full bg-gradient-to-br from-orange-500 to-red-600 !text-white grid place-items-center font-semibold text-[10px] flex-shrink-0 shadow">CLAUDE</div>
   <div className="max-w-[90%] space-y-3 flex-1">
 
-  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     Prima controllo wallet + collezione per non consigliarti doppioni, poi scansiono i top So5 recenti e incrocio con i prezzi di mercato attuali.
   </div>
 
-  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+  <div className="rounded-xl bg-zinc-950 !text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_wallet_balance</span>()</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">73,45 € EUR · 0.0042 ETH</span></div>
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_list_my_cards</span>(rarities: ["limited"])</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">6 carte (per lo più 2021-22, deboli)</span></div>
   </div>
 
-  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-zinc-100 dark:bg-zinc-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     Le tue Limited attuali sono vintage di leghe minori — non riempiono il gap. Vado fresco. Chiedo allo schema il modo migliore per fare "form vs prezzo", poi lancio una GraphQL custom sul mercato.
   </div>
 
-  <div className="rounded-xl bg-zinc-950 text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
+  <div className="rounded-xl bg-zinc-950 !text-zinc-100 p-3 font-mono text-[11px] space-y-1.5 border border-zinc-800">
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_schema</span>(search: "topPerformers")</div>
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">Trovato: football.topPerformers(window, league)</span></div>
     <div><span className="text-zinc-500">▸</span> <span className="text-sky-400">sorare_graphql_query</span>(<span className="text-amber-300">custom: Top 5 leghe, ultimi 5 GW, avg &gt;35</span>)</div>
@@ -77,7 +77,7 @@ Il tuo client AI non chiama un set fisso di tool pre-confezionati — ha a dispo
     <div><span className="text-zinc-500">←</span> <span className="text-emerald-400">3 candidati &gt;30 % sotto la media 30g ✓</span></div>
   </div>
 
-  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 text-zinc-900 dark:text-zinc-100">
+  <div className="rounded-2xl rounded-tl-md bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/40 dark:to-orange-950/40 border border-amber-200 dark:border-amber-800 px-4 py-3 !text-zinc-900 dark:!text-zinc-100">
     <div className="font-semibold mb-2">Ecco la tua shopping list — 68 € totali, 32 € di riserva</div>
     <ol className="space-y-1.5 list-decimal ml-5 text-[13px]">
       <li><strong>Calafiori (Arsenal)</strong> · Limited · <strong>3,20 €</strong> <span className="text-emerald-700 dark:text-emerald-400">— 40 % sotto media 30g, titolare</span></li>


### PR DESCRIPTION
Three changes from a real user testing the deployed guides:

1. **Claude / ChatGPT / Copilot guides** now lead with the no-code UI path: `claude.ai/customize/connectors` for Claude, ChatGPT Settings → Connectors, VS Code 'MCP: Add Server' palette for Copilot. JSON / CLI config moved into an 'Advanced' `<details>` block.
2. **Chat bubble light-mode legibility fix** — Tailwind `!` important prefix on text-white / text-zinc-* in the chat mockup + defensive inline `style={{color:'#ffffff'}}` spans around the user-message text, since MDX's `text-muted-foreground` would otherwise win on descendants.
3. **18-tool grouped table** replacing the outdated 7-row tables in the Claude guides.

Affects 12 MDX files (4 per locale × 3 locales). Docs-only; no code, no Docker, no AnythingMCP deploy needed — website re-syncs on next build.