### PR TITLE
connectors: add opentable, resy, vinted, untappd, idealista, trenitalia, trainline (7 adapters)

### DIFF
--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -89,6 +89,7 @@ import * as heap from './intl/heap.json';
 import * as height from './intl/height.json';
 import * as helpScout from './intl/help-scout.json';
 import * as hunter from './intl/hunter.json';
+import * as idealista from './intl/idealista.json';
 import * as insightly from './intl/insightly.json';
 import * as instantly from './intl/instantly.json';
 import * as invoiced from './intl/invoiced.json';
@@ -120,6 +121,7 @@ import * as nimble from './intl/nimble.json';
 import * as nominatim from './intl/nominatim.json';
 import * as nutshellCrm from './intl/nutshell-crm.json';
 import * as omnisend from './intl/omnisend.json';
+import * as opentable from './intl/opentable.json';
 import * as openweather from './intl/openweather.json';
 import * as outreach from './intl/outreach.json';
 import * as pandadoc from './intl/pandadoc.json';
@@ -131,6 +133,7 @@ import * as playtomic from './intl/playtomic.json';
 import * as playtomicPublic from './intl/playtomic-public.json';
 import * as recurly from './intl/recurly.json';
 import * as reddit from './intl/reddit.json';
+import * as resy from './intl/resy.json';
 import * as sageBusinessCloud from './intl/sage-business-cloud.json';
 import * as salesflare from './intl/salesflare.json';
 import * as salesloft from './intl/salesloft.json';
@@ -154,10 +157,14 @@ import * as tidio from './intl/tidio.json';
 import * as timetastic from './intl/timetastic.json';
 import * as todoist from './intl/todoist.json';
 import * as togglTrack from './intl/toggl-track.json';
+import * as trainline from './intl/trainline.json';
 import * as trello from './intl/trello.json';
+import * as trenitalia from './intl/trenitalia.json';
 import * as typeform from './intl/typeform.json';
+import * as untappd from './intl/untappd.json';
 import * as uptimeRobot from './intl/uptime-robot.json';
 import * as vercelAnalytics from './intl/vercel-analytics.json';
+import * as vinted from './intl/vinted.json';
 import * as waveAccounting from './intl/wave-accounting.json';
 import * as whatsappBusiness from './intl/whatsapp-business.json';
 import * as woocommerce from './intl/woocommerce.json';
@@ -337,6 +344,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   height as unknown as AdapterDefinition,
   helpScout as unknown as AdapterDefinition,
   hunter as unknown as AdapterDefinition,
+  idealista as unknown as AdapterDefinition,
   insightly as unknown as AdapterDefinition,
   instantly as unknown as AdapterDefinition,
   invoiced as unknown as AdapterDefinition,
@@ -368,6 +376,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   nominatim as unknown as AdapterDefinition,
   nutshellCrm as unknown as AdapterDefinition,
   omnisend as unknown as AdapterDefinition,
+  opentable as unknown as AdapterDefinition,
   openweather as unknown as AdapterDefinition,
   outreach as unknown as AdapterDefinition,
   pandadoc as unknown as AdapterDefinition,
@@ -379,6 +388,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   playtomicPublic as unknown as AdapterDefinition,
   recurly as unknown as AdapterDefinition,
   reddit as unknown as AdapterDefinition,
+  resy as unknown as AdapterDefinition,
   sageBusinessCloud as unknown as AdapterDefinition,
   salesflare as unknown as AdapterDefinition,
   salesloft as unknown as AdapterDefinition,
@@ -402,10 +412,14 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   timetastic as unknown as AdapterDefinition,
   todoist as unknown as AdapterDefinition,
   togglTrack as unknown as AdapterDefinition,
+  trainline as unknown as AdapterDefinition,
   trello as unknown as AdapterDefinition,
+  trenitalia as unknown as AdapterDefinition,
   typeform as unknown as AdapterDefinition,
+  untappd as unknown as AdapterDefinition,
   uptimeRobot as unknown as AdapterDefinition,
   vercelAnalytics as unknown as AdapterDefinition,
+  vinted as unknown as AdapterDefinition,
   waveAccounting as unknown as AdapterDefinition,
   whatsappBusiness as unknown as AdapterDefinition,
   woocommerce as unknown as AdapterDefinition,

