### PR TITLE
fix(license): gate cloud UI on missing license + scope MCP runtime check

### DIFF
--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -54,7 +54,7 @@ export class DynamicMcpTools {
   ): Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }> {
     // Check license before executing tool (cloud mode only)
     try {
-      await this.licenseGuard.checkLicenseActive();
+      await this.licenseGuard.checkLicenseActive(context?.organizationId);
     } catch (err: any) {
       return {
         content: [

--- a/packages/frontend/src/components/license-wall.tsx
+++ b/packages/frontend/src/components/license-wall.tsx
@@ -8,29 +8,53 @@ import { useAuth } from '@/lib/auth-context';
 import { buildPricingUrl } from '@/lib/marketing';
 import { LogoIcon } from '@/components/nav-bar';
 
+type BlockReason = 'no-license' | 'trial-ended' | 'expired';
+
 export function LicenseWall() {
-  const { token } = useAuth();
-  const [blocked, setBlocked] = useState(false);
+  const { token, deploymentMode } = useAuth();
+  const [reason, setReason] = useState<BlockReason | null>(null);
   const pathname = usePathname();
+  const isCloud = deploymentMode === 'cloud';
 
   useEffect(() => {
     if (!token) return;
 
     license.getStatus(token).then((status) => {
-      if (!status.plan) return;
+      // Cloud: no license at all means the org is not allowed to use the
+      // product. Self-hosted: a missing license means "running on the
+      // community tier", which is permitted.
+      if (!status.plan) {
+        if (isCloud) setReason('no-license');
+        return;
+      }
       // Block when trial is expired
       if (status.plan === 'trial' && status.trialDaysLeft !== undefined && status.trialDaysLeft <= 0) {
-        setBlocked(true);
+        setReason('trial-ended');
+        return;
       }
       // Block when any license is expired/revoked
       if (status.status === 'expired' || status.status === 'revoked') {
-        setBlocked(true);
+        setReason('expired');
       }
     }).catch(() => {});
-  }, [token]);
+  }, [token, isCloud]);
 
   // Don't block the license settings page so users can enter a license key
-  if (!blocked || pathname === '/settings/license') return null;
+  if (!reason || pathname === '/settings/license' || pathname?.startsWith('/settings/license/')) return null;
+
+  const title =
+    reason === 'no-license'
+      ? 'License Required'
+      : reason === 'trial-ended'
+        ? 'Your Trial Has Expired'
+        : 'Your License Has Expired';
+
+  const body =
+    reason === 'no-license'
+      ? 'This workspace doesn’t have an active license. Start a trial or purchase a plan to continue.'
+      : reason === 'trial-ended'
+        ? 'Your 7-day trial period has ended. Purchase a license to continue using AnythingMCP Cloud. Your connectors and configurations are preserved.'
+        : 'Your license is no longer active. Purchase or renew a license to continue using AnythingMCP. Your connectors and configurations are preserved.';
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm">
@@ -39,12 +63,9 @@ export function LicenseWall() {
           <LogoIcon size={48} />
         </div>
 
-        <h1 className="text-2xl font-bold mb-2">Your Trial Has Expired</h1>
+        <h1 className="text-2xl font-bold mb-2">{title}</h1>
 
-        <p className="text-[var(--muted-foreground)] text-sm mb-6">
-          Your 7-day trial period has ended. Purchase a license to continue using
-          AnythingMCP Cloud. Your connectors and configurations are preserved.
-        </p>
+        <p className="text-[var(--muted-foreground)] text-sm mb-6">{body}</p>
 
         <div className="space-y-3">
           <a
@@ -55,6 +76,15 @@ export function LicenseWall() {
           >
             View Plans &amp; Purchase License
           </a>
+
+          {reason === 'no-license' && isCloud && (
+            <Link
+              href="/settings/license"
+              className="block w-full border border-[var(--border)] px-4 py-2.5 rounded-md text-sm font-medium hover:bg-[var(--accent)] text-center"
+            >
+              Start 7-Day Free Trial
+            </Link>
+          )}
 
           <p className="text-xs text-[var(--muted-foreground)]">
             Already purchased?{' '}


### PR DESCRIPTION
## Summary

Two follow-ups to v0.1.27 surfaced when a cloud org without a license could still navigate freely in the UI.

### 1. LicenseWall didn't cover the no-license case (cloud)

The wall already blocked on trial-expired and on license-revoked/expired, but **plan === null** (the new "no license" state introduced by the per-org isolation fix in #219) was silently allowed through. After v0.1.27, an org without a purchased license sees the UI as if everything is fine — exactly what was reported on `keysersoft@gmail.com`.

Self-hosted is unaffected: a missing license there means "community tier", which is permitted.

This PR adds a `no-license` reason with title "License Required" and a body that offers three actions: **Start 7-Day Free Trial**, **View Plans & Purchase License**, **Enter your license key**.

### 2. MCP runtime check was unscoped

`dynamic-mcp-tools.executeTool` calls `checkLicenseActive()` without `organizationId`. After v0.1.27 that always resolves to `null` in cloud (no global fallback), which means **every MCP tool call in cloud would have been blocked**. This PR threads `context?.organizationId` through.

## Test plan post-deploy

- [ ] Sign in as `keysersoft@gmail.com` (no license) on cloud → see the "License Required" wall on every page except `/settings/license*`
- [ ] Click **Start 7-Day Free Trial** → lands on `/settings/license` where the trial button is visible
- [ ] Sign in as `sales@helpcode.ai` (active starter) → no wall
- [ ] Self-hosted instance with no license activated → no wall (community tier still works)
- [ ] MCP tool call on cloud from an org with an active license → succeeds; from an org without → returns license error