### PR TITLE
docs(sorare): embed launch video on the 3 announcement landings (DSGVO 2-click)

### DIFF
--- a/content/guides/de/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/de/sorare-now-on-anythingmcp.mdx
@@ -95,6 +95,16 @@ Dein KI-Client greift dabei nicht nur auf eine feste Auswahl vorgebackener Tools
 
 > **Das ist ein echter Claude-Roundtrip** — keine erfundenen Tool-Namen. Jede Box entspricht einem MCP-Call gegen die Live-Sorare-API über deine AnythingMCP-Cloud-Instanz.
 
+## Komplettes Setup + Live-Trading-Session im Video
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Sorare mit Claude AI verbinden — komplettes Setup + Live-100-€-Kaufstrategie"
+  lang="de"
+/>
+
+> 🔒 Das Video ist **DSGVO-konform per Zwei-Klick-Lösung** eingebettet — vor deinem Klick auf Play geht kein Byte an Google. Nach dem Klick läuft die Wiedergabe über `youtube-nocookie.com` ohne Tracking-Cookies.
+
 ## Was du dadurch bekommst
 
 <div className="not-prose grid gap-4 sm:grid-cols-2 my-8">

--- a/content/guides/en/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/en/sorare-now-on-anythingmcp.mdx
@@ -95,6 +95,16 @@ Your AI client doesn't just call a fixed set of pre-baked tools — it has **the
 
 > **This is a real round-trip Claude does** — not a mockup of fake tool names. Every box you see corresponds to one MCP call against the live Sorare API through your AnythingMCP cloud instance.
 
+## Watch the full setup + a live trading session
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Connect Sorare to Claude AI — full setup + live €100 buy strategy"
+  lang="en"
+/>
+
+> 🔒 The video is embedded via the **two-click consent pattern** — nothing reaches Google until you press play. Once you do, it streams from `youtube-nocookie.com` with no tracking cookies.
+
 ## What this unlocks
 
 <div className="not-prose grid gap-4 sm:grid-cols-2 my-8">

--- a/content/guides/it/sorare-now-on-anythingmcp.mdx
+++ b/content/guides/it/sorare-now-on-anythingmcp.mdx
@@ -95,6 +95,16 @@ Il tuo client AI non chiama un set fisso di tool pre-confezionati — ha a dispo
 
 > **Questo è un roundtrip vero che Claude fa** — non è un mockup con nomi tool inventati. Ogni box corrisponde a una chiamata MCP sull'API Sorare live attraverso la tua istanza AnythingMCP cloud.
 
+## Setup completo + sessione di trading live nel video
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Collegare Sorare a Claude AI — setup completo + strategia d'acquisto da 100 € live"
+  lang="it"
+/>
+
+> 🔒 Il video è incorporato con la **soluzione DSGVO/GDPR a due click** — niente raggiunge Google finché non premi Play. Da quel momento la riproduzione passa per `youtube-nocookie.com` senza tracking cookie.
+
 ## Cosa ti sblocca
 
 <div className="not-prose grid gap-4 sm:grid-cols-2 my-8">


### PR DESCRIPTION
Adds <YoutubeEmbed id="B0nNJ3fu7OY"> to the en/de/it Sorare announcement landings, right under the chat mockup. The website-side YoutubeEmbed component (see anythingmcp-website#) renders a click-to-load placeholder, then mounts an iframe against youtube-nocookie.com once the visitor consents.