--- a/packages/backend/src/adapters/intl/idealista.json
+++ b/packages/backend/src/adapters/intl/idealista.json
@@ -1,0 +1,119 @@
+{
+  "slug": "idealista",
+  "name": "Idealista",
+  "description": "Search Idealista real estate listings (Spain, Italy, Portugal) from any AI assistant. Find apartments and houses for sale or rent, read full listing detail, look up neighborhood data. 4 tools, no auth — reverse-engineered from the Idealista mobile app.",
+  "instructions": "This connector wraps the Idealista mobile app's internal API (app.idealista.it).\n\n**Setup**: nothing. The mobile API endpoints used here do not require OAuth for read access.\n\n**Markets**: Idealista operates in Italy, Spain, and Portugal. The locale path segment in URLs (`/api/3.5/it/...`, `/api/3.5/es/...`, `/api/3.5/pt/...`) selects the market. Pass `locale` as a tool parameter.\n\n**What it does NOT do**: contact sellers, save searches, post listings. Use this connector to *find* and *read* listings; act on them in the Idealista app/site.\n\n**Filter shape**: the search endpoint accepts a complex POST body with filters for operation (sale/rent), property type, price range, rooms, square meters, geo bounding box, neighborhood IDs.\n\n**Suggested starter prompts**:\n- \"Find 2-bedroom apartments for rent in Milano Navigli, under €1500/month, posted in the last 7 days.\"\n- \"Show me apartment listing 34932661 in detail.\"\n- \"Search for Madrid neighborhoods matching 'Salamanca'.\"",
+  "region": "intl",
+  "category": "real-estate",
+  "icon": "idealista",
+  "docsUrl": "https://www.idealista.com",
+  "featured": false,
+  "priority": 75,
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Idealista Mobile API",
+    "type": "REST",
+    "baseUrl": "https://app.idealista.it",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "idealista_search",
+      "description": "Search Idealista listings with filters. Returns paginated results with listing id, price, m², rooms, address, photos, energy class.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it", "description": "Market locale." },
+          "operation": { "type": "string", "enum": ["sale", "rent"], "default": "sale" },
+          "propertyType": { "type": "string", "description": "homes, garages, premises, offices, lands, storages." },
+          "locationId": { "type": "string", "description": "Idealista location code (use `idealista_search_locations` to discover)." },
+          "minPrice": { "type": "number" },
+          "maxPrice": { "type": "number" },
+          "minSize": { "type": "number", "description": "Minimum square meters." },
+          "maxSize": { "type": "number" },
+          "rooms": { "type": "integer", "description": "Minimum number of rooms." },
+          "page": { "type": "integer", "default": 1 }
+        },
+        "required": ["locale"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api/3.5/{locale}/search",
+        "bodyMapping": {
+          "operation": "$operation",
+          "propertyType": "$propertyType",
+          "locationId": "$locationId",
+          "minPrice": "$minPrice",
+          "maxPrice": "$maxPrice",
+          "minSize": "$minSize",
+          "maxSize": "$maxSize",
+          "rooms": "$rooms",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "idealista_get_listing",
+      "description": "Full detail of one Idealista listing by ID — full description, all photos, agency, contact, geocoordinate, energy class, characteristics.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it" },
+          "listing_id": { "type": "integer", "description": "Idealista listing ID." }
+        },
+        "required": ["locale", "listing_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/3/{locale}/detail/{listing_id}"
+      }
+    },
+    {
+      "name": "idealista_search_locations",
+      "description": "Search for Idealista location IDs (cities, neighborhoods, districts). Required to filter by area in `idealista_search`.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it" },
+          "query": { "type": "string", "description": "Location text (e.g. 'Navigli', 'Salamanca', 'Lisboa Centro')." }
+        },
+        "required": ["locale", "query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/3/{locale}/locations",
+        "queryParams": { "q": "$query" }
+      }
+    },
+    {
+      "name": "idealista_map_search",
+      "description": "Search Idealista listings within a geo bounding box (map-driven search). Returns clusters and individual listings.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it" },
+          "north": { "type": "number", "description": "Northern latitude of bounding box." },
+          "south": { "type": "number" },
+          "east": { "type": "number" },
+          "west": { "type": "number" },
+          "operation": { "type": "string", "enum": ["sale", "rent"], "default": "sale" },
+          "propertyType": { "type": "string", "default": "homes" }
+        },
+        "required": ["locale", "north", "south", "east", "west"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api/3.5/{locale}/map/search",
+        "bodyMapping": {
+          "north": "$north",
+          "south": "$south",
+          "east": "$east",
+          "west": "$west",
+          "operation": "$operation",
+          "propertyType": "$propertyType"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/idealista.live.spec.ts
+++ b/packages/backend/src/adapters/intl/idealista.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './idealista.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('idealista adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('idealista');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});

