### PR TITLE
docs(sorare): YouTube video embed on every Sorare guide (DSGVO 2-click)

### DIFF
--- a/content/guides/de/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/de/connect-sorare-to-chatgpt.mdx
@@ -25,6 +25,16 @@ ChatGPT unterstützt das **Model Context Protocol** in Custom Connectors und in 
 - "Wie ist der aktuelle Floor-Preis für Limited-Bukayo-Saka-Karten?"
 - "Welche Auktionen für Liverpool-Spieler enden in den nächsten 90 Minuten?"
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Sorare mit Claude AI verbinden — komplettes Setup + Live-100-€-Kaufstrategie (funktioniert auch in ChatGPT, Copilot & OpenClaw)"
+  lang="de"
+/>
+
+> 🔒 Das Video ist **DSGVO-konform per Zwei-Klick-Lösung** eingebettet — vor deinem Klick auf Play geht kein Byte an Google.
+
+
 ### Voraussetzungen
 
 - Aktives Sorare-Konto (dediziertes Read-only-Konto empfohlen; **2FA deaktivieren** für Headless-Einsatz).

--- a/content/guides/de/connect-sorare-to-claude.mdx
+++ b/content/guides/de/connect-sorare-to-claude.mdx
@@ -25,6 +25,16 @@ Sorare ist das größte NFT-Fantasy-Football-Spiel mit voller GraphQL-Abdeckung 
 - "Finde alle meine Karten von Real-Madrid-Spielern."
 - "Wer hatte den höchsten Score in So5-Aufstellung `abc-123`?"
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Sorare mit Claude AI verbinden — komplettes Setup + Live-100-€-Kaufstrategie (funktioniert auch in ChatGPT, Copilot & OpenClaw)"
+  lang="de"
+/>
+
+> 🔒 Das Video ist **DSGVO-konform per Zwei-Klick-Lösung** eingebettet — vor deinem Klick auf Play geht kein Byte an Google.
+
+
 ### Voraussetzungen
 
 - Aktives Sorare-Konto (empfohlen: dediziertes, **2FA-deaktiviertes** Read-only-Konto für Headless-Nutzung).

--- a/content/guides/de/connect-sorare-to-copilot.mdx
+++ b/content/guides/de/connect-sorare-to-copilot.mdx
@@ -25,6 +25,16 @@ GitHub Copilot Chat unterstützt jetzt das **Model Context Protocol (MCP)** übe
 - "Sorare: Liste meine Rare-Karten nach Spieler, sortiert nach jüngstem So5-Score."
 - "Sorare: Zeig die jüngsten Verkaufspreise für Vinícius-Júnior-Rare-Karten der letzten 30 Tage."
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Sorare mit Claude AI verbinden — komplettes Setup + Live-100-€-Kaufstrategie (funktioniert auch in ChatGPT, Copilot & OpenClaw)"
+  lang="de"
+/>
+
+> 🔒 Das Video ist **DSGVO-konform per Zwei-Klick-Lösung** eingebettet — vor deinem Klick auf Play geht kein Byte an Google.
+
+
 ### Voraussetzungen
 
 - Aktives Sorare-Konto auf https://sorare.com — wir empfehlen ein **dediziertes Read-only-Konto mit deaktivierter 2FA** für Headless / Agent-Nutzung.

--- a/content/guides/de/connect-sorare-to-openclaw.mdx
+++ b/content/guides/de/connect-sorare-to-openclaw.mdx
@@ -24,6 +24,16 @@ lang: "de"
 - "Zeig Auktionen für Unique-Mbappé-Karten, die heute Abend enden."
 - "Wie war der Score meiner letzten So5-Aufstellung?"
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Sorare mit Claude AI verbinden — komplettes Setup + Live-100-€-Kaufstrategie (funktioniert auch in ChatGPT, Copilot & OpenClaw)"
+  lang="de"
+/>
+
+> 🔒 Das Video ist **DSGVO-konform per Zwei-Klick-Lösung** eingebettet — vor deinem Klick auf Play geht kein Byte an Google.
+
+
 ### Voraussetzungen
 
 - OpenClaw installiert (`docs.openclaw.ai/getting-started`).

