### PR TITLE
fix(docker): copy scripts/regenerate-catalog.mjs into backend builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,10 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/backend/node_modules ./packages/backend/node_modules
 COPY package.json package-lock.json ./
 COPY packages/backend/ ./packages/backend/
+# The backend's `prebuild` hook runs scripts/regenerate-catalog.mjs to keep
+# catalog.ts in sync with the adapter JSON files. The script lives outside
+# packages/backend, so we copy it into the image (one tiny file, no deps).
+COPY scripts/regenerate-catalog.mjs ./scripts/regenerate-catalog.mjs
 
 WORKDIR /app/packages/backend
 # Dummy URL so prisma.config.ts can resolve DATABASE_URL at generate time


### PR DESCRIPTION
Hotfix: PR #232 added a prebuild hook on the backend that calls a script at the repo root. The Docker build doesn't COPY the scripts/ directory, so npm run build failed with MODULE_NOT_FOUND. One-line fix: COPY the single script file into the backend-builder stage.