### PR TITLE
connectors: add WordPress + WooCommerce adapters

### DIFF
--- a/packages/backend/src/adapters/catalog.spec.ts
+++ b/packages/backend/src/adapters/catalog.spec.ts
@@ -13,7 +13,11 @@ const VALID_AUTH_TYPES = new Set([
 const VALID_PASSWORD_HASHING_SCHEMES = new Set(['bcrypt', 'none']);
 const VALID_SALT_SOURCE_TYPES = new Set(['fetch', 'static']);
 
-const VALID_REST_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+// `STATIC` is intercepted by ConnectorsService / DynamicMcpTools BEFORE engine
+// dispatch (returns endpointMapping.staticResponse verbatim), so it's universal
+// across connector types — REST adapters can declare static "skill" or "enum
+// helper" tools without ever calling an HTTP engine.
+const VALID_REST_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'STATIC']);
 const VALID_GRAPHQL_METHODS = new Set([
   'QUERY',
   'MUTATION',

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -36,6 +36,8 @@ import * as paystack from './ng/paystack.json';
 import * as lineMessaging from './jp/line-messaging.json';
 import * as sorare from './intl/sorare.json';
 import * as whatsappBusiness from './intl/whatsapp-business.json';
+import * as wordpress from './intl/wordpress.json';
+import * as woocommerce from './intl/woocommerce.json';
 import { buildGraphqlBuiltinTools } from '../connectors/graphql-builtins';
 
 export interface AdapterMeta {
@@ -144,6 +146,8 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   lineMessaging as unknown as AdapterDefinition,
   sorare as unknown as AdapterDefinition,
   whatsappBusiness as unknown as AdapterDefinition,
+  wordpress as unknown as AdapterDefinition,
+  woocommerce as unknown as AdapterDefinition,
 ];
 
 const ALL_ADAPTERS: AdapterDefinition[] = RAW_ADAPTERS.map(withGraphqlBuiltins);

--- a/packages/backend/src/adapters/intl/woocommerce.json
+++ b/packages/backend/src/adapters/intl/woocommerce.json
@@ -1,0 +1,1180 @@
+{
+  "slug": "woocommerce",
+  "name": "WooCommerce",
+  "description": "AI-native commerce operations for any WooCommerce store. Semantic tools for products, variations, inventory, orders, refunds, customers, categories, and reports — plus documented multi-step recipes (inventory optimisation, SEO refresh, upsell/cross-sell, abandoned-order triage, revenue analysis).",
+  "instructions": "This connector talks to the WooCommerce REST API v3 (`/wp-json/wc/v3`). Works against any WordPress + WooCommerce site. HTTPS required.\n\n## Setup\n\n1. **`WOOCOMMERCE_URL`** — site root (e.g. `https://shop.example.com`). Do NOT include `/wp-json`; the adapter appends `/wp-json/wc/v3`.\n2. **`WOOCOMMERCE_CONSUMER_KEY`** + **`WOOCOMMERCE_CONSUMER_SECRET`** — generate in WP admin → WooCommerce → Settings → Advanced → REST API → Add key. Use **Read/Write** for full functionality.\n\nHTTPS is mandatory: on HTTP, WC requires OAuth1 instead of Basic Auth (the connector only does Basic Auth).\n\n## Pagination\n\nList endpoints default to `per_page=10`, max `100`. Pass explicit `per_page` + iterate `page` for full catalog scans. Total counts are in `X-WP-Total` / `X-WP-TotalPages` headers (not returned in the JSON body).\n\n## Bulk writes\n\nFor ≥ 3 product updates use `woocommerce_batch_update_products` (one call, up to 100 entries). Don't fan out single `update_product` calls.\n\n## SEO meta (Yoast / Rank Math) on products\n\nMeta lives in the `meta_data` array on the product. Set it via `woocommerce_update_product`:\n\n```json\n\"meta_data\": [\n  { \"key\": \"_yoast_wpseo_metadesc\", \"value\": \"...\" },\n  { \"key\": \"_yoast_wpseo_focuskw\", \"value\": \"...\" }\n]\n```\n\nRank Math: `rank_math_description`, `rank_math_focus_keyword`, `rank_math_title`. Full reference: `wordpress_list_seo_meta_keys` (sibling WordPress connector).\n\n## Multi-step workflows\n\nFor inventory optimisation, product SEO, upsell/cross-sell, low-conversion analysis, abandoned-order triage, or KPI snapshots → call the dedicated **`woocommerce_skill_*`** tool. It returns the step-by-step playbook on demand. Don't preload that knowledge here.\n\n## Enum reference cards\n\nValid values for order status / product type / stock status / report period / payment methods → call **`woocommerce_list_*_options`**.\n\n## Permissions cheat-sheet\n\n- All list / get / reports: Read-only key.\n- Product create/update/delete, order update, refund, batch: Read/Write key.\n- Customer create / coupon create: Read/Write key.",
+  "region": "intl",
+  "category": "ecommerce",
+  "icon": "woocommerce",
+  "docsUrl": "https://woocommerce.github.io/woocommerce-rest-api-docs/",
+  "requiredEnvVars": [
+    "WOOCOMMERCE_URL",
+    "WOOCOMMERCE_CONSUMER_KEY",
+    "WOOCOMMERCE_CONSUMER_SECRET"
+  ],
+  "priority": 50,
+  "connector": {
+    "name": "WooCommerce",
+    "type": "REST",
+    "baseUrl": "{{WOOCOMMERCE_URL}}/wp-json/wc/v3",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{WOOCOMMERCE_CONSUMER_KEY}}",
+      "password": "{{WOOCOMMERCE_CONSUMER_SECRET}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "woocommerce_search_products",
+      "description": "Search/list products with rich filters — keyword (`search`), SKU, status, type (simple/variable/grouped/external), stock_status, on_sale, price range, category, tag, featured. Paginate with `page` + `per_page` (max 100).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer", "description": "1-based page." },
+          "per_page": { "type": "integer", "description": "1-100." },
+          "search": { "type": "string", "description": "Free-text search across product name/description/SKU." },
+          "sku": { "type": "string", "description": "Filter by exact SKU." },
+          "slug": { "type": "string", "description": "Filter by exact slug." },
+          "status": { "type": "string", "description": "any | draft | pending | private | publish. Default: publish." },
+          "type": { "type": "string", "description": "simple | grouped | external | variable." },
+          "category": { "type": "string", "description": "Category term id." },
+          "tag": { "type": "string", "description": "Tag term id." },
+          "stock_status": { "type": "string", "description": "instock | outofstock | onbackorder." },
+          "on_sale": { "type": "boolean" },
+          "featured": { "type": "boolean" },
+          "min_price": { "type": "string", "description": "Decimal as string." },
+          "max_price": { "type": "string", "description": "Decimal as string." },
+          "orderby": { "type": "string", "description": "date | id | include | title | slug | price | popularity | rating | menu_order." },
+          "order": { "type": "string", "description": "asc | desc." }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "sku": "$sku",
+          "slug": "$slug",
+          "status": "$status",
+          "type": "$type",
+          "category": "$category",
+          "tag": "$tag",
+          "stock_status": "$stock_status",
+          "on_sale": "$on_sale",
+          "featured": "$featured",
+          "min_price": "$min_price",
+          "max_price": "$max_price",
+          "orderby": "$orderby",
+          "order": "$order"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_get_product",
+      "description": "Get a single product by id, including all fields: name, slug, description, short_description, sku, price/regular_price/sale_price, stock_quantity, stock_status, categories, tags, images, attributes, variations array (for variable products), upsell_ids, cross_sell_ids, meta_data.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": { "type": "integer", "description": "Product id." }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products/{productId}"
+      }
+    },
+    {
+      "name": "woocommerce_create_product",
+      "description": "Create a product. Minimal required: `name`. For variable products set `type=variable` and add variations via `woocommerce_create_product_variation` after creation. Pass `meta_data` array for Yoast / Rank Math SEO keys.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "type": { "type": "string", "description": "simple | grouped | external | variable. Default: simple." },
+          "status": { "type": "string", "description": "publish | draft | pending | private." },
+          "featured": { "type": "boolean" },
+          "catalog_visibility": { "type": "string", "description": "visible | catalog | search | hidden." },
+          "description": { "type": "string", "description": "Long description (HTML)." },
+          "short_description": { "type": "string", "description": "Short description (HTML)." },
+          "sku": { "type": "string" },
+          "regular_price": { "type": "string", "description": "Decimal as string." },
+          "sale_price": { "type": "string" },
+          "manage_stock": { "type": "boolean" },
+          "stock_quantity": { "type": "integer" },
+          "stock_status": { "type": "string", "description": "instock | outofstock | onbackorder." },
+          "backorders": { "type": "string", "description": "no | notify | yes." },
+          "weight": { "type": "string" },
+          "dimensions": { "type": "object", "description": "{ length, width, height } — strings (cm or per store unit)." },
+          "categories": { "type": "array", "description": "Array of { id }.", "items": { "type": "object" } },
+          "tags": { "type": "array", "description": "Array of { id }.", "items": { "type": "object" } },
+          "images": { "type": "array", "description": "Array of { id } (existing media) or { src } (URL — WC will sideload). First image = featured.", "items": { "type": "object" } },
+          "attributes": { "type": "array", "description": "Product attributes — see WC REST docs.", "items": { "type": "object" } },
+          "upsell_ids": { "type": "array", "description": "Product IDs to show as upsells.", "items": { "type": "integer" } },
+          "cross_sell_ids": { "type": "array", "description": "Product IDs to show as cross-sells.", "items": { "type": "integer" } },
+          "meta_data": { "type": "array", "description": "Array of { key, value } — for Yoast/Rank Math SEO keys.", "items": { "type": "object" } }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/products",
+        "bodyMapping": {
+          "name": "$name",
+          "slug": "$slug",
+          "type": "$type",
+          "status": "$status",
+          "featured": "$featured",
+          "catalog_visibility": "$catalog_visibility",
+          "description": "$description",
+          "short_description": "$short_description",
+          "sku": "$sku",
+          "regular_price": "$regular_price",
+          "sale_price": "$sale_price",
+          "manage_stock": "$manage_stock",
+          "stock_quantity": "$stock_quantity",
+          "stock_status": "$stock_status",
+          "backorders": "$backorders",
+          "weight": "$weight",
+          "dimensions": "$dimensions",
+          "categories": "$categories",
+          "tags": "$tags",
+          "images": "$images",
+          "attributes": "$attributes",
+          "upsell_ids": "$upsell_ids",
+          "cross_sell_ids": "$cross_sell_ids",
+          "meta_data": "$meta_data"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_update_product",
+      "description": "Partial-update a product by id. Only fields you pass are touched. Use for single-product edits; for bulk use `woocommerce_batch_update_products`.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "type": { "type": "string", "description": "simple | grouped | external | variable." },
+          "status": { "type": "string" },
+          "featured": { "type": "boolean" },
+          "catalog_visibility": { "type": "string", "description": "visible | catalog | search | hidden." },
+          "description": { "type": "string" },
+          "short_description": { "type": "string" },
+          "sku": { "type": "string" },
+          "regular_price": { "type": "string" },
+          "sale_price": { "type": "string" },
+          "manage_stock": { "type": "boolean" },
+          "stock_quantity": { "type": "integer" },
+          "stock_status": { "type": "string" },
+          "backorders": { "type": "string" },
+          "weight": { "type": "string" },
+          "dimensions": { "type": "object", "description": "{ length, width, height } — strings (cm or per store unit)." },
+          "categories": { "type": "array", "items": { "type": "object" } },
+          "tags": { "type": "array", "items": { "type": "object" } },
+          "images": { "type": "array", "items": { "type": "object" } },
+          "attributes": { "type": "array", "items": { "type": "object" } },
+          "upsell_ids": { "type": "array", "items": { "type": "integer" } },
+          "cross_sell_ids": { "type": "array", "items": { "type": "integer" } },
+          "meta_data": { "type": "array", "items": { "type": "object" } }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/products/{productId}",
+        "bodyMapping": {
+          "name": "$name",
+          "slug": "$slug",
+          "type": "$type",
+          "status": "$status",
+          "featured": "$featured",
+          "catalog_visibility": "$catalog_visibility",
+          "description": "$description",
+          "short_description": "$short_description",
+          "sku": "$sku",
+          "regular_price": "$regular_price",
+          "sale_price": "$sale_price",
+          "manage_stock": "$manage_stock",
+          "stock_quantity": "$stock_quantity",
+          "stock_status": "$stock_status",
+          "backorders": "$backorders",
+          "weight": "$weight",
+          "dimensions": "$dimensions",
+          "categories": "$categories",
+          "tags": "$tags",
+          "images": "$images",
+          "attributes": "$attributes",
+          "upsell_ids": "$upsell_ids",
+          "cross_sell_ids": "$cross_sell_ids",
+          "meta_data": "$meta_data"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_delete_product",
+      "description": "Move a product to trash, or pass `force=true` to delete permanently (cannot be undone).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": { "type": "integer" },
+          "force": { "type": "boolean", "description": "true = permanent delete; false (default) = move to trash." }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/products/{productId}",
+        "queryParams": {
+          "force": "$force"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_batch_update_products",
+      "description": "Bulk create / update / delete products in a single call. WooCommerce allows up to 100 entries per array. Best primitive for inventory bumps, SEO refresh waves, or category re-tags.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "create": { "type": "array", "description": "Array of product objects to create.", "items": { "type": "object" } },
+          "update": { "type": "array", "description": "Array of product objects — each MUST include an `id` field.", "items": { "type": "object" } },
+          "delete": { "type": "array", "description": "Array of product IDs to delete.", "items": { "type": "integer" } }
+        }
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/products/batch",
+        "bodyMapping": {
+          "create": "$create",
+          "update": "$update",
+          "delete": "$delete"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_product_variations",
+      "description": "List variations for a variable product. Returns id, sku, price, stock_quantity, attributes per variation.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": { "type": "integer", "description": "Parent (variable) product id." },
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "stock_status": { "type": "string" },
+          "on_sale": { "type": "boolean" }
+        },
+        "required": ["productId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products/{productId}/variations",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "stock_status": "$stock_status",
+          "on_sale": "$on_sale"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_update_product_variation",
+      "description": "Update a single variation of a variable product — price, SKU, stock, attributes.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": { "type": "integer", "description": "Parent product id." },
+          "variationId": { "type": "integer", "description": "Variation id." },
+          "sku": { "type": "string" },
+          "regular_price": { "type": "string" },
+          "sale_price": { "type": "string" },
+          "manage_stock": { "type": "boolean" },
+          "stock_quantity": { "type": "integer" },
+          "stock_status": { "type": "string" },
+          "weight": { "type": "string" },
+          "meta_data": { "type": "array", "items": { "type": "object" } }
+        },
+        "required": ["productId", "variationId"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/products/{productId}/variations/{variationId}",
+        "bodyMapping": {
+          "sku": "$sku",
+          "regular_price": "$regular_price",
+          "sale_price": "$sale_price",
+          "manage_stock": "$manage_stock",
+          "stock_quantity": "$stock_quantity",
+          "stock_status": "$stock_status",
+          "weight": "$weight",
+          "meta_data": "$meta_data"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_product_categories",
+      "description": "List product categories. Returns id, name, slug, parent, count.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "parent": { "type": "integer" },
+          "hide_empty": { "type": "boolean" },
+          "orderby": { "type": "string" },
+          "order": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products/categories",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "parent": "$parent",
+          "hide_empty": "$hide_empty",
+          "orderby": "$orderby",
+          "order": "$order"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_create_product_category",
+      "description": "Create a product category.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "parent": { "type": "integer" },
+          "description": { "type": "string" },
+          "display": { "type": "string", "description": "default | products | subcategories | both." },
+          "image": { "type": "object", "description": "{ id } or { src } for the category image." }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/products/categories",
+        "bodyMapping": {
+          "name": "$name",
+          "slug": "$slug",
+          "parent": "$parent",
+          "description": "$description",
+          "display": "$display",
+          "image": "$image"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_product_tags",
+      "description": "List product tags.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "hide_empty": { "type": "boolean" },
+          "orderby": { "type": "string" },
+          "order": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products/tags",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "hide_empty": "$hide_empty",
+          "orderby": "$orderby",
+          "order": "$order"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_product_attributes",
+      "description": "List the global attribute definitions configured for the store (e.g. Size, Colour). Needed when building variable products.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products/attributes"
+      }
+    },
+    {
+      "name": "woocommerce_find_low_stock",
+      "description": "Find products that are out of stock OR have `manage_stock=true` with `stock_quantity` at/below `threshold`. Pages through the catalog using `per_page` (max 100) and the supplied `page`. Returns the raw `/products` page filtered by stock status — combine with the agent's own threshold check on `stock_quantity` if needed. For the simple case, set `stock_status=outofstock` or `stock_status=onbackorder`.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "stock_status": { "type": "string", "description": "outofstock | onbackorder | instock. Default: outofstock." },
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer", "description": "Max 100." },
+          "category": { "type": "string", "description": "Restrict to a category id." },
+          "orderby": { "type": "string", "description": "Default: date." }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products",
+        "queryParams": {
+          "stock_status": "$stock_status",
+          "page": "$page",
+          "per_page": "$per_page",
+          "category": "$category",
+          "orderby": "$orderby"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_update_stock",
+      "description": "Convenience wrapper over `update_product`: enables stock management and sets quantity + status in one call. Use for single-product stock bumps; for bulk use `batch_update_products`.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "productId": { "type": "integer" },
+          "stock_quantity": { "type": "integer", "description": "New on-hand quantity." },
+          "stock_status": { "type": "string", "description": "instock | outofstock | onbackorder. Default: instock." },
+          "manage_stock": { "type": "boolean", "description": "Default: true (enables WooCommerce stock management)." }
+        },
+        "required": ["productId", "stock_quantity"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/products/{productId}",
+        "bodyMapping": {
+          "manage_stock": "$manage_stock",
+          "stock_quantity": "$stock_quantity",
+          "stock_status": "$stock_status"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_orders",
+      "description": "List orders with status, date, customer, and product filters. For abandoned-order triage use status=pending,on-hold,failed with a recent `after`.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "status": { "type": "string", "description": "Comma-separated: any | pending | processing | on-hold | completed | cancelled | refunded | failed | trash." },
+          "customer": { "type": "integer", "description": "Customer user id." },
+          "product": { "type": "integer", "description": "Filter to orders that include this product id." },
+          "after": { "type": "string", "description": "ISO 8601." },
+          "before": { "type": "string", "description": "ISO 8601." },
+          "orderby": { "type": "string", "description": "date | id | include | title | slug." },
+          "order": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "status": "$status",
+          "customer": "$customer",
+          "product": "$product",
+          "after": "$after",
+          "before": "$before",
+          "orderby": "$orderby",
+          "order": "$order"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_get_order",
+      "description": "Get a single order by id — full payload incl. line_items, billing, shipping, customer_id, totals, payment, refunds.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/{orderId}"
+      }
+    },
+    {
+      "name": "woocommerce_update_order_status",
+      "description": "Set an order's status (e.g. processing → completed, on-hold → cancelled). Triggers WooCommerce's email + stock side-effects associated with the new status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "status": { "type": "string", "description": "pending | processing | on-hold | completed | cancelled | refunded | failed." }
+        },
+        "required": ["orderId", "status"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/orders/{orderId}",
+        "bodyMapping": {
+          "status": "$status"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_add_order_note",
+      "description": "Add a note to an order. Customer-visible notes trigger an email; private notes are admin-only (audit trail).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "note": { "type": "string", "description": "Note body (plain text)." },
+          "customer_note": { "type": "boolean", "description": "true = customer-visible + emailed; false (default) = private admin note." }
+        },
+        "required": ["orderId", "note"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/orders/{orderId}/notes",
+        "bodyMapping": {
+          "note": "$note",
+          "customer_note": "$customer_note"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_refunds",
+      "description": "List refunds attached to an order.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/{orderId}/refunds"
+      }
+    },
+    {
+      "name": "woocommerce_create_refund",
+      "description": "Create a refund against an order. Pass an `amount` for a partial refund, or `api_refund=true` to also trigger refund via the payment gateway (Stripe, PayPal, etc.) when supported. Pass `line_items` to refund specific line items with their quantities.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "amount": { "type": "string", "description": "Decimal as string. Omit for full refund." },
+          "reason": { "type": "string", "description": "Internal reason (admin-visible)." },
+          "refunded_by": { "type": "integer", "description": "User id performing the refund." },
+          "api_refund": { "type": "boolean", "description": "When true (WC default), also refund via the payment gateway API (Stripe, PayPal, ...) where supported. Pass false to record the refund in WC only — useful for manual / bank-transfer flows." },
+          "line_items": { "type": "array", "description": "Array of { id, quantity, refund_total, refund_tax }.", "items": { "type": "object" } }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/orders/{orderId}/refunds",
+        "bodyMapping": {
+          "amount": "$amount",
+          "reason": "$reason",
+          "refunded_by": "$refunded_by",
+          "api_refund": "$api_refund",
+          "line_items": "$line_items"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_customers",
+      "description": "List customers. Filter by email, role, or registration date.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string", "description": "Match against email / first/last name." },
+          "email": { "type": "string", "description": "Exact email match." },
+          "role": { "type": "string", "description": "Default: customer." },
+          "orderby": { "type": "string", "description": "id | include | name | registered_date." },
+          "order": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customers",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "email": "$email",
+          "role": "$role",
+          "orderby": "$orderby",
+          "order": "$order"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_get_customer",
+      "description": "Get a customer by id (includes billing/shipping addresses, order count, total spent, last_order info).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerId": { "type": "integer" }
+        },
+        "required": ["customerId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/customers/{customerId}"
+      }
+    },
+    {
+      "name": "woocommerce_sales_report",
+      "description": "Sales report for a date window or named period. Returns total_sales, net_sales, average_sales, total_orders, total_items, total_tax, total_shipping, total_refunds, total_discount.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "period": { "type": "string", "description": "week | month | last_month | year. Mutually exclusive with date_min/date_max." },
+          "date_min": { "type": "string", "description": "YYYY-MM-DD." },
+          "date_max": { "type": "string", "description": "YYYY-MM-DD." }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/reports/sales",
+        "queryParams": {
+          "period": "$period",
+          "date_min": "$date_min",
+          "date_max": "$date_max"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_top_sellers_report",
+      "description": "Top-selling products for a date window or named period. Returns array of { title, product_id, quantity }.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "period": { "type": "string", "description": "week | month | last_month | year." },
+          "date_min": { "type": "string" },
+          "date_max": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/reports/top_sellers",
+        "queryParams": {
+          "period": "$period",
+          "date_min": "$date_min",
+          "date_max": "$date_max"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_coupons_totals_report",
+      "description": "Coupon counts grouped by discount type (percent | fixed_cart | fixed_product). NOTE: this endpoint accepts NO query params — it returns store-wide totals, not a usage-over-time window. For per-coupon usage history pair this with `woocommerce_list_orders` filtered to a date window and aggregate over `coupon_lines` client-side.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/reports/coupons/totals"
+      }
+    },
+    {
+      "name": "woocommerce_orders_totals_report",
+      "description": "Counts of orders grouped by status (pending, processing, completed, ...). Lightweight KPI snapshot of pipeline state.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/reports/orders/totals"
+      }
+    },
+    {
+      "name": "woocommerce_update_customer",
+      "description": "Partial-update a customer by id. Only fields you pass are touched. Use for fixing email, billing/shipping addresses, or password resets.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerId": { "type": "integer" },
+          "email": { "type": "string" },
+          "first_name": { "type": "string" },
+          "last_name": { "type": "string" },
+          "username": { "type": "string", "description": "WC may reject username changes after creation depending on store settings." },
+          "password": { "type": "string", "description": "Set a new password." },
+          "billing": { "type": "object" },
+          "shipping": { "type": "object" },
+          "meta_data": { "type": "array", "items": { "type": "object" } }
+        },
+        "required": ["customerId"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/customers/{customerId}",
+        "bodyMapping": {
+          "email": "$email",
+          "first_name": "$first_name",
+          "last_name": "$last_name",
+          "username": "$username",
+          "password": "$password",
+          "billing": "$billing",
+          "shipping": "$shipping",
+          "meta_data": "$meta_data"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_delete_customer",
+      "description": "Permanently delete a customer. WC does NOT trash customers — deletion is always permanent. `force=true` is mandatory. Optionally pass `reassign` to transfer the deleted customer's orders to another user id.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerId": { "type": "integer" },
+          "force": { "type": "boolean", "description": "Must be true. WC REST refuses customer delete without it." },
+          "reassign": { "type": "integer", "description": "User id to reassign orders/content to. Omit to keep the data orphaned." }
+        },
+        "required": ["customerId", "force"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/customers/{customerId}",
+        "queryParams": {
+          "force": "$force",
+          "reassign": "$reassign"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_create_customer",
+      "description": "Create a customer account. Email + at least one identifying field required. WC will hash the password and email a welcome message (unless suppressed by the store config).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string" },
+          "first_name": { "type": "string" },
+          "last_name": { "type": "string" },
+          "username": { "type": "string", "description": "Leave empty to let WC derive from email." },
+          "password": { "type": "string", "description": "Initial password. Omit to let WC auto-generate and email." },
+          "billing": { "type": "object", "description": "{ first_name, last_name, company, address_1, address_2, city, state, postcode, country, email, phone }." },
+          "shipping": { "type": "object", "description": "{ first_name, last_name, company, address_1, address_2, city, state, postcode, country }." },
+          "meta_data": { "type": "array", "items": { "type": "object" } }
+        },
+        "required": ["email"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/customers",
+        "bodyMapping": {
+          "email": "$email",
+          "first_name": "$first_name",
+          "last_name": "$last_name",
+          "username": "$username",
+          "password": "$password",
+          "billing": "$billing",
+          "shipping": "$shipping",
+          "meta_data": "$meta_data"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_create_order",
+      "description": "Create an order. Useful for manual order creation, B2B quote-to-order flows, or migrating data from another system. Pass `line_items` as array of `{ product_id, quantity, variation_id?, total? }`. Defaults to `status=pending` — use `status=processing` to skip the pending step.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string", "description": "pending | processing | on-hold | completed. Default pending." },
+          "customer_id": { "type": "integer", "description": "Existing customer id, or 0 for guest order." },
+          "currency": { "type": "string", "description": "ISO 4217. Defaults to store currency." },
+          "customer_note": { "type": "string" },
+          "billing": { "type": "object" },
+          "shipping": { "type": "object" },
+          "line_items": { "type": "array", "description": "Array of { product_id, quantity, variation_id?, subtotal?, total? }.", "items": { "type": "object" } },
+          "shipping_lines": { "type": "array", "description": "Array of { method_id, method_title, total }.", "items": { "type": "object" } },
+          "fee_lines": { "type": "array", "items": { "type": "object" } },
+          "coupon_lines": { "type": "array", "description": "Array of { code }.", "items": { "type": "object" } },
+          "payment_method": { "type": "string", "description": "Slug, e.g. `bacs`, `cheque`, `cod`, `stripe`." },
+          "payment_method_title": { "type": "string" },
+          "set_paid": { "type": "boolean", "description": "If true, mark order as paid immediately (sets `date_paid`)." },
+          "meta_data": { "type": "array", "items": { "type": "object" } }
+        },
+        "required": ["line_items"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/orders",
+        "bodyMapping": {
+          "status": "$status",
+          "customer_id": "$customer_id",
+          "currency": "$currency",
+          "customer_note": "$customer_note",
+          "billing": "$billing",
+          "shipping": "$shipping",
+          "line_items": "$line_items",
+          "shipping_lines": "$shipping_lines",
+          "fee_lines": "$fee_lines",
+          "coupon_lines": "$coupon_lines",
+          "payment_method": "$payment_method",
+          "payment_method_title": "$payment_method_title",
+          "set_paid": "$set_paid",
+          "meta_data": "$meta_data"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_delete_order",
+      "description": "Move an order to trash, or pass `force=true` to delete permanently. Permanent delete is irreversible and unlinks all order notes / refunds.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "force": { "type": "boolean", "description": "true = permanent delete; false (default) = trash." }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/orders/{orderId}",
+        "queryParams": {
+          "force": "$force"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_order_notes",
+      "description": "List notes attached to an order (both internal admin notes and customer-visible notes). Used for audit trails and to read the message history attached to an order.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "type": { "type": "string", "description": "Filter: `any` (default) | `internal` | `customer`." }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/{orderId}/notes",
+        "queryParams": {
+          "type": "$type"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_get_order_note",
+      "description": "Retrieve a single order note by id.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "noteId": { "type": "integer" }
+        },
+        "required": ["orderId", "noteId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/{orderId}/notes/{noteId}"
+      }
+    },
+    {
+      "name": "woocommerce_delete_order_note",
+      "description": "Delete an order note. Always permanent — order notes do not support trash.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": { "type": "integer" },
+          "noteId": { "type": "integer" },
+          "force": { "type": "boolean", "description": "Must be true for WC to allow deletion of an order note." }
+        },
+        "required": ["orderId", "noteId"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/orders/{orderId}/notes/{noteId}",
+        "queryParams": {
+          "force": "$force"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_coupons",
+      "description": "List discount coupons in the store. Filter by code or product.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string", "description": "Match against coupon code." },
+          "code": { "type": "string", "description": "Exact code match." },
+          "after": { "type": "string", "description": "ISO 8601 — created after." },
+          "before": { "type": "string", "description": "ISO 8601 — created before." },
+          "orderby": { "type": "string" },
+          "order": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/coupons",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "code": "$code",
+          "after": "$after",
+          "before": "$before",
+          "orderby": "$orderby",
+          "order": "$order"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_create_coupon",
+      "description": "Create a discount coupon. Use for marketing campaigns, recovery emails, or B2B negotiated discounts.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "description": "Coupon code (case-insensitive)." },
+          "discount_type": { "type": "string", "description": "percent | fixed_cart | fixed_product. Default: fixed_cart." },
+          "amount": { "type": "string", "description": "Decimal as string. For percent: a number like '10' = 10%." },
+          "description": { "type": "string" },
+          "date_expires": { "type": "string", "description": "ISO 8601 (in site timezone)." },
+          "individual_use": { "type": "boolean", "description": "If true, can't be combined with other coupons." },
+          "product_ids": { "type": "array", "description": "Restrict to these products.", "items": { "type": "integer" } },
+          "excluded_product_ids": { "type": "array", "items": { "type": "integer" } },
+          "usage_limit": { "type": "integer", "description": "Max total usages across all customers." },
+          "usage_limit_per_user": { "type": "integer" },
+          "limit_usage_to_x_items": { "type": "integer", "description": "Max number of items the discount applies to." },
+          "free_shipping": { "type": "boolean" },
+          "product_categories": { "type": "array", "items": { "type": "integer" } },
+          "excluded_product_categories": { "type": "array", "items": { "type": "integer" } },
+          "exclude_sale_items": { "type": "boolean" },
+          "minimum_amount": { "type": "string", "description": "Min cart total to qualify." },
+          "maximum_amount": { "type": "string" },
+          "email_restrictions": { "type": "array", "description": "Whitelist of customer emails (supports wildcards: `*@example.com`).", "items": { "type": "string" } }
+        },
+        "required": ["code", "discount_type", "amount"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/coupons",
+        "bodyMapping": {
+          "code": "$code",
+          "discount_type": "$discount_type",
+          "amount": "$amount",
+          "description": "$description",
+          "date_expires": "$date_expires",
+          "individual_use": "$individual_use",
+          "product_ids": "$product_ids",
+          "excluded_product_ids": "$excluded_product_ids",
+          "usage_limit": "$usage_limit",
+          "usage_limit_per_user": "$usage_limit_per_user",
+          "limit_usage_to_x_items": "$limit_usage_to_x_items",
+          "free_shipping": "$free_shipping",
+          "product_categories": "$product_categories",
+          "excluded_product_categories": "$excluded_product_categories",
+          "exclude_sale_items": "$exclude_sale_items",
+          "minimum_amount": "$minimum_amount",
+          "maximum_amount": "$maximum_amount",
+          "email_restrictions": "$email_restrictions"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_get_coupon",
+      "description": "Get a single coupon by id, including full usage stats (`usage_count`, `used_by` array).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "couponId": { "type": "integer" }
+        },
+        "required": ["couponId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/coupons/{couponId}"
+      }
+    },
+    {
+      "name": "woocommerce_update_coupon",
+      "description": "Partial-update a coupon. Common use: extend expiry, change amount, raise usage limit, restrict to additional products.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "couponId": { "type": "integer" },
+          "code": { "type": "string", "description": "WC allows code rename but it's risky for existing campaigns." },
+          "discount_type": { "type": "string" },
+          "amount": { "type": "string" },
+          "description": { "type": "string" },
+          "date_expires": { "type": "string" },
+          "individual_use": { "type": "boolean" },
+          "product_ids": { "type": "array", "items": { "type": "integer" } },
+          "excluded_product_ids": { "type": "array", "items": { "type": "integer" } },
+          "usage_limit": { "type": "integer" },
+          "usage_limit_per_user": { "type": "integer" },
+          "limit_usage_to_x_items": { "type": "integer" },
+          "free_shipping": { "type": "boolean" },
+          "product_categories": { "type": "array", "items": { "type": "integer" } },
+          "excluded_product_categories": { "type": "array", "items": { "type": "integer" } },
+          "exclude_sale_items": { "type": "boolean" },
+          "minimum_amount": { "type": "string" },
+          "maximum_amount": { "type": "string" },
+          "email_restrictions": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["couponId"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/coupons/{couponId}",
+        "bodyMapping": {
+          "code": "$code",
+          "discount_type": "$discount_type",
+          "amount": "$amount",
+          "description": "$description",
+          "date_expires": "$date_expires",
+          "individual_use": "$individual_use",
+          "product_ids": "$product_ids",
+          "excluded_product_ids": "$excluded_product_ids",
+          "usage_limit": "$usage_limit",
+          "usage_limit_per_user": "$usage_limit_per_user",
+          "limit_usage_to_x_items": "$limit_usage_to_x_items",
+          "free_shipping": "$free_shipping",
+          "product_categories": "$product_categories",
+          "excluded_product_categories": "$excluded_product_categories",
+          "exclude_sale_items": "$exclude_sale_items",
+          "minimum_amount": "$minimum_amount",
+          "maximum_amount": "$maximum_amount",
+          "email_restrictions": "$email_restrictions"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_delete_coupon",
+      "description": "Move a coupon to trash, or pass `force=true` to delete permanently.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "couponId": { "type": "integer" },
+          "force": { "type": "boolean", "description": "true = permanent; false (default) = trash." }
+        },
+        "required": ["couponId"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/coupons/{couponId}",
+        "queryParams": {
+          "force": "$force"
+        }
+      }
+    },
+    {
+      "name": "woocommerce_list_order_status_options",
+      "description": "Reference card: valid order status slugs. Use when calling `woocommerce_list_orders` (filter), `woocommerce_create_order` / `woocommerce_update_order_status`.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WooCommerce order status — valid slugs\n\n| Slug         | Description                                                                                |\n|--------------|--------------------------------------------------------------------------------------------|\n| `pending`    | Received, awaiting payment. Default for new orders that didn't reach payment.              |\n| `processing` | Payment received, stock reduced, awaiting fulfilment.                                      |\n| `on-hold`    | Awaiting payment confirmation (manual gateway like bank transfer / cheque). Stock reserved.|\n| `completed`  | Fulfilled. Final state.                                                                    |\n| `cancelled`  | Cancelled by admin or auto-expired. Stock returned.                                        |\n| `refunded`   | Fully refunded. Stock returned.                                                            |\n| `failed`     | Payment failed or was declined. Doesn't reduce stock.                                      |\n| `trash`      | Soft-deleted. Set via `woocommerce_delete_order`, not via `update_order_status`.           |\n\n## Filter syntax\n\nIn `woocommerce_list_orders`, comma-separated: `status=processing,on-hold`.\n\n## Lifecycle gotchas\n\n- `processing → completed` is typical fulfilment flow.\n- `pending → cancelled` releases stock and is the right move for abandoned checkout cleanup.\n- Plugins may register additional statuses (e.g. `wc-awaiting-shipment`); use `woocommerce_orders_totals_report` to see what your store actually has.\n"
+      }
+    },
+    {
+      "name": "woocommerce_list_product_type_options",
+      "description": "Reference card: valid `type` values for `woocommerce_create_product` / `woocommerce_update_product` and product type filter on search.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WooCommerce product type — valid values\n\n| Type        | Description                                                                                   |\n|-------------|-----------------------------------------------------------------------------------------------|\n| `simple`    | Default. One SKU, one price, optional stock.                                                  |\n| `grouped`   | Container for child products that customer buys together. No price on the parent.             |\n| `external`  | Listed in catalogue but \"Buy\" button links off-site (affiliate / external).                   |\n| `variable`  | Has variations (size / colour / etc.). Each variation is its own SKU + price + stock.         |\n\n## When using `variable`\n\n1. Create the parent with `type=variable` + `attributes` array describing the variation axes.\n2. Create each variation via `woocommerce_update_product_variation` (the actual variations endpoint is `/products/{id}/variations` — create variations one by one or use `woocommerce_batch_update_products` on the parent).\n\n## When using `grouped`\n\n1. Create the children first (`simple` products with their own SKUs).\n2. Create the parent with `type=grouped` + `grouped_products: [<child_ids>]`.\n\n## Plugin types\n\nSubscriptions, bookings, and similar plugins register additional types (`subscription`, `variable-subscription`, `booking`). Behaviour depends on the plugin — read its docs.\n"
+      }
+    },
+    {
+      "name": "woocommerce_list_stock_status_options",
+      "description": "Reference card: valid `stock_status` values for product create/update + list filter.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WooCommerce stock status — valid values\n\n| Value          | Description                                                                                 |\n|----------------|---------------------------------------------------------------------------------------------|\n| `instock`      | Available now.                                                                              |\n| `outofstock`   | Not available. Add-to-cart hidden by default.                                               |\n| `onbackorder`  | Not currently in stock but accepting orders (with delayed shipment).                        |\n\n## Related: the `backorders` field\n\nWhen `manage_stock=true` and `stock_quantity=0`, the `backorders` field controls behaviour:\n\n| `backorders` | Behaviour                                                                                  |\n|--------------|--------------------------------------------------------------------------------------------|\n| `no` (default) | Show out-of-stock, block purchase.                                                       |\n| `notify`     | Allow purchase, notify customer that backorder.                                            |\n| `yes`        | Allow purchase silently as backorder.                                                      |\n\n## In `woocommerce_search_products`\n\nFilter with `stock_status=instock` (single value, not CSV). For multi-status filtering you'd need multiple calls.\n"
+      }
+    },
+    {
+      "name": "woocommerce_list_report_period_options",
+      "description": "Reference card: valid `period` values for `woocommerce_sales_report` and `woocommerce_top_sellers_report`. Plus the alternative date-range syntax.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WooCommerce report period — valid values\n\nFor `woocommerce_sales_report` and `woocommerce_top_sellers_report`.\n\n## Named periods (shortcut)\n\n| Period       | Window                                                |\n|--------------|-------------------------------------------------------|\n| `week`       | Current week (Sunday or Monday start per WP setting). |\n| `month`      | Current calendar month, day 1 → today.                |\n| `last_month` | Entire previous calendar month.                       |\n| `year`       | Current calendar year, Jan 1 → today.                 |\n\nUsage: `period=\"month\"`.\n\n## Custom date range\n\nMutually exclusive with `period`. Use both `date_min` and `date_max`:\n\n```\nwoocommerce_sales_report(date_min=\"2026-01-01\", date_max=\"2026-03-31\")\n```\n\nDates are `YYYY-MM-DD` (inclusive). Interpreted in the store's timezone (`wordpress_get_settings.timezone_string` on the WP side).\n\n## Endpoints that do NOT accept date filters\n\n- `woocommerce_orders_totals_report` (counts by status — always store-wide).\n- `woocommerce_coupons_totals_report` (counts by discount type — always store-wide).\n\nFor period-over-period growth, call `sales_report` twice and compute deltas in context.\n"
+      }
+    },
+    {
+      "name": "woocommerce_skill_inventory_optimization",
+      "description": "Skill recipe: find out-of-stock and low-stock products, cross-reference with demand (top sellers), and bulk-bump stock via batch update.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: inventory optimisation\n\nGoal: identify stock gaps in the catalogue and bump quantities based on demand signals.\n\n## Steps\n\n1. **Out-of-stock products**\n   - `woocommerce_find_low_stock` with `stock_status=outofstock&per_page=100`. Iterate pages until exhausted.\n\n2. **Backorder products**\n   - `woocommerce_find_low_stock` with `stock_status=onbackorder&per_page=100`.\n\n3. **Demand leaders**\n   - `woocommerce_top_sellers_report` with `period=month` (or `last_month`). Returns `[{ title, product_id, quantity }]`.\n\n4. **Cross-reference** (agent-side)\n   - OUT-OF-STOCK ∩ TOP-SELLERS = URGENT restock. Add note for buyer review.\n   - OUT-OF-STOCK − TOP-SELLERS = low priority. Consider `catalog_visibility=hidden` if 3+ months stagnant.\n   - LOW STOCK ∩ TOP-SELLERS = preemptive bump (call `woocommerce_get_product` to read current `stock_quantity`, then decide a target).\n\n5. **Bulk-bump**\n   - `woocommerce_batch_update_products` with `update=[ { id, stock_quantity, stock_status: 'instock' }, ... ]`. Up to 100 entries per call.\n   - For items that should accept backorders: also `backorders: \"notify\"`. Run `woocommerce_list_stock_status_options` if you forget the values.\n\n6. **Verify**\n   - Repeat step 1: out-of-stock list should be smaller.\n\n## Gotchas\n\n- For ≥3 products, ALWAYS use `batch_update_products`. Don't fan out single calls.\n- `top_sellers_report` returns top 5 by default — for deeper analysis, also fetch `sales_report` and pair with category breakdown.\n- The decision logic (target quantity, backorder policy) is the agent's — the connector just persists.\n"
+      }
+    },
+    {
+      "name": "woocommerce_skill_product_seo_optimization",
+      "description": "Skill recipe: optimise a product's name, description, slug, and Yoast/Rank Math SEO meta.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: product SEO optimisation\n\nGoal: improve a product's organic search performance.\n\n## Steps\n\n1. **Read the full product**\n   - `woocommerce_get_product` with `productId=<id>`. Note `name`, `slug`, `short_description`, `description`, existing `meta_data`.\n\n2. **Rewrite in context** (agent-side)\n   - `name`: lead with the primary keyword. Brand/model precise. ≤ 60 chars.\n   - `short_description`: ~150 chars, conversion-focused.\n   - `description`: long-form HTML. Include keyword 2-3x naturally, plus secondary terms. Bullet key features.\n   - `slug`: kebab-case, ≤ 60 chars, no stop words. Leave existing slug alone unless it's truly bad (changes break URLs).\n\n3. **Persist core fields**\n   - `woocommerce_update_product` with `productId=<id>` + the rewritten fields.\n\n4. **Set SEO meta**\n   - Call `wordpress_list_seo_meta_keys` if you don't remember the keys.\n   - Append/overwrite entries in `meta_data`:\n     ```json\n     {\n       \"productId\": <id>,\n       \"meta_data\": [\n         { \"key\": \"_yoast_wpseo_metadesc\", \"value\": \"...\" },\n         { \"key\": \"_yoast_wpseo_focuskw\", \"value\": \"...\" }\n       ]\n     }\n     ```\n   - Send via `woocommerce_update_product`. `meta_data` is upsert: existing keys overwritten, new keys added, untouched keys preserved.\n\n5. **For batch (≥5 products)**\n   - Build an `update` array → `woocommerce_batch_update_products`.\n\n## Gotchas\n\n- Don't change `slug` on an indexed product. URL changes need a 301 upstream.\n- For variable products: optimise the parent + each variation separately (variation has its own description / sku / price).\n- Verify that Yoast/Rank Math is installed and at a version that registers `meta_data` keys in REST — see `wordpress_list_seo_meta_keys`.\n"
+      }
+    },
+    {
+      "name": "woocommerce_skill_upsell_cross_sell",
+      "description": "Skill recipe: build upsell + cross-sell relationships for a product based on category, price tier, and tags.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: upsell / cross-sell recommendations\n\nGoal: configure the 'You may also like' relationships rendered by WooCommerce.\n\n## Steps\n\n1. **Read the target product**\n   - `woocommerce_get_product` with `productId=<id>`. Note `categories`, `tags`, `regular_price`, current `upsell_ids` / `cross_sell_ids`.\n\n2. **Find candidates**\n   - Same category, similar price: `woocommerce_search_products` with `category=<id>&min_price=<X>&max_price=<Y>&stock_status=instock&per_page=20`.\n   - Same tag: `woocommerce_search_products` with `tag=<tag_id>&stock_status=instock&per_page=20`.\n\n3. **Score candidates** (agent-side)\n   - **UPSELL** = higher tier: 1.3-2.0× the source price, same category.\n   - **CROSS-SELL** = same tier: 0.7-1.3× the source price, complementary (different functional category).\n\n4. **Pick 3-5 per list** based on margin, current stock, and complementarity. Reject anything `stock_status != instock`.\n\n5. **Persist**\n   - `woocommerce_update_product` with:\n     ```json\n     {\n       \"productId\": <id>,\n       \"upsell_ids\": [<3-5 higher-tier ids>],\n       \"cross_sell_ids\": [<3-5 same-tier ids>]\n     }\n     ```\n\n## Where they appear\n\n- **Upsells**: product page, 'You might also like' block.\n- **Cross-sells**: cart page, 'Frequently bought with' block.\n\n## Gotchas\n\n- Both fields are ARRAYS OF PRODUCT IDS — not objects.\n- Don't include the source product itself (filter `id !== productId`).\n- Stagnant relationships: re-run periodically (e.g. monthly) as the catalogue evolves.\n"
+      }
+    },
+    {
+      "name": "woocommerce_skill_low_conversion_analysis",
+      "description": "Skill recipe: identify products visible in the catalogue but not selling, with an honest framing of what WooCommerce REST can and cannot measure.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: low-conversion product analysis\n\nGoal: identify products that exist in the catalogue but underperform.\n\n## Honest framing\n\nWooCommerce REST does NOT expose impressions, add-to-cart, or page-view data — only purchases. So 'low conversion' here is actually 'low purchases per catalog-day'. For real funnel metrics, pair with a web analytics connector (Google Analytics, Plausible).\n\n## Steps\n\n1. **List visible candidates**\n   - `woocommerce_search_products` with `status=publish&stock_status=instock&per_page=100`. Page through.\n\n2. **List top sellers for the window**\n   - `woocommerce_top_sellers_report` with `period=month` (or `last_month`). Returns `[{ product_id, quantity }]`.\n\n3. **Set difference** (agent-side)\n   - `visible_ids − top_seller_ids` = products in catalogue with zero/few sales in the window.\n\n4. **Filter by age** — exclude products that haven't had time to sell\n   - `woocommerce_search_products` with `before=<14_days_ago_iso>` to keep only products older than 14 days.\n\n5. **Diagnose each candidate** (agent-side)\n   - `woocommerce_get_product` on each. Common low-conversion causes:\n     - Missing/bad images.\n     - Short / generic `description`.\n     - Price out-of-line with category siblings.\n     - Missing SEO `meta_data`.\n     - No `upsell_ids` / `cross_sell_ids`.\n\n6. **Generate recommendations**\n   - For each candidate, propose specific fixes. Then run the corresponding skill: `woocommerce_skill_product_seo_optimization`, `woocommerce_skill_upsell_cross_sell`, or surface for manual buyer review.\n\n## Gotchas\n\n- 'Zero sales' over a short window can be noise. Use month or last_month, not week, for confidence.\n- For seasonal items, compare to same period last year if possible (custom `date_min` / `date_max`).\n- Don't auto-hide products. Surface the list for human triage first.\n"
+      }
+    },
+    {
+      "name": "woocommerce_skill_abandoned_order_triage",
+      "description": "Skill recipe: process stuck orders (pending / on-hold / failed) — chase or cancel based on age and reason.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: abandoned-order triage\n\nGoal: process orders that are stuck in pending / on-hold / failed and decide chase vs cancel.\n\n## Honest framing\n\nWC REST has NO 'abandoned cart' endpoint — that requires a plugin (e.g. WooCommerce Cart Abandonment Recovery). The closest proxy in core is `status=pending` (reached checkout, didn't complete payment).\n\n## Steps\n\n1. **List stuck orders**\n   - `woocommerce_list_orders` with `status=pending,on-hold,failed&per_page=50&orderby=date&order=asc`. Oldest first.\n\n2. **Per order** — `woocommerce_get_order` to see customer, line_items, payment_method, date_created.\n\n3. **Classify by age + status** (agent-side)\n   - `pending` > 24h → payment never completed. Email reminder OR cancel.\n   - `on-hold` > 7d (manual gateway like bank transfer) → chase customer OR cancel.\n   - `failed` → log + cancel (rarely worth chasing).\n\n4. **Act per case**\n   - Customer-visible reminder: `woocommerce_add_order_note` with `customer_note=true`. Triggers an email.\n   - Internal audit note: `woocommerce_add_order_note` with `customer_note=false`.\n   - Give up on the order: `woocommerce_update_order_status` with `status=cancelled`. Releases stock automatically.\n   - For permanent cleanup: `woocommerce_delete_order` with `force=true`.\n\n## Gotchas\n\n- Cancelling restores stock to inventory immediately.\n- Some gateways (Stripe, PayPal) auto-expire pending after 24-48h — check before manual cleanup.\n- Customer emails go through WP's mailer; ensure SMTP is configured.\n- For a real abandoned-cart funnel (started checkout but didn't finish), install the cart-abandonment-recovery plugin and add its endpoints in a v2.\n"
+      }
+    },
+    {
+      "name": "woocommerce_skill_revenue_kpi_snapshot",
+      "description": "Skill recipe: build a one-page KPI snapshot — revenue, AOV, top sellers, pipeline state, coupon mix.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: revenue / KPI snapshot\n\nGoal: produce a one-page markdown KPI report for a date window.\n\n## Steps\n\n1. **Sales totals for the window**\n   - `woocommerce_sales_report` with `period=month` (or `date_min` / `date_max` for custom). Returns `total_sales`, `net_sales`, `average_sales`, `total_orders`, `total_items`, `total_tax`, `total_shipping`, `total_refunds`, `total_discount`.\n\n2. **Top sellers for the same window**\n   - `woocommerce_top_sellers_report` with the same period / dates.\n\n3. **Store-wide pipeline + coupon mix** (always store-wide, no date filter)\n   - `woocommerce_orders_totals_report` → counts grouped by status.\n   - `woocommerce_coupons_totals_report` → counts grouped by discount type.\n\n4. **(Optional) Period-over-period**\n   - Call `sales_report` again with the previous window (same length, ending right before this window's start). Compute deltas in context.\n\n5. **Compose the markdown report** (agent-side)\n   - Headline: window, total revenue, orders, AOV (= net_sales / total_orders).\n   - Top sellers table.\n   - Pipeline state (status counts as a small table).\n   - Coupon mix (counts per discount type).\n   - Deltas vs previous period if available.\n\n## Gotchas\n\n- Currency comes from `woocommerce_currency` site option (read via `wordpress_get_settings`).\n- Reports use store timezone, not UTC — same gotcha as scheduled publishing.\n- `*_totals_report` endpoints don't accept date filters — they're snapshots, not windowed. Don't try to backdate them.\n- `top_sellers_report` returns top 5 by default. To rank deeper, the agent must combine multiple `sales_report` calls or query `list_orders` with date filter.\n"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/wordpress.json
+++ b/packages/backend/src/adapters/intl/wordpress.json
@@ -1,0 +1,904 @@
+{
+  "slug": "wordpress",
+  "name": "WordPress",
+  "description": "AI-native publishing and content operations for any self-hosted WordPress site. Semantic tools for posts, pages, taxonomies, media metadata, users, comments, SEO meta and site health — plus documented multi-step recipes (SEO content pipeline, scheduled publishing, content refresh, internal linking, media optimisation).",
+  "instructions": "This connector talks to the WordPress core REST API (`/wp-json/wp/v2`). WordPress 5.6+ (Application Passwords) and HTTPS required.\n\n## Setup\n\n1. **`WORDPRESS_URL`** — the site root (e.g. `https://example.com`). Do NOT include `/wp-json`; the adapter appends it. HTTPS mandatory.\n2. **`WORDPRESS_USERNAME`** — login name with the role needed (Editor for posts, Administrator for users / site-health).\n3. **`WORDPRESS_APP_PASSWORD`** — generate in `/wp-admin/profile.php` → Application Passwords. Forward verbatim (spaces or no-spaces both work).\n\n## Payload control\n\nWP responses are large by default. Every `list_*` and `get_*` accepts `_fields` (comma-separated allowlist, e.g. `id,title,status,modified,slug,link`). Use it.\n\n## SEO plugin meta keys (Yoast / Rank Math)\n\nMeta is REST-visible only if registered with `show_in_rest: true`. Yoast and Rank Math do this on modern versions. Call `wordpress_list_seo_meta_keys` for the full reference card.\n\n## Multi-step workflows\n\nFor recipes like SEO refresh, content refresh, scheduled publishing, internal linking, or media optimisation, call the dedicated **`wordpress_skill_*`** tool — it returns the step-by-step playbook on demand. Don't preload that knowledge here.\n\n## Enum reference cards\n\nFor valid values of status / role / comment-status / site-health test slugs, call the corresponding **`wordpress_list_*_options`** tool. The site-health slugs in particular use hyphens, not underscores — easy to get wrong.\n\n## Permissions cheat-sheet\n\nPosts CRUD: Editor. Users CRUD: Administrator. Site health / settings: Administrator. Comments moderate: Editor. `rest_cannot_*` errors mean the App Password user lacks the capability.",
+  "region": "intl",
+  "category": "cms",
+  "icon": "wordpress",
+  "docsUrl": "https://developer.wordpress.org/rest-api/",
+  "requiredEnvVars": [
+    "WORDPRESS_URL",
+    "WORDPRESS_USERNAME",
+    "WORDPRESS_APP_PASSWORD"
+  ],
+  "priority": 50,
+  "connector": {
+    "name": "WordPress",
+    "type": "REST",
+    "baseUrl": "{{WORDPRESS_URL}}/wp-json",
+    "authType": "BASIC_AUTH",
+    "authConfig": {
+      "username": "{{WORDPRESS_USERNAME}}",
+      "password": "{{WORDPRESS_APP_PASSWORD}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "wordpress_list_posts",
+      "description": "List posts with rich filtering — status, author, search term, taxonomy (categories/tags), date range, ordering. Use `_fields` to trim the response (recommended: `id,title,status,date,modified,slug,link,author`). Default order is newest-first; pass `orderby=modified&order=asc` to find stalest content for refresh workflows.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer", "description": "1-based page number." },
+          "per_page": { "type": "integer", "description": "Results per page (1-100, default 10)." },
+          "search": { "type": "string", "description": "Full-text search across title/content." },
+          "status": { "type": "string", "description": "Comma-separated: publish, future, draft, pending, private, trash, auto-draft. Default: publish." },
+          "author": { "type": "string", "description": "Comma-separated author user IDs." },
+          "categories": { "type": "string", "description": "Comma-separated category term IDs." },
+          "tags": { "type": "string", "description": "Comma-separated tag term IDs." },
+          "after": { "type": "string", "description": "ISO 8601 — return posts published after this date." },
+          "before": { "type": "string", "description": "ISO 8601 — return posts published before this date." },
+          "orderby": { "type": "string", "description": "date | modified | title | slug | id | include | author. Default date." },
+          "order": { "type": "string", "description": "asc | desc. Default desc." },
+          "_fields": { "type": "string", "description": "Comma-separated allowlist of top-level fields to return — keeps payloads small." }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/posts",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "status": "$status",
+          "author": "$author",
+          "categories": "$categories",
+          "tags": "$tags",
+          "after": "$after",
+          "before": "$before",
+          "orderby": "$orderby",
+          "order": "$order",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_get_post",
+      "description": "Get a single post by id. Returns full content (rendered + raw blocks if available), title, status, author, categories, tags, featured_media id, and any REST-exposed meta keys. Pass `_fields` to trim.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "integer", "description": "Post ID." },
+          "context": { "type": "string", "description": "view | embed | edit. Use `edit` to get raw block content for refresh workflows (requires edit_posts capability)." },
+          "_fields": { "type": "string", "description": "Comma-separated field allowlist." }
+        },
+        "required": ["postId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/posts/{postId}",
+        "queryParams": {
+          "context": "$context",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_create_post",
+      "description": "Create a post. For drafts pass `status: draft`; to schedule pass `status: future` plus an ISO `date` (site timezone). Content accepts HTML or Gutenberg block markup. Categories/tags are term IDs (use `wordpress_list_categories` / `wordpress_list_tags` first).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string", "description": "Post title (plain text or HTML)." },
+          "content": { "type": "string", "description": "Post body — HTML or Gutenberg blocks." },
+          "excerpt": { "type": "string", "description": "Optional excerpt." },
+          "status": { "type": "string", "description": "publish | future | draft | pending | private. Default: draft." },
+          "date": { "type": "string", "description": "ISO 8601 publish date (site timezone). Required when status=future." },
+          "slug": { "type": "string", "description": "URL slug. Omit to let WordPress derive from title." },
+          "author": { "type": "integer", "description": "Author user id." },
+          "categories": { "type": "array", "description": "Array of category term IDs.", "items": { "type": "integer" } },
+          "tags": { "type": "array", "description": "Array of tag term IDs.", "items": { "type": "integer" } },
+          "featured_media": { "type": "integer", "description": "Media library id for the featured image." },
+          "meta": { "type": "object", "description": "Map of REST-exposed meta keys (e.g. Yoast/Rank Math fields)." },
+          "comment_status": { "type": "string", "description": "open | closed." },
+          "ping_status": { "type": "string", "description": "open | closed." },
+          "sticky": { "type": "boolean", "description": "Whether to pin to the front page." }
+        },
+        "required": ["title"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/posts",
+        "bodyMapping": {
+          "title": "$title",
+          "content": "$content",
+          "excerpt": "$excerpt",
+          "status": "$status",
+          "date": "$date",
+          "slug": "$slug",
+          "author": "$author",
+          "categories": "$categories",
+          "tags": "$tags",
+          "featured_media": "$featured_media",
+          "meta": "$meta",
+          "comment_status": "$comment_status",
+          "ping_status": "$ping_status",
+          "sticky": "$sticky"
+        }
+      }
+    },
+    {
+      "name": "wordpress_update_post",
+      "description": "Partial-update a post by id. Only fields you pass are touched — omit `content` to keep the body, etc. `modified` is bumped automatically by WordPress. Use for the content-refresh recipe.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "integer", "description": "Post id to update." },
+          "title": { "type": "string", "description": "New title." },
+          "content": { "type": "string", "description": "New body — HTML or Gutenberg blocks." },
+          "excerpt": { "type": "string", "description": "New excerpt." },
+          "status": { "type": "string", "description": "publish | future | draft | pending | private | trash." },
+          "date": { "type": "string", "description": "ISO 8601 publish date." },
+          "slug": { "type": "string", "description": "New slug." },
+          "categories": { "type": "array", "description": "Replacement array of category term IDs.", "items": { "type": "integer" } },
+          "tags": { "type": "array", "description": "Replacement array of tag term IDs.", "items": { "type": "integer" } },
+          "featured_media": { "type": "integer", "description": "Featured media id (0 to clear)." },
+          "meta": { "type": "object", "description": "Map of REST-exposed meta keys to overwrite." },
+          "comment_status": { "type": "string", "description": "open | closed." },
+          "sticky": { "type": "boolean", "description": "Pin to front page." }
+        },
+        "required": ["postId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/posts/{postId}",
+        "bodyMapping": {
+          "title": "$title",
+          "content": "$content",
+          "excerpt": "$excerpt",
+          "status": "$status",
+          "date": "$date",
+          "slug": "$slug",
+          "categories": "$categories",
+          "tags": "$tags",
+          "featured_media": "$featured_media",
+          "meta": "$meta",
+          "comment_status": "$comment_status",
+          "sticky": "$sticky"
+        }
+      }
+    },
+    {
+      "name": "wordpress_delete_post",
+      "description": "Move a post to trash, or pass `force=true` to delete permanently. Trash is reversible from the admin UI.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "integer", "description": "Post id." },
+          "force": { "type": "boolean", "description": "true = permanent delete; false (default) = move to trash." }
+        },
+        "required": ["postId"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/wp/v2/posts/{postId}",
+        "queryParams": {
+          "force": "$force"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_pages",
+      "description": "List static pages. Same filter/order semantics as posts. Pages support hierarchy via `parent`.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "status": { "type": "string", "description": "Comma-separated statuses." },
+          "parent": { "type": "string", "description": "Comma-separated parent IDs (0 = top-level)." },
+          "orderby": { "type": "string", "description": "date | modified | title | menu_order | slug | id." },
+          "order": { "type": "string", "description": "asc | desc." },
+          "_fields": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/pages",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "status": "$status",
+          "parent": "$parent",
+          "orderby": "$orderby",
+          "order": "$order",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_get_page",
+      "description": "Get a single page by id.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageId": { "type": "integer", "description": "Page id." },
+          "context": { "type": "string", "description": "view | embed | edit." },
+          "_fields": { "type": "string" }
+        },
+        "required": ["pageId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/pages/{pageId}",
+        "queryParams": {
+          "context": "$context",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_create_page",
+      "description": "Create a static page (`/wp/v2/pages`). Supports `parent` for hierarchy and `menu_order` for sorting.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "content": { "type": "string" },
+          "excerpt": { "type": "string" },
+          "status": { "type": "string", "description": "publish | future | draft | pending | private." },
+          "date": { "type": "string" },
+          "slug": { "type": "string" },
+          "parent": { "type": "integer", "description": "Parent page id (0 = top-level)." },
+          "menu_order": { "type": "integer", "description": "Sort order within siblings." },
+          "featured_media": { "type": "integer" },
+          "meta": { "type": "object" },
+          "template": { "type": "string", "description": "Theme template slug (when the theme registers page templates)." }
+        },
+        "required": ["title"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/pages",
+        "bodyMapping": {
+          "title": "$title",
+          "content": "$content",
+          "excerpt": "$excerpt",
+          "status": "$status",
+          "date": "$date",
+          "slug": "$slug",
+          "parent": "$parent",
+          "menu_order": "$menu_order",
+          "featured_media": "$featured_media",
+          "meta": "$meta",
+          "template": "$template"
+        }
+      }
+    },
+    {
+      "name": "wordpress_update_page",
+      "description": "Partial-update a page by id.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pageId": { "type": "integer" },
+          "title": { "type": "string" },
+          "content": { "type": "string" },
+          "excerpt": { "type": "string" },
+          "status": { "type": "string" },
+          "slug": { "type": "string" },
+          "parent": { "type": "integer" },
+          "menu_order": { "type": "integer" },
+          "featured_media": { "type": "integer" },
+          "meta": { "type": "object" },
+          "template": { "type": "string" }
+        },
+        "required": ["pageId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/pages/{pageId}",
+        "bodyMapping": {
+          "title": "$title",
+          "content": "$content",
+          "excerpt": "$excerpt",
+          "status": "$status",
+          "slug": "$slug",
+          "parent": "$parent",
+          "menu_order": "$menu_order",
+          "featured_media": "$featured_media",
+          "meta": "$meta",
+          "template": "$template"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_categories",
+      "description": "List post categories. Returns id, name, slug, parent, count, description.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "parent": { "type": "integer", "description": "Filter to children of this parent term id." },
+          "hide_empty": { "type": "boolean", "description": "Hide categories with no posts." },
+          "orderby": { "type": "string", "description": "id | include | name | slug | count | term_group." },
+          "order": { "type": "string", "description": "asc | desc." },
+          "_fields": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/categories",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "parent": "$parent",
+          "hide_empty": "$hide_empty",
+          "orderby": "$orderby",
+          "order": "$order",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_create_category",
+      "description": "Create a category term.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "description": "Display name." },
+          "slug": { "type": "string", "description": "URL slug (defaults to derived from name)." },
+          "description": { "type": "string" },
+          "parent": { "type": "integer", "description": "Parent term id (0 = top-level)." }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/categories",
+        "bodyMapping": {
+          "name": "$name",
+          "slug": "$slug",
+          "description": "$description",
+          "parent": "$parent"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_tags",
+      "description": "List post tags. Returns id, name, slug, count, description.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "hide_empty": { "type": "boolean" },
+          "orderby": { "type": "string" },
+          "order": { "type": "string" },
+          "_fields": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/tags",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "hide_empty": "$hide_empty",
+          "orderby": "$orderby",
+          "order": "$order",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_create_tag",
+      "description": "Create a tag term.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "description": { "type": "string" }
+        },
+        "required": ["name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/tags",
+        "bodyMapping": {
+          "name": "$name",
+          "slug": "$slug",
+          "description": "$description"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_media",
+      "description": "List media-library items. Filter by `media_type` (image | video | audio | application) and `mime_type` (e.g. image/jpeg). Use `_fields=id,alt_text,caption,media_details,source_url` to keep the payload small for the media-optimisation recipe.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "media_type": { "type": "string", "description": "image | video | audio | application | text." },
+          "mime_type": { "type": "string", "description": "Specific MIME, e.g. image/png." },
+          "author": { "type": "string", "description": "Comma-separated author IDs." },
+          "after": { "type": "string" },
+          "before": { "type": "string" },
+          "orderby": { "type": "string" },
+          "order": { "type": "string" },
+          "_fields": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/media",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "media_type": "$media_type",
+          "mime_type": "$mime_type",
+          "author": "$author",
+          "after": "$after",
+          "before": "$before",
+          "orderby": "$orderby",
+          "order": "$order",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_get_media",
+      "description": "Get a single media-library item by id. Use for inspecting `alt_text`, `caption`, image sizes, EXIF.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "mediaId": { "type": "integer" },
+          "_fields": { "type": "string" }
+        },
+        "required": ["mediaId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/media/{mediaId}",
+        "queryParams": {
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_update_media",
+      "description": "Update metadata on an existing media item — alt text (accessibility + SEO), caption, description, title. Does NOT replace the binary; v1 does not support binary upload (see connector instructions).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "mediaId": { "type": "integer" },
+          "alt_text": { "type": "string", "description": "Image alt text. Empty string clears it." },
+          "caption": { "type": "string", "description": "Caption (shown below image in some themes)." },
+          "description": { "type": "string", "description": "Long description (shown on the attachment page)." },
+          "title": { "type": "string", "description": "Media library title." },
+          "post": { "type": "integer", "description": "Attach to a specific parent post id (0 to detach)." }
+        },
+        "required": ["mediaId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/media/{mediaId}",
+        "bodyMapping": {
+          "alt_text": "$alt_text",
+          "caption": "$caption",
+          "description": "$description",
+          "title": "$title",
+          "post": "$post"
+        }
+      }
+    },
+    {
+      "name": "wordpress_set_featured_image",
+      "description": "Convenience tool: attach an existing media-library item as the featured image of a post or page. Equivalent to `wordpress_update_post` / `wordpress_update_page` with `featured_media: <mediaId>`, but explicit about intent. Pass `mediaId=0` to clear.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postType": { "type": "string", "description": "REST base for the target object — typically `posts` or `pages`. For a custom post type pass its `rest_base`." },
+          "postId": { "type": "integer", "description": "Target post or page id." },
+          "mediaId": { "type": "integer", "description": "Media-library id (0 to clear)." }
+        },
+        "required": ["postType", "postId", "mediaId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/{postType}/{postId}",
+        "bodyMapping": {
+          "featured_media": "$mediaId"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_users",
+      "description": "List users. Requires Administrator for full visibility; lower roles see only public author info. Use for finding author IDs when creating/assigning posts.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "roles": { "type": "string", "description": "Comma-separated role slugs: administrator, editor, author, contributor, subscriber." },
+          "orderby": { "type": "string", "description": "id | include | name | registered_date | slug | email | url." },
+          "order": { "type": "string" },
+          "_fields": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/users",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "roles": "$roles",
+          "orderby": "$orderby",
+          "order": "$order",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_comments",
+      "description": "List comments across all posts, with status filter for moderation workflows.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" },
+          "search": { "type": "string" },
+          "post": { "type": "string", "description": "Comma-separated post IDs to filter to." },
+          "status": { "type": "string", "description": "approve | hold | spam | trash. Default: approve." },
+          "author_email": { "type": "string" },
+          "after": { "type": "string" },
+          "before": { "type": "string" },
+          "_fields": { "type": "string" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/comments",
+        "queryParams": {
+          "page": "$page",
+          "per_page": "$per_page",
+          "search": "$search",
+          "post": "$post",
+          "status": "$status",
+          "author_email": "$author_email",
+          "after": "$after",
+          "before": "$before",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_moderate_comment",
+      "description": "Change a comment's moderation status — approve, hold, spam, or trash. To delete permanently use status=trash plus a follow-up DELETE (not exposed in v1).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "commentId": { "type": "integer" },
+          "status": { "type": "string", "description": "approve | hold | spam | trash." }
+        },
+        "required": ["commentId", "status"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/comments/{commentId}",
+        "bodyMapping": {
+          "status": "$status"
+        }
+      }
+    },
+    {
+      "name": "wordpress_search",
+      "description": "Cross-post-type full-text search via `/wp/v2/search`. Returns lightweight hits ({id, title, url, type, subtype}) — use this when you don't know whether the match is a post or a page. Pair with `wordpress_get_post` / `wordpress_get_page` to fetch full content.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "search": { "type": "string", "description": "Search term." },
+          "type": { "type": "string", "description": "post | term | post-format. Default: post." },
+          "subtype": { "type": "string", "description": "Restrict to a specific post type slug (e.g. `post`, `page`, or a custom post type). Default: any." },
+          "page": { "type": "integer" },
+          "per_page": { "type": "integer" }
+        },
+        "required": ["search"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/search",
+        "queryParams": {
+          "search": "$search",
+          "type": "$type",
+          "subtype": "$subtype",
+          "page": "$page",
+          "per_page": "$per_page"
+        }
+      }
+    },
+    {
+      "name": "wordpress_update_post_meta",
+      "description": "Overwrite REST-exposed meta keys on a post — typically Yoast (`_yoast_wpseo_title`, `_yoast_wpseo_metadesc`, `_yoast_wpseo_focuskw`) or Rank Math (`rank_math_title`, `rank_math_description`, `rank_math_focus_keyword`). Pass any subset of keys; only those keys are written. Returns the updated post.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postId": { "type": "integer" },
+          "meta": {
+            "type": "object",
+            "description": "Map of meta key → value. Keys must be registered with `show_in_rest: true` (Yoast/Rank Math do this by default)."
+          }
+        },
+        "required": ["postId", "meta"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/posts/{postId}",
+        "bodyMapping": {
+          "meta": "$meta"
+        }
+      }
+    },
+    {
+      "name": "wordpress_site_health_status",
+      "description": "Run one of WordPress's built-in Site Health checks. Wraps `/wp-site-health/v1/tests/{test}` (core since WP 5.5) — requires Administrator. Useful for an agent triaging deploy / hosting issues. Call once per test slug. NOTE: test slugs use hyphens, not underscores.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "test": {
+            "type": "string",
+            "description": "Test slug (hyphenated): background-updates | loopback-requests | https-status | dotorg-communication | authorization-header | page-cache."
+          }
+        },
+        "required": ["test"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp-site-health/v1/tests/{test}"
+      }
+    },
+    {
+      "name": "wordpress_get_settings",
+      "description": "Read site-level settings (title, description, url, timezone_string, date_format, posts_per_page, default_category, etc.). Requires Administrator.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/settings"
+      }
+    },
+    {
+      "name": "wordpress_get_user",
+      "description": "Get a single user by id. Public fields for any role; private fields (email, registration date, capabilities) require Administrator. Use to resolve an author id when creating/assigning posts.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "integer", "description": "User id. Pass `0` and use `me=true` to read the authenticated user." },
+          "context": { "type": "string", "description": "view | embed | edit. `edit` returns email / registered_date / capabilities (Admin only)." },
+          "_fields": { "type": "string", "description": "Comma-separated field allowlist." }
+        },
+        "required": ["userId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/wp/v2/users/{userId}",
+        "queryParams": {
+          "context": "$context",
+          "_fields": "$_fields"
+        }
+      }
+    },
+    {
+      "name": "wordpress_create_user",
+      "description": "Create a user account. Requires Administrator. Returns the full user object including id.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "username": { "type": "string", "description": "Login (lowercase, no spaces)." },
+          "email": { "type": "string" },
+          "password": { "type": "string", "description": "Initial password. The user can change it after login." },
+          "first_name": { "type": "string" },
+          "last_name": { "type": "string" },
+          "name": { "type": "string", "description": "Display name (defaults to username)." },
+          "nickname": { "type": "string" },
+          "url": { "type": "string", "description": "Author URL." },
+          "description": { "type": "string", "description": "Biographical info." },
+          "roles": { "type": "array", "description": "Array of role slugs. Common: subscriber, contributor, author, editor, administrator.", "items": { "type": "string" } },
+          "locale": { "type": "string", "description": "e.g. `en_US`, `it_IT`." }
+        },
+        "required": ["username", "email", "password"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/users",
+        "bodyMapping": {
+          "username": "$username",
+          "email": "$email",
+          "password": "$password",
+          "first_name": "$first_name",
+          "last_name": "$last_name",
+          "name": "$name",
+          "nickname": "$nickname",
+          "url": "$url",
+          "description": "$description",
+          "roles": "$roles",
+          "locale": "$locale"
+        }
+      }
+    },
+    {
+      "name": "wordpress_update_user",
+      "description": "Partial-update an existing user. Only fields you pass are touched. Requires Administrator (or the user updating their own profile).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "integer" },
+          "email": { "type": "string" },
+          "password": { "type": "string", "description": "Set a new password." },
+          "first_name": { "type": "string" },
+          "last_name": { "type": "string" },
+          "name": { "type": "string" },
+          "nickname": { "type": "string" },
+          "url": { "type": "string" },
+          "description": { "type": "string" },
+          "roles": { "type": "array", "items": { "type": "string" } },
+          "locale": { "type": "string" }
+        },
+        "required": ["userId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/wp/v2/users/{userId}",
+        "bodyMapping": {
+          "email": "$email",
+          "password": "$password",
+          "first_name": "$first_name",
+          "last_name": "$last_name",
+          "name": "$name",
+          "nickname": "$nickname",
+          "url": "$url",
+          "description": "$description",
+          "roles": "$roles",
+          "locale": "$locale"
+        }
+      }
+    },
+    {
+      "name": "wordpress_delete_user",
+      "description": "Permanently delete a user. WordPress does NOT trash users — deletion is always permanent. `reassign` is required: pass the user id that should inherit the deleted user's posts (or `0` to delete the posts too). Requires Administrator.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "integer" },
+          "reassign": { "type": "integer", "description": "User id to reassign content to. Pass 0 to delete the user's posts and links as well." },
+          "force": { "type": "boolean", "description": "Must be true — WP REST refuses user delete without it." }
+        },
+        "required": ["userId", "reassign", "force"]
+      },
+      "endpointMapping": {
+        "method": "DELETE",
+        "path": "/wp/v2/users/{userId}",
+        "queryParams": {
+          "reassign": "$reassign",
+          "force": "$force"
+        }
+      }
+    },
+    {
+      "name": "wordpress_list_post_status_options",
+      "description": "Reference card: the valid `status` values you can pass to `wordpress_create_post` / `wordpress_update_post`. Call this on-demand instead of guessing.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WordPress post status — valid values\n\n| Status     | Meaning                                                                 |\n|------------|-------------------------------------------------------------------------|\n| `publish`  | Public.                                                                 |\n| `future`   | Scheduled — requires `date` in the future (ISO 8601, site timezone).    |\n| `draft`    | Saved, not visible.                                                     |\n| `pending`  | Awaiting review (typically Contributor-submitted).                      |\n| `private`  | Visible only to logged-in users with appropriate role.                  |\n| `trash`    | Soft-deleted. Set via `wordpress_delete_post` (DELETE), not by update.  |\n| `auto-draft` | Internal — created by autosave. Don't set explicitly.                 |\n\n## Filter syntax\n\nIn `wordpress_list_posts`, the `status` param accepts comma-separated values: `status=draft,pending`.\n\n## Notes\n\n- `trash` is NOT a value to pass on update. Use the DELETE call.\n- `future` requires a `date` parameter strictly in the future, in the site's timezone (read via `wordpress_get_settings`).\n- Custom post types may register additional statuses via `register_post_status`.\n"
+      }
+    },
+    {
+      "name": "wordpress_list_comment_status_options",
+      "description": "Reference card: valid `status` values for `wordpress_moderate_comment` and `wordpress_list_comments` filtering.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WordPress comment status — valid values\n\n| Status       | Synonym   | Description                                                |\n|--------------|-----------|------------------------------------------------------------|\n| `approve`    | `approved`| Visible publicly.                                          |\n| `hold`       | `unapproved` | In moderation queue.                                    |\n| `spam`       |           | Flagged as spam (typically by Akismet).                    |\n| `trash`      |           | Soft-deleted.                                              |\n\nBoth the short (`approve` / `hold`) and long (`approved` / `unapproved`) variants are accepted by WP core. In `wordpress_list_comments` you can pass comma-separated: `status=approve,hold`.\n"
+      }
+    },
+    {
+      "name": "wordpress_list_user_role_options",
+      "description": "Reference card: built-in WordPress user roles and their core capabilities. Use when calling `wordpress_create_user` or `wordpress_update_user` with the `roles` array.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# WordPress built-in user roles\n\n| Role slug         | Description                                                                            |\n|-------------------|----------------------------------------------------------------------------------------|\n| `administrator`   | Full access to all administrative features within a single site.                       |\n| `editor`          | Can publish and manage posts including the posts of other users.                       |\n| `author`          | Can publish and manage their own posts.                                                |\n| `contributor`     | Can write and manage their own posts but cannot publish them.                          |\n| `subscriber`      | Can read content and manage their own profile.                                         |\n\n## WooCommerce additions (when WooCommerce is installed)\n\n| Role slug         | Description                                                                            |\n|-------------------|----------------------------------------------------------------------------------------|\n| `customer`        | Default role for shop customers (read-only on the store).                              |\n| `shop_manager`    | Can manage products, orders, customers without admin access.                           |\n\n## Notes\n\n- The `roles` parameter is an array; pass `[\"editor\"]` even for a single role.\n- Plugins can register custom roles; if `wordpress_create_user` returns `rest_invalid_param` on `roles`, check what the site has registered.\n- A user can have multiple roles; capabilities are the union.\n"
+      }
+    },
+    {
+      "name": "wordpress_list_site_health_test_slugs",
+      "description": "Reference card: the exact slugs you can pass to `wordpress_site_health_status`. They use HYPHENS, not underscores — a very common gotcha.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Site Health test slugs\n\nWordPress core registers these tests at `/wp-json/wp-site-health/v1/tests/{slug}`. **Slugs use hyphens, not underscores.**\n\n| Slug                       | What it checks                                                              |\n|----------------------------|-----------------------------------------------------------------------------|\n| `background-updates`       | Can the install receive core auto-updates?                                  |\n| `loopback-requests`        | Can WP make HTTP requests to itself (needed for cron, async tasks).         |\n| `https-status`             | Is the site fully on HTTPS, and is the SSL config valid.                    |\n| `dotorg-communication`     | Can WP reach api.wordpress.org (for updates and plugin info).               |\n| `authorization-header`     | Does the server pass through the `Authorization` header to PHP (critical for REST + App Passwords). |\n| `page-cache`               | Is a page cache active (and if so, is it configured correctly).             |\n\n## Calling\n\nOne test per call: `wordpress_site_health_status` with `test=\"background-updates\"`.\n\nFor a full health sweep, call all six in sequence and aggregate the responses in context.\n\n## Notes\n\n- All require Administrator capability.\n- Custom plugins may register additional test slugs via the `site_status_tests` filter — these are not in core and not listed here.\n"
+      }
+    },
+    {
+      "name": "wordpress_list_seo_meta_keys",
+      "description": "Reference card: the most useful Yoast SEO and Rank Math meta keys for use with `wordpress_update_post_meta` or `meta` in `wordpress_create_post` / `wordpress_update_post`.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# SEO plugin meta keys (Yoast SEO & Rank Math)\n\nThese keys are written via `wordpress_update_post_meta` with `meta={ \"<key>\": \"<value>\", ... }`. They become REST-visible because the plugin (Yoast/Rank Math) calls `register_post_meta` with `show_in_rest: true`. If a key doesn't take effect, the plugin isn't installed or is out of date.\n\n## Yoast SEO (`_yoast_wpseo_*`)\n\n| Key                          | Purpose                                                  |\n|------------------------------|----------------------------------------------------------|\n| `_yoast_wpseo_title`         | SEO title (overrides default).                           |\n| `_yoast_wpseo_metadesc`      | Meta description (~155 chars).                           |\n| `_yoast_wpseo_focuskw`       | Focus keyphrase.                                         |\n| `_yoast_wpseo_canonical`     | Custom canonical URL.                                    |\n| `_yoast_wpseo_meta-robots-noindex`   | `1` to noindex this post.                        |\n| `_yoast_wpseo_meta-robots-nofollow`  | `1` to nofollow links from this post.            |\n| `_yoast_wpseo_opengraph-title`       | Custom OG title (Facebook / generic).            |\n| `_yoast_wpseo_opengraph-description` | Custom OG description.                           |\n| `_yoast_wpseo_opengraph-image`       | Custom OG image URL.                             |\n| `_yoast_wpseo_twitter-title`         | Custom Twitter card title.                       |\n| `_yoast_wpseo_twitter-description`   | Custom Twitter card description.                 |\n| `_yoast_wpseo_twitter-image`         | Custom Twitter card image URL.                   |\n\n## Rank Math (`rank_math_*`)\n\n| Key                          | Purpose                                                  |\n|------------------------------|----------------------------------------------------------|\n| `rank_math_title`            | SEO title.                                               |\n| `rank_math_description`      | Meta description.                                        |\n| `rank_math_focus_keyword`    | Focus keyword (comma-separated for secondary).           |\n| `rank_math_canonical_url`    | Custom canonical.                                        |\n| `rank_math_robots`           | Array, e.g. `[\"noindex\",\"nofollow\"]`.                    |\n| `rank_math_facebook_title`   | Facebook OG title.                                       |\n| `rank_math_facebook_description` | Facebook OG description.                             |\n| `rank_math_facebook_image`   | Facebook OG image URL.                                   |\n| `rank_math_twitter_title`    | Twitter card title.                                      |\n| `rank_math_twitter_description` | Twitter card description.                             |\n| `rank_math_twitter_image`    | Twitter card image URL.                                  |\n| `rank_math_schema_*`         | Various Schema.org structured-data overrides.            |\n\n## Calling\n\n```\nwordpress_update_post_meta(postId=42, meta={\n  \"_yoast_wpseo_title\": \"Best practices for WP REST in 2026\",\n  \"_yoast_wpseo_metadesc\": \"A practical guide ... (~155 chars).\",\n  \"_yoast_wpseo_focuskw\": \"wordpress rest api\"\n})\n```\n\nFor WooCommerce products, use these same keys inside the `meta_data` array on `woocommerce_update_product` (different syntax — see that tool's docs).\n"
+      }
+    },
+    {
+      "name": "wordpress_skill_seo_content_pipeline",
+      "description": "Skill recipe: improve the SEO of an existing post on a target keyword. Returns the exact step-by-step tool chain (search → get → rewrite → update post → update meta).",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: SEO content pipeline\n\nGoal: improve the SEO of an existing post on a target keyword.\n\n## Steps\n\n1. **Find the post**\n   - `wordpress_search` with `search=<topic keywords>&type=post&per_page=5` → light hits `{id, title, url, type, subtype}`.\n   - If you already know the slug or id, skip this step.\n\n2. **Read the current content (raw)**\n   - `wordpress_get_post` with `postId=<id>&context=edit&_fields=id,title,slug,content,excerpt,categories,tags,meta`.\n   - `context=edit` returns raw block content (requires `edit_posts` capability).\n\n3. **Rewrite in context** (agent-side, no tool call)\n   - Title: include the primary keyword early. Stay under 60 chars.\n   - Body: keep heading structure. Add keyword to ≥1 H2 naturally. Don't inflate length more than ~30%.\n   - Excerpt: ~155 chars, conversion-focused.\n\n4. **Persist body + title**\n   - `wordpress_update_post` with `postId=<id>`, the rewritten `title`, `content`, `excerpt`. WordPress bumps `modified` automatically.\n\n5. **Set SEO meta**\n   - Call `wordpress_list_seo_meta_keys` first if you don't remember the keys.\n   - `wordpress_update_post_meta` with:\n     ```json\n     { \"postId\": <id>, \"meta\": {\n       \"_yoast_wpseo_title\": \"<title>\",\n       \"_yoast_wpseo_metadesc\": \"<desc ~155ch>\",\n       \"_yoast_wpseo_focuskw\": \"<keyword>\"\n     } }\n     ```\n   - Rank Math equivalents: `rank_math_title`, `rank_math_description`, `rank_math_focus_keyword`.\n\n## Gotchas\n\n- If `update_post_meta` silently no-ops, the key isn't registered with `show_in_rest: true`. Verify Yoast/Rank Math is active and up-to-date.\n- Don't change `slug` on an indexed post unless you also set a 301 upstream.\n- For 2+ posts, chain this skill — don't try to batch via a single call.\n"
+      }
+    },
+    {
+      "name": "wordpress_skill_content_refresh",
+      "description": "Skill recipe: find stale posts and refresh them. Returns the playbook for finding oldest-by-modified, reviewing, and persisting updates.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: content refresh\n\nGoal: find posts whose `modified` date is stale and refresh them.\n\n## Steps\n\n1. **Surface the stalest content**\n   - `wordpress_list_posts` with `orderby=modified&order=asc&per_page=20&_fields=id,title,modified,link,categories`.\n   - First items = oldest by last-modified. Page through with `page=2,3,...` as needed.\n\n2. **Pick a candidate** (agent-side)\n   - Title relevance to current trends.\n   - Age (anything > 12 months is fair game).\n   - Categories — pick high-traffic categories first.\n\n3. **Read full body**\n   - `wordpress_get_post` with `postId=<id>&context=edit`. No `_fields` — you want everything.\n\n4. **Refresh in context**\n   - Update outdated facts, broken links, year references, screenshots references.\n   - Keep voice, structure, internal links intact.\n   - Add a discreet \"Updated <Month Year>\" note near the top.\n\n5. **Push the update**\n   - `wordpress_update_post` with new `content`. WordPress bumps `modified` automatically.\n\n6. **(Optional) Refresh SEO meta**\n   - If the focus keyword should shift, follow up with `wordpress_update_post_meta`.\n\n## Gotchas\n\n- Do NOT change `date` (the original publish date). Only `modified` should update. URL/slug stays the same.\n- For pages, swap `list_posts` → `list_pages` and `update_post` → `update_page`.\n- Don't refresh everything in one session — small batches, human-reviewable.\n"
+      }
+    },
+    {
+      "name": "wordpress_skill_scheduled_publishing",
+      "description": "Skill recipe: publish a post at a future date with categories, tags, and featured image.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: scheduled publishing\n\nGoal: schedule a new post to publish at a future date with all metadata in place.\n\n## Steps\n\n1. **Prepare media first** (if you need a featured image)\n   - `wordpress_list_media` with `mime_type=image&per_page=20&_fields=id,title,source_url,alt_text` to find a reusable asset.\n   - Note: binary upload is NOT supported in v1. To use a new image: upload via WP admin or sideload externally, then reference its id.\n\n2. **Resolve taxonomy IDs**\n   - `wordpress_list_categories` and `wordpress_list_tags` with `search=...` to find term ids.\n   - Missing? Create them: `wordpress_create_category` / `wordpress_create_tag`.\n\n3. **Check site timezone**\n   - `wordpress_get_settings` → `timezone_string` (e.g. `Europe/Berlin`). The `date` you pass will be interpreted in that timezone.\n\n4. **Create the future-dated post**\n   - `wordpress_create_post` with:\n     ```json\n     {\n       \"title\": \"...\",\n       \"content\": \"...\",\n       \"excerpt\": \"...\",\n       \"status\": \"future\",\n       \"date\": \"2026-06-01T09:00:00\",\n       \"categories\": [<ids>],\n       \"tags\": [<ids>],\n       \"featured_media\": <media_id>\n     }\n     ```\n\n5. **(Optional) Set SEO meta** with `wordpress_update_post_meta` after creation. See `wordpress_list_seo_meta_keys`.\n\n## Gotchas\n\n- `status=\"future\"` with a `date` in the past becomes immediately `publish`.\n- Dates are SITE-TIMEZONE, not UTC. Always check `timezone_string` first.\n- For repeating series, run this skill per post — there's no schedule-recurring endpoint in core WP.\n"
+      }
+    },
+    {
+      "name": "wordpress_skill_internal_linking",
+      "description": "Skill recipe: add internal links to an existing post by finding anchor candidates via wordpress_search.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: internal linking\n\nGoal: add 2-4 internal links to an existing post to improve the site link graph.\n\n## Steps\n\n1. **Read the target post (raw)**\n   - `wordpress_get_post` with `postId=<id>&context=edit`.\n\n2. **Identify 3-5 keyword anchors** (agent-side)\n   - Pick phrases naturally present in the body that relate to other content on the site. Avoid generic phrases (\"learn more\", \"click here\").\n\n3. **Find anchor candidates per keyword**\n   - For each candidate keyword: `wordpress_search` with `search=<keyword>&type=post&per_page=5`.\n   - Returns up to 5 hits `{id, title, url}`.\n   - Filter out self-links (don't link to `<id>` itself).\n\n4. **Decide which anchors to insert** (agent-side)\n   - 2-4 internal links per 1000 words of body. Use natural anchor text from the source body — DON'T keyword-stuff.\n   - Choose the most topically relevant hit per keyword.\n\n5. **Rewrite the HTML/blocks** (agent-side)\n   - Wrap the phrase in `<a href=\"<url>\">...</a>`.\n   - For Gutenberg blocks, preserve `<!-- wp:paragraph -->` comments unchanged. The connector does NO HTML parsing.\n\n6. **Persist**\n   - `wordpress_update_post` with the rewritten `content`.\n\n## Gotchas\n\n- The connector does no HTML/block parsing — the agent owns rewrites entirely. Verify the body before pushing.\n- Don't link the same phrase twice in one post.\n- For a site-wide linking pass: pair with `wordpress_skill_content_refresh` to surface posts to update.\n"
+      }
+    },
+    {
+      "name": "wordpress_skill_media_optimization",
+      "description": "Skill recipe: bulk-fix missing alt text and captions on media library items for accessibility + SEO.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "",
+        "staticResponse": "# Skill: media optimisation (alt text / SEO)\n\nGoal: bulk-fix media items with empty / generic alt text.\n\n## Steps\n\n1. **Survey the library**\n   - `wordpress_list_media` with `media_type=image&per_page=50&_fields=id,alt_text,caption,source_url,media_details,post`.\n   - Page through (`page=2,3,...`) until exhausted.\n\n2. **Identify gaps** (agent-side)\n   - Empty `alt_text`.\n   - Generic alt (`DSC_*`, `IMG_*`, `image-1`, filename without extension).\n\n3. **Generate alt text** (agent-side)\n   - If you have vision capability: fetch `source_url` and describe the image factually.\n   - Otherwise: read the parent post via `wordpress_get_post` on the `post` field and infer from context.\n   - Aim for 5-15 words, factual, no \"image of\" / \"photo of\" prefix.\n\n4. **Update each item**\n   - `wordpress_update_media` with `mediaId=<id>&alt_text=<descriptive>`.\n   - Optionally also set `caption` (visible under the image in some themes) and `description` (the attachment page body).\n\n## Gotchas\n\n- Decorative images (dividers, icons): leave `alt_text=\"\"`. That is the CORRECT accessibility behavior — don't generate alt text for them.\n- Run in batches of 10-20 with a human spot-check between batches.\n- Alt text should describe the image, NOT repeat the page/post title or stuff keywords.\n"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Two new connectors landing as declarative JSON manifests under `packages/backend/src/adapters/intl/`. Zero platform code changes.

- **WordPress (39 tools)** — `BASIC_AUTH` via WP Application Passwords, hits `/wp-json/wp/v2`. Covers posts, pages, taxonomies, media, users, comments, search, site-health, settings, plus post-meta for Yoast/Rank Math SEO.
- **WooCommerce (50 tools)** — `BASIC_AUTH` via REST consumer key+secret, hits `/wp-json/wc/v3`. Covers products + variations, orders + notes + refunds, customers, coupons, reports.

Both connectors require **HTTPS** in production (documented in `instructions`).

## New tool families (pattern)

- **CRUD primitives** for every major entity (create/read/update/delete where the upstream API supports it).
- **9 enum-helper static tools** (e.g. `wordpress_list_site_health_test_slugs`, `woocommerce_list_order_status_options`) — reference cards delivered on-demand via `method:"static"`. Pattern inspired by Pipedream's `list-*-options` actions.
- **11 skill static tools** (e.g. `wordpress_skill_seo_content_pipeline`, `woocommerce_skill_inventory_optimization`) — multi-step workflow playbooks that the agent reads only when actually running that workflow, instead of preloading them into the always-on `instructions` block.

## Platform alignment

`STATIC` added to `VALID_REST_METHODS` in `catalog.spec.ts`. The runtime (`ConnectorsService` + `DynamicMcpTools`) was already intercepting `method:"static"` + `staticResponse` before engine dispatch — the test gate was the only thing blocking the pattern for REST adapters.

## Test plan

- [x] `catalog.spec.ts` — 450/450 pass (was 426; +24 for the new tools)
- [x] Full backend test suite — 839/839 pass
- [x] `tsc --noEmit` clean
- [x] End-to-end live test against a docker-compose WP 6.8 + WC stack with seeded data (7 products, 3 orders, 1 customer, 1 coupon, 1 comment, 1 variable product) — **92/92 pass**, all tool families exercised:
  - All read tools, write tools, batch ops, refunds, order-notes chain, coupon CRUD, customer CRUD
  - User delete with reassign
  - Static skill + enum tools structurally verified