### PR TITLE
deutsche-bahn: rewrite adapter against bahn.de directly (drop v6.db.transport.rest)

### DIFF
--- a/packages/backend/src/adapters/de/deutsche-bahn.json
+++ b/packages/backend/src/adapters/de/deutsche-bahn.json
@@ -1,187 +1,199 @@
 {
   "slug": "deutsche-bahn",
   "name": "Deutsche Bahn Fahrplan",
-  "description": "Query the Deutsche Bahn (DB) timetable via the community-maintained v6.db.transport.rest proxy over the official HAFAS API. Search stations, look up departures/arrivals in real time, and plan journeys between any two DB stops.",
-  "instructions": "This connector uses https://v6.db.transport.rest — a free, no-auth wrapper around Deutsche Bahn's HAFAS endpoints maintained by the public-transport community.\n\n**No authentication required**, but the service is hosted best-effort — for production use you may want to self-host (see https://github.com/derhuerst/db-rest).\n\n**Typical workflow**:\n1. Resolve a station name to a stop `id` with `db_search_locations`\n2. Call `db_get_departures` or `db_get_arrivals` with that id\n3. For trip planning, use `db_get_journeys` with `from` and `to` stop ids\n\n**Time format**: All times are ISO 8601 with timezone (e.g. `2026-04-21T08:30+02:00`). If omitted, `when` defaults to now.\n\n**Delay tracking**: departure/arrival entries include `delay` in seconds, `cancelled`, and `platform` vs `plannedPlatform` for live monitoring.\n\n**Multi-modal**: results can include S-Bahn, U-Bahn, bus, tram where operated by DB or partner agencies.",
+  "description": "Query the Deutsche Bahn (DB) timetable directly via bahn.de's own JSON API. Search stations, look up real-time departures/arrivals, and plan journeys between any two DB stops — same backend that powers the bahn.de website.",
+  "instructions": "This connector talks directly to **int.bahn.de/web/api**, the JSON API that powers the bahn.de website. No authentication required — same SLA as bahn.de itself.\n\n**Typical workflow**:\n1. Resolve a station name to an `extId` (IBNR, e.g. `8000107` = Freiburg Hbf) with `db_search_locations`.\n2. Pass that `extId` to `db_get_departures` / `db_get_arrivals` / `db_get_stop`.\n3. For trip planning, pass `from` and `to` (both IBNR) to `db_get_journeys`.\n\n**Field naming**: responses use German enterprise-style keys:\n- `extId` — the stable IBNR id (use this as `id` in other tools).\n- `zeit` — planned time. `ezZeit` — real/estimated time (if present; otherwise on time). `delay seconds` = `ezZeit - zeit`.\n- `gleis` — platform.\n- `terminus` — direction (final destination of the line).\n- `verkehrmittel` — line/product info (`name`, `linienNummer`, `produktGattung` ∈ {ICE, EC_IC, IR, REGIONAL, SBAHN, BUS, TRAM, UBAHN, SCHIFF}).\n- `meldungen` — service messages / disruptions.\n\n**Times** are ISO 8601 in Europe/Berlin **without timezone offset** (e.g. `2026-05-27T08:55:00`). All input times must be in the same format.\n\n**Departures/arrivals**: `zeit` (HH:mm) and `datum` (YYYY-MM-DD) are optional — omit both for live boards starting now.\n\n**Journeys**: `when` is required (the LLM should pass the current local Berlin time for 'now' queries). Set `direction=ABFAHRT` for 'depart at' or `ANKUNFT` for 'arrive by'.",
   "region": "de",
   "category": "transport",
   "icon": "db",
-  "docsUrl": "https://v6.db.transport.rest/",
+  "docsUrl": "https://www.bahn.de/",
   "requiredEnvVars": [],
   "connector": {
     "name": "Deutsche Bahn Fahrplan",
     "type": "REST",
-    "baseUrl": "https://v6.db.transport.rest",
-    "authType": "NONE"
+    "baseUrl": "https://int.bahn.de/web/api",
+    "authType": "NONE",
+    "headers": {
+      "Accept-Language": "de-DE",
+      "User-Agent": "anythingmcp/1.0 (+https://anythingmcp.com)"
+    }
   },
   "tools": [
     {
       "name": "db_search_locations",
-      "description": "Search for DB stops/stations, addresses, or points of interest by name. Returns a list of matches with id, name, type, and geo coordinates. Use the returned id with other tools.",
+      "description": "Search Deutsche Bahn stops/stations by name. Returns an array of matches, each with `extId` (the stable IBNR id used everywhere else), `name`, `lat`, `lon`, and `products` (list of services that call at this stop: ICE, EC_IC, IR, REGIONAL, SBAHN, BUS, TRAM, …). Use the returned `extId` as the `id` parameter for db_get_departures, db_get_arrivals, db_get_stop, and as `from`/`to` for db_get_journeys.",
       "parameters": {
         "type": "object",
         "properties": {
           "query": {
             "type": "string",
-            "description": "Search term (e.g. 'Freiburg Hbf', 'Berlin Ostbahnhof', 'München Hauptbahnhof')."
+            "description": "Search term — station name, city, abbreviation. Examples: 'Freiburg Hbf', 'Berlin Ostbahnhof', 'München Hauptbahnhof', 'Köln'."
           },
-          "results": {
+          "limit": {
             "type": "number",
-            "description": "Max results to return (default: 10)."
-          },
-          "stops": {
-            "type": "boolean",
-            "description": "Include train stops (default: true)."
-          },
-          "addresses": {
-            "type": "boolean",
-            "description": "Include street addresses (default: true)."
+            "description": "Max results to return (default: 10).",
+            "default": 10
           }
         },
         "required": ["query"]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/locations",
+        "path": "/reiseloesung/orte",
         "queryParams": {
-          "query": "$query",
-          "results": "$results",
-          "stops": "$stops",
-          "addresses": "$addresses"
+          "suchbegriff": "$query",
+          "typ": "ALL",
+          "limit": "$limit"
         }
       }
     },
     {
       "name": "db_get_stop",
-      "description": "Retrieve details for a specific stop/station by its DB id, including name, location, station category, and products served (ICE, IC, RE, S, etc.).",
+      "description": "Retrieve a single Deutsche Bahn stop by its `extId` (IBNR), returning `name`, `lat`, `lon`, and the list of `products` that call there (ICE, EC_IC, IR, REGIONAL, SBAHN, BUS, TRAM, …). Useful when you already have the id but need the station metadata.",
       "parameters": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "The stop id from db_search_locations (e.g. '8000105' for Frankfurt(Main)Hbf)."
+            "description": "The stop's IBNR / extId from db_search_locations (e.g. '8000105' = Frankfurt(Main)Hbf, '8000107' = Freiburg(Breisgau) Hbf, '8011160' = Berlin Hbf)."
           }
         },
         "required": ["id"]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/stops/{id}"
+        "path": "/reiseloesung/orte",
+        "queryParams": {
+          "suchbegriff": "$id",
+          "limit": "1"
+        }
       }
     },
     {
       "name": "db_get_departures",
-      "description": "List upcoming departures from a stop. Returns each departure with line, destination (direction), planned and actual time, platform, delay in seconds, and cancellation status.",
+      "description": "List upcoming departures from a DB stop with live delays. Returns `entries[]` — each entry has `journeyId` (use with `db_get_journey_detail`-equivalent), `zeit` (planned ISO time), `ezZeit` (real/estimated time if delayed), `gleis` (platform), `terminus` (direction = where the train is heading), `verkehrmittel` (line info: name, product type, line number), and `meldungen` (disruption messages, if any). If `ezZeit` is absent the train is on time. Delay in seconds = `(ezZeit - zeit)`.",
       "parameters": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "The stop id."
+            "description": "The stop's IBNR / extId (e.g. '8000107' for Freiburg Hbf)."
           },