--- a/packages/backend/src/adapters/intl/opentable.json
+++ b/packages/backend/src/adapters/intl/opentable.json
@@ -1,0 +1,113 @@
+{
+  "slug": "opentable",
+  "name": "OpenTable",
+  "description": "Search restaurants on OpenTable from any AI assistant. Find restaurants near a coordinate, read full restaurant detail (menu, hours, photos, reviews), check live table availability for a given party size and time window. 4 tools, no auth — reverse-engineered from the OpenTable mobile app.",
+  "instructions": "This connector wraps the OpenTable mobile app's internal API (mobile-api.opentable.co.uk).\n\n**Setup**: nothing. The endpoints exposed here are the same the OpenTable iOS app uses for restaurant discovery; they do not require an API key or user login.\n\n**What it does NOT do**: complete reservations. OpenTable's reservation-completion flow requires a logged-in session + payment-method-on-file + bot-detection checks that we deliberately don't automate. Use this connector to *find* the right restaurant and slot; book in the OpenTable app or web site.\n\n**Geo coordinate**: `latitude` and `longitude` as floats. Use 48.0707,7.8674 for Freiburg, 41.3851,2.1734 for Barcelona, 40.7128,-74.0060 for NYC.\n\n**Date/time**: ISO-8601 local format `2026-05-24T19:30`. The API interprets in the restaurant's local timezone.\n\n**Party size**: integer `covers` field, 1–12.\n\n**Stability**: this is the OpenTable mobile app's internal API, not the partner OpenTable affiliate API. Endpoints can change without notice; if a tool starts failing, check the AnythingMCP repo for updates.\n\n**Rate limits**: OpenTable does not publish public-API limits for the mobile endpoints. Be gentle — under 1 req/s steady state is safe.\n\n**Suggested starter prompts**:\n- \"Find restaurants near Milan central for tomorrow at 8 PM, party of 4, Italian cuisine under €40/person.\"\n- \"Show me top-rated French restaurants in NYC available Friday night.\"\n- \"Check availability for restaurant 12213 next Saturday at 19:00 for 2 people.\"",
+  "region": "intl",
+  "category": "food",
+  "icon": "opentable",
+  "docsUrl": "https://www.opentable.com",
+  "featured": true,
+  "priority": 85,
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "OpenTable Mobile API",
+    "type": "REST",
+    "baseUrl": "https://mobile-api.opentable.co.uk",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "opentable_search_restaurants",
+      "description": "Search OpenTable restaurants near a coordinate, with optional filters for party size, date/time, cuisine, and price. Returns a ranked list of restaurants with id, name, cuisine, neighborhood, price band, and ratings.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "latitude": { "type": "number", "description": "Center latitude (e.g. 48.0707)" },
+          "longitude": { "type": "number", "description": "Center longitude (e.g. 7.8674)" },
+          "covers": { "type": "integer", "description": "Party size (1-12).", "default": 2, "minimum": 1, "maximum": 12 },
+          "dateTime": { "type": "string", "description": "Naive ISO-8601 local time, e.g. '2026-05-24T19:30'. If omitted, uses 'now'." },
+          "leadTime": { "type": "integer", "description": "Days ahead to allow (default 14).", "default": 14 },
+          "size": { "type": "integer", "description": "Max restaurants to return (default 30).", "default": 30, "minimum": 1, "maximum": 100 },
+          "cuisine": { "type": "string", "description": "Optional cuisine filter (e.g. 'Italian', 'French', 'Japanese')." }
+        },
+        "required": ["latitude", "longitude"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api/v5/personalize/search/1",
+        "bodyMapping": {
+          "location": { "latitude": "$latitude", "longitude": "$longitude" },
+          "covers": "$covers",
+          "dateTime": "$dateTime",
+          "leadTime": "$leadTime",
+          "size": "$size",
+          "cuisine": "$cuisine",
+          "now": true,
+          "requestMatchRelevance": true,
+          "requestOffer": true,
+          "stats": "numBooked"
+        }
+      }
+    },
+    {
+      "name": "opentable_get_restaurant",
+      "description": "Full detail of one OpenTable restaurant — name, address, cuisine, hours, menu URL, photos, reviews summary, price band, dress code, parking, neighborhood.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "restaurant_id": { "type": "integer", "description": "OpenTable restaurant ID (numeric, e.g. 12213). Get it from `opentable_search_restaurants`." }
+        },
+        "required": ["restaurant_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v3/restaurant/{restaurant_id}"
+      }
+    },
+    {
+      "name": "opentable_check_availability",
+      "description": "Check live table availability at one or more OpenTable restaurants for a given party size and date/time. Returns time slots available with their booking URL.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "restaurant_id": { "type": "integer", "description": "Restaurant ID." },
+          "covers": { "type": "integer", "description": "Party size.", "default": 2 },
+          "dateTime": { "type": "string", "description": "Naive ISO-8601, e.g. '2026-05-24T19:30'." }
+        },
+        "required": ["restaurant_id", "dateTime"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/api/v3/restaurant/availability",
+        "bodyMapping": {
+          "restaurantId": "$restaurant_id",
+          "covers": "$covers",
+          "dateTime": "$dateTime"
+        }
+      }
+    },
+    {
+      "name": "opentable_autocomplete",
+      "description": "Autocomplete restaurant or location names. Useful before search — when the user says 'find me a sushi place in Mayfair', resolve 'Mayfair' to a coordinate first.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string", "description": "Partial restaurant or location name." },
+          "latitude": { "type": "number", "description": "User location latitude for ranking." },
+          "longitude": { "type": "number", "description": "User location longitude for ranking." }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "PUT",
+        "path": "/api/v4/personalize/autocompleteInterspersed",
+        "bodyMapping": {
+          "query": "$query",
+          "location": { "latitude": "$latitude", "longitude": "$longitude" }
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/opentable.live.spec.ts
+++ b/packages/backend/src/adapters/intl/opentable.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './opentable.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('opentable adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('opentable');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});

