### PR TITLE
adapters: SAP Concur + Business One + S/4HANA Cloud + 2 engine extensions

### DIFF
--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -21,6 +21,7 @@ import * as oxomi from './de/oxomi.json';
 import * as payone from './de/payone.json';
 import * as personio from './de/personio.json';
 import * as planradar from './de/planradar.json';
+import * as sapBusinessOne from './de/sap-business-one.json';
 import * as scopevisio from './de/scopevisio.json';
 import * as sendcloud from './de/sendcloud.json';
 import * as shipcloud from './de/shipcloud.json';
@@ -131,6 +132,8 @@ import * as reddit from './intl/reddit.json';
 import * as sageBusinessCloud from './intl/sage-business-cloud.json';
 import * as salesflare from './intl/salesflare.json';
 import * as salesloft from './intl/salesloft.json';
+import * as sapConcur from './intl/sap-concur.json';
+import * as sapS4hanaCloud from './intl/sap-s4hana-cloud.json';
 import * as savvycal from './intl/savvycal.json';
 import * as sendgrid from './intl/sendgrid.json';
 import * as signwell from './intl/signwell.json';
@@ -264,6 +267,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   payone as unknown as AdapterDefinition,
   personio as unknown as AdapterDefinition,
   planradar as unknown as AdapterDefinition,
+  sapBusinessOne as unknown as AdapterDefinition,
   scopevisio as unknown as AdapterDefinition,
   sendcloud as unknown as AdapterDefinition,
   shipcloud as unknown as AdapterDefinition,
@@ -374,6 +378,8 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   sageBusinessCloud as unknown as AdapterDefinition,
   salesflare as unknown as AdapterDefinition,
   salesloft as unknown as AdapterDefinition,
+  sapConcur as unknown as AdapterDefinition,
+  sapS4hanaCloud as unknown as AdapterDefinition,
   savvycal as unknown as AdapterDefinition,
   sendgrid as unknown as AdapterDefinition,
   signwell as unknown as AdapterDefinition,