-          "when": {
+          "datum": {
             "type": "string",
-            "description": "ISO 8601 timestamp for the reference time (default: now). Example: '2026-04-21T08:30+02:00'."
+            "description": "Optional reference date in YYYY-MM-DD format. Omit for 'now'. Example: '2026-05-27'."
           },
-          "duration": {
-            "type": "number",
-            "description": "Look-ahead window in minutes (default: 10, max: 120)."
-          },
-          "results": {
-            "type": "number",
-            "description": "Max number of departures (default: 10)."
+          "zeit": {
+            "type": "string",
+            "description": "Optional reference time in HH:mm format (local Berlin time, 24h). Omit for 'now'. Example: '08:30'."
           }
         },
         "required": ["id"]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/stops/{id}/departures",
+        "path": "/reiseloesung/abfahrten",
         "queryParams": {
-          "when": "$when",
-          "duration": "$duration",
-          "results": "$results"
+          "ortExtId": "$id",
+          "datum": "$datum",
+          "zeit": "$zeit"
         }
       }
     },
     {
       "name": "db_get_arrivals",
-      "description": "List upcoming arrivals at a stop with origin, planned and actual time, platform, delay, and cancellation status.",
+      "description": "List upcoming arrivals at a DB stop with live delays. Same response shape as db_get_departures (`entries[]`), but each entry's `terminus` is the train's *origin* and `zeit`/`ezZeit` are arrival times.",
       "parameters": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "The stop id."
+            "description": "The stop's IBNR / extId (e.g. '8011160' for Berlin Hbf)."
           },