--- a/packages/backend/src/adapters/intl/resy.json
+++ b/packages/backend/src/adapters/intl/resy.json
@@ -1,0 +1,142 @@
+{
+  "slug": "resy",
+  "name": "Resy",
+  "description": "Search Resy restaurants from any AI assistant. Find restaurants by city, geo coordinate, or curated list (top-rated, new, etc.), read venue detail, check live availability calendar. 6 tools, no auth — reverse-engineered from the Resy mobile app.",
+  "instructions": "This connector wraps the Resy mobile app's internal API (api.resy.com).\n\n**Setup**: nothing. The endpoints exposed here are the same the Resy iOS app uses for restaurant discovery and are accessible without a user login.\n\n**What it does NOT do**: complete reservations. Resy's notify/book flow requires a logged-in session and triggers bot-detection. Use this connector to *find* slots; book in the Resy app.\n\n**City codes**: Resy uses short codes like `ny` (NYC), `la` (LA), `lon` (London), `mia` (Miami), `dc` (Washington DC), `ath` (Athens). Use `resy_get_location_config` to discover available cities.\n\n**Curated lists**: Resy publishes editorial lists per city — `top-rated`, `new-on-resy`, `most-bookmarked`, etc. Use `resy_get_city_list` with the list slug to fetch them.\n\n**Date format**: `YYYY-MM-DD` (e.g. `2026-05-24`).\n\n**Suggested starter prompts**:\n- \"Find the top-rated Italian restaurants in NYC this Saturday at 7 PM for 4 people.\"\n- \"What's new on Resy in London this week?\"\n- \"Check Carbone's calendar for the next 30 days, party of 2.\"",
+  "region": "intl",
+  "category": "food",
+  "icon": "resy",
+  "docsUrl": "https://resy.com",
+  "featured": true,
+  "priority": 84,
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Resy Mobile API",
+    "type": "REST",
+    "baseUrl": "https://api.resy.com",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "resy_search_venues",
+      "description": "Geo search Resy venues near a coordinate, with optional party size and date filters. Returns venues with id, name, neighborhood, cuisine, price band, and available time slots.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "latitude": { "type": "number", "description": "Search center latitude." },
+          "longitude": { "type": "number", "description": "Search center longitude." },
+          "party_size": { "type": "integer", "description": "Party size.", "default": 2, "minimum": 1, "maximum": 20 },
+          "day": { "type": "string", "description": "Date in YYYY-MM-DD, e.g. '2026-05-24'." }
+        },
+        "required": ["latitude", "longitude"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/3/venuesearch/search",
+        "bodyMapping": {
+          "venue_filter": { "venue_id": [] },
+          "availability": true,
+          "slot_filter": { "party_size": "$party_size", "day": "$day" },
+          "geo": { "user": { "latitude": "$latitude", "longitude": "$longitude" } }
+        }
+      }
+    },
+    {
+      "name": "resy_find_availability",
+      "description": "Find available slots at one or more venues on a given day for a party size, optionally near a coordinate. Returns slots with start time, table type, and configuration token for booking.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "day": { "type": "string", "description": "Date in YYYY-MM-DD." },
+          "party_size": { "type": "integer", "default": 2, "minimum": 1, "maximum": 20 },
+          "location": { "type": "string", "description": "City code (e.g. 'ny', 'la', 'lon', 'mia', 'ath')." },
+          "venue_id": { "type": "integer", "description": "Optional: limit to one venue." },
+          "lat": { "type": "number", "description": "Search center latitude." },
+          "long": { "type": "number", "description": "Search center longitude." }
+        },
+        "required": ["day", "party_size"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/4/find",
+        "queryParams": {
+          "day": "$day",
+          "party_size": "$party_size",
+          "location": "$location",
+          "venue_id": "$venue_id",
+          "lat": "$lat",
+          "long": "$long"
+        }
+      }
+    },
+    {
+      "name": "resy_get_venue",
+      "description": "Full venue detail — name, address, cuisine, photos, menu, hours, descriptions. Pass venue_id from search or find.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Venue ID." }
+        },
+        "required": ["id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/3/venue",
+        "queryParams": { "id": "$id" }
+      }
+    },
+    {
+      "name": "resy_get_venue_calendar",
+      "description": "Get the booking calendar for one venue across a date range — which days have availability for a given party size.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "venue_id": { "type": "integer" },
+          "num_seats": { "type": "integer", "description": "Party size.", "default": 2 },
+          "start_date": { "type": "string", "description": "YYYY-MM-DD." },
+          "end_date": { "type": "string", "description": "YYYY-MM-DD." }
+        },
+        "required": ["venue_id", "start_date", "end_date"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/4/venue/calendar",
+        "queryParams": {
+          "venue_id": "$venue_id",
+          "num_seats": "$num_seats",
+          "start_date": "$start_date",
+          "end_date": "$end_date"
+        }
+      }
+    },
+    {
+      "name": "resy_get_city_list",
+      "description": "Get a Resy editorial list for a city — e.g. 'top-rated', 'new-on-resy', 'most-bookmarked'. Returns the curated venues.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string", "description": "City code, e.g. 'ny', 'la', 'lon', 'ath'." },
+          "list": { "type": "string", "description": "List slug, e.g. 'top-rated', 'new-on-resy', 'climbing' (city-specific lists vary)." }
+        },
+        "required": ["city", "list"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/3/cities/{city}/list/{list}"
+      }
+    },
+    {
+      "name": "resy_get_location_config",
+      "description": "Get Resy's configuration for available cities, neighborhoods, and cuisines. Use first to discover what's queryable.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/3/location/config"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/resy.live.spec.ts
+++ b/packages/backend/src/adapters/intl/resy.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './resy.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('resy adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('resy');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});

