### PR TITLE
Bump version to 0.1.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "license": "BUSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -24482,7 +24482,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "license": "BUSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.1.21",
@@ -24936,7 +24936,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "license": "BUSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Source-available (BSL-1.1 → Apache 2030).",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BUSL-1.1",


### PR DESCRIPTION
Release 0.1.28: LicenseWall covers cloud no-license case + MCP runtime check is org-scoped (#221).