-          "when": {
+          "datum": {
             "type": "string",
-            "description": "ISO 8601 timestamp (default: now)."
+            "description": "Optional reference date in YYYY-MM-DD format. Omit for 'now'."
           },
-          "duration": {
-            "type": "number",
-            "description": "Look-ahead window in minutes (default: 10)."
-          },
-          "results": {
-            "type": "number",
-            "description": "Max number of arrivals (default: 10)."
+          "zeit": {
+            "type": "string",
+            "description": "Optional reference time in HH:mm format (local Berlin time, 24h). Omit for 'now'."
           }
         },
         "required": ["id"]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/stops/{id}/arrivals",
+        "path": "/reiseloesung/ankuenfte",
         "queryParams": {
-          "when": "$when",
-          "duration": "$duration",
-          "results": "$results"
+          "ortExtId": "$id",
+          "datum": "$datum",
+          "zeit": "$zeit"
         }
       }
     },
     {
       "name": "db_get_journeys",
-      "description": "Plan a journey between two stops. Returns one or more itinerary options with legs (train/bus/S-Bahn), departure and arrival times per leg, transfers, duration, and any delays. Use stop ids from db_search_locations.",
+      "description": "Plan one or more itineraries between two DB stops. Returns `verbindungen[]` — each itinerary has `verbindungsAbschnitte[]` (the legs), `tripId`, and `ctxRecon` (opaque continuation token). Each leg includes `startHalt`/`zielHalt` (`extId`, `name`, `abfahrt.sollzeit`/`istzeit`, `ankunft.sollzeit`/`istzeit`, `gleis`), `verkehrsmittel` (line name, product, kategorie), `risNotizen`/`himMeldungen` (alerts), and `halte[]` (intermediate stops, when available). Use `extId` (IBNR) for `from` and `to`. The `when` parameter is the departure or arrival time depending on `direction`.",
       "parameters": {
         "type": "object",
         "properties": {
           "from": {
             "type": "string",
-            "description": "Origin stop id."
+            "description": "Origin stop's IBNR / extId (e.g. '8000107' for Freiburg Hbf)."
           },
           "to": {
             "type": "string",
-            "description": "Destination stop id."
+            "description": "Destination stop's IBNR / extId (e.g. '8011160' for Berlin Hbf)."
           },
-          "departure": {
+          "when": {
             "type": "string",
-            "description": "Desired departure time (ISO 8601). Defaults to now. Use either 'departure' or 'arrival', not both."
+            "description": "Reference time as a local Berlin ISO 8601 string WITHOUT timezone offset, e.g. '2026-05-27T08:00:00'. For 'now' queries, pass the current local time in Europe/Berlin in this format. Required."
           },
-          "arrival": {
+          "direction": {
             "type": "string",
-            "description": "Desired latest arrival time (ISO 8601). Use for 'arrive by' queries."
+            "enum": ["ABFAHRT", "ANKUNFT"],
+            "description": "ABFAHRT = depart-at (default) — when is the departure time. ANKUNFT = arrive-by — when is the latest acceptable arrival time.",
+            "default": "ABFAHRT"
           },
-          "results": {
-            "type": "number",
-            "description": "Number of itinerary options to return (default: 3)."
+          "fastOnly": {
+            "type": "boolean",
+            "description": "If true, prefer fast (ICE/IC) connections. Default: true.",
+            "default": true
           },
-          "transfers": {
-            "type": "number",
-            "description": "Max number of transfers (-1 = unlimited)."
+          "bike": {
+            "type": "boolean",
+            "description": "If true, only return legs that allow bicycle carriage. Default: false.",
+            "default": false
           }
         },
-        "required": ["from", "to"]
+        "required": ["from", "to", "when"]
       },
       "endpointMapping": {
-        "method": "GET",
-        "path": "/journeys",
-        "queryParams": {
-          "from": "$from",
-          "to": "$to",
-          "departure": "$departure",
-          "arrival": "$arrival",
-          "results": "$results",
-          "transfers": "$transfers"
+        "method": "POST",
+        "path": "/angebote/fahrplan",
+        "bodyMapping": {
+          "abfahrtsHalt": "A=1@L=${from}@",
+          "ankunftsHalt": "A=1@L=${to}@",
+          "anfrageZeitpunkt": "$when",
+          "ankunftSuche": "$direction",
+          "schnelleVerbindungen": "$fastOnly",
+          "bikeCarriage": "$bike",
+          "reservierungsKontingenteVorhanden": false,
+          "sitzplatzOnly": false,
+          "deutschlandTicketVorhanden": false,
+          "nurDeutschlandTicketVerbindungen": false,
+          "produktgattungen": ["ICE", "EC_IC", "IR", "REGIONAL", "SBAHN", "BUS", "SCHIFF", "UBAHN", "TRAM", "ANRUFPFLICHTIG"],
+          "klasse": "KLASSE_2",
+          "reisende": [
+            {
+              "typ": "ERWACHSENER",
+              "anzahl": 1,
+              "alter": [],
+              "ermaessigungen": [
+                { "art": "KEINE_ERMAESSIGUNG", "klasse": "KLASSENLOS" }
+              ]
+            }
+          ]
         }
       }
     }

--- a/packages/backend/src/adapters/de/deutsche-bahn.live.spec.ts
+++ b/packages/backend/src/adapters/de/deutsche-bahn.live.spec.ts
@@ -1,0 +1,182 @@
+import * as adapter from './deutsche-bahn.json';
+import { RestEngine } from '../../connectors/engines/rest.engine';
+import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
+
+/**
+ * Two-layer verification for the deutsche-bahn adapter:
+ *
+ *   1. Static — always runs. Locks in the int.bahn.de upstream (so a future
+ *      refactor doesn't silently regress back to v6.db.transport.rest, the
+ *      community proxy that started returning 503s and motivated this rewrite),
+ *      the five expected tools, and the journeys body shape (POST to
+ *      /angebote/fahrplan with the German-enterprise field names DB's website
+ *      uses internally).
+ *
+ *   2. Live — opt-in. Hits int.bahn.de for real and asserts response shape.
+ *      Run with:  RUN_DB_LIVE=1 npx jest src/adapters/de/deutsche-bahn.live.spec.ts
+ */
+
+const a = adapter as unknown as {
+  slug: string;
+  category: string;
+  requiredEnvVars: string[];
+  connector: {
+    baseUrl: string;
+    authType: string;
+    headers?: Record<string, string>;
+  };
+  tools: Array<{
+    name: string;
+    endpointMapping: {
+      method: string;
+      path: string;
+      queryParams?: Record<string, string>;
+      bodyMapping?: Record<string, unknown>;
+    };
+  }>;
+};
+
+describe('deutsche-bahn adapter — static spec conformance', () => {
+  it('targets bahn.de directly (not the deprecated v6.db.transport.rest proxy)', () => {
+    expect(a.slug).toBe('deutsche-bahn');
+    expect(a.connector.baseUrl).toBe('https://int.bahn.de/web/api');
+    expect(a.connector.baseUrl).not.toContain('v6.db.transport.rest');
+    expect(a.connector.authType).toBe('NONE');
+    expect(a.requiredEnvVars).toEqual([]);
+  });
+
+  it('sends Accept-Language=de-DE and a real User-Agent (Akamai rejects axios-default UA on int.bahn.de)', () => {
+    expect(a.connector.headers?.['Accept-Language']).toBe('de-DE');
+    expect(a.connector.headers?.['User-Agent']).toMatch(/anythingmcp/i);
+  });
+
+  it('exposes the five timetable tools', () => {
+    expect(a.tools).toHaveLength(5);
+    const names = a.tools.map((t) => t.name);
+    expect(names).toEqual([
+      'db_search_locations',
+      'db_get_stop',
+      'db_get_departures',
+      'db_get_arrivals',
+      'db_get_journeys',
+    ]);
+  });
+
+  it('search/departures/arrivals use the int.bahn.de v2-style endpoints', () => {
+    const byName = (n: string) => a.tools.find((t) => t.name === n)!;
+    expect(byName('db_search_locations').endpointMapping.path).toBe(
+      '/reiseloesung/orte',
+    );
+    expect(byName('db_get_departures').endpointMapping.path).toBe(
+      '/reiseloesung/abfahrten',
+    );
+    expect(byName('db_get_arrivals').endpointMapping.path).toBe(
+      '/reiseloesung/ankuenfte',
+    );
+    // departures/arrivals pass the IBNR as ortExtId (not as a path segment)
+    expect(
+      byName('db_get_departures').endpointMapping.queryParams?.ortExtId,
+    ).toBe('$id');
+    expect(
+      byName('db_get_arrivals').endpointMapping.queryParams?.ortExtId,
+    ).toBe('$id');
+  });
+
+  it('journeys POSTs the German-enterprise body to /angebote/fahrplan', () => {
+    const j = a.tools.find((t) => t.name === 'db_get_journeys')!;
+    expect(j.endpointMapping.method).toBe('POST');
+    expect(j.endpointMapping.path).toBe('/angebote/fahrplan');
+    const body = j.endpointMapping.bodyMapping!;
+    // The lid wrapper is what bahn.de actually expects — searches return the
+    // IBNR as extId; the journeys endpoint wants it boxed into the location
+    // identifier format `A=1@L=<ibnr>@`. Locking it in here so nobody passes
+    // the bare IBNR and gets a silent 422.
+    expect(body.abfahrtsHalt).toBe('A=1@L=${from}@');
+    expect(body.ankunftsHalt).toBe('A=1@L=${to}@');
+    expect(body.anfrageZeitpunkt).toBe('$when');
+    // Required scalar fields the API enforces (422 otherwise — verified live)
+    expect(body.reisende).toBeDefined();
+    expect(body.klasse).toBe('KLASSE_2');
+    expect(body.produktgattungen).toEqual(
+      expect.arrayContaining(['ICE', 'REGIONAL', 'SBAHN']),
+    );
+  });
+});
+
+const maybe = process.env.RUN_DB_LIVE ? describe : describe.skip;
+
+maybe('deutsche-bahn adapter — live smoke test', () => {
+  const oauth = {} as unknown as OAuth2TokenService;
+  const login = {} as unknown as LoginTokenService;
+  const engine = new RestEngine(oauth, login);
+
+  const cfg = {
+    baseUrl: a.connector.baseUrl,
+    authType: 'NONE',
+    headers: a.connector.headers,
+  };
+
+  it('search_locations: returns Freiburg(Breisgau) Hbf with IBNR 8000107', async () => {
+    const res = (await engine.execute(
+      cfg,
+      a.tools.find((t) => t.name === 'db_search_locations')!.endpointMapping,
+      { query: 'Freiburg/Breisgau Hbf', limit: 3 },
+    )) as Array<{ extId: string; name: string; products: string[] }>;
+    expect(Array.isArray(res)).toBe(true);
+    expect(res.length).toBeGreaterThan(0);
+    const fr = res.find((r) => r.extId === '8000107');
+    expect(fr).toBeDefined();
+    expect(fr!.name).toContain('Freiburg');
+    expect(fr!.products).toEqual(expect.arrayContaining(['ICE']));
+  }, 30000);
+
+  it('get_departures: returns entries[] with verkehrmittel + terminus', async () => {
+    const res = (await engine.execute(
+      cfg,
+      a.tools.find((t) => t.name === 'db_get_departures')!.endpointMapping,
+      { id: '8000107' },
+    )) as { entries: Array<{ verkehrmittel: unknown; terminus: string }> };
+    expect(res.entries).toBeDefined();
+    expect(res.entries.length).toBeGreaterThan(0);
+    expect(res.entries[0].verkehrmittel).toBeDefined();
+    expect(typeof res.entries[0].terminus).toBe('string');
+  }, 30000);
+
+  it('get_arrivals: returns entries[] for Berlin Hbf', async () => {
+    const res = (await engine.execute(
+      cfg,
+      a.tools.find((t) => t.name === 'db_get_arrivals')!.endpointMapping,
+      { id: '8011160' },
+    )) as { entries: unknown[] };
+    expect(res.entries).toBeDefined();
+    expect(res.entries.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('get_journeys: Freiburg → Berlin returns at least one verbindung', async () => {
+    // Use tomorrow 08:00 Berlin to avoid edge cases around past/future of "now"
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const yyyy = tomorrow.getFullYear();
+    const mm = String(tomorrow.getMonth() + 1).padStart(2, '0');
+    const dd = String(tomorrow.getDate()).padStart(2, '0');
+    const whenLocal = `${yyyy}-${mm}-${dd}T08:00:00`;
+
+    const res = (await engine.execute(
+      cfg,
+      a.tools.find((t) => t.name === 'db_get_journeys')!.endpointMapping,
+      {
+        from: '8000107',
+        to: '8011160',
+        when: whenLocal,
+        direction: 'ABFAHRT',
+        maxTransfers: -1,
+        minTransferTime: 0,
+        fastOnly: true,
+        bike: false,
+      },
+    )) as { verbindungen: unknown[] };
+    expect(res.verbindungen).toBeDefined();
+    expect(res.verbindungen.length).toBeGreaterThan(0);
+  }, 60000);
+});


### PR DESCRIPTION
## Why

The connector was talking to `v6.db.transport.rest` — a community proxy whose maintainer explicitly documents it as *hosted best-effort*. It started returning 503 in production (see Tool Invocation Logs on cloud.anythingmcp.com, search \`db_search_locations\` ERROR rows from 2026-05-26) and the connector became unusable.

Probed live: every endpoint on the proxy (`/locations`, `/stops/*/departures`, `/journeys`) is currently 503 while the proxy's homepage 200s. Upstream issue, not ours.

## What

Switch the adapter to `https://int.bahn.de/web/api` — the JSON API the bahn.de website itself calls. No auth, same SLA as bahn.de, and the same data backend.

## Endpoint map

| Tool | Old (v6.db.transport.rest) | New (int.bahn.de) |
|---|---|---|
| `db_search_locations` | `GET /locations` | `GET /reiseloesung/orte?suchbegriff=…&typ=ALL` |
| `db_get_stop` | `GET /stops/{id}` | `GET /reiseloesung/orte?suchbegriff={ibnr}&limit=1` |
| `db_get_departures` | `GET /stops/{id}/departures` | `GET /reiseloesung/abfahrten?ortExtId={ibnr}` |
| `db_get_arrivals` | `GET /stops/{id}/arrivals` | `GET /reiseloesung/ankuenfte?ortExtId={ibnr}` |
| `db_get_journeys` | `GET /journeys?from=…&to=…` | `POST /angebote/fahrplan` (full JSON body) |

## Notes on `db_get_journeys`

bahn.de wants the IBNR boxed into the location-identifier format `A=1@L=<ibnr>@` (the lid). Everything required by the endpoint is now in the `bodyMapping`: `klasse`, `reisende`, `produktgattungen`, `reservierungsKontingenteVorhanden`, etc. — verified by probing the real endpoint until it stopped 422'ing.

Dropped from the previous interface:
- `maxTransfers` / `minTransferTime` — the API 422s on `-1` (the old "no limit" sentinel) and the engine has no way to conditionally drop a field. Out for now; the typical max-transfer result is fine without these.
- The `when` parameter is now **required** for journeys (the engine has no \"now\" template default; LLM passes current Europe/Berlin local time).

## Response shape

The LLM sees the raw German-enterprise schema (`extId`, `zeit`/`ezZeit`, `gleis`, `verkehrmittel`, `terminus`, `meldungen`). Instructions and tool descriptions document the fields explicitly so the model knows what to expect.

## Tests

`packages/backend/src/adapters/de/deutsche-bahn.live.spec.ts` — 5 static specs + 4 live smoke tests through `RestEngine`:

```
Tests:       9 passed, 9 total  (RUN_DB_LIVE=1, locally)
```

Static specs lock in:
- the int.bahn.de upstream (so nobody silently regresses back to v6.db.transport.rest)
- the lid wrapper format for `abfahrtsHalt`/`ankunftsHalt` (the silent-422 trap)
- the required body fields (`reisende`, `klasse`, `produktgattungen`)

## Test plan

- [ ] CI passes (the static spec subset, no network)
- [ ] After deploy: open the Deutsche Bahn connector in cloud.anythingmcp.com, call `db_search_locations("Freiburg/Breisgau Hbf")` → 200 with IBNR `8000107`
- [ ] Call `db_get_departures(id="8000107")` → returns `entries[]` with `verkehrmittel` + `terminus`
- [ ] Call `db_get_journeys(from="8000107", to="8011160", when="<tomorrow 08:00>")` → returns `verbindungen[]`