--- a/packages/backend/src/adapters/intl/trainline.json
+++ b/packages/backend/src/adapters/intl/trainline.json
@@ -1,0 +1,81 @@
+{
+  "slug": "trainline",
+  "name": "Trainline",
+  "description": "Search European trains and coaches via Trainline's mobile API. Find trips across 270+ rail and coach operators in 45 countries — UK, Italy, France, Germany, Spain, and more. 3 tools, no auth — reverse-engineered from the Trainline iOS app.",
+  "instructions": "This connector wraps the Trainline mobile app's internal API (api.thetrainline.com).\n\n**Setup**: nothing. The search endpoints exposed here don't require a user login.\n\n**What it does NOT do**: complete bookings. The purchase flow requires a logged-in session, payment method, and Trainline's checkout. Use this connector to *find* trains; book in the Trainline app.\n\n**Coverage**: Trainline aggregates 270+ rail and coach operators across 45 countries. Search results include trains from Trenitalia, Italo, SNCF, Renfe, Deutsche Bahn, NS, SBB, ÖBB, plus coach operators like FlixBus.\n\n**Locations**: Trainline uses URN identifiers like `urn:trainline:generic:loc:7597` for stations. Use `trainline_search_locations` to resolve city/station names.\n\n**Suggested starter prompts**:\n- \"Find trains from London St Pancras to Paris Gare du Nord this Friday morning.\"\n- \"What's the fastest train from Milano Centrale to Roma Termini Saturday at 9 AM?\"\n- \"Search Trainline locations for 'Frankfurt'.\"",
+  "region": "intl",
+  "category": "travel",
+  "icon": "trainline",
+  "docsUrl": "https://www.thetrainline.com",
+  "featured": true,
+  "priority": 77,
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Trainline Mobile API",
+    "type": "REST",
+    "baseUrl": "https://api.thetrainline.com",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "trainline_search_trips",
+      "description": "Search Trainline trips between two locations on a date. Returns trips with operator, departure/arrival, duration, transfers, fares.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "from_urn": { "type": "string", "description": "Origin location URN (e.g. 'urn:trainline:generic:loc:7597'). Resolve via `trainline_search_locations`." },
+          "to_urn": { "type": "string", "description": "Destination location URN." },
+          "departure": { "type": "string", "description": "Departure datetime, ISO-8601." },
+          "passengers": { "type": "integer", "default": 1, "minimum": 1, "maximum": 9 },
+          "directOnly": { "type": "boolean", "default": false }
+        },
+        "required": ["from_urn", "to_urn", "departure"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/experience/search/",
+        "bodyMapping": {
+          "from": "$from_urn",
+          "to": "$to_urn",
+          "departure": "$departure",
+          "passengers": "$passengers",
+          "directOnly": "$directOnly"
+        }
+      }
+    },
+    {
+      "name": "trainline_search_locations",
+      "description": "Resolve a city or station name to a Trainline URN — required as input for trip search.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string", "description": "Free-text location (e.g. 'Milano Centrale', 'Frankfurt Hbf', 'London King's Cross')." }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/locations-search/v3/search/",
+        "queryParams": { "q": "$query" }
+      }
+    },
+    {
+      "name": "trainline_get_recommendations",
+      "description": "Get curated trip recommendations for a location — e.g. popular weekend trips departing from a station with a given duration window.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location_urn": { "type": "string", "description": "Origin location URN." },
+          "horizon": { "type": "string", "enum": ["weekEnd", "thisWeek", "nextMonth"], "default": "weekEnd" },
+          "price_range": { "type": "string", "description": "Optional price range (e.g. '1200-1800' meaning €12.00-€18.00)." }
+        },
+        "required": ["location_urn"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/locations-search/v3/recommendations/{location_urn}/{horizon}/{price_range}"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/trainline.live.spec.ts
+++ b/packages/backend/src/adapters/intl/trainline.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './trainline.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('trainline adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('trainline');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});

