### PR TITLE
whatsapp-business: add WhatsApp Business Cloud API connector + multilingual guides

### DIFF
--- a/content/guides/de/connect-whatsapp-business-to-chatgpt.mdx
+++ b/content/guides/de/connect-whatsapp-business-to-chatgpt.mdx
@@ -1,0 +1,87 @@
+---
+title: "WhatsApp Business mit ChatGPT verbinden — WhatsApp aus ChatGPT über MCP senden"
+description: "Metas WhatsApp Business Cloud API mit AnythingMCP an ChatGPT (Plus / Pro / Team / Enterprise) anbinden. Text, Vorlagen, Medien, Sprachnachrichten und interaktive Buttons aus ChatGPT per natürlicher Sprache senden."
+category: "connectors"
+keyword: "WhatsApp ChatGPT, WhatsApp KI, WhatsApp MCP ChatGPT, WhatsApp Business ChatGPT, WhatsApp aus ChatGPT senden"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "de"
+---
+
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → WhatsApp Business** klicken, dauerhaftes System-User-Access-Token + WhatsApp Business Account ID einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
+## WhatsApp Business mit ChatGPT verbinden
+
+Die WhatsApp Business Cloud API ist Metas gehostetes Gateway zum programmatischen Versenden von WhatsApp-Nachrichten — Text, Vorlagen, Medien, Sprachnachrichten, interaktive Buttons, Standort. Mit AnythingMCP steuerst du alles aus ChatGPT auf Deutsch.
+
+ChatGPT unterstützt MCP-Server über die **Connectors**-Funktion (Plus-/Pro-/Team-/Enterprise-Pläne). Einmal verdrahtet, erscheinen alle 14 WhatsApp-Tools nativ in der ChatGPT-Toolbar.
+
+### Was du tun kannst
+
+- "Sende 'Deine Buchung ist bestätigt für Freitag um 18:00' an +49 30 12345678."
+- "Sende die Vorlage `terminerinnerung` (de) an alle Nummern in dieser CSV, fülle Vorname und Datum ein."
+- "Sende das PDF auf https://acme.com/inv/9912.pdf an meinen Kunden mit Untertitel 'Rechnung 9912'."
+- "Markiere die letzte eingehende Nachricht von +49 151 5123 4567 als gelesen."
+
+### Voraussetzungen
+
+- Ein **WhatsApp Business Account (WABA)** mit mindestens einer verifizierten Absende-Nummer.
+- Ein **dauerhaftes System-User-Access-Token** mit `whatsapp_business_messaging` + `whatsapp_business_management`-Berechtigungen.
+- AnythingMCP lokal oder auf cloud.anythingmcp.com (3-Minuten-Setup).
+- Ein ChatGPT-**Plus-/Pro-/Team-/Enterprise**-Konto (der kostenlose Tarif unterstützt keine eigenen Connectors).
+
+### Schritt 1 — WhatsApp-Business-Zugangsdaten holen
+
+1. Öffne https://developers.facebook.com/ → deine App → **WhatsApp → API Setup**. Notiere die **WhatsApp Business Account ID** (WABA ID).
+2. Gehe zu **Meta Business Suite → Unternehmenseinstellungen → System Users**, erstelle einen System User, weise dein WABA zu und **Generiere ein neues Token** mit `whatsapp_business_messaging` + `whatsapp_business_management`. Kopiere es — du siehst es nicht noch einmal.
+
+### Schritt 2 — WhatsApp-Business-Adapter installieren
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffne `http://localhost:3000/connectors/store`, klicke **WhatsApp Business**, trage Token + WABA ID ein, klicke **Install**.
+
+### Schritt 3 — Connector in ChatGPT hinzufügen (kein Code, 4 Klicks)
+
+1. Öffne **ChatGPT → Einstellungen → Connectors** (oder klicke das 🔧-Icon im Composer → **Manage connectors**).
+2. Klicke **"Add custom connector"**.
+3. Trage ein:
+   - **Name:** `WhatsApp Business`
+   - **MCP server URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer Token → MCP-API-Key einfügen (aus AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Klicke **Connect** zum Autorisieren.
+
+Alle 14 WhatsApp-Tools erscheinen nun im 🔧-Menü von ChatGPT.
+
+### Verfügbare Tools (14 insgesamt)
+
+| Gruppe | Tools |
+|---|---|
+| **Discovery** | `whatsapp_list_phone_numbers`, `whatsapp_list_message_templates`, `whatsapp_get_message_template` |
+| **Text & Vorlage** | `whatsapp_send_text_message`, `whatsapp_send_template_message` |
+| **Medien (URL oder Media-ID)** | `whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document` |
+| **Interaktiv & Standort** | `whatsapp_send_location`, `whatsapp_send_interactive_buttons` |
+| **Lesebestätigungen & Profil** | `whatsapp_mark_message_as_read`, `whatsapp_get_business_profile`, `whatsapp_update_business_profile` |
+
+### Das 24-Stunden-Fenster
+
+WhatsApp erlaubt **Freitext**-Nachrichten (Text, Medien, interaktiv, Standort) nur in den **24 Stunden** nach der letzten eingehenden Nachricht des Nutzers. Außerhalb dieses Fensters: nur **vorab genehmigte Vorlagen**. Das `instructions`-Feld des Adapters lehrt ChatGPT diese Regel, sodass es bei Bedarf `whatsapp_send_template_message` greift.
+
+### FAQ
+
+**Funktioniert der kostenlose ChatGPT-Tarif mit eigenen MCP-Connectors?**
+Nein. Du brauchst Plus, Pro, Team oder Enterprise, um eigene Connectors hinzuzufügen.
+
+**Sprachnachrichten?**
+Nutze `whatsapp_send_audio` mit einer OGG-Opus-Datei auf einer öffentlichen HTTPS-URL — WhatsApp rendert das als echte Sprachnachricht.
+
+**Kann ChatGPT eingehende WhatsApp empfangen?**
+Nicht über diesen Connector — Meta liefert Inbound per Webhook (außerhalb des MCP-Request/Response-Modells). Betreibe einen kleinen Webhook-Receiver neben AnythingMCP für die Inbound-Seite.
+
+### Nächste Schritte
+
+- [WhatsApp Business zu MCP — die generische Anleitung](./whatsapp-business-to-mcp)
+- [WhatsApp Business mit Claude verbinden](./connect-whatsapp-business-to-claude)

--- a/content/guides/de/connect-whatsapp-business-to-claude.mdx
+++ b/content/guides/de/connect-whatsapp-business-to-claude.mdx
@@ -1,0 +1,141 @@
+---
+title: "WhatsApp Business mit Claude verbinden — WhatsApp aus Claude über MCP senden"
+description: "Metas WhatsApp Business Cloud API mit AnythingMCP an Claude anbinden. Text, Vorlagen, Medien, Sprachnachrichten und interaktive Buttons aus Claude Desktop, Claude Code oder claude.ai per natürlicher Sprache senden."
+category: "connectors"
+keyword: "WhatsApp Claude, WhatsApp KI, WhatsApp MCP Claude, WhatsApp Business Claude, WhatsApp aus Claude senden"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "de"
+---
+
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → WhatsApp Business** klicken, dauerhaftes System-User-Access-Token + WhatsApp Business Account ID einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
+## WhatsApp Business mit Claude verbinden
+
+Die WhatsApp Business Cloud API ist Metas gehostetes Gateway zum programmatischen Versenden von WhatsApp-Nachrichten — Text, Vorlagen, Medien, Sprachnachrichten, interaktive Buttons, Standorte. Mit AnythingMCP steuerst du alles aus Claude Desktop, Claude Code oder claude.ai in Klartext. Kein SDK zu kleben, kein JSON-von-Hand für jeden Nachrichtentyp.
+
+### Was du tun kannst
+
+- "Sende 'Deine Bestellung wurde verschickt — verfolge sie auf https://acme.com/t/12345' an +49 151 5123 4567."
+- "Sende die Vorlage `bestellbestaetigung` (de) an +49 30 12345678, fülle 'Anna' und 'ORD-9912' ein."
+- "Sende das Rechnungs-PDF von https://acme.com/inv/9912.pdf an meinen Kunden mit Untertitel 'Rechnung 9912'."
+- "Liste die genehmigten Vorlagen auf meinem WABA und sende dann die Willkommensvorlage auf Deutsch an diesen neuen Lead."
+
+### Voraussetzungen
+
+- Ein **WhatsApp Business Account (WABA)** mit mindestens einer verifizierten Absende-Nummer.
+- Ein **dauerhaftes System-User-Access-Token** mit `whatsapp_business_messaging` + `whatsapp_business_management`-Berechtigungen (das temporäre 24h-Dev-Token taugt zum Testen, läuft aber aus).
+- AnythingMCP lokal oder auf cloud.anythingmcp.com (3-Minuten-Setup).
+- Claude Desktop, Claude Code oder ein claude.ai-Konto.
+
+### Schritt 1 — WhatsApp-Business-Zugangsdaten holen
+
+1. Öffne https://developers.facebook.com/ → deine App → **WhatsApp → API Setup**. Notiere die **WhatsApp Business Account ID** (WABA ID).
+2. Gehe zu **Meta Business Suite → Unternehmenseinstellungen → System Users**, erstelle einen System User, weise dein WABA zu und **Generiere ein neues Token** mit `whatsapp_business_messaging` + `whatsapp_business_management`. Kopiere es — du siehst es nicht noch einmal.
+3. Stelle sicher, dass deine Absende-Nummer in API Setup **verifiziert** ist (die Test-Nummer funktioniert sofort; für Produktion eigene Nummer hinzufügen und verifizieren).
+
+### Schritt 2 — WhatsApp-Business-Adapter installieren
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffne `http://localhost:3000/connectors/store`, klicke **WhatsApp Business** und trage ein:
+
+| Feld | Wert |
+|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | das dauerhafte System-User-Token |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | deine WABA ID (z. B. `123456789012345`) |
+
+Klicke **Install** — der Adapter ist nun mit 14 Tools in deinem Katalog.
+
+### Schritt 3 — phoneNumberId einmalig ermitteln
+
+Bitte Claude, `whatsapp_list_phone_numbers` aufzurufen (mit deiner WABA ID als `businessAccountId`). Du erhältst die `id` jeder Absende-Nummer zurück — diesen Wert fixieren, jedes Send-Tool braucht ihn als `phoneNumberId`.
+
+### Schritt 4 — Connector in Claude hinzufügen (kein Code, 4 Klicks)
+
+Empfohlener Weg — funktioniert auf **claude.ai web** ohne Anfassen einer Konfigurationsdatei.
+
+1. Öffne **[claude.ai/customize/connectors](https://claude.ai/customize/connectors)**.
+2. Klicke **"Add custom connector"**.
+3. Trage ein:
+   - **Name:** `WhatsApp Business`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer Token → MCP-API-Key einfügen (aus AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Klicke **Connect** zum Autorisieren.
+
+Fertig. Alle 14 WhatsApp-Tools erscheinen in deinem Chat — leg los mit Prompts.
+
+<details>
+<summary><strong>Fortgeschritten: Claude Desktop / Claude Code (JSON / CLI)</strong></summary>
+
+**Claude Desktop** — bearbeite `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) oder `%AppData%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "whatsapp-business": {
+      "url": "https://cloud.anythingmcp.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Claude Desktop neu starten. WhatsApp-Tools erscheinen im 🔧-Menü.
+
+**Claude Code** — ein CLI-Befehl:
+
+```bash
+claude mcp add whatsapp-business \
+  --transport http \
+  --url https://cloud.anythingmcp.com/mcp \
+  --header "Authorization: Bearer YOUR_MCP_API_KEY"
+```
+
+Prüfen mit `claude mcp list`.
+
+</details>
+
+### Verfügbare Tools (14 insgesamt)
+
+| Gruppe | Tools |
+|---|---|
+| **Discovery** | `whatsapp_list_phone_numbers`, `whatsapp_list_message_templates`, `whatsapp_get_message_template` |
+| **Text & Vorlage** | `whatsapp_send_text_message`, `whatsapp_send_template_message` |
+| **Medien (URL oder Media-ID)** | `whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document` |
+| **Interaktiv & Standort** | `whatsapp_send_location`, `whatsapp_send_interactive_buttons` |
+| **Lesebestätigungen & Profil** | `whatsapp_mark_message_as_read`, `whatsapp_get_business_profile`, `whatsapp_update_business_profile` |
+
+### Das 24-Stunden-Fenster — was dein Agent wissen muss
+
+WhatsApp erlaubt **Freitext**-Nachrichten (Text, Medien, interaktiv, Standort) nur in den **24 Stunden** nach der letzten eingehenden Nachricht des Nutzers an deine Nummer. Außerhalb dieses Fensters sind nur **vorab genehmigte Vorlagen** erlaubt — rufe `whatsapp_send_template_message` mit Name und Sprache der Vorlage auf.
+
+Das `instructions`-Feld des Adapters teilt Claude diese Regel mit, sodass Claude bei "sende ein Follow-up an diesen Kunden" Tage nach der letzten Antwort `whatsapp_send_template_message` statt Freitext nutzt.
+
+### Sprachnachrichten
+
+Nutze `whatsapp_send_audio` mit `link` auf eine OGG-Opus-Datei auf einer öffentlichen HTTPS-URL. WhatsApp rendert OGG-Opus als echte Sprachnachricht (Wellenform + Play-Button). MP3 und AMR funktionieren, erscheinen aber als reine Audio-Anhänge.
+
+### FAQ
+
+**Funktioniert das ohne verifizierte Geschäftsnummer?**
+Metas Test-Nummer funktioniert zum Testen (nur Versand an als Tester hinzugefügte Nummern). Für Produktionsversand an beliebige Empfänger muss deine Absende-Nummer verifiziert und auf deinem WABA registriert sein.
+
+**Was passiert, wenn ich Freitext außerhalb des 24h-Fensters sende?**
+Meta antwortet mit Fehlercode `131047` ("Re-engagement message"). Nutze `whatsapp_send_template_message`.
+
+**Kann der Adapter eingehende Nachrichten empfangen?**
+Nicht direkt — Meta nutzt Webhooks für Inbound, und die AnythingMCP REST-Engine ist nur outbound. Betreibe einen kleinen Webhook-Receiver neben AnythingMCP und nutze diesen Connector für outbound + `whatsapp_mark_message_as_read` für Lesebestätigungen.
+
+**Funktioniert es mit Claude Code genauso wie mit Claude Desktop?**
+Ja — selbe MCP-URL.
+
+### Nächste Schritte
+
+- [WhatsApp Business zu MCP — die generische Anleitung](./whatsapp-business-to-mcp)
+- [WhatsApp Business mit ChatGPT verbinden](./connect-whatsapp-business-to-chatgpt)

--- a/content/guides/de/whatsapp-business-to-mcp.mdx
+++ b/content/guides/de/whatsapp-business-to-mcp.mdx
@@ -1,0 +1,83 @@
+---
+title: "WhatsApp Business zu MCP — WhatsApp-Nachrichten aus jedem KI-Agent senden"
+description: "Metas WhatsApp Business Cloud API mit AnythingMCP als MCP-Server exponieren. 14 fertige Tools für Text, Vorlagen, Medien (Bild/Audio/Sprach/Video/Dokument), Standort, interaktive Buttons und Verwaltung des Geschäftsprofils. Bearer-Token-Auth, kein SDK, kein Client-Code."
+category: "connectors"
+keyword: "WhatsApp MCP, WhatsApp Business API MCP, WhatsApp KI-Agent, WhatsApp Cloud API, WhatsApp aus KI senden"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "de"
+---
+
+> 💡 **Keine Installation? Nutze [cloud.anythingmcp.com](https://cloud.anythingmcp.com) direkt.** Einloggen, **Connectors → WhatsApp Business** klicken, dauerhaftes System-User-Access-Token + WhatsApp Business Account ID einfügen, MCP-API-Key erzeugen — fertig. Kein Docker, kein `git clone`, kein lokaler Server. Du kannst die lokalen Installationsschritte unten überspringen und direkt zur Client-Konfiguration weitergehen.
+
+## WhatsApp Business auf dem Model Context Protocol
+
+Die [WhatsApp Business Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api) ist Metas offiziell gehostetes Gateway zum programmatischen Versenden von WhatsApp-Nachrichten — Text, vorab genehmigte Vorlagen, Medien, Standortmarkierungen, interaktive Button-Flows und Geschäftsprofil-Verwaltung. AnythingMCP wickelt sie als **MCP-Server** ein, sodass jeder Agent — Claude, ChatGPT, Copilot, dein eigener — sie per natürlicher Sprache steuern kann.
+
+Der WhatsApp-Adapter ist eingebaut. Es gibt kein SDK zu pflegen und keinen Client-Code zu schreiben: Die Engine erledigt die Bearer-Token-Authentifizierung und erzeugt Requests, die exakt zu Metas `messaging_product=whatsapp`-Schema für jeden Nachrichtentyp passen.
+
+### Warum WhatsApp ohne AnythingMCP umständlich ist
+
+| Schritt | Was die WhatsApp Cloud API verlangt |
+|---|---|
+| 1 | Ein dauerhaftes System-User-Access-Token in der Meta Business Suite erzeugen (≠ vom temporären 24h-Dev-Token) mit `whatsapp_business_messaging` + `whatsapp_business_management`-Berechtigungen |
+| 2 | Die `phoneNumberId` jedes Absende-Numerus unter deinem WhatsApp Business Account (WABA) ermitteln |
+| 3 | Den korrekten JSON-Body pro Nachrichtentyp bauen — `text`/`template`/`image`/`audio`/`video`/`document`/`location`/`interactive` — jeder mit eigenem Schema und Feldplatzierungs-Eigenheiten |
+| 4 | Auf einer noch unterstützten Graph-API-Version bleiben (v15 ist tot, v20 läuft September 2026 aus; der Adapter nutzt **v22.0**) |
+| 5 | Das 24-Stunden-Kundenservice-Fenster respektieren — außerhalb davon sind nur vorab genehmigte Vorlagen erlaubt |
+
+Das ist das gesamte **`BEARER_TOKEN`**-Auth-Profil + 14 Message-Shape-Tools, einmal als JSON in der Adapter-Spec deklariert. Kein Client-Code zu pflegen.
+
+### Installation
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Öffne `http://localhost:3000/connectors/store`, wähle **WhatsApp Business** und trage ein:
+
+| Feld | Wert |
+|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | das dauerhafte System-User-Access-Token |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | deine WABA ID (z. B. `123456789012345`) |
+
+Erzeuge einen MCP-API-Key unter **Profile → MCP API Keys** und richte deinen Agenten auf `http://localhost:4000/mcp`.
+
+### Verfügbare Tools (14)
+
+| Tool | Was es tut |
+|---|---|
+| `whatsapp_list_phone_numbers` | Ermittelt die `phoneNumberId` jeder Nummer auf deinem WABA |
+| `whatsapp_list_message_templates` | Listet genehmigte Vorlagen mit ihren Komponenten |
+| `whatsapp_get_message_template` | Holt eine einzelne Vorlage per ID |
+| `whatsapp_send_text_message` | Sendet freien Text (nur im 24h-Fenster) |
+| `whatsapp_send_template_message` | Sendet eine vorab genehmigte Vorlage (immer erlaubt) |
+| `whatsapp_send_image` | Sendet JPG/PNG per öffentlicher URL oder Media-ID |
+| `whatsapp_send_audio` | Sendet eine Audiodatei — OGG-Opus erscheint als echte Sprachnachricht |
+| `whatsapp_send_video` | Sendet ein MP4/3GPP-Video |
+| `whatsapp_send_document` | Sendet PDF/DOC/XLS mit optionalem Dateinamen |
+| `whatsapp_send_location` | Sendet einen Standort |
+| `whatsapp_send_interactive_buttons` | Sendet 1–3 Antwort-Buttons |
+| `whatsapp_mark_message_as_read` | Sendet eine Lesebestätigung (doppelter blauer Haken) |
+| `whatsapp_get_business_profile` | Liest das öffentliche Geschäftsprofil |
+| `whatsapp_update_business_profile` | Aktualisiert About/Adresse/E-Mail/Webseiten |
+
+### Das 24-Stunden-Fenster, erklärt
+
+WhatsApp erzwingt ein **Kundenservice-Fenster**: Freitext-Nachrichten (Text, Medien, interaktiv, Standort) sind nur in den 24 Stunden nach der letzten eingehenden Nachricht des Nutzers an deine Nummer erlaubt. Außerhalb dieses Fensters sind nur **vorab genehmigte Vorlagen** erlaubt — du erstellst sie in der Meta Business Suite, wartest auf die Genehmigung und rufst dann `whatsapp_send_template_message` mit Name und Sprachcode der Vorlage auf.
+
+Der Adapter verfolgt das Fenster nicht für dich. Er ruft nur die API; Meta gibt den Fehlercode `131047` ("Re-engagement message") zurück, wenn du außerhalb des Fensters Freitext sendest. Das `instructions`-Feld des Adapters erklärt die Regel, damit dein Agent weiß, wann auf eine Vorlage zurückzugreifen ist.
+
+### Medien — URL vs. Upload
+
+WhatsApp akzeptiert Medien auf zwei Wegen: zuerst eine Binärdatei nach `/PHONE_NUMBER_ID/media` hochladen, um eine `media_id` zu erhalten, oder einen öffentlichen HTTPS-`link` übergeben. AnythingMCP empfiehlt den **Link-Pfad**, weil die REST-Engine den Multipart-Upload-und-Send-Tanz nicht in einem einzigen Tool-Call orchestriert. Hoste die Datei auf einem CDN oder einem Signed-URL-Bucket und gib die URL an `whatsapp_send_image` / `audio` / `video` / `document`. Das `mediaId`-Feld steht als Escape-Hatch zur Verfügung, falls du anderswo vor-hochlädst.
+
+### Eingehende Nachrichten — nicht im Umfang
+
+Dieser Connector ist **nur outbound**. WhatsApp liefert eingehende Nachrichten über einen Webhook aus, den du selbst hostest, und die aktuelle Architektur von AnythingMCP ist Request/Response. Wenn du einen Chatbot brauchst, der auf Nutzernachrichten antwortet, betreibe einen kleinen Webhook-Receiver neben AnythingMCP und nutze diesen Connector für die Outbound-Seite (plus `whatsapp_mark_message_as_read` für Lesebestätigungen).
+
+### Nächste Schritte
+
+- [WhatsApp Business mit Claude verbinden](./connect-whatsapp-business-to-claude)
+- [WhatsApp Business mit ChatGPT verbinden](./connect-whatsapp-business-to-chatgpt)

--- a/content/guides/en/connect-whatsapp-business-to-chatgpt.mdx
+++ b/content/guides/en/connect-whatsapp-business-to-chatgpt.mdx
@@ -1,0 +1,87 @@
+---
+title: "How to Connect WhatsApp Business to ChatGPT — Send WhatsApp from ChatGPT via MCP"
+description: "Connect Meta's WhatsApp Business Cloud API to ChatGPT (Plus / Pro / Team / Enterprise) with AnythingMCP. Send text, templates, media, voice notes, and interactive buttons from ChatGPT in natural language."
+category: "connectors"
+keyword: "WhatsApp ChatGPT, WhatsApp AI, WhatsApp MCP ChatGPT, WhatsApp Business ChatGPT, send WhatsApp from ChatGPT"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "en"
+---
+
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → WhatsApp Business**, paste your permanent System User access token + WhatsApp Business Account ID, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
+## Connect WhatsApp Business to ChatGPT
+
+WhatsApp Business Cloud API is Meta's hosted gateway for sending WhatsApp messages programmatically — text, templates, media, voice notes, interactive buttons, location pins. With AnythingMCP you drive all of it from ChatGPT in plain English.
+
+ChatGPT supports MCP servers via the **Connectors** feature (Plus / Pro / Team / Enterprise plans). Once wired, all 14 WhatsApp tools show up natively in your ChatGPT toolbar.
+
+### What you can do
+
+- "Send 'Your booking is confirmed for Friday at 18:00' to +44 7700 900123."
+- "Send the `appointment_reminder` template (it) to all the numbers in this CSV, fill in their first name and date."
+- "Send the PDF at https://acme.com/inv/9912.pdf to my customer with caption 'Invoice 9912'."
+- "Mark the last inbound message from +1 555 123 4567 as read."
+
+### Prerequisites
+
+- A **WhatsApp Business Account (WABA)** with at least one verified sending number.
+- A **permanent System User access token** with `whatsapp_business_messaging` + `whatsapp_business_management` permissions.
+- AnythingMCP running locally or on cloud.anythingmcp.com (3-minute setup).
+- A ChatGPT **Plus / Pro / Team / Enterprise** account (free tier does not support custom Connectors).
+
+### Step 1 — Get your WhatsApp Business credentials
+
+1. Open https://developers.facebook.com/ → your App → **WhatsApp → API Setup**. Note the **WhatsApp Business Account ID** (WABA ID).
+2. Go to **Meta Business Suite → Business Settings → System Users**, create a System User, assign your WABA, and **Generate a New Token** with both `whatsapp_business_messaging` and `whatsapp_business_management` permissions. Copy it — you can't see it again.
+
+### Step 2 — Install the WhatsApp Business adapter
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **WhatsApp Business**, fill in the token + WABA ID, click **Install**.
+
+### Step 3 — Add the connector in ChatGPT (no code, 4 clicks)
+
+1. Open **ChatGPT → Settings → Connectors** (or click the 🔧 icon in the composer → **Manage connectors**).
+2. Click **"Add custom connector"**.
+3. Fill in:
+   - **Name:** `WhatsApp Business`
+   - **MCP server URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → paste your MCP API key (from AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Click **Connect** to authorize.
+
+All 14 WhatsApp tools now appear in the ChatGPT 🔧 menu.
+
+### Available tools (14 total)
+
+| Group | Tools |
+|---|---|
+| **Discovery** | `whatsapp_list_phone_numbers`, `whatsapp_list_message_templates`, `whatsapp_get_message_template` |
+| **Text & template** | `whatsapp_send_text_message`, `whatsapp_send_template_message` |
+| **Media (URL or media ID)** | `whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document` |
+| **Interactive & location** | `whatsapp_send_location`, `whatsapp_send_interactive_buttons` |
+| **Read receipts & profile** | `whatsapp_mark_message_as_read`, `whatsapp_get_business_profile`, `whatsapp_update_business_profile` |
+
+### The 24-hour window
+
+WhatsApp only lets you send **free-form** messages (text, media, interactive, location) inside the **24 hours** following the user's last inbound message. Outside that window: pre-approved **templates only**. The adapter's `instructions` field teaches ChatGPT this rule, so it'll reach for `whatsapp_send_template_message` when needed.
+
+### FAQ
+
+**Does ChatGPT free tier work with custom MCP connectors?**
+No. You need Plus, Pro, Team, or Enterprise to add custom connectors.
+
+**Voice notes?**
+Use `whatsapp_send_audio` with an OGG-Opus file hosted on a public HTTPS URL — WhatsApp renders it as a true voice message.
+
+**Can ChatGPT receive inbound WhatsApp messages?**
+Not via this connector — Meta delivers inbound via webhooks (outside the MCP request/response model). Host a small webhook receiver next to AnythingMCP for the inbound side.
+
+### Next steps
+
+- [WhatsApp Business to MCP — the generic guide](./whatsapp-business-to-mcp)
+- [Connect WhatsApp Business to Claude](./connect-whatsapp-business-to-claude)

--- a/content/guides/en/connect-whatsapp-business-to-claude.mdx
+++ b/content/guides/en/connect-whatsapp-business-to-claude.mdx
@@ -1,0 +1,141 @@
+---
+title: "How to Connect WhatsApp Business to Claude — Send WhatsApp from Claude via MCP"
+description: "Connect Meta's WhatsApp Business Cloud API to Claude with AnythingMCP. Send text, templates, media, voice notes, and interactive buttons from Claude Desktop, Claude Code, or claude.ai in natural language."
+category: "connectors"
+keyword: "WhatsApp Claude, WhatsApp AI, WhatsApp MCP Claude, WhatsApp Business Claude, send WhatsApp from Claude"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "en"
+---
+
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → WhatsApp Business**, paste your permanent System User access token + WhatsApp Business Account ID, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
+## Connect WhatsApp Business to Claude
+
+WhatsApp Business Cloud API is Meta's hosted gateway for sending WhatsApp messages programmatically — text, templates, media, voice notes, interactive buttons, location pins. With AnythingMCP you drive all of it from Claude Desktop, Claude Code, or claude.ai in plain English. No SDK to glue, no JSON-by-hand for every message type.
+
+### What you can do
+
+- "Send 'Your order has shipped — track it at https://acme.com/t/12345' to +49 151 5123 4567."
+- "Send the `order_confirmation` template (en_US) to +1 555 123 4567, fill in 'John' and 'ORD-9912'."
+- "Send the invoice PDF at https://acme.com/inv/9912.pdf to my customer with caption 'Invoice 9912'."
+- "List the approved templates on my WABA, then send the welcome one in Italian to this new lead."
+
+### Prerequisites
+
+- A **WhatsApp Business Account (WABA)** with at least one verified sending number.
+- A **permanent System User access token** with `whatsapp_business_messaging` + `whatsapp_business_management` permissions (the temporary 24h dev token works for testing but expires).
+- AnythingMCP running locally or on cloud.anythingmcp.com (3-minute setup).
+- Claude Desktop, Claude Code, or a claude.ai account.
+
+### Step 1 — Get your WhatsApp Business credentials
+
+1. Open https://developers.facebook.com/ → your App → **WhatsApp → API Setup**. Note the **WhatsApp Business Account ID** (WABA ID).
+2. Go to **Meta Business Suite → Business Settings → System Users**, create a System User, assign your WABA, and **Generate a New Token** with both `whatsapp_business_messaging` and `whatsapp_business_management` permissions. Copy it — you can't see it again.
+3. Make sure your sending phone number is **verified** in API Setup (the test number works out of the box; for production, add and verify your own).
+
+### Step 2 — Install the WhatsApp Business adapter
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, click **WhatsApp Business**, and fill in:
+
+| Field | Value |
+|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | the permanent System User token |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | your WABA ID (e.g. `123456789012345`) |
+
+Click **Install** — the adapter is now in your catalog with 14 tools.
+
+### Step 3 — Find your phoneNumberId once
+
+Ask Claude to call `whatsapp_list_phone_numbers` (with your WABA ID as `businessAccountId`). You'll get back the `id` of each sending number — pin that value, every send tool needs it as `phoneNumberId`.
+
+### Step 4 — Add the connector in Claude (no code, 4 clicks)
+
+Recommended path — works on **claude.ai web** without touching any config file.
+
+1. Open **[claude.ai/customize/connectors](https://claude.ai/customize/connectors)**.
+2. Click **"Add custom connector"**.
+3. Fill in:
+   - **Name:** `WhatsApp Business`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → paste your MCP API key (from AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Click **Connect** to authorize.
+
+That's it. All 14 WhatsApp tools appear in your chat — start typing prompts.
+
+<details>
+<summary><strong>Advanced: Claude Desktop / Claude Code (JSON / CLI)</strong></summary>
+
+**Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%AppData%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "whatsapp-business": {
+      "url": "https://cloud.anythingmcp.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. WhatsApp tools appear in the 🔧 menu.
+
+**Claude Code** — one CLI command:
+
+```bash
+claude mcp add whatsapp-business \
+  --transport http \
+  --url https://cloud.anythingmcp.com/mcp \
+  --header "Authorization: Bearer YOUR_MCP_API_KEY"
+```
+
+Verify with `claude mcp list`.
+
+</details>
+
+### Available tools (14 total)
+
+| Group | Tools |
+|---|---|
+| **Discovery** | `whatsapp_list_phone_numbers`, `whatsapp_list_message_templates`, `whatsapp_get_message_template` |
+| **Text & template** | `whatsapp_send_text_message`, `whatsapp_send_template_message` |
+| **Media (URL or media ID)** | `whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document` |
+| **Interactive & location** | `whatsapp_send_location`, `whatsapp_send_interactive_buttons` |
+| **Read receipts & profile** | `whatsapp_mark_message_as_read`, `whatsapp_get_business_profile`, `whatsapp_update_business_profile` |
+
+### The 24-hour window — what your agent needs to know
+
+WhatsApp only lets you send **free-form** messages (text, media, interactive, location) inside the **24 hours** following the user's last inbound message to your number. Outside that window the only allowed sends are **pre-approved templates** — call `whatsapp_send_template_message` with the template name and language.
+
+The adapter's `instructions` block tells Claude this rule, so when you ask "send a follow-up to that customer" days after their last reply, Claude will reach for `whatsapp_send_template_message` instead of free-form text.
+
+### Voice notes
+
+Use `whatsapp_send_audio` with `link` pointing to an OGG-Opus file hosted on a public HTTPS URL. WhatsApp renders OGG-Opus as a true voice message (waveform + play button). MP3 and AMR also work but render as plain audio attachments.
+
+### FAQ
+
+**Does this work without a verified business number?**
+Meta's test number works for testing (only sends to numbers you've added as testers). For production sends to any recipient, your sending number must be verified and registered to your WABA.
+
+**What happens if I send free-form text outside the 24h window?**
+Meta returns error code `131047` ("Re-engagement message"). Use `whatsapp_send_template_message` instead.
+
+**Can the adapter receive inbound messages?**
+Not directly — Meta uses webhooks for inbound, and the AnythingMCP REST engine is outbound-only. Host a small webhook receiver next to AnythingMCP and use this connector for outbound + `whatsapp_mark_message_as_read` for receipts.
+
+**Does it work with Claude Code as well as Claude Desktop?**
+Yes — same MCP URL.
+
+### Next steps
+
+- [WhatsApp Business to MCP — the generic guide](./whatsapp-business-to-mcp)
+- [Connect WhatsApp Business to ChatGPT](./connect-whatsapp-business-to-chatgpt)

--- a/content/guides/en/whatsapp-business-to-mcp.mdx
+++ b/content/guides/en/whatsapp-business-to-mcp.mdx
@@ -1,0 +1,83 @@
+---
+title: "WhatsApp Business to MCP — Send WhatsApp Messages from Any AI Agent"
+description: "Expose Meta's WhatsApp Business Cloud API as an MCP server with AnythingMCP. 14 ready-to-use tools for text, templates, media (image/audio/voice/video/document), location, interactive buttons, and business profile management. Bearer-token auth, no SDK, no client code."
+category: "connectors"
+keyword: "WhatsApp MCP, WhatsApp Business API MCP, WhatsApp AI agent, WhatsApp Cloud API, send WhatsApp from AI"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "en"
+---
+
+> 💡 **No install? Use [cloud.anythingmcp.com](https://cloud.anythingmcp.com) directly.** Sign in, click **Connectors → WhatsApp Business**, paste your permanent System User access token + WhatsApp Business Account ID, mint an MCP API key — done. No Docker, no `git clone`, no local server to run. You can skip the local-install steps below and jump straight to the client-wiring section.
+
+## WhatsApp Business on the Model Context Protocol
+
+[WhatsApp Business Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api) is Meta's officially-hosted gateway for sending WhatsApp messages programmatically — text, pre-approved templates, media, location pins, interactive button flows, and business-profile management. AnythingMCP wraps it as an **MCP server** so any agent — Claude, ChatGPT, Copilot, your own — can drive it with natural language.
+
+The WhatsApp adapter ships built-in. There is no SDK to maintain and no client code to write: the engine handles the Bearer-token authentication and produces requests that exactly match Meta's `messaging_product=whatsapp` schema for every message type.
+
+### Why WhatsApp is awkward without AnythingMCP
+
+| Step | What WhatsApp Cloud API requires |
+|---|---|
+| 1 | Generate a permanent System User access token in Meta Business Suite (≠ the temporary 24h dev token) with `whatsapp_business_messaging` + `whatsapp_business_management` permissions |
+| 2 | Discover the `phoneNumberId` of each sending number under your WhatsApp Business Account (WABA) |
+| 3 | Build the correct JSON body per message type — `text`/`template`/`image`/`audio`/`video`/`document`/`location`/`interactive` — each with its own schema and field-placement quirks |
+| 4 | Stay on a currently-supported Graph API version (v15 is gone, v20 expires Sept 2026; the adapter ships on **v22.0**) |
+| 5 | Respect the 24-hour customer service window — outside it you can only send pre-approved templates |
+
+That's the entire **`BEARER_TOKEN`** auth profile + 14 message-shape tools, declared once as JSON in the adapter spec. No client code to maintain.
+
+### Install
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Open `http://localhost:3000/connectors/store`, pick **WhatsApp Business**, and paste in:
+
+| Field | Value |
+|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | the permanent System User access token |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | your WABA ID (e.g. `123456789012345`) |
+
+Mint an MCP API key from **Profile → MCP API Keys** and point your agent at `http://localhost:4000/mcp`.
+
+### Available tools (14)
+
+| Tool | What it does |
+|---|---|
+| `whatsapp_list_phone_numbers` | Discover the `phoneNumberId` of each number on your WABA |
+| `whatsapp_list_message_templates` | List approved templates with their components |
+| `whatsapp_get_message_template` | Fetch one template by ID |
+| `whatsapp_send_text_message` | Send free-form text (24h window only) |
+| `whatsapp_send_template_message` | Send a pre-approved template (always allowed) |
+| `whatsapp_send_image` | Send a JPG/PNG via public URL or media ID |
+| `whatsapp_send_audio` | Send an audio file — OGG-Opus renders as a true voice note |
+| `whatsapp_send_video` | Send an MP4/3GPP video |
+| `whatsapp_send_document` | Send a PDF/DOC/XLS with optional filename |
+| `whatsapp_send_location` | Send a location pin |
+| `whatsapp_send_interactive_buttons` | Send 1–3 reply buttons |
+| `whatsapp_mark_message_as_read` | Send a read receipt (double blue tick) |
+| `whatsapp_get_business_profile` | Read the public business profile |
+| `whatsapp_update_business_profile` | Update about/address/email/websites |
+
+### The 24-hour window, explained
+
+WhatsApp enforces a **customer service window**: free-form messages (text, media, interactive, location) are only allowed in the 24 hours after the user last messaged your number. Outside that window the only allowed sends are **pre-approved templates** — you create them in Meta Business Suite, wait for approval, then call `whatsapp_send_template_message` with the template name and language code.
+
+The adapter doesn't track the window for you. It just calls the API; Meta returns a `131047` "Re-engagement message" error if you try to send free-form text outside the window. The instructions field in the adapter explains the rule so your agent knows when to fall back to a template.
+
+### Media — URL vs upload
+
+WhatsApp accepts media in two ways: upload a binary first to `/PHONE_NUMBER_ID/media` to get a `media_id`, or pass a public HTTPS `link`. AnythingMCP recommends the **link path** because the REST engine doesn't orchestrate the multipart upload + send dance in a single tool call. Host the file on a CDN or signed-URL bucket and pass the URL to `whatsapp_send_image` / `audio` / `video` / `document`. The `mediaId` field is available as an escape hatch if you pre-upload elsewhere.
+
+### Inbound messages — not in scope
+
+This connector is **outbound-only**. WhatsApp delivers inbound messages via a webhook you host yourself, and AnythingMCP's current architecture is request/response. If you need a chatbot that replies to user messages, run a small webhook receiver next to your AnythingMCP instance and use this connector for the outbound side (plus `whatsapp_mark_message_as_read` for read receipts).
+
+### Next steps
+
+- [Connect WhatsApp Business to Claude](./connect-whatsapp-business-to-claude)
+- [Connect WhatsApp Business to ChatGPT](./connect-whatsapp-business-to-chatgpt)

--- a/content/guides/it/connect-whatsapp-business-to-chatgpt.mdx
+++ b/content/guides/it/connect-whatsapp-business-to-chatgpt.mdx
@@ -1,0 +1,87 @@
+---
+title: "Come collegare WhatsApp Business a ChatGPT — Invia WhatsApp da ChatGPT via MCP"
+description: "Collega la WhatsApp Business Cloud API di Meta a ChatGPT (Plus / Pro / Team / Enterprise) con AnythingMCP. Invia testo, template, media, messaggi vocali e pulsanti interattivi da ChatGPT in linguaggio naturale."
+category: "connectors"
+keyword: "WhatsApp ChatGPT, WhatsApp AI, WhatsApp MCP ChatGPT, WhatsApp Business ChatGPT, inviare WhatsApp da ChatGPT"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "it"
+---
+
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → WhatsApp Business**, inserisci il System User access token permanente + l'ID del WhatsApp Business Account, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
+## Collegare WhatsApp Business a ChatGPT
+
+La WhatsApp Business Cloud API è il gateway ospitato da Meta per inviare messaggi WhatsApp via API — testo, template, media, messaggi vocali, pulsanti interattivi, posizione. Con AnythingMCP guidi tutto da ChatGPT in italiano.
+
+ChatGPT supporta server MCP tramite la funzione **Connectors** (piani Plus / Pro / Team / Enterprise). Una volta collegato, tutti i 14 tool WhatsApp appaiono nativamente nella toolbar di ChatGPT.
+
+### Cosa puoi fare
+
+- "Invia 'La tua prenotazione è confermata per venerdì alle 18:00' al +39 348 5123 456."
+- "Invia il template `promemoria_appuntamento` (it) a tutti i numeri di questo CSV, compila nome e data."
+- "Invia il PDF su https://acme.com/inv/9912.pdf al mio cliente con didascalia 'Fattura 9912'."
+- "Segna come letto l'ultimo messaggio in entrata dal +39 333 123 4567."
+
+### Prerequisiti
+
+- Un **WhatsApp Business Account (WABA)** con almeno un numero mittente verificato.
+- Un **System User access token permanente** con i permessi `whatsapp_business_messaging` + `whatsapp_business_management`.
+- AnythingMCP in locale o su cloud.anythingmcp.com (setup di 3 minuti).
+- Un account ChatGPT **Plus / Pro / Team / Enterprise** (il piano free non supporta i Connectors personalizzati).
+
+### Step 1 — Ottieni le credenziali WhatsApp Business
+
+1. Apri https://developers.facebook.com/ → la tua App → **WhatsApp → API Setup**. Annota il **WhatsApp Business Account ID** (WABA ID).
+2. Vai su **Meta Business Suite → Impostazioni Business → System Users**, crea un System User, assegna il tuo WABA e **Genera un nuovo token** con `whatsapp_business_messaging` + `whatsapp_business_management`. Copialo — non lo rivedi più.
+
+### Step 2 — Installa l'adapter WhatsApp Business
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, clicca **WhatsApp Business**, inserisci token + WABA ID, clicca **Install**.
+
+### Step 3 — Aggiungi il connettore in ChatGPT (zero codice, 4 click)
+
+1. Apri **ChatGPT → Impostazioni → Connectors** (o clicca l'icona 🔧 nel composer → **Manage connectors**).
+2. Clicca **"Add custom connector"**.
+3. Compila:
+   - **Name:** `WhatsApp Business`
+   - **MCP server URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → incolla la tua MCP API key (da AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Clicca **Connect** per autorizzare.
+
+Tutti i 14 tool WhatsApp ora appaiono nel menu 🔧 di ChatGPT.
+
+### Tool disponibili (14 totali)
+
+| Gruppo | Tool |
+|---|---|
+| **Discovery** | `whatsapp_list_phone_numbers`, `whatsapp_list_message_templates`, `whatsapp_get_message_template` |
+| **Testo & template** | `whatsapp_send_text_message`, `whatsapp_send_template_message` |
+| **Media (URL o media ID)** | `whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document` |
+| **Interattivi & posizione** | `whatsapp_send_location`, `whatsapp_send_interactive_buttons` |
+| **Ricevute & profilo** | `whatsapp_mark_message_as_read`, `whatsapp_get_business_profile`, `whatsapp_update_business_profile` |
+
+### La finestra di 24 ore
+
+WhatsApp consente l'invio di messaggi **free-form** (testo, media, interattivi, posizione) solo nelle **24 ore** successive all'ultimo messaggio in entrata dell'utente. Fuori da quella finestra: solo **template pre-approvati**. Il campo `instructions` dell'adapter insegna questa regola a ChatGPT, che userà `whatsapp_send_template_message` quando serve.
+
+### FAQ
+
+**Il piano free di ChatGPT funziona con i Connectors MCP custom?**
+No. Servono Plus, Pro, Team o Enterprise per aggiungere connettori custom.
+
+**Messaggi vocali?**
+Usa `whatsapp_send_audio` con un file OGG-Opus ospitato su un URL HTTPS pubblico — WhatsApp lo renderizza come vero messaggio vocale.
+
+**ChatGPT può ricevere WhatsApp in entrata?**
+Non tramite questo connettore — Meta consegna l'inbound via webhook (fuori dal modello request/response di MCP). Fai girare un piccolo receiver webhook accanto a AnythingMCP per il lato in entrata.
+
+### Prossimi passi
+
+- [WhatsApp Business su MCP — la guida generica](./whatsapp-business-to-mcp)
+- [Collegare WhatsApp Business a Claude](./connect-whatsapp-business-to-claude)

--- a/content/guides/it/connect-whatsapp-business-to-claude.mdx
+++ b/content/guides/it/connect-whatsapp-business-to-claude.mdx
@@ -1,0 +1,141 @@
+---
+title: "Come collegare WhatsApp Business a Claude — Invia WhatsApp da Claude via MCP"
+description: "Collega la WhatsApp Business Cloud API di Meta a Claude con AnythingMCP. Invia testo, template, media, messaggi vocali e pulsanti interattivi da Claude Desktop, Claude Code o claude.ai in linguaggio naturale."
+category: "connectors"
+keyword: "WhatsApp Claude, WhatsApp AI, WhatsApp MCP Claude, WhatsApp Business Claude, inviare WhatsApp da Claude"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "it"
+---
+
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → WhatsApp Business**, inserisci il System User access token permanente + l'ID del WhatsApp Business Account, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
+## Collegare WhatsApp Business a Claude
+
+La WhatsApp Business Cloud API è il gateway ospitato da Meta per inviare messaggi WhatsApp via API — testo, template, media, messaggi vocali, pulsanti interattivi, geolocalizzazione. Con AnythingMCP guidi tutto da Claude Desktop, Claude Code o claude.ai in italiano. Niente SDK da incollare, niente JSON-a-mano per ogni tipo di messaggio.
+
+### Cosa puoi fare
+
+- "Invia 'Il tuo ordine è stato spedito — traccialo su https://acme.com/t/12345' al +39 348 5123 456."
+- "Invia il template `conferma_ordine` (it) al +39 333 123 4567, compila 'Mario' e 'ORD-9912'."
+- "Invia il PDF di fattura su https://acme.com/inv/9912.pdf al mio cliente con didascalia 'Fattura 9912'."
+- "Lista i template approvati sul mio WABA, poi invia quello di benvenuto in italiano a questo nuovo lead."
+
+### Prerequisiti
+
+- Un **WhatsApp Business Account (WABA)** con almeno un numero mittente verificato.
+- Un **System User access token permanente** con i permessi `whatsapp_business_messaging` + `whatsapp_business_management` (il token dev temporaneo di 24h va bene per test ma scade).
+- AnythingMCP in locale o su cloud.anythingmcp.com (setup di 3 minuti).
+- Claude Desktop, Claude Code o un account claude.ai.
+
+### Step 1 — Ottieni le credenziali WhatsApp Business
+
+1. Apri https://developers.facebook.com/ → la tua App → **WhatsApp → API Setup**. Annota il **WhatsApp Business Account ID** (WABA ID).
+2. Vai su **Meta Business Suite → Impostazioni Business → System Users**, crea un System User, assegna il tuo WABA e **Genera un nuovo token** con i permessi `whatsapp_business_messaging` + `whatsapp_business_management`. Copialo — non lo rivedi più.
+3. Verifica che il numero mittente sia **verificato** in API Setup (il numero di test funziona subito; per la produzione aggiungi e verifica il tuo).
+
+### Step 2 — Installa l'adapter WhatsApp Business
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, clicca **WhatsApp Business** e compila:
+
+| Campo | Valore |
+|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | il System User token permanente |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | il tuo WABA ID (es. `123456789012345`) |
+
+Clicca **Install** — l'adapter è ora nel tuo catalogo con 14 tool.
+
+### Step 3 — Scopri il tuo phoneNumberId
+
+Chiedi a Claude di chiamare `whatsapp_list_phone_numbers` (con il tuo WABA ID come `businessAccountId`). Riceverai l'`id` di ciascun numero mittente — fissa quel valore, ogni tool di invio lo richiede come `phoneNumberId`.
+
+### Step 4 — Aggiungi il connettore in Claude (zero codice, 4 click)
+
+Percorso consigliato — funziona su **claude.ai web** senza toccare alcun file di configurazione.
+
+1. Apri **[claude.ai/customize/connectors](https://claude.ai/customize/connectors)**.
+2. Clicca **"Add custom connector"**.
+3. Compila:
+   - **Name:** `WhatsApp Business`
+   - **URL:** `https://cloud.anythingmcp.com/mcp`
+   - **Authentication:** Bearer token → incolla la tua MCP API key (da AnythingMCP → **Profile → MCP API Keys → New Key**)
+4. Clicca **Connect** per autorizzare.
+
+Fatto. Tutti i 14 tool WhatsApp compaiono nella tua chat — inizia a scrivere prompt.
+
+<details>
+<summary><strong>Avanzato: Claude Desktop / Claude Code (JSON / CLI)</strong></summary>
+
+**Claude Desktop** — modifica `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o `%AppData%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "whatsapp-business": {
+      "url": "https://cloud.anythingmcp.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Riavvia Claude Desktop. I tool WhatsApp compaiono nel menu 🔧.
+
+**Claude Code** — un comando CLI:
+
+```bash
+claude mcp add whatsapp-business \
+  --transport http \
+  --url https://cloud.anythingmcp.com/mcp \
+  --header "Authorization: Bearer YOUR_MCP_API_KEY"
+```
+
+Verifica con `claude mcp list`.
+
+</details>
+
+### Tool disponibili (14 totali)
+
+| Gruppo | Tool |
+|---|---|
+| **Discovery** | `whatsapp_list_phone_numbers`, `whatsapp_list_message_templates`, `whatsapp_get_message_template` |
+| **Testo & template** | `whatsapp_send_text_message`, `whatsapp_send_template_message` |
+| **Media (URL o media ID)** | `whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document` |
+| **Interattivi & posizione** | `whatsapp_send_location`, `whatsapp_send_interactive_buttons` |
+| **Ricevute & profilo** | `whatsapp_mark_message_as_read`, `whatsapp_get_business_profile`, `whatsapp_update_business_profile` |
+
+### La finestra di 24 ore — cosa deve sapere il tuo agente
+
+WhatsApp consente l'invio di messaggi **free-form** (testo, media, interattivi, posizione) solo nelle **24 ore** successive all'ultimo messaggio in entrata dell'utente verso il tuo numero. Fuori da quella finestra puoi inviare solo **template pre-approvati** — chiama `whatsapp_send_template_message` con il nome del template e la lingua.
+
+Il campo `instructions` dell'adapter comunica questa regola a Claude, così quando chiedi "manda un follow-up a quel cliente" giorni dopo la sua ultima risposta, Claude userà `whatsapp_send_template_message` invece del testo libero.
+
+### Messaggi vocali
+
+Usa `whatsapp_send_audio` con `link` puntato a un file OGG-Opus ospitato su un URL HTTPS pubblico. WhatsApp renderizza OGG-Opus come vero messaggio vocale (forma d'onda + pulsante play). MP3 e AMR funzionano ma compaiono come allegati audio normali.
+
+### FAQ
+
+**Funziona senza un numero business verificato?**
+Il numero di test di Meta funziona per le prove (solo verso numeri aggiunti come tester). Per inviare in produzione a qualsiasi destinatario, il tuo numero mittente deve essere verificato e registrato sul tuo WABA.
+
+**Cosa succede se invio testo libero fuori dalla finestra 24h?**
+Meta risponde con codice `131047` ("Re-engagement message"). Usa `whatsapp_send_template_message`.
+
+**L'adapter può ricevere messaggi in entrata?**
+No direttamente — Meta usa webhook per l'inbound, e il REST engine di AnythingMCP è outbound-only. Fai girare un piccolo receiver webhook accanto a AnythingMCP e usa questo connettore per outbound + `whatsapp_mark_message_as_read` per le ricevute.
+
+**Funziona con Claude Code come con Claude Desktop?**
+Sì — stesso URL MCP.
+
+### Prossimi passi
+
+- [WhatsApp Business su MCP — la guida generica](./whatsapp-business-to-mcp)
+- [Collegare WhatsApp Business a ChatGPT](./connect-whatsapp-business-to-chatgpt)

--- a/content/guides/it/whatsapp-business-to-mcp.mdx
+++ b/content/guides/it/whatsapp-business-to-mcp.mdx
@@ -1,0 +1,83 @@
+---
+title: "WhatsApp Business su MCP — Invia messaggi WhatsApp da qualsiasi agente AI"
+description: "Esponi la WhatsApp Business Cloud API di Meta come server MCP con AnythingMCP. 14 tool pronti all'uso per testo, template, media (immagini/audio/voce/video/documenti), posizione, pulsanti interattivi e gestione del profilo business. Auth Bearer, niente SDK, niente codice client."
+category: "connectors"
+keyword: "WhatsApp MCP, WhatsApp Business API MCP, WhatsApp AI agent, WhatsApp Cloud API, inviare WhatsApp da AI"
+publishedAt: "2026-05-19"
+adapterSlug: "whatsapp-business"
+lang: "it"
+---
+
+> 💡 **Niente installazione? Vai direttamente su [cloud.anythingmcp.com](https://cloud.anythingmcp.com).** Accedi, clicca **Connectors → WhatsApp Business**, inserisci il System User access token permanente + l'ID del WhatsApp Business Account, genera una MCP API key — fatto. Niente Docker, niente `git clone`, niente server locale da avviare. Salta i passi di installazione locale qui sotto e vai direttamente alla configurazione del client.
+
+## WhatsApp Business sul Model Context Protocol
+
+La [WhatsApp Business Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api) è il gateway ospitato da Meta per inviare messaggi WhatsApp via API — testo, template pre-approvati, media, geolocalizzazione, flussi con pulsanti interattivi e gestione del profilo business. AnythingMCP la espone come **server MCP** così qualsiasi agente — Claude, ChatGPT, Copilot, il tuo — la guida in linguaggio naturale.
+
+L'adapter WhatsApp è incluso di default. Non c'è SDK da mantenere e non c'è codice client da scrivere: l'engine gestisce l'autenticazione Bearer e produce richieste che combaciano esattamente con lo schema `messaging_product=whatsapp` di Meta per ogni tipo di messaggio.
+
+### Perché WhatsApp è scomodo senza AnythingMCP
+
+| Passo | Cosa richiede la WhatsApp Cloud API |
+|---|---|
+| 1 | Generare un System User access token permanente in Meta Business Suite (≠ dal token dev temporaneo di 24h) con i permessi `whatsapp_business_messaging` + `whatsapp_business_management` |
+| 2 | Scoprire il `phoneNumberId` di ogni numero mittente sotto il tuo WhatsApp Business Account (WABA) |
+| 3 | Costruire il body JSON corretto per ciascun tipo di messaggio — `text`/`template`/`image`/`audio`/`video`/`document`/`location`/`interactive` — ognuno con il suo schema e le sue particolarità di posizionamento dei campi |
+| 4 | Restare su una versione Graph API ancora supportata (v15 è chiusa, v20 scade a settembre 2026; l'adapter usa **v22.0**) |
+| 5 | Rispettare la finestra di customer service di 24 ore — fuori da essa puoi inviare solo template pre-approvati |
+
+Tutto questo è incapsulato nel profilo auth **`BEARER_TOKEN`** + 14 tool per i message-shape, dichiarati una volta come JSON nella spec dell'adapter. Nessun codice client.
+
+### Installazione
+
+```bash
+git clone https://github.com/HelpCode-ai/anythingmcp.git
+cd anythingmcp && docker compose up -d
+```
+
+Apri `http://localhost:3000/connectors/store`, scegli **WhatsApp Business** e inserisci:
+
+| Campo | Valore |
+|---|---|
+| `WHATSAPP_ACCESS_TOKEN` | il System User access token permanente |
+| `WHATSAPP_BUSINESS_ACCOUNT_ID` | il tuo WABA ID (es. `123456789012345`) |
+
+Genera una MCP API key da **Profile → MCP API Keys** e punta il tuo agente a `http://localhost:4000/mcp`.
+
+### Tool disponibili (14)
+
+| Tool | Cosa fa |
+|---|---|
+| `whatsapp_list_phone_numbers` | Scopri il `phoneNumberId` di ciascun numero sul tuo WABA |
+| `whatsapp_list_message_templates` | Elenca i template approvati con i loro componenti |
+| `whatsapp_get_message_template` | Recupera un template per ID |
+| `whatsapp_send_text_message` | Invia testo libero (solo nella finestra di 24h) |
+| `whatsapp_send_template_message` | Invia un template pre-approvato (sempre consentito) |
+| `whatsapp_send_image` | Invia JPG/PNG tramite URL pubblico o media ID |
+| `whatsapp_send_audio` | Invia un audio — OGG-Opus appare come vero messaggio vocale |
+| `whatsapp_send_video` | Invia un video MP4/3GPP |
+| `whatsapp_send_document` | Invia PDF/DOC/XLS con nome file opzionale |
+| `whatsapp_send_location` | Invia una posizione |
+| `whatsapp_send_interactive_buttons` | Invia 1–3 pulsanti di risposta |
+| `whatsapp_mark_message_as_read` | Invia la conferma di lettura (doppia spunta blu) |
+| `whatsapp_get_business_profile` | Leggi il profilo business pubblico |
+| `whatsapp_update_business_profile` | Aggiorna about/indirizzo/email/siti |
+
+### La finestra di 24 ore, spiegata
+
+WhatsApp applica una **finestra di customer service**: i messaggi free-form (testo, media, interattivi, posizione) sono consentiti solo nelle 24 ore successive all'ultimo messaggio in entrata dell'utente verso il tuo numero. Fuori da quella finestra puoi inviare solo **template pre-approvati** — li crei in Meta Business Suite, attendi l'approvazione, poi chiami `whatsapp_send_template_message` con il nome del template e il language code.
+
+L'adapter non traccia la finestra al posto tuo. Chiama solo l'API; Meta risponde con l'errore `131047` "Re-engagement message" se provi a inviare testo libero fuori dalla finestra. Il campo instructions dell'adapter spiega la regola così che il tuo agente sappia quando passare a un template.
+
+### Media — URL vs upload
+
+WhatsApp accetta i media in due modi: upload prima del binario su `/PHONE_NUMBER_ID/media` per ottenere un `media_id`, oppure passare un `link` HTTPS pubblico. AnythingMCP raccomanda il **percorso link** perché il REST engine non orchestra il flusso multipart upload + send in una sola chiamata tool. Ospita il file su un CDN o un bucket con signed URL e passa l'URL a `whatsapp_send_image` / `audio` / `video` / `document`. Il campo `mediaId` è disponibile come escape hatch se carichi il file altrove.
+
+### Messaggi in entrata — fuori scope
+
+Questo connettore è **solo outbound**. WhatsApp consegna i messaggi in entrata via webhook che devi ospitare tu, e l'architettura attuale di AnythingMCP è request/response. Se ti serve un chatbot che risponda ai messaggi degli utenti, fai girare un piccolo receiver webhook accanto a AnythingMCP e usa questo connettore per il lato outbound (più `whatsapp_mark_message_as_read` per le ricevute di lettura).
+
+### Prossimi passi
+
+- [Collegare WhatsApp Business a Claude](./connect-whatsapp-business-to-claude)
+- [Collegare WhatsApp Business a ChatGPT](./connect-whatsapp-business-to-chatgpt)

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -35,6 +35,7 @@ import * as mercadoLibre from './br/mercado-libre.json';
 import * as paystack from './ng/paystack.json';
 import * as lineMessaging from './jp/line-messaging.json';
 import * as sorare from './intl/sorare.json';
+import * as whatsappBusiness from './intl/whatsapp-business.json';
 import { buildGraphqlBuiltinTools } from '../connectors/graphql-builtins';
 
 export interface AdapterMeta {
@@ -142,6 +143,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   paystack as unknown as AdapterDefinition,
   lineMessaging as unknown as AdapterDefinition,
   sorare as unknown as AdapterDefinition,
+  whatsappBusiness as unknown as AdapterDefinition,
 ];
 
 const ALL_ADAPTERS: AdapterDefinition[] = RAW_ADAPTERS.map(withGraphqlBuiltins);

--- a/packages/backend/src/adapters/intl/whatsapp-business.json
+++ b/packages/backend/src/adapters/intl/whatsapp-business.json
@@ -1,0 +1,556 @@
+{
+  "slug": "whatsapp-business",
+  "name": "WhatsApp Business Cloud API",
+  "description": "Send WhatsApp messages (text, templates, images, audio/voice notes, video, documents, location, interactive buttons) from a WhatsApp Business account using Meta's Cloud API. Free tier of 1000 service conversations per month per business account.",
+  "instructions": "This connector uses Meta's WhatsApp Business Cloud API (Graph API v22.0).\n\n**Setup**:\n1. Go to https://developers.facebook.com/ → create or pick an App → add the **WhatsApp** product.\n2. Under WhatsApp → API Setup, you find: a temporary 24h access token (for testing), the test **Phone Number ID**, and the **WhatsApp Business Account ID** (WABA ID).\n3. For production, generate a **permanent System User access token** at Meta Business Suite → Business Settings → System Users → add user → assign the WhatsApp Business Account → generate token with `whatsapp_business_messaging` and `whatsapp_business_management` permissions.\n4. Paste the token as `WHATSAPP_ACCESS_TOKEN` and the WABA ID as `WHATSAPP_BUSINESS_ACCOUNT_ID`.\n\n**Phone Number ID**: every business account has one or more sending phone numbers, each identified by a `phoneNumberId`. Call `whatsapp_list_phone_numbers` once after setup to discover the IDs available on your WABA. Every send tool requires `phoneNumberId` — the connector does NOT auto-resolve a default, you must pass it explicitly on each call.\n\n**Recipient format**: the `to` field is the recipient's phone number in **international format without the `+` sign, country code first** (e.g. `15551234567` for the US, `4915151234567` for Germany).\n\n**Templates vs free-form text**:\n- Outside the **24-hour customer service window**, you can ONLY send pre-approved **template messages** (`whatsapp_send_template_message`). Templates must be created and approved in Meta Business Suite before they can be used.\n- Inside the 24-hour window (i.e. the user has messaged your number in the last 24h), you can send free-form text, media, interactive messages, location, etc.\n\n**Sending media (image / audio / voice / video / document)**: WhatsApp accepts media in two ways:\n  1. **By public URL** (recommended on AnythingMCP): use the per-type tools (`whatsapp_send_image`, `whatsapp_send_audio`, `whatsapp_send_video`, `whatsapp_send_document`) and pass `link` = a publicly accessible HTTPS URL. The URL must be reachable from Meta's servers and respect WhatsApp size limits (image 5 MB, audio/voice 16 MB, video 16 MB, document 100 MB).\n  2. **By uploaded media ID**: upload a binary first to `/PHONE_NUMBER_ID/media` (multipart/form-data with a real file) to obtain a `media_id`, then reference it in a send call. AnythingMCP's REST engine does not currently orchestrate the binary upload step in a single tool — for this flow either pre-upload via your own infrastructure and pass the resulting `mediaId` to the per-type send tools, or stick to the URL-based path above.\n\n**Voice notes specifically**: use `whatsapp_send_audio` with an OGG-Opus or AMR file. WhatsApp renders OGG-Opus as a true voice message (waveform + play button) in the client.\n\n**Cost / quota**: WhatsApp pricing is per **conversation** (24-hour session), not per message. Marketing, utility and authentication conversations are priced differently per country — see https://developers.facebook.com/docs/whatsapp/pricing/.\n\n**Inbound messages (webhook)**: this connector does NOT receive inbound messages. Meta delivers them via a webhook you must host yourself; AnythingMCP's current architecture is request/response only. If you need a chatbot that replies to user messages, host a webhook receiver separately and use this connector for the outbound side. Use `whatsapp_mark_message_as_read` to send read receipts for messages your webhook has processed.",
+  "region": "intl",
+  "category": "messaging",
+  "icon": "whatsapp",
+  "docsUrl": "https://developers.facebook.com/docs/whatsapp/cloud-api",
+  "requiredEnvVars": ["WHATSAPP_ACCESS_TOKEN", "WHATSAPP_BUSINESS_ACCOUNT_ID"],
+  "connector": {
+    "name": "WhatsApp Business Cloud API",
+    "type": "REST",
+    "baseUrl": "https://graph.facebook.com/v22.0",
+    "authType": "BEARER_TOKEN",
+    "authConfig": {
+      "token": "{{WHATSAPP_ACCESS_TOKEN}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "whatsapp_list_phone_numbers",
+      "description": "List all phone numbers registered on the WhatsApp Business Account. Returns each number's `id` (the phoneNumberId you pass to send tools), `display_phone_number`, `verified_name` and `quality_rating`. Call this once after setup to discover which phoneNumberId to use.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "businessAccountId": {
+            "type": "string",
+            "description": "WhatsApp Business Account ID (WABA ID). Use the value of WHATSAPP_BUSINESS_ACCOUNT_ID configured on this connector — pass it explicitly here on each call (path parameter)."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Max phone numbers to return per page (default 20, max 100)."
+          }
+        },
+        "required": ["businessAccountId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{businessAccountId}/phone_numbers",
+        "queryParams": {
+          "limit": "$limit"
+        }
+      }
+    },
+    {
+      "name": "whatsapp_list_message_templates",
+      "description": "List the message templates approved on the WhatsApp Business Account. Returns each template's `id`, `name`, `language`, `status` (APPROVED / PENDING / REJECTED) and `components` (header/body/footer/buttons structure). Use this to discover which templates you can send via whatsapp_send_template_message.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "businessAccountId": {
+            "type": "string",
+            "description": "WhatsApp Business Account ID (WABA ID)."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Max templates per page (default 20, max 100)."
+          },
+          "fields": {
+            "type": "string",
+            "description": "Comma-separated list of fields to return. Default: 'name,language,status,category,components,id'."
+          }
+        },
+        "required": ["businessAccountId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{businessAccountId}/message_templates",
+        "queryParams": {
+          "limit": "$limit",
+          "fields": "$fields"
+        }
+      }
+    },
+    {
+      "name": "whatsapp_get_message_template",
+      "description": "Fetch a single message template by its ID. Returns the full template definition including components, sample variables and approval status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "templateId": {
+            "type": "string",
+            "description": "The template ID returned by whatsapp_list_message_templates."
+          },
+          "fields": {
+            "type": "string",
+            "description": "Comma-separated list of fields to return. Default: 'name,language,status,category,components,id'."
+          }
+        },
+        "required": ["templateId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{templateId}",
+        "queryParams": {
+          "fields": "$fields"
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_text_message",
+      "description": "Send a plain text message to a recipient. Only allowed inside the 24-hour customer service window (i.e. the user must have messaged your business number in the last 24h). For first contact or outside the window, use whatsapp_send_template_message instead.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID (from whatsapp_list_phone_numbers)."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+', e.g. '15551234567'."
+          },
+          "body": {
+            "type": "string",
+            "description": "Message text. Max 4096 characters. Supports WhatsApp markdown: *bold*, _italic_, ~strikethrough~, ```monospace```."
+          },
+          "previewUrl": {
+            "type": "boolean",
+            "description": "If true and `body` contains an http(s) URL, show a link preview card. Default false."
+          }
+        },
+        "required": ["phoneNumberId", "to", "body"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "text",
+          "text": {
+            "body": "$body",
+            "preview_url": "$previewUrl"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_template_message",
+      "description": "Send a pre-approved message template. This is the only way to message a user OUTSIDE the 24-hour customer service window or to initiate first contact. The template must already be APPROVED in Meta Business Suite (check via whatsapp_list_message_templates).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "templateName": {
+            "type": "string",
+            "description": "The exact template name (e.g. 'order_confirmation'). Names are case-sensitive."
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "BCP-47 language tag of the approved template, e.g. 'en_US', 'de', 'it', 'pt_BR'."
+          },
+          "components": {
+            "type": "array",
+            "description": "Optional array of component objects that fill in template variables. Example for a body with two {{1}} {{2}} placeholders: [{\"type\":\"body\",\"parameters\":[{\"type\":\"text\",\"text\":\"John\"},{\"type\":\"text\",\"text\":\"ORD-123\"}]}]. Omit if the template has no variables. See https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates for full component schema (header, body, button, etc.)."
+          }
+        },
+        "required": ["phoneNumberId", "to", "templateName", "languageCode"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "to": "$to",
+          "type": "template",
+          "template": {
+            "name": "$templateName",
+            "language": { "code": "$languageCode" },
+            "components": "$components"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_image",
+      "description": "Send an image (JPG or PNG, max 5 MB). Provide EITHER `link` (a public HTTPS URL — recommended on AnythingMCP) OR `mediaId` (returned by a prior media upload). Only allowed inside the 24-hour customer service window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "link": {
+            "type": "string",
+            "description": "Public HTTPS URL of the image. Use either this OR `mediaId`."
+          },
+          "mediaId": {
+            "type": "string",
+            "description": "ID of a previously uploaded image. Use either this OR `link`."
+          },
+          "caption": {
+            "type": "string",
+            "description": "Optional caption shown under the image. Max 1024 chars."
+          }
+        },
+        "required": ["phoneNumberId", "to"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "image",
+          "image": {
+            "link": "$link",
+            "id": "$mediaId",
+            "caption": "$caption"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_audio",
+      "description": "Send an audio file or voice note (OGG-Opus, AMR or MP3, max 16 MB). OGG-Opus renders as a true voice message (waveform + play button). Provide EITHER `link` (a public HTTPS URL — recommended on AnythingMCP) OR `mediaId`. Only allowed inside the 24-hour customer service window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "link": {
+            "type": "string",
+            "description": "Public HTTPS URL of the audio file. Use either this OR `mediaId`. For a voice-note appearance use OGG-Opus."
+          },
+          "mediaId": {
+            "type": "string",
+            "description": "ID of a previously uploaded audio file. Use either this OR `link`."
+          }
+        },
+        "required": ["phoneNumberId", "to"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "audio",
+          "audio": {
+            "link": "$link",
+            "id": "$mediaId"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_video",
+      "description": "Send a video (MP4 or 3GPP, max 16 MB). Provide EITHER `link` (a public HTTPS URL — recommended on AnythingMCP) OR `mediaId`. Only allowed inside the 24-hour customer service window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "link": {
+            "type": "string",
+            "description": "Public HTTPS URL of the video. Use either this OR `mediaId`."
+          },
+          "mediaId": {
+            "type": "string",
+            "description": "ID of a previously uploaded video. Use either this OR `link`."
+          },
+          "caption": {
+            "type": "string",
+            "description": "Optional caption shown under the video. Max 1024 chars."
+          }
+        },
+        "required": ["phoneNumberId", "to"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "video",
+          "video": {
+            "link": "$link",
+            "id": "$mediaId",
+            "caption": "$caption"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_document",
+      "description": "Send a document (PDF, DOC(X), XLS(X), PPT(X), TXT — max 100 MB). Provide EITHER `link` (a public HTTPS URL — recommended on AnythingMCP) OR `mediaId`. Only allowed inside the 24-hour customer service window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "link": {
+            "type": "string",
+            "description": "Public HTTPS URL of the document. Use either this OR `mediaId`."
+          },
+          "mediaId": {
+            "type": "string",
+            "description": "ID of a previously uploaded document. Use either this OR `link`."
+          },
+          "filename": {
+            "type": "string",
+            "description": "Optional filename shown in the WhatsApp UI (e.g. 'invoice.pdf'). Recommended for documents."
+          },
+          "caption": {
+            "type": "string",
+            "description": "Optional caption shown under the document. Max 1024 chars."
+          }
+        },
+        "required": ["phoneNumberId", "to"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "document",
+          "document": {
+            "link": "$link",
+            "id": "$mediaId",
+            "filename": "$filename",
+            "caption": "$caption"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_location",
+      "description": "Send a location pin to a recipient. Only allowed inside the 24-hour customer service window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Latitude in decimal degrees, e.g. 37.4847"
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Longitude in decimal degrees, e.g. -122.1477"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional place name shown above the pin."
+          },
+          "address": {
+            "type": "string",
+            "description": "Optional street address shown below the pin."
+          }
+        },
+        "required": ["phoneNumberId", "to", "latitude", "longitude"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "location",
+          "location": {
+            "latitude": "$latitude",
+            "longitude": "$longitude",
+            "name": "$name",
+            "address": "$address"
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_send_interactive_buttons",
+      "description": "Send an interactive message with 1–3 reply buttons. The user taps a button and your webhook receives the selected button id. Only allowed inside the 24-hour customer service window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID."
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number in international format without '+'."
+          },
+          "bodyText": {
+            "type": "string",
+            "description": "Main message text shown above the buttons. Max 1024 chars."
+          },
+          "buttons": {
+            "type": "array",
+            "description": "Array of 1–3 button objects in the exact shape WhatsApp expects: [{\"type\":\"reply\",\"reply\":{\"id\":\"yes\",\"title\":\"Yes\"}},{\"type\":\"reply\",\"reply\":{\"id\":\"no\",\"title\":\"No\"}}]. Each title max 20 chars, each id max 256 chars."
+          }
+        },
+        "required": ["phoneNumberId", "to", "bodyText", "buttons"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "recipient_type": "individual",
+          "to": "$to",
+          "type": "interactive",
+          "interactive": {
+            "type": "button",
+            "body": { "text": "$bodyText" },
+            "action": { "buttons": "$buttons" }
+          }
+        }
+      }
+    },
+    {
+      "name": "whatsapp_mark_message_as_read",
+      "description": "Mark an incoming message as read (shows the double blue tick to the sender). Pass the `messageId` (wamid) from the webhook event that delivered the message.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The sending phone number ID that received the message."
+          },
+          "messageId": {
+            "type": "string",
+            "description": "The wamid (WhatsApp message ID) of the incoming message to mark as read."
+          }
+        },
+        "required": ["phoneNumberId", "messageId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/messages",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "status": "read",
+          "message_id": "$messageId"
+        }
+      }
+    },
+    {
+      "name": "whatsapp_get_business_profile",
+      "description": "Get the public business profile attached to a phone number (about text, address, description, email, websites, vertical, profile picture URL).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The phone number ID whose profile to fetch."
+          }
+        },
+        "required": ["phoneNumberId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/{phoneNumberId}/whatsapp_business_profile",
+        "queryParams": {
+          "fields": "about,address,description,email,profile_picture_url,websites,vertical"
+        }
+      }
+    },
+    {
+      "name": "whatsapp_update_business_profile",
+      "description": "Update fields of the public business profile attached to a phone number. Only the fields you pass are updated.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "phoneNumberId": {
+            "type": "string",
+            "description": "The phone number ID whose profile to update."
+          },
+          "about": {
+            "type": "string",
+            "description": "Short status text shown under the business name. Max 139 chars."
+          },
+          "address": {
+            "type": "string",
+            "description": "Street address. Max 256 chars."
+          },
+          "description": {
+            "type": "string",
+            "description": "Longer description of the business. Max 512 chars."
+          },
+          "email": {
+            "type": "string",
+            "description": "Contact email. Max 128 chars."
+          },
+          "websites": {
+            "type": "array",
+            "description": "Up to 2 URLs."
+          },
+          "vertical": {
+            "type": "string",
+            "description": "Industry vertical. One of: UNDEFINED, OTHER, AUTO, BEAUTY, APPAREL, EDU, ENTERTAIN, EVENT_PLAN, FINANCE, GROCERY, GOVT, HOTEL, HEALTH, NONPROFIT, PROF_SERVICES, RETAIL, TRAVEL, RESTAURANT, NOT_A_BIZ."
+          }
+        },
+        "required": ["phoneNumberId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/{phoneNumberId}/whatsapp_business_profile",
+        "bodyMapping": {
+          "messaging_product": "whatsapp",
+          "about": "$about",
+          "address": "$address",
+          "description": "$description",
+          "email": "$email",
+          "websites": "$websites",
+          "vertical": "$vertical"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/whatsapp-business.live.spec.ts
+++ b/packages/backend/src/adapters/intl/whatsapp-business.live.spec.ts
@@ -1,0 +1,285 @@
+import * as adapter from './whatsapp-business.json';
+import { RestEngine } from '../../connectors/engines/rest.engine';
+import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
+
+/**
+ * Two layers of verification for the whatsapp-business adapter:
+ *
+ *   1. Static — always runs. Asserts the adapter targets a currently-supported
+ *      Graph API version, that send-tool bodies carry the mandatory
+ *      `messaging_product: "whatsapp"` discriminator, and that paths follow the
+ *      Meta Cloud API routing convention (`/{phoneNumberId}/messages`,
+ *      `/{businessAccountId}/message_templates`, etc.). Catches the most common
+ *      failure modes: pinning back to a deprecated API version, omitting the
+ *      messaging_product field, or accidentally pointing at the old On-Premises
+ *      API base path.
+ *
+ *   2. Live — skipped in CI. Hits graph.facebook.com with a bogus token to
+ *      prove every endpoint path is recognised by Meta's router (401 OAuth
+ *      error, not 404 path-not-found). A real end-to-end test requires a
+ *      verified WhatsApp Business Account, a permanent system-user token and
+ *      a test recipient — Meta provides a free sandbox tier in the Developer
+ *      Console (up to 5 test numbers).
+ *
+ *   Run live with:  RUN_WHATSAPP_LIVE=1 npx jest src/adapters/intl/whatsapp-business.live.spec.ts
+ */
+
+interface Tool {
+  name: string;
+  endpointMapping: {
+    method: string;
+    path: string;
+    bodyMapping?: Record<string, unknown>;
+    bodyTemplate?: string;
+  };
+}
+
+const a = adapter as unknown as {
+  slug: string;
+  connector: {
+    baseUrl: string;
+    authType: string;
+    authConfig: Record<string, string>;
+  };
+  tools: Tool[];
+};
+
+describe('whatsapp-business adapter — static spec conformance', () => {
+  it('targets a currently-supported Graph API version (>= v18, not deprecated)', () => {
+    // v15.0 expired May 2024; v16/v17 expire 2025. v18+ are still active as of
+    // 2026. v25 is the newest. Anything below v18 should not be used.
+    const match = a.connector.baseUrl.match(/\/v(\d+)\.0$/);
+    expect(match).not.toBeNull();
+    const major = parseInt(match![1], 10);
+    expect(major).toBeGreaterThanOrEqual(18);
+    expect(major).toBeLessThanOrEqual(30);
+  });
+
+  it('uses the Cloud API base (graph.facebook.com), not the deprecated On-Premises API', () => {
+    expect(a.connector.baseUrl).toContain('graph.facebook.com');
+    // The On-Prem API used a self-hosted /v1/messages base — make sure nobody
+    // accidentally re-introduces it.
+    expect(a.connector.baseUrl).not.toMatch(/\/v1\/?$/);
+  });
+
+  it('authenticates with Bearer token (System User permanent access token)', () => {
+    expect(a.connector.authType).toBe('BEARER_TOKEN');
+    expect(a.connector.authConfig.token).toContain('{{WHATSAPP_ACCESS_TOKEN}}');
+  });
+
+  it('every send tool posts to /{phoneNumberId}/messages', () => {
+    const sendTools = a.tools.filter((t) => t.name.startsWith('whatsapp_send_') || t.name === 'whatsapp_mark_message_as_read');
+    expect(sendTools.length).toBeGreaterThan(0);
+    for (const tool of sendTools) {
+      expect(tool.endpointMapping.method).toBe('POST');
+      expect(tool.endpointMapping.path).toBe('/{phoneNumberId}/messages');
+    }
+  });
+
+  it('every send tool sets messaging_product="whatsapp" (mandatory discriminator per Meta API)', () => {
+    const sendTools = a.tools.filter((t) => t.name.startsWith('whatsapp_send_') || t.name === 'whatsapp_mark_message_as_read');
+    for (const tool of sendTools) {
+      const body = tool.endpointMapping.bodyMapping;
+      expect(body).toBeDefined();
+      expect(body!['messaging_product']).toBe('whatsapp');
+    }
+  });
+
+  it('whatsapp_mark_message_as_read sends status:"read" + message_id', () => {
+    const tool = a.tools.find((t) => t.name === 'whatsapp_mark_message_as_read')!;
+    const body = tool.endpointMapping.bodyMapping!;
+    expect(body['status']).toBe('read');
+    expect(body['message_id']).toBe('$messageId');
+  });
+
+  it('whatsapp_send_text_message places preview_url inside the text object (not at root)', () => {
+    const tool = a.tools.find((t) => t.name === 'whatsapp_send_text_message')!;
+    const body = tool.endpointMapping.bodyMapping!;
+    expect(body['type']).toBe('text');
+    expect((body['text'] as Record<string, unknown>)['body']).toBe('$body');
+    expect((body['text'] as Record<string, unknown>)['preview_url']).toBe('$previewUrl');
+    // preview_url must NOT be at the top level — Meta's API would silently drop it
+    expect(body['preview_url']).toBeUndefined();
+  });
+
+  it('whatsapp_send_template_message uses template:{name, language:{code}, components}', () => {
+    const tool = a.tools.find((t) => t.name === 'whatsapp_send_template_message')!;
+    const body = tool.endpointMapping.bodyMapping!;
+    expect(body['type']).toBe('template');
+    const template = body['template'] as Record<string, unknown>;
+    expect(template['name']).toBe('$templateName');
+    expect((template['language'] as Record<string, unknown>)['code']).toBe('$languageCode');
+    expect(template['components']).toBe('$components');
+  });
+
+  it('media tools place filename only on document (not on image/audio/video)', () => {
+    const docTool = a.tools.find((t) => t.name === 'whatsapp_send_document')!;
+    const docBody = docTool.endpointMapping.bodyMapping!;
+    expect((docBody['document'] as Record<string, unknown>)['filename']).toBe('$filename');
+
+    for (const name of ['whatsapp_send_image', 'whatsapp_send_audio', 'whatsapp_send_video']) {
+      const tool = a.tools.find((t) => t.name === name)!;
+      const body = tool.endpointMapping.bodyMapping!;
+      const typeKey = name.replace('whatsapp_send_', '');
+      const mediaObj = body[typeKey] as Record<string, unknown>;
+      expect(mediaObj['filename']).toBeUndefined();
+    }
+  });
+
+  it('whatsapp_send_audio does NOT accept caption (Meta API rejects caption on audio)', () => {
+    const tool = a.tools.find((t) => t.name === 'whatsapp_send_audio')!;
+    const audioObj = (tool.endpointMapping.bodyMapping!['audio'] as Record<string, unknown>);
+    expect(audioObj['caption']).toBeUndefined();
+  });
+
+  it('WABA-scoped tools target /{businessAccountId}/...', () => {
+    const listPhones = a.tools.find((t) => t.name === 'whatsapp_list_phone_numbers')!;
+    expect(listPhones.endpointMapping.path).toBe('/{businessAccountId}/phone_numbers');
+    expect(listPhones.endpointMapping.method).toBe('GET');
+
+    const listTemplates = a.tools.find((t) => t.name === 'whatsapp_list_message_templates')!;
+    expect(listTemplates.endpointMapping.path).toBe('/{businessAccountId}/message_templates');
+    expect(listTemplates.endpointMapping.method).toBe('GET');
+  });
+
+  it('business profile tools target /{phoneNumberId}/whatsapp_business_profile', () => {
+    const get = a.tools.find((t) => t.name === 'whatsapp_get_business_profile')!;
+    expect(get.endpointMapping.path).toBe('/{phoneNumberId}/whatsapp_business_profile');
+    expect(get.endpointMapping.method).toBe('GET');
+
+    const update = a.tools.find((t) => t.name === 'whatsapp_update_business_profile')!;
+    expect(update.endpointMapping.path).toBe('/{phoneNumberId}/whatsapp_business_profile');
+    expect(update.endpointMapping.method).toBe('POST');
+  });
+});
+
+const maybe = process.env.RUN_WHATSAPP_LIVE ? describe : describe.skip;
+
+maybe('whatsapp-business adapter — live edge reachability', () => {
+  const oauth = {} as unknown as OAuth2TokenService;
+  const login = {} as unknown as LoginTokenService;
+  const engine = new RestEngine(oauth, login);
+
+  const baseUrl = a.connector.baseUrl;
+  const FAKE_PHONE_NUMBER_ID = '1234567890';
+  const FAKE_WABA_ID = '1234567890';
+
+  // With a bogus bearer token, Meta returns 401 OAuthException for valid paths
+  // and 404 for unknown paths. So 401 on each endpoint proves the path is
+  // recognised by Meta's router.
+
+  it('POST /{phoneNumberId}/messages reaches Meta (401 OAuthException with bogus token)', async () => {
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'bogus-token-for-endpoint-validation' },
+        },
+        {
+          method: 'POST',
+          path: `/${FAKE_PHONE_NUMBER_ID}/messages`,
+          bodyMapping: {
+            messaging_product: 'whatsapp',
+            recipient_type: 'individual',
+            to: '15551234567',
+            type: 'text',
+            text: { body: 'smoke-test' },
+          },
+        },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.response?.status).toBe(401);
+    expect(err.response?.data?.error?.type).toBe('OAuthException');
+  }, 30000);
+
+  it('GET /{wabaId}/phone_numbers reaches Meta (401 OAuthException)', async () => {
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'bogus-token' },
+        },
+        { method: 'GET', path: `/${FAKE_WABA_ID}/phone_numbers` },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.response?.status).toBe(401);
+    expect(err.response?.data?.error?.type).toBe('OAuthException');
+  }, 30000);
+
+  it('GET /{wabaId}/message_templates reaches Meta (401 OAuthException)', async () => {
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'bogus-token' },
+        },
+        { method: 'GET', path: `/${FAKE_WABA_ID}/message_templates` },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.response?.status).toBe(401);
+    expect(err.response?.data?.error?.type).toBe('OAuthException');
+  }, 30000);
+
+  it('GET /{phoneNumberId}/whatsapp_business_profile reaches Meta (401 OAuthException)', async () => {
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'bogus-token' },
+        },
+        {
+          method: 'GET',
+          path: `/${FAKE_PHONE_NUMBER_ID}/whatsapp_business_profile`,
+          queryParams: { fields: 'about' },
+        },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.response?.status).toBe(401);
+    expect(err.response?.data?.error?.type).toBe('OAuthException');
+  }, 30000);
+
+  it('Authorization: Bearer header is actually injected by RestEngine', async () => {
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl,
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'sentinel-token-12345' },
+        },
+        { method: 'GET', path: `/${FAKE_WABA_ID}/phone_numbers` },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    const sentHeaders = err.config?.headers || {};
+    expect(String(sentHeaders.Authorization || '')).toBe('Bearer sentinel-token-12345');
+  }, 30000);
+});

