### PR TITLE
fix(license): scope license lookup per-org in cloud mode

### DIFF
--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -104,8 +104,8 @@ export class LicenseController {
   @Roles('ADMIN')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Force re-verify license against remote API (ADMIN)' })
-  async verifyLicense() {
-    const result = await this.licenseService.verifyLicense();
+  async verifyLicense(@Req() req: any) {
+    const result = await this.licenseService.verifyLicense(undefined, req.user.organizationId);
     return result;
   }
 
@@ -127,6 +127,7 @@ export class LicenseController {
       const result = await this.licenseService.requestTrialLicense(
         user.email,
         user.name || user.email,
+        req.user.organizationId,
       );
       return {
         message: 'Trial activated successfully',

--- a/packages/backend/src/license/license.service.spec.ts
+++ b/packages/backend/src/license/license.service.spec.ts
@@ -1,0 +1,141 @@
+import { LicenseService } from './license.service';
+
+type MockLicense = {
+  id: string;
+  licenseKey: string;
+  plan: string;
+  status: string;
+  features: Record<string, unknown> | null;
+  expiresAt: Date | null;
+  lastVerifiedAt: Date | null;
+  instanceId: string | null;
+  activatedAt: Date | null;
+  organizationId: string | null;
+  createdAt: Date;
+};
+
+function mkLicense(p: Partial<MockLicense>): MockLicense {
+  return {
+    id: p.id || 'id-' + Math.random().toString(36).slice(2, 8),
+    licenseKey: p.licenseKey || 'AMCP-0000-0000-0000-0000',
+    plan: p.plan || 'starter',
+    status: p.status || 'active',
+    features: p.features ?? null,
+    expiresAt: p.expiresAt ?? null,
+    lastVerifiedAt: p.lastVerifiedAt ?? null,
+    instanceId: p.instanceId ?? 'instance-1',
+    activatedAt: p.activatedAt ?? null,
+    organizationId: p.organizationId ?? null,
+    createdAt: p.createdAt ?? new Date(),
+  };
+}
+
+function makeService({ isCloud, licenses, settings }: {
+  isCloud: boolean;
+  licenses: MockLicense[];
+  settings?: Record<string, string>;
+}) {
+  const settingsStore: Record<string, string> = { ...(settings || {}) };
+  const prisma = {
+    license: {
+      findFirst: jest.fn(async ({ where, orderBy: _orderBy }: any) => {
+        const matches = licenses.filter((l) => {
+          if (where?.organizationId !== undefined && l.organizationId !== where.organizationId) return false;
+          if (where?.status && l.status !== where.status) return false;
+          return true;
+        });
+        return matches[0] || null;
+      }),
+      findUnique: jest.fn(async ({ where }: any) =>
+        licenses.find((l) => l.licenseKey === where.licenseKey) || null,
+      ),
+      update: jest.fn(async ({ where, data }: any) => {
+        const lic = licenses.find((l) => l.id === where.id);
+        if (lic) Object.assign(lic, data);
+        return lic;
+      }),
+    },
+  };
+  const siteSettings = {
+    get: jest.fn(async (key: string) => settingsStore[key] ?? null),
+    set: jest.fn(async (key: string, value: string) => { settingsStore[key] = value; }),
+  };
+  const deployment = { isCloud: () => isCloud, isSelfHosted: () => !isCloud, mode: isCloud ? 'cloud' : 'self-hosted' };
+  const svc = new LicenseService(prisma as any, siteSettings as any, deployment as any);
+  return { svc, prisma, siteSettings, settingsStore };
+}
+
+describe('LicenseService — tenant scoping', () => {
+  describe('getCurrentLicense (cloud)', () => {
+    it('returns the license that belongs to the calling org', async () => {
+      const orgALicense = mkLicense({ licenseKey: 'AMCP-A', organizationId: 'org-a', plan: 'starter' });
+      const { svc } = makeService({
+        isCloud: true,
+        licenses: [orgALicense],
+        settings: { license_key: 'AMCP-A' },
+      });
+      const result = await svc.getCurrentLicense('org-a');
+      expect(result?.licenseKey).toBe('AMCP-A');
+    });
+
+    it('returns null for an org that has no license, even if the global pointer is set', async () => {
+      // This is the exact scenario from the keysersoft@gmail.com bug report:
+      // org B has no license of its own but site_settings.license_key still
+      // points at org A's key. Pre-fix the lookup would resolve to A's key.
+      const orgALicense = mkLicense({ licenseKey: 'AMCP-A', organizationId: 'org-a', plan: 'starter' });
+      const { svc } = makeService({
+        isCloud: true,
+        licenses: [orgALicense],
+        settings: { license_key: 'AMCP-A' },
+      });
+      const result = await svc.getCurrentLicense('org-b');
+      expect(result).toBeNull();
+    });
+
+    it('does not auto-bind an unassigned license to a requesting org', async () => {
+      const orphan = mkLicense({ licenseKey: 'AMCP-ORPH', organizationId: null, plan: 'enterprise' });
+      const { svc, prisma } = makeService({
+        isCloud: true,
+        licenses: [orphan],
+        settings: {},
+      });
+      const result = await svc.getCurrentLicense('org-x');
+      expect(result).toBeNull();
+      expect(prisma.license.update).not.toHaveBeenCalled();
+      expect(orphan.organizationId).toBeNull();
+    });
+  });
+
+  describe('getCurrentLicense (self-hosted)', () => {
+    it('still falls back to the site_settings global key for single-tenant installs', async () => {
+      const global = mkLicense({ licenseKey: 'AMCP-SH', organizationId: null, plan: 'business' });
+      const { svc } = makeService({
+        isCloud: false,
+        licenses: [global],
+        settings: { license_key: 'AMCP-SH' },
+      });
+      const result = await svc.getCurrentLicense();
+      expect(result?.licenseKey).toBe('AMCP-SH');
+    });
+
+    it('auto-binds an orphan license to the calling org on first request', async () => {
+      const orphan = mkLicense({ licenseKey: 'AMCP-ORPH', organizationId: null });
+      const { svc, prisma } = makeService({
+        isCloud: false,
+        licenses: [orphan],
+        settings: { license_key: 'AMCP-ORPH' },
+      });
+      await svc.getCurrentLicense('org-y');
+      expect(prisma.license.update).toHaveBeenCalled();
+      expect(orphan.organizationId).toBe('org-y');
+    });
+  });
+
+  describe('verifyOnStartup', () => {
+    it('is a no-op in cloud mode (per-org verification happens elsewhere)', async () => {
+      const { svc, siteSettings } = makeService({ isCloud: true, licenses: [] });
+      await svc.verifyOnStartup();
+      expect(siteSettings.get).not.toHaveBeenCalledWith('license_key');
+    });
+  });
+});

--- a/packages/backend/src/license/license.service.ts
+++ b/packages/backend/src/license/license.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import axios from 'axios';
 import * as crypto from 'crypto';
 import { PrismaService } from '../common/prisma.service';
+import { DeploymentService } from '../common/deployment.service';
 import { SiteSettingsService } from '../settings/site-settings.service';
 
 const LICENSE_API_URL =
@@ -35,6 +36,7 @@ export class LicenseService implements OnModuleInit {
   constructor(
     private readonly prisma: PrismaService,
     private readonly siteSettings: SiteSettingsService,
+    private readonly deployment: DeploymentService,
   ) {}
 
   async onModuleInit() {
@@ -94,6 +96,7 @@ export class LicenseService implements OnModuleInit {
   async requestTrialLicense(
     email: string,
     name: string,
+    organizationId?: string,
   ): Promise<{ licenseKey: string; plan: string; expiresAt: string; trialDaysLeft: number }> {
     const instanceId = await this.getInstanceId();
 
@@ -114,6 +117,7 @@ export class LicenseService implements OnModuleInit {
           expiresAt: new Date(data.expiresAt),
           lastVerifiedAt: new Date(),
           instanceId,
+          organizationId: organizationId || undefined,
         },
         create: {
           licenseKey: data.licenseKey,
@@ -123,10 +127,16 @@ export class LicenseService implements OnModuleInit {
           expiresAt: new Date(data.expiresAt),
           lastVerifiedAt: new Date(),
           instanceId,
+          organizationId: organizationId || undefined,
         },
       });
 
-      await this.siteSettings.set('license_key', data.licenseKey);
+      // Self-hosted = single tenant, the instance-wide pointer is meaningful.
+      // Cloud = multi tenant, a global pointer would let one org's verify
+      // resolve to another org's key, so we skip the write.
+      if (!this.deployment.isCloud()) {
+        await this.siteSettings.set('license_key', data.licenseKey);
+      }
 
       return {
         licenseKey: data.licenseKey,
@@ -172,9 +182,27 @@ export class LicenseService implements OnModuleInit {
 
   // ── License Verification ───────────────────────────────────────────────────
 
-  async verifyLicense(key?: string): Promise<RemoteVerifyResponse> {
-    const licenseKey =
-      key || (await this.siteSettings.get('license_key'));
+  async verifyLicense(
+    key?: string,
+    organizationId?: string,
+  ): Promise<RemoteVerifyResponse> {
+    let licenseKey = key;
+
+    if (!licenseKey) {
+      if (this.deployment.isCloud()) {
+        // Multi-tenant: only verify the key that actually belongs to the
+        // requesting organization. No fallback to a global pointer.
+        if (organizationId) {
+          const existing = await this.prisma.license.findFirst({
+            where: { organizationId },
+            orderBy: { createdAt: 'desc' },
+          });
+          licenseKey = existing?.licenseKey;
+        }
+      } else {
+        licenseKey = await this.siteSettings.get('license_key') || undefined;
+      }
+    }
 
     if (!licenseKey) {
       return { valid: false, error: 'No license key configured' };
@@ -217,6 +245,11 @@ export class LicenseService implements OnModuleInit {
   }
 
   async verifyOnStartup(): Promise<void> {
+    // In cloud mode "the" instance-wide license key is meaningless — each
+    // org has its own. Per-org background verification (if needed) belongs
+    // elsewhere; here we only handle the self-hosted single-tenant case.
+    if (this.deployment.isCloud()) return;
+
     try {
       const licenseKey = await this.siteSettings.get('license_key');
       if (!licenseKey) return;
@@ -282,7 +315,12 @@ export class LicenseService implements OnModuleInit {
       },
     });
 
-    await this.siteSettings.set('license_key', licenseKey);
+    // Self-hosted: this is "the" instance license, so we point site_settings
+    // at it. In cloud the same write would leak the key across tenants on the
+    // next unscoped lookup.
+    if (!this.deployment.isCloud()) {
+      await this.siteSettings.set('license_key', licenseKey);
+    }
 
     // Activate in background
     this.activateLicense(licenseKey).catch((err) =>
@@ -304,7 +342,14 @@ export class LicenseService implements OnModuleInit {
       if (license) return this.toLicenseInfo(license);
     }
 
-    // 2. Fallback: global license via site_settings key
+    // Cloud: stop here. Falling back to a global key or to any unassigned
+    // license would let one org see another org's entitlement (or auto-bind
+    // someone else's license to the calling org).
+    if (this.deployment.isCloud()) {
+      return null;
+    }
+
+    // 2. Self-hosted fallback: global license via site_settings key
     const licenseKey = await this.siteSettings.get('license_key');
     if (licenseKey) {
       const license = await this.prisma.license.findUnique({
@@ -322,7 +367,7 @@ export class LicenseService implements OnModuleInit {
       }
     }
 
-    // 3. Fallback: any active license without an org (migrated but unassigned)
+    // 3. Self-hosted fallback: any active license without an org (migrated but unassigned)
     const unassigned = await this.prisma.license.findFirst({
       where: { status: 'active', organizationId: null },
       orderBy: { createdAt: 'desc' },


### PR DESCRIPTION
## Summary

Fixes a cross-tenant entitlement leak in cloud mode.

`getCurrentLicense` falls back to `site_settings.license_key` (a single instance-wide pointer) when the calling org has no license of its own, and on hit it auto-binds the unassigned license to whichever org happens to ask first. Combined with the unscoped `POST /api/license/verify` (which reads the same global pointer), an org with **zero** licenses can see another org's key as "License verified successfully".

Reproducer on the live cloud:
1. Sign in as a user belonging to an org with no purchased license (in my case `keysersoft@gmail.com` → `Matteo's Workspace`).
2. Open `/settings/license` and click **Verify Now**.
3. UI reports "License verified successfully", showing the plan & expiry of an unrelated org's license (here, the starter under `sales@helpcode.ai`).

## What changes

This isolates lookups per `organizationId` in cloud mode while keeping the existing single-tenant fallbacks for self-hosted, where `site_settings.license_key` is the legitimate "this is the instance license" mechanism.

- `getCurrentLicense`: in cloud, returns `null` when the calling org has no license; no more global pointer fallback, no auto-binding of orphan licenses to a random caller. **Self-hosted behavior unchanged.**
- `verifyLicense`: now accepts `organizationId` and, in cloud, resolves the key to verify from the org's own license; falls back to the global setting only in self-hosted.
- `setLicenseKey` / `requestTrialLicense`: stop overwriting `site_settings.license_key` in cloud; persist `organizationId` on the trial record so future lookups can find it.
- `verifyOnStartup`: no-op in cloud (per-org background verification belongs to a separate cron, not to instance boot).
- `POST /api/license/verify`: passes `req.user.organizationId`.
- `POST /api/license/activate-trial`: passes `req.user.organizationId`.

## Pre-deploy data backfill

Performed directly on the cloud Postgres (one-off, environment-specific — not a Prisma migration on purpose): 3 orphan trial licenses re-assigned to their owning orgs based on `licenses.email` ↔ `users.email`. One enterprise license (`AMCP-3076-FFD0-DFCC-D619`) has no corresponding row in the marketing-site Mongo and was left orphan; after this PR it will no longer be visible to any org.

## Tests

6 new unit tests in `license.service.spec.ts`:
- cloud: license is returned for the owning org
- cloud: another org sees `null` even when `site_settings.license_key` points at the first org's key (the exact bug)
- cloud: orphan licenses are not auto-bound to the caller
- self-hosted: `site_settings.license_key` fallback still works
- self-hosted: orphan auto-bind still works
- `verifyOnStartup` is a no-op in cloud

Full suite: **752 passed, 5 skipped** (unchanged from before this PR).

## Test plan post-deploy

- [ ] Sign in as `keysersoft@gmail.com` → `/settings/license` shows "No license" (no plan info, no "Verify now" success)
- [ ] Sign in as `sales@helpcode.ai` → still sees `AMCP-3887-…-15D8` (starter, active)
- [ ] Sign in as `matteo.morelli@kochfreiburg.de` → still sees `AMCP-96ED-…-6B51` (enterprise, active)
- [ ] Self-hosted instance (local docker compose): activating a license still writes `site_settings.license_key` and `getCurrentLicense()` resolves to it