--- a/packages/backend/src/adapters/intl/trenitalia.json
+++ b/packages/backend/src/adapters/intl/trenitalia.json
@@ -1,0 +1,76 @@
+{
+  "slug": "trenitalia",
+  "name": "Trenitalia",
+  "description": "Search Italian high-speed and regional trains via Trenitalia's Le Frecce mobile API. Find trips by origin/destination/date, read offers and prices, see live home alerts and mobility info. 3 tools, no auth — reverse-engineered from the Le Frecce iOS app.",
+  "instructions": "This connector wraps the Trenitalia Le Frecce mobile app's internal API (app.lefrecce.it, channel `Channels.Mobile.BFF`).\n\n**Setup**: nothing. The endpoints exposed here are the same the Le Frecce iOS app uses for trip discovery.\n\n**What it does NOT do**: complete bookings. The booking flow requires a logged-in session and the Trenitalia payment hub. Use this connector to *find* trains and prices; book in the Le Frecce app or trenitalia.com.\n\n**Station codes**: Trenitalia uses internal station codes (e.g. `S08409` for Milano Centrale, `S08400` for Roma Termini). Use `trenitalia_search_stations` to discover them, or pass `from_name` / `to_name` as free-text — the search endpoint usually resolves names internally.\n\n**Date/time**: ISO-8601 local, e.g. `2026-05-24T08:00:00`.\n\n**Suggested starter prompts**:\n- \"Find Milano-Roma Frecciarossa trains for Saturday morning, 2 adults.\"\n- \"What's the cheapest train from Bologna to Firenze tomorrow afternoon?\"\n- \"Show me Trenitalia alerts on the Milano-Napoli line today.\"",
+  "region": "intl",
+  "category": "travel",
+  "icon": "trenitalia",
+  "docsUrl": "https://www.trenitalia.com",
+  "featured": true,
+  "priority": 78,
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Trenitalia Le Frecce Mobile BFF",
+    "type": "REST",
+    "baseUrl": "https://app.lefrecce.it",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "trenitalia_search_trips",
+      "description": "Search Trenitalia trains between two stations on a date. Returns trips with departure/arrival time, train type (Frecciarossa, Frecciargento, Intercity, regional), duration, transfers, available fares and prices.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "from_name": { "type": "string", "description": "Origin station name (e.g. 'Milano Centrale', 'Roma Termini')." },
+          "to_name": { "type": "string", "description": "Destination station name." },
+          "departure_date": { "type": "string", "description": "Departure date/time, naive ISO-8601 (e.g. '2026-05-24T08:00:00')." },
+          "return_date": { "type": "string", "description": "Optional return date/time for round-trip." },
+          "adults": { "type": "integer", "default": 1, "minimum": 1, "maximum": 9 },
+          "children": { "type": "integer", "default": 0 },
+          "page": { "type": "integer", "default": 1 }
+        },
+        "required": ["from_name", "to_name", "departure_date"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/Channels.Mobile.BFF/api/search/page",
+        "bodyMapping": {
+          "from": "$from_name",
+          "to": "$to_name",
+          "departureDate": "$departure_date",
+          "returnDate": "$return_date",
+          "adults": "$adults",
+          "children": "$children",
+          "page": "$page"
+        }
+      }
+    },
+    {
+      "name": "trenitalia_get_home_alerts",
+      "description": "Get current service alerts and mobility info from Trenitalia's home feed — strikes, delays, line-wide notices.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Channels.Mobile.BFF/api/home/alerts"
+      }
+    },
+    {
+      "name": "trenitalia_get_mobility_info",
+      "description": "Get general mobility info — strikes (`scioperi`), planned outages, network status — from Trenitalia's home info feed.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/Channels.Mobile.BFF/api/home/info/mobility"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/trenitalia.live.spec.ts
+++ b/packages/backend/src/adapters/intl/trenitalia.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './trenitalia.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('trenitalia adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('trenitalia');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});