--- a/packages/frontend/src/app/connectors/store/page.tsx
+++ b/packages/frontend/src/app/connectors/store/page.tsx
@@ -14,6 +14,7 @@ const REGION_LABELS: Record<string, string> = {
   eu: 'Europe',
   us: 'United States',
   global: 'Global',
+  intl: 'International',
 };
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -27,6 +28,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   'field-service': 'Field Service',
   accounting: 'Accounting',
   hr: 'HR',
+  messaging: 'Messaging',
 };
 
 const AUTH_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- New WhatsApp Business Cloud API connector (Graph API v22.0, BEARER_TOKEN auth) with 14 tools: phone-number / template discovery, text + template sends, media (image / audio / voice / video / document via public URL or media ID), location pin, interactive buttons, read receipts, business profile read/update.
- Outbound-only by design — the adapter's \`instructions\` field explains the 24-hour customer service window, the template-vs-free-form rule, and the URL-vs-upload media choice so agents pick the right tool.
- Multilingual guides under \`content/guides/{en,it,de}/\`: landing (\`whatsapp-business-to-mcp.mdx\`) + Claude (\`connect-whatsapp-business-to-claude.mdx\`) + ChatGPT (\`connect-whatsapp-business-to-chatgpt.mdx\`).
- Connectors-store labels: added \`messaging\` category and \`intl\` region labels so the new connector renders with proper labels (Sorare and LINE benefit too).
- Live spec at \`packages/backend/src/adapters/intl/whatsapp-business.live.spec.ts\` — static asserts always on (API version, mandatory \`messaging_product\`, field placement, paths), live edge probes gated by \`RUN_WHATSAPP_LIVE=1\`.

## Verification
- Adapter body shapes cross-checked against Meta's official Node SDK type definitions (\`WhatsApp/WhatsApp-Nodejs-SDK\`).
- All four endpoint paths smoke-tested live against \`graph.facebook.com/v22.0\` with a bogus token — every path returns 401 OAuthException, confirming Meta's router recognises them (not 404 path-not-found).

## Test plan
- [ ] \`npm --workspace packages/backend run test -- whatsapp-business.live.spec\` (static section) passes
- [ ] Optional live check: \`RUN_WHATSAPP_LIVE=1 npm --workspace packages/backend run test -- whatsapp-business.live.spec\` — confirms RestEngine injects the Bearer header and Meta accepts all four endpoint paths
- [ ] Connector appears in the in-app store under \`/connectors/store\` with category "Messaging" and region "International"
- [ ] All 9 MDX guides render in the marketing site under \`/guides/{en,it,de}/\`