--- a/packages/backend/src/adapters/de/sap-business-one.json
+++ b/packages/backend/src/adapters/de/sap-business-one.json
@@ -1,0 +1,237 @@
+{
+  "slug": "sap-business-one",
+  "name": "SAP Business One",
+  "description": "Drive SAP Business One ERP (popular Mittelstand SMB target in DACH) from any AI agent: business partners, items, sales orders, A/R invoices, quotations, deliveries. Service Layer OData v4. Session-cookie auth via /Login.",
+  "region": "de",
+  "category": "erp",
+  "icon": "sap-business-one",
+  "docsUrl": "https://help.sap.com/doc/056f69366b5345a386bb8149f1700c19/10.0/en-US/Service%20Layer%20API%20Reference.html",
+  "instructions": "**Setup**:\n1. Identify your Service Layer host (typically the same machine that runs HANA + SAP B1). Default HTTPS port is `50000`.\n2. Create or pick a B1 user that has API access for the company database you want to expose.\n3. Find the `CompanyDB` name in **Choose Company** dialog of the B1 client (looks like `SBODEMOGB`).\n4. Set the five env vars below. The adapter logs in once per session (~25 min TTL) and re-uses the `B1SESSION` cookie.\n\n**OData**: this adapter targets the **v2 / OData v4** Service Layer endpoint at `/b1s/v2/`. Older `/b1s/v1/` (OData v3) deployments are not covered — upgrade to FP 2405+ first.\n\n**Filtering**: use standard OData `$filter` syntax, e.g. `CardCode eq 'C20000'` or `DocDate ge '2026-01-01'`.\n\n**Self-host caveat**: Business One is on-premise. The Service Layer is reachable from inside the customer network. To use the AnythingMCP Cloud, expose Service Layer via a reverse proxy + TLS cert; otherwise self-host the adapter on the same network.",
+  "requiredEnvVars": ["SAP_B1_HOST", "SAP_B1_PORT", "SAP_B1_COMPANY_DB", "SAP_B1_USERNAME", "SAP_B1_PASSWORD"],
+  "connector": {
+    "name": "SAP Business One Service Layer",
+    "type": "REST",
+    "baseUrl": "https://{{SAP_B1_HOST}}:{{SAP_B1_PORT}}/b1s/v2",
+    "authType": "LOGIN_TOKEN",
+    "authConfig": {
+      "loginUrl": "https://{{SAP_B1_HOST}}:{{SAP_B1_PORT}}/b1s/v2/Login",
+      "loginMethod": "POST",
+      "loginBody": {
+        "UserName": "${username}",
+        "Password": "${password}",
+        "CompanyDB": "{{SAP_B1_COMPANY_DB}}"
+      },
+      "username": "{{SAP_B1_USERNAME}}",
+      "password": "{{SAP_B1_PASSWORD}}",
+      "tokenSource": "cookie",
+      "cookieName": "B1SESSION",
+      "tokenJsonPath": "SessionId",
+      "tokenTTLSeconds": 1500,
+      "proactiveRefreshSeconds": 120,
+      "refreshOn401": true,
+      "headerName": "Cookie",
+      "headerTemplate": "B1SESSION=${token}"
+    }
+  },
+  "tools": [
+    {
+      "name": "b1_list_business_partners",
+      "description": "List business partners (customers, suppliers, leads). Use $filter, $top, $select.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows (default 50, max 1000)" },
+          "filter": { "type": "string", "description": "OData $filter expression, e.g. CardType eq 'cCustomer'" },
+          "select": { "type": "string", "description": "OData $select list, e.g. CardCode,CardName,Phone1" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/BusinessPartners",
+        "queryParams": { "$top": "$top", "$filter": "$filter", "$select": "$select" }
+      }
+    },
+    {
+      "name": "b1_get_business_partner",
+      "description": "Get one business partner by CardCode.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "cardCode": { "type": "string", "description": "BP CardCode, e.g. C20000" }
+        },
+        "required": ["cardCode"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/BusinessPartners('{cardCode}')"
+      }
+    },
+    {
+      "name": "b1_list_items",
+      "description": "List inventory items (articles). Use $filter, $top.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Items",
+        "queryParams": { "$top": "$top", "$filter": "$filter" }
+      }
+    },
+    {
+      "name": "b1_get_item",
+      "description": "Get one item by ItemCode.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "itemCode": { "type": "string", "description": "Item code" }
+        },
+        "required": ["itemCode"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Items('{itemCode}')"
+      }
+    },
+    {
+      "name": "b1_list_orders",
+      "description": "List sales orders. Sorted by DocDate desc by default.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Orders",
+        "queryParams": {
+          "$top": "$top",
+          "$filter": "$filter",
+          "$orderby": "DocDate desc"
+        }
+      }
+    },
+    {
+      "name": "b1_get_order",
+      "description": "Get one sales order by DocEntry (integer primary key).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "docEntry": { "type": "number", "description": "Order DocEntry" }
+        },
+        "required": ["docEntry"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Orders({docEntry})"
+      }
+    },
+    {
+      "name": "b1_create_order",
+      "description": "Create a new sales order. Provide CardCode (the customer BP) and DocumentLines (array of {ItemCode, Quantity}).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "cardCode": { "type": "string", "description": "Customer CardCode" },
+          "documentLines": {
+            "type": "array",
+            "description": "Array of {ItemCode, Quantity, Price?} line objects",
+            "items": { "type": "object" }
+          },
+          "comments": { "type": "string", "description": "Free-text comments printed on the order" }
+        },
+        "required": ["cardCode", "documentLines"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/Orders",
+        "bodyMapping": {
+          "CardCode": "$cardCode",
+          "DocumentLines": "$documentLines",
+          "Comments": "$comments"
+        }
+      }
+    },
+    {
+      "name": "b1_list_invoices",
+      "description": "List A/R invoices. Use $filter, $top.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Invoices",
+        "queryParams": { "$top": "$top", "$filter": "$filter" }
+      }
+    },
+    {
+      "name": "b1_get_invoice",
+      "description": "Get one A/R invoice by DocEntry.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "docEntry": { "type": "number", "description": "Invoice DocEntry" }
+        },
+        "required": ["docEntry"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Invoices({docEntry})"
+      }
+    },
+    {
+      "name": "b1_list_quotations",
+      "description": "List sales quotations.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Quotations",
+        "queryParams": { "$top": "$top", "$filter": "$filter" }
+      }
+    },
+    {
+      "name": "b1_list_delivery_notes",
+      "description": "List delivery notes (outgoing goods movements).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/DeliveryNotes",
+        "queryParams": { "$top": "$top", "$filter": "$filter" }
+      }
+    },
+    {
+      "name": "b1_get_company_info",
+      "description": "Sanity check: returns company metadata (admin info). Fast call; use it to verify credentials.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/CompanyService_GetAdminInfo"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/sap-concur.json
+++ b/packages/backend/src/adapters/intl/sap-concur.json
@@ -1,0 +1,193 @@
+{
+  "slug": "sap-concur",
+  "name": "SAP Concur",
+  "description": "Manage Concur expense reports, approvals, attendees, locations, users and travel itineraries from any AI agent. OAuth 2.0 refresh-token flow. Free developer sandbox on developer.concur.com.",
+  "region": "intl",
+  "category": "finance",
+  "icon": "sap-concur",
+  "docsUrl": "https://developer.concur.com/api-reference/",
+  "instructions": "**Setup**:\n1. Sign up on https://developer.concur.com and create a Company Sandbox.\n2. Register a new app in the **My Apps** page → request scopes `EXPRPT`, `USER`, `LIST` (and optionally `TRVPRO` for travel).\n3. Concur emails you a `Client ID` + `Client Secret`. Generate a `Refresh Token` via the Password Grant — needed once.\n4. Decide your region: `us` (https://us.api.concursolutions.com) or `eu` (https://eu.api.concursolutions.com).\n5. Set the four env vars below.\n\n**Authentication**: OAuth2 refresh-token grant. The adapter auto-refreshes the access token before expiry.\n\n**Rate limits**: 25 requests/sec per refresh token (defaults). Bulk export endpoints have stricter quotas.",
+  "requiredEnvVars": ["CONCUR_REGION", "CONCUR_CLIENT_ID", "CONCUR_CLIENT_SECRET", "CONCUR_REFRESH_TOKEN"],
+  "connector": {
+    "name": "SAP Concur",
+    "type": "REST",
+    "baseUrl": "https://{{CONCUR_REGION}}.api.concursolutions.com",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "clientId": "{{CONCUR_CLIENT_ID}}",
+      "clientSecret": "{{CONCUR_CLIENT_SECRET}}",
+      "refreshToken": "{{CONCUR_REFRESH_TOKEN}}",
+      "tokenUrl": "https://{{CONCUR_REGION}}.api.concursolutions.com/oauth2/v0/token",
+      "scope": "EXPRPT USER LIST"
+    }
+  },
+  "tools": [
+    {
+      "name": "concur_list_reports",
+      "description": "List expense reports for the connected company. Use `user=ALL` (default) for org-wide view or a specific login ID for a single user.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": { "type": "number", "description": "Page size (default 25, max 100)" },
+          "user": { "type": "string", "description": "Login ID of the user to filter, or `ALL` for all users (default)" },
+          "approvalStatusCode": { "type": "string", "description": "Approval status filter, e.g. A_PEND, A_APPR, A_REJC" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/expense/reports",
+        "queryParams": {
+          "limit": "$limit",
+          "user": "$user",
+          "approvalStatusCode": "$approvalStatusCode"
+        }
+      }
+    },
+    {
+      "name": "concur_get_report",
+      "description": "Get the full detail of one expense report by its ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportId": { "type": "string", "description": "The Concur Report ID" }
+        },
+        "required": ["reportId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/expense/reports/{reportId}"
+      }
+    },
+    {
+      "name": "concur_list_report_entries",
+      "description": "List the individual expense entries (line items) inside a given report.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportId": { "type": "string", "description": "The Concur Report ID" },
+          "limit": { "type": "number", "description": "Page size" }
+        },
+        "required": ["reportId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/expense/entries",
+        "queryParams": {
+          "reportID": "$reportId",
+          "limit": "$limit"
+        }
+      }
+    },
+    {
+      "name": "concur_submit_report",
+      "description": "Submit an expense report for approval. The report must be in a non-submitted state.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportId": { "type": "string", "description": "The Concur Report ID" }
+        },
+        "required": ["reportId"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api/v3.0/expense/reports/{reportId}/submit"
+      }
+    },
+    {
+      "name": "concur_workflow_action",
+      "description": "Approve, send-back or reject a submitted expense report. Action ∈ Approve, Send Back, Reject.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportId": { "type": "string", "description": "The Concur Report ID" },
+          "action": { "type": "string", "description": "Approve | Send Back | Reject" },
+          "comment": { "type": "string", "description": "Optional comment shown in the workflow" }
+        },
+        "required": ["reportId", "action"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api/v3.0/expense/reports/{reportId}/workflowaction",
+        "bodyMapping": {
+          "Action": "$action",
+          "Comment": "$comment"
+        }
+      }
+    },
+    {
+      "name": "concur_list_attendees",
+      "description": "List meeting/expense attendees registered in the company directory.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": { "type": "number", "description": "Page size" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/common/attendees",
+        "queryParams": { "limit": "$limit" }
+      }
+    },
+    {
+      "name": "concur_list_locations",
+      "description": "List travel/expense locations (cities, regions) available to your tenant.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": { "type": "number", "description": "Page size" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/common/locations",
+        "queryParams": { "limit": "$limit" }
+      }
+    },
+    {
+      "name": "concur_list_users",
+      "description": "List user accounts in the connected Concur tenant.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": { "type": "number", "description": "Page size" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/common/users",
+        "queryParams": { "limit": "$limit" }
+      }
+    },
+    {
+      "name": "concur_get_user",
+      "description": "Get one user profile by its Concur user ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "string", "description": "Concur user ID" }
+        },
+        "required": ["userId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/common/users/{userId}"
+      }
+    },
+    {
+      "name": "concur_list_itineraries",
+      "description": "List travel itineraries (Concur Travel). Requires TRVPRO scope on the OAuth client.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "limit": { "type": "number", "description": "Page size" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3.0/travel/itineraries",
+        "queryParams": { "limit": "$limit" }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/sap-s4hana-cloud.json
+++ b/packages/backend/src/adapters/intl/sap-s4hana-cloud.json
@@ -1,0 +1,262 @@
+{
+  "slug": "sap-s4hana-cloud",
+  "name": "SAP S/4HANA Cloud",
+  "description": "Drive SAP S/4HANA Cloud Public Edition from any AI agent: business partners, customers, suppliers, sales orders, purchase orders, billing documents, products, journal entries. OAuth 2.0 client_credentials via BTP Communication Arrangement.",
+  "region": "intl",
+  "category": "erp",
+  "icon": "sap-s4hana-cloud",
+  "docsUrl": "https://api.sap.com/package/SAPS4HANACloud",
+  "instructions": "**Setup (one-off, done by the S/4 admin)**:\n1. In your S/4HANA Cloud tenant open **Communication Arrangements** and create one for *SAP_COM_0008 — Business Partner Integration* (and others as needed: 0109 Sales Order, 0026 Purchase Order, 0186 Billing).\n2. Create a **Communication User** + **Communication System**. Pick **OAuth 2.0** as the authentication method, grant type **Client Credentials**.\n3. S/4 generates a `Client ID`, `Client Secret`, and a per-tenant **Token URL** like `https://my300000.authentication.eu10.hana.ondemand.com/oauth/token`.\n4. The tenant **Base URL** is `https://my300000.s4hana.cloud.sap` (your tenant ID replaces 300000).\n5. Set the four env vars below.\n\n**Auth header method**: Public Edition strictly requires Client ID/Secret sent via **HTTP Basic Authorization header** (not form fields). This adapter does that automatically.\n\n**Token lifetime**: typically 1 hour. The connector engine refreshes proactively 5 min before expiry, single-shot client_credentials grant (no refresh_token needed).",
+  "requiredEnvVars": ["S4_BASE_URL", "S4_TOKEN_URL", "S4_CLIENT_ID", "S4_CLIENT_SECRET"],
+  "connector": {
+    "name": "SAP S/4HANA Cloud",
+    "type": "REST",
+    "baseUrl": "{{S4_BASE_URL}}/sap/opu/odata",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "grant": "client_credentials",
+      "tokenUrl": "{{S4_TOKEN_URL}}",
+      "clientId": "{{S4_CLIENT_ID}}",
+      "clientSecret": "{{S4_CLIENT_SECRET}}"
+    }
+  },
+  "tools": [
+    {
+      "name": "s4_list_business_partners",
+      "description": "List business partners (combined customers + suppliers) from API_BUSINESS_PARTNER.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter, e.g. BusinessPartnerCategory eq '1'" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_BUSINESS_PARTNER/A_BusinessPartner",
+        "queryParams": { "$top": "$top", "$filter": "$filter", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_get_business_partner",
+      "description": "Get one business partner by its 10-character ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "businessPartner": { "type": "string", "description": "10-char Business Partner ID, e.g. 1000050" }
+        },
+        "required": ["businessPartner"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_BUSINESS_PARTNER/A_BusinessPartner('{businessPartner}')",
+        "queryParams": { "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_customers",
+      "description": "List customer master records (subset of business partners).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_BUSINESS_PARTNER/A_Customer",
+        "queryParams": { "$top": "$top", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_suppliers",
+      "description": "List supplier master records (subset of business partners).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_BUSINESS_PARTNER/A_Supplier",
+        "queryParams": { "$top": "$top", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_sales_orders",
+      "description": "List sales orders (headers).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter, e.g. SalesOrganization eq '1710'" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_SALES_ORDER_SRV/A_SalesOrder",
+        "queryParams": { "$top": "$top", "$filter": "$filter", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_get_sales_order",
+      "description": "Get one sales order by its 10-char number.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "salesOrder": { "type": "string", "description": "Sales Order number, e.g. 0000000001" }
+        },
+        "required": ["salesOrder"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_SALES_ORDER_SRV/A_SalesOrder('{salesOrder}')",
+        "queryParams": { "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_sales_order_items",
+      "description": "List the items (line entries) of a given sales order.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "salesOrder": { "type": "string", "description": "Parent Sales Order number" }
+        },
+        "required": ["salesOrder"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_SALES_ORDER_SRV/A_SalesOrderItem",
+        "queryParams": {
+          "$filter": "SalesOrder eq '${salesOrder}'",
+          "$format": "json"
+        }
+      }
+    },
+    {
+      "name": "s4_list_purchase_orders",
+      "description": "List purchase orders (headers).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_PURCHASEORDER_PROCESS_SRV/A_PurchaseOrder",
+        "queryParams": { "$top": "$top", "$filter": "$filter", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_get_purchase_order",
+      "description": "Get one purchase order by its 10-char number.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "purchaseOrder": { "type": "string", "description": "Purchase Order number" }
+        },
+        "required": ["purchaseOrder"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_PURCHASEORDER_PROCESS_SRV/A_PurchaseOrder('{purchaseOrder}')",
+        "queryParams": { "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_billing_documents",
+      "description": "List billing documents (customer invoices, credit memos).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" },
+          "filter": { "type": "string", "description": "OData $filter expression" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_BILLING_DOCUMENT_SRV/A_BillingDocument",
+        "queryParams": { "$top": "$top", "$filter": "$filter", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_outbound_deliveries",
+      "description": "List outbound delivery headers (goods leaving the warehouse).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_OUTBOUND_DELIVERY_SRV/A_OutbDeliveryHeader",
+        "queryParams": { "$top": "$top", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_journal_entries",
+      "description": "List journal entry items (general ledger postings).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_JOURNALENTRYITEMBASIC/JournalEntryItemBasic",
+        "queryParams": { "$top": "$top", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_products",
+      "description": "List materials / products (item master).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_PRODUCT_SRV/A_Product",
+        "queryParams": { "$top": "$top", "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_get_product",
+      "description": "Get one product/material by its ID.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "product": { "type": "string", "description": "Product ID" }
+        },
+        "required": ["product"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_PRODUCT_SRV/A_Product('{product}')",
+        "queryParams": { "$format": "json" }
+      }
+    },
+    {
+      "name": "s4_list_purchase_requisitions",
+      "description": "List purchase requisition items (pre-PO demand requests).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "top": { "type": "number", "description": "Max rows" }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sap/API_PURCHASEREQ_PROCESS_SRV/A_PurchaseRequisitionItem",
+        "queryParams": { "$top": "$top", "$format": "json" }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/connectors/engines/login-token.service.spec.ts
+++ b/packages/backend/src/connectors/engines/login-token.service.spec.ts
@@ -5,6 +5,7 @@ import {
   LoginTokenService,
   jsonPath,
   interpolateDeep,
+  extractSetCookieValue,
   LoginTokenAuthConfig,
 } from './login-token.service';
 import { encrypt } from '../../common/crypto/encryption.util';
@@ -268,6 +269,103 @@ describe('LoginTokenService', () => {
 
     await expect(service.getToken(baseAuth, 'conn-8')).rejects.toThrow(
       /token not found/,
+    );
+  });
+});
+
+describe('extractSetCookieValue helper', () => {
+  it('reads single Set-Cookie string', () => {
+    const headers = {
+      'set-cookie': 'B1SESSION=ABC123; Path=/; HttpOnly',
+    };
+    expect(extractSetCookieValue(headers, 'B1SESSION')).toBe('ABC123');
+  });
+
+  it('reads from an array of Set-Cookie headers and skips non-matching', () => {
+    const headers = {
+      'set-cookie': [
+        'route=node1; Path=/',
+        'B1SESSION=XYZ789; Path=/; Secure; HttpOnly',
+      ],
+    };
+    expect(extractSetCookieValue(headers, 'B1SESSION')).toBe('XYZ789');
+  });
+
+  it('returns null when the named cookie is absent', () => {
+    expect(
+      extractSetCookieValue({ 'set-cookie': 'other=1' }, 'B1SESSION'),
+    ).toBeNull();
+  });
+
+  it('handles missing headers safely', () => {
+    expect(extractSetCookieValue(undefined, 'B1SESSION')).toBeNull();
+    expect(extractSetCookieValue({}, 'B1SESSION')).toBeNull();
+  });
+});
+
+describe('LoginTokenService — tokenSource=cookie (SAP B1 pattern)', () => {
+  let service: LoginTokenService;
+  let mockPrisma: any;
+  let mockConfigService: jest.Mocked<ConfigService>;
+  const encryptionKey = 'test-encryption-key-32-chars!!!!';
+
+  beforeEach(() => {
+    mockPrisma = { connector: { findUnique: jest.fn(), update: jest.fn() } } as any;
+    mockConfigService = { get: jest.fn().mockReturnValue(encryptionKey) } as any;
+    service = new LoginTokenService(mockPrisma, mockConfigService);
+    jest.clearAllMocks();
+  });
+
+  const cookieAuth: LoginTokenAuthConfig = {
+    loginUrl: 'https://b1.example.com:50000/b1s/v2/Login',
+    loginMethod: 'POST',
+    loginBody: {
+      UserName: '${username}',
+      Password: '${password}',
+      CompanyDB: 'SBODEMO',
+    },
+    username: 'manager',
+    password: 'secret',
+    tokenSource: 'cookie',
+    cookieName: 'B1SESSION',
+    tokenJsonPath: 'SessionId',
+    tokenTTLSeconds: 1500,
+    proactiveRefreshSeconds: 120,
+    headerName: 'Cookie',
+    headerTemplate: 'B1SESSION=${token}',
+  };
+
+  it('extracts B1SESSION from the Set-Cookie header on login', async () => {
+    (mockedAxios as unknown as jest.Mock).mockResolvedValue({
+      data: { SessionId: 'SID-IGNORED' },
+      headers: {
+        'set-cookie': 'B1SESSION=cookie-abc-123; Path=/; HttpOnly',
+      },
+    });
+
+    const bundle = await service.getToken(cookieAuth, 'conn-b1');
+    expect(bundle.token).toBe('cookie-abc-123');
+    expect(bundle.expiresAt).toBeGreaterThan(Date.now() + 1_400_000);
+  });
+
+  it('throws when cookieName is missing', async () => {
+    const broken = { ...cookieAuth, cookieName: undefined };
+    (mockedAxios as unknown as jest.Mock).mockResolvedValue({
+      data: {},
+      headers: { 'set-cookie': 'whatever=1' },
+    });
+    await expect(service.getToken(broken, 'conn-bad')).rejects.toThrow(
+      /cookieName/,
+    );
+  });
+
+  it('throws when the named cookie is absent from the response', async () => {
+    (mockedAxios as unknown as jest.Mock).mockResolvedValue({
+      data: {},
+      headers: { 'set-cookie': 'OTHER=1; Path=/' },
+    });
+    await expect(service.getToken(cookieAuth, 'conn-x')).rejects.toThrow(
+      /B1SESSION/,
     );
   });
 });

--- a/packages/backend/src/connectors/engines/login-token.service.ts
+++ b/packages/backend/src/connectors/engines/login-token.service.ts
@@ -43,6 +43,14 @@ export interface LoginTokenAuthConfig {
   expiryFormat?: 'iso8601' | 'unix' | 'ttl_seconds';
   tokenTTLSeconds?: number;
 
+  // Where to extract the token from the login response.
+  // 'body' (default) → jsonPath(response.data, tokenJsonPath) — JWT pattern.
+  // 'cookie'         → parse Set-Cookie header for the cookie named
+  //                    {cookieName}, return its value. SAP B1 Service Layer
+  //                    uses this with cookieName="B1SESSION".
+  tokenSource?: 'body' | 'cookie';
+  cookieName?: string;
+
   refreshOn401?: boolean;
   proactiveRefreshSeconds?: number;
 
@@ -148,7 +156,9 @@ export class LoginTokenService {
     this.requireString(authConfig.loginUrl, 'loginUrl');
     this.requireString(authConfig.username, 'username');
     this.requireString(authConfig.password, 'password');
-    this.requireString(authConfig.tokenJsonPath, 'tokenJsonPath');
+    if (authConfig.tokenSource !== 'cookie') {
+      this.requireString(authConfig.tokenJsonPath, 'tokenJsonPath');
+    }
 
     const passwordToSend = await this.preparePassword(authConfig);
 
@@ -199,11 +209,27 @@ export class LoginTokenService {
       timeout: 15000,
     });
 
-    const token = jsonPath(response.data, authConfig.tokenJsonPath);
-    if (!token || typeof token !== 'string') {
-      throw new Error(
-        `LOGIN_TOKEN: token not found at "${authConfig.tokenJsonPath}" in login response`,
-      );
+    let token: unknown;
+    if (authConfig.tokenSource === 'cookie') {
+      const cookieName = authConfig.cookieName;
+      if (!cookieName) {
+        throw new Error(
+          'LOGIN_TOKEN: tokenSource=cookie requires "cookieName" to be set',
+        );
+      }
+      token = extractSetCookieValue(response.headers, cookieName);
+      if (!token) {
+        throw new Error(
+          `LOGIN_TOKEN: cookie "${cookieName}" not found in Set-Cookie response headers`,
+        );
+      }
+    } else {
+      token = jsonPath(response.data, authConfig.tokenJsonPath);
+      if (!token || typeof token !== 'string') {
+        throw new Error(
+          `LOGIN_TOKEN: token not found at "${authConfig.tokenJsonPath}" in login response`,
+        );
+      }
     }
 
     const expiresAt = this.computeExpiresAt(authConfig, response.data);
@@ -214,7 +240,7 @@ export class LoginTokenService {
       : authConfig.aud;
 
     const bundle: LoginTokenBundle = {
-      token,
+      token: String(token),
       aud: aud || undefined,
       expiresAt,
       metadata: aud ? { aud } : undefined,
@@ -432,6 +458,41 @@ export function renderTemplate(
  * - Embedded "...${name}..." → string interpolation, missing → ''
  * - Non-strings → returned unchanged
  */
+/**
+ * Pull the value of a named cookie from a response's Set-Cookie header(s).
+ * Axios exposes the header as either a single string or an array of strings
+ * depending on whether the upstream sent multiple Set-Cookie headers.
+ *
+ * Example: extractSetCookieValue(headers, "B1SESSION") with
+ *   Set-Cookie: B1SESSION=ABC123; Path=/; HttpOnly
+ * returns "ABC123".
+ */
+export function extractSetCookieValue(
+  headers: Record<string, unknown> | undefined,
+  cookieName: string,
+): string | null {
+  if (!headers) return null;
+  const raw = (headers['set-cookie'] ?? headers['Set-Cookie']) as
+    | string
+    | string[]
+    | undefined;
+  if (!raw) return null;
+  const entries = Array.isArray(raw) ? raw : [raw];
+  const prefix = `${cookieName}=`;
+  for (const entry of entries) {
+    const trimmed = entry.trimStart();
+    if (trimmed.startsWith(prefix)) {
+      const valueEnd = trimmed.indexOf(';', prefix.length);
+      const value = trimmed.slice(
+        prefix.length,
+        valueEnd === -1 ? undefined : valueEnd,
+      );
+      return value;
+    }
+  }
+  return null;
+}
+
 export function interpolateDeep(
   value: unknown,
   params: Record<string, string>,

--- a/packages/backend/src/connectors/engines/oauth2-token.service.spec.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.spec.ts
@@ -352,4 +352,59 @@ describe('OAuth2TokenService', () => {
       expect(mockPrisma.connector.update).toHaveBeenCalled();
     });
   });
+
+  describe('client_credentials grant', () => {
+    it('posts grant_type=client_credentials with HTTP Basic auth header', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { access_token: 's4-at', expires_in: 3600 },
+      });
+
+      const token = await service.refreshToken({
+        grant: 'client_credentials',
+        tokenUrl:
+          'https://my300000.authentication.eu10.hana.ondemand.com/oauth/token',
+        clientId: 'my-client-id',
+        clientSecret: 'my-client-secret',
+        scope: 'API_BUSINESS_PARTNER_0001',
+      });
+
+      expect(token).toBe('s4-at');
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+      const [url, body, opts] = mockedAxios.post.mock.calls[0] as any;
+      expect(url).toContain('hana.ondemand.com');
+      expect(body).toContain('grant_type=client_credentials');
+      expect(body).toContain('scope=API_BUSINESS_PARTNER_0001');
+      // Critical: client creds in Basic header, NOT in body.
+      const expectedBasic =
+        'Basic ' +
+        Buffer.from('my-client-id:my-client-secret').toString('base64');
+      expect(opts.headers.Authorization).toBe(expectedBasic);
+      expect(body).not.toContain('client_id=');
+      expect(body).not.toContain('client_secret=');
+    });
+
+    it('returns null when client_credentials grant lacks clientId/Secret', async () => {
+      const token = await service.refreshToken({
+        grant: 'client_credentials',
+        tokenUrl: 'https://example.com/oauth/token',
+      });
+      expect(token).toBeNull();
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('client_credentials path is reachable from getAccessToken without a refreshToken', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: { access_token: 'fresh', expires_in: 3600 },
+      });
+
+      const token = await service.getAccessToken({
+        grant: 'client_credentials',
+        tokenUrl: 'https://example.com/oauth/token',
+        clientId: 'id',
+        clientSecret: 'secret',
+      });
+
+      expect(token).toBe('fresh');
+    });
+  });
 });

--- a/packages/backend/src/connectors/engines/oauth2-token.service.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.ts
@@ -52,6 +52,7 @@ export class OAuth2TokenService {
     connectorId?: string,
   ): Promise<string> {
     const cacheKey = connectorId || String(authConfig.tokenUrl || '');
+    const grant = String(authConfig.grant || 'refresh_token');
 
     // 1. Check cache — return immediately if well within validity
     if (cacheKey) {
@@ -61,12 +62,17 @@ export class OAuth2TokenService {
       }
     }
 
-    // 2. Determine if proactive refresh is possible and needed
-    const hasRefreshCapability = !!(authConfig.refreshToken && authConfig.tokenUrl);
+    // 2. Determine if proactive refresh is possible and needed.
+    // client_credentials needs only tokenUrl + clientId/Secret; refresh_token
+    // also needs a stored refreshToken.
+    const hasRefreshCapability =
+      grant === 'client_credentials'
+        ? !!(authConfig.tokenUrl && authConfig.clientId && authConfig.clientSecret)
+        : !!(authConfig.refreshToken && authConfig.tokenUrl);
     const tokenNearExpiry = this.isTokenNearExpiry(authConfig, cacheKey);
 
     if (hasRefreshCapability && tokenNearExpiry) {
-      this.logger.debug('OAuth2: token near expiry, proactive refresh...');
+      this.logger.debug(`OAuth2 (${grant}): token near expiry, proactive refresh...`);
       const refreshed = await this.refreshTokenWithMutex(authConfig, connectorId);
       if (refreshed) {
         return refreshed;
@@ -95,34 +101,65 @@ export class OAuth2TokenService {
     connectorId?: string,
   ): Promise<string | null> {
     const tokenUrl = String(authConfig.tokenUrl || '');
+    const grant = String(authConfig.grant || 'refresh_token');
     const refreshToken = String(authConfig.refreshToken || '');
-
-    if (!tokenUrl || !refreshToken) {
-      this.logger.warn('OAuth2 refresh: missing tokenUrl or refreshToken');
-      return null;
-    }
-
     const clientId = authConfig.clientId
       ? String(authConfig.clientId)
       : undefined;
     const clientSecret = authConfig.clientSecret
       ? String(authConfig.clientSecret)
       : undefined;
+    const scope = authConfig.scope ? String(authConfig.scope) : undefined;
+
+    if (!tokenUrl) {
+      this.logger.warn('OAuth2 refresh: missing tokenUrl');
+      return null;
+    }
+
+    if (grant === 'client_credentials') {
+      // SAP S/4HANA Cloud Public Edition and most service-to-service OAuth2
+      // servers reject client_id/client_secret in the body — they MUST be
+      // sent via HTTP Basic Authorization header (RFC 6749 §2.3.1). We rely
+      // on the Basic header path and keep the body to grant_type + scope.
+      if (!clientId || !clientSecret) {
+        this.logger.warn(
+          'OAuth2 client_credentials: missing clientId/clientSecret',
+        );
+        return null;
+      }
+    } else if (!refreshToken) {
+      this.logger.warn('OAuth2 refresh: missing refreshToken');
+      return null;
+    }
 
     try {
-      const body: Record<string, string> = {
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
+      let body: Record<string, string>;
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/x-www-form-urlencoded',
       };
-      if (clientId) body.client_id = clientId;
-      if (clientSecret) body.client_secret = clientSecret;
+
+      if (grant === 'client_credentials') {
+        body = { grant_type: 'client_credentials' };
+        if (scope) body.scope = scope;
+        const basic = Buffer.from(`${clientId}:${clientSecret}`).toString(
+          'base64',
+        );
+        headers.Authorization = `Basic ${basic}`;
+      } else {
+        body = {
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+        };
+        if (clientId) body.client_id = clientId;
+        if (clientSecret) body.client_secret = clientSecret;
+      }
 
       await assertSafeOutboundUrl(tokenUrl);
       const response = await axios.post(
         tokenUrl,
         new URLSearchParams(body).toString(),
         {
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers,
           timeout: 10000,
         },
       );
@@ -139,20 +176,22 @@ export class OAuth2TokenService {
         expiresAt: Date.now() + expiresInMs,
       });
 
-      // Persist to DB if connectorId is available
+      // Persist to DB if connectorId is available. For client_credentials
+      // there's no refresh_token to store — we just record the latest
+      // access_token + its expiry so a cold-start can reuse it briefly.
       if (connectorId) {
         await this.persistRefreshedToken(
           connectorId,
           access_token,
-          newRefreshToken || refreshToken,
+          newRefreshToken || refreshToken || '',
           Date.now() + expiresInMs,
         );
       }
 
-      this.logger.debug('OAuth2: token refreshed successfully');
+      this.logger.debug(`OAuth2 (${grant}): token refreshed successfully`);
       return access_token;
     } catch (err: any) {
-      this.logger.warn(`OAuth2 token refresh failed: ${err.message}`);
+      this.logger.warn(`OAuth2 (${grant}) token refresh failed: ${err.message}`);
       return null;
     }
   }

--- a/packages/backend/src/connectors/parsers/openapi.parser.ts
+++ b/packages/backend/src/connectors/parsers/openapi.parser.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 
 const SwaggerParser = require('swagger-parser');
 import axios from 'axios';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+ 
 const yaml = require('js-yaml') as { load: (s: string) => unknown };
 import { assertSafeOutboundUrl } from '../../common/ssrf.util';
 import { normalizeOpenApi31 } from './openapi-3.1-normalizer';


### PR DESCRIPTION
## Why

\`How to Connect SAP to Claude AI\` is currently the **single most-visited guide on the marketing site** (149 views, 8.6% of total traffic, 29s engagement) — but we don't ship a real SAP adapter, so every visitor bounces. DATEV proves the DACH demand. Time to ship.

## Scope

Three SAP-family adapters + two minimal engine extensions, **in one PR**:

### Engine extensions

- **OAuth2 \`client_credentials\` grant** — \`oauth2-token.service.ts\` now branches on \`authConfig.grant\`. \`client_credentials\` POSTs to \`tokenUrl\` with client_id:secret in the **HTTP Basic Authorization header** (S/4HANA Cloud Public Edition requires this method). Default stays \`refresh_token\` — back-compat.
- **Cookie-session LOGIN_TOKEN variant** — \`login-token.service.ts\` accepts \`tokenSource: 'body' | 'cookie'\`. When \`'cookie'\`, the engine parses \`Set-Cookie\` headers and extracts the cookie named \`{cookieName}\`, then attaches it as a \`Cookie\` header on every call. SAP B1 Service Layer's \`/b1s/v2/Login\` uses this with cookieName=B1SESSION.

### New adapters

| Slug | Region | Auth | Tools | Engine extension needed |
|---|---|---|---|---|
| \`sap-concur\` | intl | OAUTH2 refresh-token | 10 | none |
| \`sap-business-one\` | de | LOGIN_TOKEN cookie-session | 12 | A2 |
| \`sap-s4hana-cloud\` | intl | OAUTH2 client_credentials | 15 | A1 |

Catalog: 168 → 171.

## Tests

\`\`\`
$ npx jest --testPathPatterns=\"oauth2-token|login-token\"
Test Suites: 2 passed, 2 total
Tests:       41 passed, 41 total
\`\`\`

(was 31 — +10 new for the two extensions). tsc + lint clean.

## Test plan

- [x] tsc clean
- [x] unit tests green
- [x] catalog regen succeeds (171 adapters)
- [x] adapter JSONs validate against the catalog schema
- [ ] First customer with a real SAP Concur sandbox installs the adapter, calls \`concur_list_reports\`, gets a 200
- [ ] First customer with a real S/4HANA Cloud tenant repeats for \`s4_list_business_partners\`
- [ ] First customer with SAP Business One repeats for \`b1_get_company_info\`

## Notes for reviewers

- We have **no live SAP test tenant**, so engine paths are validated by spec + tool-path strings are cross-checked against published SAP docs (URLs in plan file). Risk is acceptable in exchange for shipping.
- The unrelated \`openapi.parser.ts\` 1-line diff is a lint autofix that ran during \`npm run lint --fix\` — safe to keep.

Source citations and adapter rationale are in the website-repo companion PR.