### PR TITLE
fix(css): add custom chevron arrow for select elements and adjust pad…

### DIFF
--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -102,7 +102,7 @@ button:not(:disabled), select, summary, [role="button"] {
 /* Custom chevron arrow for native select elements.
    appearance-none removes the browser's built-in arrow so we can control spacing.
    padding-right !important overrides Tailwind px-* utilities to make room for the arrow. */
-select {
+main select {
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m19 9-7 7-7-7'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
@@ -111,7 +111,7 @@ select {
   padding-right: 2rem !important;
 }
 
-.dark select {
+.dark main select {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%239ca3af'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m19 9-7 7-7-7'/%3E%3C/svg%3E");
 }
 button:disabled {

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -98,6 +98,22 @@ button, a, input, select, textarea {
 button:not(:disabled), select, summary, [role="button"] {
   cursor: pointer;
 }
+
+/* Custom chevron arrow for native select elements.
+   appearance-none removes the browser's built-in arrow so we can control spacing.
+   padding-right !important overrides Tailwind px-* utilities to make room for the arrow. */
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m19 9-7 7-7-7'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 1.25em 1.25em;
+  padding-right: 2rem !important;
+}
+
+.dark select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%239ca3af'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='m19 9-7 7-7-7'/%3E%3C/svg%3E");
+}
 button:disabled {
   cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary

Fix native `<select>` dropdown buttons showing the arrow icon with no spacing from the right border. The arrow was visually crammed against the edge across all pages (logs, connectors, MCP servers, settings, etc.).

## Changes

- Add `appearance: none` to all native `<select>` elements via `globals.css` to remove the browser's built-in arrow and decouple trigger button styling from the open dropdown list
- Replace the native arrow with a custom chevron-down SVG via CSS `background-image`, positioned with `0.5rem` clearance from the right border
- Override `padding-right` with `!important` to make room for the custom arrow (needed to outrank Tailwind's `px-*` utility specificity)
- Add a dark-mode variant using the appropriate muted foreground color

## Type

- [x] Bug fix

## Testing

- [x] Tested manually (describe steps below)

Verified on `/logs`, `/connectors`, `/mcp-server`, `/settings/users`, `/settings/roles`, `/admin/users`, `/admin/roles`, and the tool editor. Confirmed:
1. The closed select button shows the chevron with proper right spacing in both light and dark mode
2. The open dropdown options are visually unchanged (OS-rendered, unaffected by the CSS change)

## Checklist

- [x] My code follows the existing code style
- [x] I have tested my changes locally
- [x] All existing tests pass (`npm test`)
- [x] This PR has a descriptive title

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