--- a/content/guides/de/sorare-to-mcp.mdx
+++ b/content/guides/de/sorare-to-mcp.mdx
@@ -31,6 +31,14 @@ Der Sorare-Adapter ist out-of-the-box enthalten. Kein SDK zu pflegen, keine Toke
 
 Das gesamte **`LOGIN_TOKEN`**-Auth-Profil wird einmal als JSON in der Adapter-Spezifikation deklariert. Kein Client-Code, der gepflegt werden muss.
 
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Sorare mit Claude AI verbinden — komplettes Setup + Live-100-€-Kaufstrategie (funktioniert auch in ChatGPT, Copilot & OpenClaw)"
+  lang="de"
+/>
+
+> 🔒 Das Video ist **DSGVO-konform per Zwei-Klick-Lösung** eingebettet — vor deinem Klick auf Play geht kein Byte an Google.
+
 ### Installation
 
 ```bash

--- a/content/guides/en/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/en/connect-sorare-to-chatgpt.mdx
@@ -25,6 +25,16 @@ ChatGPT supports the **Model Context Protocol** in custom connectors and in the 
 - "What's the floor price right now for limited Bukayo Saka cards?"
 - "Find auctions ending in the next 90 minutes for Liverpool players."
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Connect Sorare to Claude AI — full setup + live €100 buy strategy (works for ChatGPT, Copilot & OpenClaw too)"
+  lang="en"
+/>
+
+> 🔒 The video is embedded via the **two-click consent pattern** — nothing reaches Google until you press Play.
+
+
 ### Prerequisites
 
 - Active Sorare account (dedicated read-only account recommended; **disable 2FA** for headless use).

--- a/content/guides/en/connect-sorare-to-claude.mdx
+++ b/content/guides/en/connect-sorare-to-claude.mdx
@@ -25,6 +25,16 @@ Sorare is the largest NFT fantasy football game, with full GraphQL coverage over
 - "Find all my cards for Real Madrid players."
 - "Who scored highest in So5 lineup `abc-123`?"
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Connect Sorare to Claude AI — full setup + live €100 buy strategy (works for ChatGPT, Copilot & OpenClaw too)"
+  lang="en"
+/>
+
+> 🔒 The video is embedded via the **two-click consent pattern** — nothing reaches Google until you press Play.
+
+
 ### Prerequisites
 
 - An active Sorare account (we recommend a dedicated, **2FA-disabled** read-only account for headless use).

--- a/content/guides/en/connect-sorare-to-copilot.mdx
+++ b/content/guides/en/connect-sorare-to-copilot.mdx
@@ -25,6 +25,16 @@ GitHub Copilot Chat now supports the **Model Context Protocol (MCP)** through it
 - "Sorare: list my Rare cards by player, sorted by recent So5 score."
 - "Sorare: show recent sale prices for Vinícius Júnior Rare cards over the last 30 days."
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Connect Sorare to Claude AI — full setup + live €100 buy strategy (works for ChatGPT, Copilot & OpenClaw too)"
+  lang="en"
+/>
+
+> 🔒 The video is embedded via the **two-click consent pattern** — nothing reaches Google until you press Play.
+
+
 ### Prerequisites
 
 - An active Sorare account at https://sorare.com — we recommend a **dedicated read-only account with 2FA disabled** for headless / agent use.

--- a/content/guides/en/connect-sorare-to-openclaw.mdx
+++ b/content/guides/en/connect-sorare-to-openclaw.mdx
@@ -24,6 +24,16 @@ lang: "en"
 - "Surface auctions for unique Mbappé cards closing tonight."
 - "Show me the score of my last So5 lineup."
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Connect Sorare to Claude AI — full setup + live €100 buy strategy (works for ChatGPT, Copilot & OpenClaw too)"
+  lang="en"
+/>
+
+> 🔒 The video is embedded via the **two-click consent pattern** — nothing reaches Google until you press Play.
+
+
 ### Prerequisites
 
 - OpenClaw installed (`docs.openclaw.ai/getting-started`).

--- a/content/guides/en/sorare-to-mcp.mdx
+++ b/content/guides/en/sorare-to-mcp.mdx
@@ -31,6 +31,14 @@ The Sorare adapter ships built-in. There is no SDK to maintain, no token plumbin
 
 That's the entire **`LOGIN_TOKEN`** auth profile, declared once as JSON in the adapter spec. No client code to maintain.
 
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Connect Sorare to Claude AI — full setup + live €100 buy strategy (works for ChatGPT, Copilot & OpenClaw too)"
+  lang="en"
+/>
+
+> 🔒 The video is embedded via the **two-click consent pattern** — nothing reaches Google until you press Play.
+
 ### Install
 
 ```bash