--- a/packages/backend/src/adapters/intl/untappd.json
+++ b/packages/backend/src/adapters/intl/untappd.json
@@ -1,0 +1,106 @@
+{
+  "slug": "untappd",
+  "name": "Untappd",
+  "description": "Search Untappd's beer database from any AI assistant. Find beers by name, brewery, or style; read beer detail with ratings; look up venues and check-ins. 4 tools, requires free Untappd API client_id + client_secret.",
+  "instructions": "This connector wraps Untappd's REST API (api.untappd.com/v4).\n\n**Setup**: Untappd requires a free API client_id + client_secret. Apply for them at https://untappd.com/api/register. Approval is usually fast.\n\nProvide:\n- `UNTAPPD_CLIENT_ID` — your app's client ID\n- `UNTAPPD_CLIENT_SECRET` — your app's client secret\n\n**What's exposed**: public, unauthenticated endpoints (no user OAuth needed for basic search + lookup). For per-user data (your check-ins, your wishlist), you'd need OAuth — not included in this connector.\n\n**Rate limits**: Untappd publishes 100 req/hour per client. The connector does not auto-retry on 429; respect the limit.\n\n**Suggested starter prompts**:\n- \"Search Untappd for a Hazy IPA with 4.0+ stars.\"\n- \"Look up beer ID 12345 on Untappd.\"\n- \"Find breweries near coordinate 48.07, 7.87.\"",
+  "region": "intl",
+  "category": "food",
+  "icon": "untappd",
+  "docsUrl": "https://untappd.com/api/docs",
+  "requiredEnvVars": ["UNTAPPD_CLIENT_ID", "UNTAPPD_CLIENT_SECRET"],
+  "connector": {
+    "name": "Untappd API v4",
+    "type": "REST",
+    "baseUrl": "https://api.untappd.com/v4",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "untappd_search_beer",
+      "description": "Search Untappd for beers by free-text query (name, brewery, style). Returns a paginated list with beer id, name, brewery, style, ABV, IBU, rating, label image.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": { "type": "string", "description": "Search query (e.g. 'Hazy IPA', 'Westvleteren 12')." },
+          "limit": { "type": "integer", "default": 25, "minimum": 1, "maximum": 50 },
+          "offset": { "type": "integer", "default": 0 },
+          "sort": { "type": "string", "enum": ["checkin", "name", "count", "all"], "default": "checkin" }
+        },
+        "required": ["q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/search/beer",
+        "queryParams": {
+          "q": "$q",
+          "limit": "$limit",
+          "offset": "$offset",
+          "sort": "$sort",
+          "client_id": "{{UNTAPPD_CLIENT_ID}}",
+          "client_secret": "{{UNTAPPD_CLIENT_SECRET}}"
+        }
+      }
+    },
+    {
+      "name": "untappd_get_beer",
+      "description": "Full detail of one beer by ID — brewery, style, ABV, IBU, ratings, recent check-ins, label.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "bid": { "type": "integer", "description": "Untappd beer ID." }
+        },
+        "required": ["bid"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/beer/info/{bid}",
+        "queryParams": {
+          "client_id": "{{UNTAPPD_CLIENT_ID}}",
+          "client_secret": "{{UNTAPPD_CLIENT_SECRET}}"
+        }
+      }
+    },
+    {
+      "name": "untappd_search_brewery",
+      "description": "Search Untappd for breweries by free-text query.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "q": { "type": "string" },
+          "offset": { "type": "integer", "default": 0 }
+        },
+        "required": ["q"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/search/brewery",
+        "queryParams": {
+          "q": "$q",
+          "offset": "$offset",
+          "client_id": "{{UNTAPPD_CLIENT_ID}}",
+          "client_secret": "{{UNTAPPD_CLIENT_SECRET}}"
+        }
+      }
+    },
+    {
+      "name": "untappd_get_brewery",
+      "description": "Full detail of one brewery by ID — location, beer list, social stats.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "brewery_id": { "type": "integer" }
+        },
+        "required": ["brewery_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/brewery/info/{brewery_id}",
+        "queryParams": {
+          "client_id": "{{UNTAPPD_CLIENT_ID}}",
+          "client_secret": "{{UNTAPPD_CLIENT_SECRET}}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/untappd.live.spec.ts
+++ b/packages/backend/src/adapters/intl/untappd.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './untappd.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('untappd adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('untappd');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});

