### PR TITLE
auth: mandatory email verification in cloud mode

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { LocalOAuthProvider } from './auth/local-oauth.provider';
 import { PrismaOAuthStore } from './auth/prisma-oauth.store';
 import { PrismaService } from './common/prisma.service';
 import { OAuthUrlRewriteInterceptor } from './auth/oauth-url-rewrite.interceptor';
+import { EmailVerifiedGuard } from './auth/email-verified.guard';
 import { AdaptersModule } from './adapters/adapters.module';
 import { OrganizationsModule } from './organizations/organizations.module';
 import { CloudModule } from './cloud/cloud.module';
@@ -139,6 +140,7 @@ if (useOAuth) {
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_GUARD, useClass: EmailVerifiedGuard },
     ...(useOAuth
       ? [{ provide: APP_INTERCEPTOR, useClass: OAuthUrlRewriteInterceptor }]
       : []),

--- a/packages/backend/src/auth/email-verified.guard.ts
+++ b/packages/backend/src/auth/email-verified.guard.ts
@@ -1,0 +1,54 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * In cloud mode, users must verify their email before they can access any
+ * non-auth endpoint. Self-hosted deployments are unaffected.
+ *
+ * Applied globally via APP_GUARD. The allowlist below covers the endpoints
+ * needed to *complete* the verification flow (and to log out).
+ */
+@Injectable()
+export class EmailVerifiedGuard implements CanActivate {
+  private static readonly PATH_ALLOWLIST = [
+    '/api/auth/verify-email',
+    '/api/auth/verify-email-link',
+    '/api/auth/resend-verification',
+    '/api/auth/logout',
+    '/api/auth/login',
+    '/api/auth/register',
+    '/api/auth/forgot-password',
+    '/api/auth/reset-password',
+    '/api/auth/accept-invite',
+    '/health',
+  ];
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isCloud = this.configService.get<string>('DEPLOYMENT_MODE') === 'cloud';
+    if (!isCloud) return true;
+
+    const req = context.switchToHttp().getRequest();
+    const user = req?.user;
+    if (!user?.sub) return true;
+
+    const path: string = req.path || req.url || '';
+    if (EmailVerifiedGuard.PATH_ALLOWLIST.some((p) => path.startsWith(p))) {
+      return true;
+    }
+
+    const dbUser = await this.prisma.user.findUnique({
+      where: { id: user.sub },
+      select: { emailVerified: true },
+    });
+    if (!dbUser?.emailVerified) {
+      throw new ForbiddenException('Email verification required');
+    }
+    return true;
+  }
+}

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -271,7 +271,7 @@ function LoginForm() {
             </button>
           </p>
 
-          {isFirstUserFlag && (
+          {isFirstUserFlag && !isCloudMode && (
             <div className="text-center mt-3">
               <button
                 onClick={() => {


### PR DESCRIPTION
## Summary

- Hide the **Skip for now** button on the email-verification step when `DEPLOYMENT_MODE=cloud` so cloud users cannot bypass verification post-registration.
- New `EmailVerifiedGuard` registered as a global `APP_GUARD`. In cloud mode it rejects authenticated requests from users with `emailVerified=false` with `403 Forbidden`, except on the auth-flow paths needed to actually verify (`verify-email`, `resend-verification`, `login`, `register`, `forgot/reset-password`, `logout`, `health`).
- Self-hosted deployments are untouched.

## Why

On `cloud.anythingmcp.com` users were able to register, click **Skip for now**, and use the service indefinitely without ever verifying their email. That broke abuse-prevention and trial-tracking. Behavior must remain unchanged for self-hosted operators who don't run SMTP.

## Test plan

- [ ] `DEPLOYMENT_MODE=cloud` — register, confirm Skip button is gone, confirm protected endpoints return 403 until verified, confirm `/api/auth/verify-email` works
- [ ] `DEPLOYMENT_MODE=cloud` — after verification, all endpoints work as before
- [ ] `DEPLOYMENT_MODE=self-hosted` (or unset) — Skip still appears, all endpoints work regardless of `emailVerified`