--- a/content/guides/it/connect-sorare-to-chatgpt.mdx
+++ b/content/guides/it/connect-sorare-to-chatgpt.mdx
@@ -25,6 +25,16 @@ ChatGPT supporta il **Model Context Protocol** nei custom connector e nell'area 
 - "Qual è il floor price ora per le carte limited di Bukayo Saka?"
 - "Trova aste per giocatori del Liverpool che chiudono nei prossimi 90 minuti."
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Collegare Sorare a Claude AI — setup completo + strategia d'acquisto da 100 € live (funziona anche in ChatGPT, Copilot e OpenClaw)"
+  lang="it"
+/>
+
+> 🔒 Il video è incorporato con la **soluzione DSGVO/GDPR a due click** — niente raggiunge Google finché non premi Play.
+
+
 ### Prerequisiti
 
 - Account Sorare attivo (consigliato uno dedicato in sola lettura; **disattiva 2FA** per uso headless).

--- a/content/guides/it/connect-sorare-to-claude.mdx
+++ b/content/guides/it/connect-sorare-to-claude.mdx
@@ -25,6 +25,16 @@ Sorare è il più grande gioco di fantasy football NFT, con copertura GraphQL co
 - "Trova tutte le mie carte dei giocatori del Real Madrid."
 - "Chi ha fatto lo score più alto nella line-up So5 `abc-123`?"
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Collegare Sorare a Claude AI — setup completo + strategia d'acquisto da 100 € live (funziona anche in ChatGPT, Copilot e OpenClaw)"
+  lang="it"
+/>
+
+> 🔒 Il video è incorporato con la **soluzione DSGVO/GDPR a due click** — niente raggiunge Google finché non premi Play.
+
+
 ### Prerequisiti
 
 - Account Sorare attivo (consigliato un account dedicato in sola lettura con **2FA disattivata** per uso headless).

--- a/content/guides/it/connect-sorare-to-copilot.mdx
+++ b/content/guides/it/connect-sorare-to-copilot.mdx
@@ -25,6 +25,16 @@ GitHub Copilot Chat ora supporta il **Model Context Protocol (MCP)** tramite la 
 - "Sorare: lista le mie carte Rare per giocatore, ordinate per ultimo score So5."
 - "Sorare: mostrami le vendite recenti di carte Rare di Vinícius Júnior negli ultimi 30 giorni."
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Collegare Sorare a Claude AI — setup completo + strategia d'acquisto da 100 € live (funziona anche in ChatGPT, Copilot e OpenClaw)"
+  lang="it"
+/>
+
+> 🔒 Il video è incorporato con la **soluzione DSGVO/GDPR a due click** — niente raggiunge Google finché non premi Play.
+
+
 ### Prerequisiti
 
 - Account Sorare attivo su https://sorare.com — consigliato un **account dedicato in sola lettura con 2FA disattivata** per uso headless / agent.

--- a/content/guides/it/connect-sorare-to-openclaw.mdx
+++ b/content/guides/it/connect-sorare-to-openclaw.mdx
@@ -24,6 +24,16 @@ lang: "it"
 - "Mostra aste per carte uniche di Mbappé che chiudono stasera."
 - "Qual è stato lo score della mia ultima line-up So5?"
 
+
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Collegare Sorare a Claude AI — setup completo + strategia d'acquisto da 100 € live (funziona anche in ChatGPT, Copilot e OpenClaw)"
+  lang="it"
+/>
+
+> 🔒 Il video è incorporato con la **soluzione DSGVO/GDPR a due click** — niente raggiunge Google finché non premi Play.
+
+
 ### Prerequisiti
 
 - OpenClaw installato (`docs.openclaw.ai/getting-started`).

--- a/content/guides/it/sorare-to-mcp.mdx
+++ b/content/guides/it/sorare-to-mcp.mdx
@@ -31,6 +31,14 @@ L'adapter Sorare è incluso di default. Niente SDK da mantenere, nessun plumbing
 
 È esattamente il profilo auth **`LOGIN_TOKEN`**, dichiarato una volta come JSON nello spec dell'adapter. Zero codice client da mantenere.
 
+<YoutubeEmbed
+  id="B0nNJ3fu7OY"
+  title="Collegare Sorare a Claude AI — setup completo + strategia d'acquisto da 100 € live (funziona anche in ChatGPT, Copilot e OpenClaw)"
+  lang="it"
+/>
+
+> 🔒 Il video è incorporato con la **soluzione DSGVO/GDPR a due click** — niente raggiunge Google finché non premi Play.
+
 ### Installazione
 
 ```bash


### PR DESCRIPTION
Adds the launch-video YoutubeEmbed to all 4 client guides + the hub guide (en/de/it = 15 files). Closes the gap raised by 'non lo trovo in produzione' — the embed was only on the announcement landing before.