--- a/packages/backend/src/adapters/intl/vinted.json
+++ b/packages/backend/src/adapters/intl/vinted.json
@@ -1,0 +1,87 @@
+{
+  "slug": "vinted",
+  "name": "Vinted",
+  "description": "Search Vinted's second-hand fashion marketplace from any AI assistant. Find items by text query, filter by category, price, brand, size, condition. 3 tools, no auth — reverse-engineered from the Vinted mobile app.",
+  "instructions": "This connector wraps the Vinted mobile app's internal API (www.vinted.fr — works across all 16 Vinted markets).\n\n**Setup**: nothing. The endpoints exposed here are the same the Vinted iOS app uses for catalog discovery.\n\n**What it does NOT do**: complete purchases, message sellers, or create listings. Write operations require a logged-in session and Vinted's mobile anti-bot checks. Use this connector to *find* items; transact in the Vinted app.\n\n**Markets**: Vinted operates in 16 countries (FR, DE, IT, ES, NL, BE, AT, PL, CZ, SK, LT, LV, PT, FI, UK, US). The catalog is shared but with different default currencies and language preferences. Pass `currency=EUR`, `currency=GBP`, etc. to filter prices accordingly.\n\n**Pricing**: prices come as floats with `currency`. `price_numeric` is the parsed amount.\n\n**Suggested starter prompts**:\n- \"Find Stone Island jackets size L under €50 on Vinted, sorted by newest.\"\n- \"Search 'Carhartt WIP' in Vinted, EUR, pages 1-3, condition 'very good'.\"\n- \"What filters are available for searching trousers on Vinted?\"",
+  "region": "intl",
+  "category": "e-commerce",
+  "icon": "vinted",
+  "docsUrl": "https://www.vinted.com",
+  "featured": true,
+  "priority": 80,
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "Vinted Catalog API",
+    "type": "REST",
+    "baseUrl": "https://www.vinted.fr",
+    "authType": "NONE",
+    "authConfig": {}
+  },
+  "tools": [
+    {
+      "name": "vinted_search_items",
+      "description": "Free-text search across Vinted's catalog. Returns a paginated list of items with id, title, price, currency, brand, size, condition, photos, seller info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "search_text": { "type": "string", "description": "Free-text query (e.g. 'Stone Island jacket', 'Carhartt WIP trousers')." },
+          "currency": { "type": "string", "description": "Currency code: EUR, GBP, PLN, CZK, USD.", "default": "EUR" },
+          "order": { "type": "string", "enum": ["relevance", "newest_first", "price_low_to_high", "price_high_to_low"], "default": "relevance" },
+          "page": { "type": "integer", "default": 1, "minimum": 1 },
+          "per_page": { "type": "integer", "default": 24, "minimum": 1, "maximum": 96 },
+          "catalog_ids": { "type": "string", "description": "Optional comma-separated Vinted catalog (category) IDs." },
+          "brand_ids": { "type": "string", "description": "Optional comma-separated brand IDs." },
+          "size_ids": { "type": "string", "description": "Optional comma-separated size IDs." },
+          "status_ids": { "type": "string", "description": "Optional condition filter: '6' new with tags, '1' new without tags, '2' very good, '3' good, '4' satisfactory." },
+          "price_from": { "type": "number" },
+          "price_to": { "type": "number" }
+        },
+        "required": ["search_text"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v2/catalog/items",
+        "queryParams": {
+          "search_text": "$search_text",
+          "currency": "$currency",
+          "order": "$order",
+          "page": "$page",
+          "per_page": "$per_page",
+          "catalog_ids": "$catalog_ids",
+          "brand_ids": "$brand_ids",
+          "size_ids": "$size_ids",
+          "status_ids": "$status_ids",
+          "price_from": "$price_from",
+          "price_to": "$price_to"
+        }
+      }
+    },
+    {
+      "name": "vinted_get_filters",
+      "description": "Get the available filter options for Vinted catalog search — categories, brands, sizes, colors, conditions. Useful before search to know what filter IDs are queryable.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "catalog_ids": { "type": "string", "description": "Optional: limit filter discovery to a specific catalog (e.g. one category)." }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v2/catalog/filters",
+        "queryParams": { "catalog_ids": "$catalog_ids" }
+      }
+    },
+    {
+      "name": "vinted_homepage",
+      "description": "Get Vinted's curated homepage feed — featured items, promoted closets, banners. Useful for editorial discovery.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v2/homepage/all"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/vinted.live.spec.ts
+++ b/packages/backend/src/adapters/intl/vinted.live.spec.ts
@@ -1,0 +1,21 @@
+import * as adapter from './vinted.json';
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  connector: { baseUrl: string; authType: string };
+  tools: Array<{ name: string }>;
+};
+
+describe('vinted adapter — static spec conformance', () => {
+  it('has the expected slug + non-empty tool set', () => {
+    expect(a.slug).toBe('vinted');
+    expect(a.connector.baseUrl).toMatch(/^https:\/\//);
+    expect(a.tools.length).toBeGreaterThan(0);
+  });
+
+  it('all tools have a name starting with the adapter slug prefix', () => {
+    const prefix = a.slug.replace(/-/g, '_');
+    a.tools.forEach((t) => expect(t.name.startsWith(prefix + '_')).toBe(true));
+  });
+});


### PR DESCRIPTION
## Summary

Adds **7 new Playtomic-style adapters** based on the May 24 2026 Charles Proxy capture session and verified mobile-app endpoints. Each adapter is read-only, NONE auth where possible (Untappd needs free app client_id/secret), focused on search/detail/availability.

| Slug | Category | Tools | Notable |
|---|---|---:|---|
| `opentable` | food | 4 | restaurant search + detail + live availability + autocomplete |
| `resy` | food | 6 | venue search, find slots, calendar, editorial city lists, location config |
| `vinted` | e-commerce | 3 | catalog search with filters, filter discovery, homepage feed |
| `untappd` | food | 4 | beer + brewery search/detail (requires free app keys) |
| `idealista` | real-estate | 4 | listing search/detail across IT/ES/PT + map-bbox + location resolve |
| `trenitalia` | travel | 3 | Le Frecce trip search + alerts + mobility info |
| `trainline` | travel | 3 | pan-EU 270+ operator search + location resolve + curated recommendations |

Catalog goes from 173 → 180 adapters across 7 regions.

## Why no logos in this PR

Shipping the backend first so the website's idempotent guide-generator scripts can pull the new adapters from the live `cloud.anythingmcp.com/api/adapters` endpoint. Logos + ADAPTER_LOGO map updates + ~330 generated guides land in the follow-up website PR.

## Test plan

- [x] All 7 adapter JSONs validate
- [x] 14 conformance specs pass (`*.live.spec.ts` — 2 per adapter)
- [x] `regenerate-catalog.mjs` succeeds, catalog count 180
- [ ] Post-deploy: `curl https://cloud.anythingmcp.com/api/adapters | jq '.[] | select(.slug | IN(\"opentable\",\"resy\",\"vinted\",\"untappd\",\"idealista\",\"trenitalia\",\"trainline\"))'` returns 7 entries