### PR TITLE
cloud: add optional GTM + Consent Mode v2 cookie banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,18 @@ SERVER_URL=http://localhost:4000
 # Max requests per minute per client (by API key or IP). Only enforced when Redis is available.
 MCP_RATE_LIMIT_PER_MINUTE=60
 
+# ── Operator Analytics (cloud build only — leave empty on self-hosted) ──────
+# Loads Google Tag Manager + a Consent Mode v2 cookie banner. Self-hosted
+# builds must leave both empty so no tracking is shipped to community users.
+#
+# GTM_ID         — Google Tag Manager container ID (e.g. GTM-XXXXXXX).
+# COOKIE_DOMAIN  — Domain attribute for the consent cookie. Set to a parent
+#                  domain (e.g. .anythingmcp.com) to share consent with the
+#                  marketing site running on the same parent domain. Leave
+#                  unset for host-only scope.
+# GTM_ID=
+# COOKIE_DOMAIN=
+
 # ── Reverse Proxy (Caddy) ────────────────────────────────────────────────────
 # Uncomment to enable Caddy reverse proxy with automatic HTTPS (Let's Encrypt).
 # Requires a Caddyfile in the project root (setup.sh generates it automatically).

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -49,6 +49,9 @@ services:
       - MCP_AUTH_MODE=${MCP_AUTH_MODE:-oauth2}
       - ALLOW_OPEN_REGISTRATION=${ALLOW_OPEN_REGISTRATION:-true}
       - LICENSE_API_URL=${LICENSE_API_URL:-https://anythingmcp.com}
+      # Operator analytics — cloud build only. Leave unset on self-hosted.
+      - GTM_ID=${GTM_ID:-}
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/package-lock.json
+++ b/package-lock.json
@@ -23786,6 +23786,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/vanilla-cookieconsent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+      "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -24958,7 +24964,8 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
-        "tailwind-merge": "^3.6.0"
+        "tailwind-merge": "^3.6.0",
+        "vanilla-cookieconsent": "^3.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -32,7 +32,8 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Providers } from './providers';
 import { TrialBanner } from '@/components/trial-banner';
 import { UsageBanner } from '@/components/usage-banner';
 import { LicenseWall } from '@/components/license-wall';
+import { GoogleTagManager, GoogleTagManagerNoscript } from '@/components/google-tag-manager';
+import { CookieConsentBanner } from '@/components/cookie-consent';
 
 export const metadata: Metadata = {
   title: 'Anything MCP',
@@ -19,18 +21,24 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const gtmEnabled = Boolean(process.env.GTM_ID);
+  const cookieDomain = process.env.COOKIE_DOMAIN;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <GoogleTagManager />
       </head>
       <body>
+        <GoogleTagManagerNoscript />
         <Providers>
           <TrialBanner />
           <UsageBanner />
           <LicenseWall />
           {children}
         </Providers>
+        {gtmEnabled && <CookieConsentBanner cookieDomain={cookieDomain} />}
       </body>
     </html>
   );

--- a/packages/frontend/src/components/cookie-consent.tsx
+++ b/packages/frontend/src/components/cookie-consent.tsx
@@ -1,0 +1,442 @@
+'use client';
+
+import { useEffect } from 'react';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+import * as CookieConsent from 'vanilla-cookieconsent';
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+// Mirrors the banner on anythingmcp.com. When `cookieDomain` is
+// '.anythingmcp.com', the consent cookie is shared between the
+// marketing site and cloud.anythingmcp.com so users only see the
+// banner once across both properties.
+
+function updateGtagConsent() {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+
+  window.gtag('consent', 'update', {
+    analytics_storage: CookieConsent.acceptedCategory('analytics') ? 'granted' : 'denied',
+    ad_storage: CookieConsent.acceptedCategory('marketing') ? 'granted' : 'denied',
+    ad_user_data: CookieConsent.acceptedCategory('marketing') ? 'granted' : 'denied',
+    ad_personalization: CookieConsent.acceptedCategory('marketing') ? 'granted' : 'denied',
+    functionality_storage: CookieConsent.acceptedCategory('functionality') ? 'granted' : 'denied',
+    personalization_storage: CookieConsent.acceptedCategory('functionality') ? 'granted' : 'denied',
+  });
+}
+
+function policyLink(locale: string, label: string) {
+  const prefix = locale === 'en' ? '' : `/${locale}`;
+  return `<a href="https://anythingmcp.com${prefix}/cookie-policy" target="_blank" rel="noopener">${label}</a>`;
+}
+
+const translations: Record<string, CookieConsent.Translation> = {
+  en: {
+    consentModal: {
+      title: 'We use cookies',
+      description:
+        'We use cookies to improve your experience and to analyze site traffic. You can choose which categories to allow.',
+      acceptAllBtn: 'Accept all',
+      acceptNecessaryBtn: 'Reject all',
+      showPreferencesBtn: 'Manage preferences',
+    },
+    preferencesModal: {
+      title: 'Cookie Preferences',
+      acceptAllBtn: 'Accept all',
+      acceptNecessaryBtn: 'Reject all',
+      savePreferencesBtn: 'Save preferences',
+      closeIconLabel: 'Close',
+      sections: [
+        {
+          title: 'Cookie usage',
+          description:
+            'We use cookies to ensure the basic functionality of the website, to enhance your experience, and for analytics and marketing purposes. You can manage your preferences for each category.',
+        },
+        {
+          title: 'Essential cookies',
+          description:
+            'These cookies are necessary for the website to function and cannot be switched off.',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: 'Analytics cookies',
+          description:
+            'These cookies help us understand how visitors interact with the website by collecting anonymous information.',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: 'Functionality cookies',
+          description:
+            'These cookies enable personalized features and remember your preferences.',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: 'Marketing cookies',
+          description:
+            'These cookies are used to track visitors across websites and display relevant advertisements.',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: 'More information',
+          description: `For any questions about our cookie policy, please ${policyLink('en', 'read our cookie policy')}.`,
+        },
+      ],
+    },
+  },
+  de: {
+    consentModal: {
+      title: 'Wir verwenden Cookies',
+      description:
+        'Wir verwenden Cookies, um Ihre Erfahrung zu verbessern und den Website-Traffic zu analysieren. Sie können wählen, welche Kategorien Sie zulassen möchten.',
+      acceptAllBtn: 'Alle akzeptieren',
+      acceptNecessaryBtn: 'Alle ablehnen',
+      showPreferencesBtn: 'Einstellungen verwalten',
+    },
+    preferencesModal: {
+      title: 'Cookie-Einstellungen',
+      acceptAllBtn: 'Alle akzeptieren',
+      acceptNecessaryBtn: 'Alle ablehnen',
+      savePreferencesBtn: 'Einstellungen speichern',
+      closeIconLabel: 'Schließen',
+      sections: [
+        {
+          title: 'Cookie-Nutzung',
+          description:
+            'Wir verwenden Cookies, um die grundlegende Funktionalität der Website sicherzustellen, Ihre Erfahrung zu verbessern sowie für Analyse- und Marketingzwecke. Sie können Ihre Einstellungen für jede Kategorie verwalten.',
+        },
+        {
+          title: 'Essenzielle Cookies',
+          description:
+            'Diese Cookies sind für die Funktion der Website notwendig und können nicht deaktiviert werden.',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: 'Analyse-Cookies',
+          description:
+            'Diese Cookies helfen uns zu verstehen, wie Besucher mit der Website interagieren, indem sie anonyme Informationen sammeln.',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: 'Funktionalitäts-Cookies',
+          description:
+            'Diese Cookies ermöglichen personalisierte Funktionen und merken sich Ihre Einstellungen.',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: 'Marketing-Cookies',
+          description:
+            'Diese Cookies werden verwendet, um Besucher über Websites hinweg zu verfolgen und relevante Werbung anzuzeigen.',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: 'Weitere Informationen',
+          description: `Bei Fragen zu unserer Cookie-Richtlinie lesen Sie bitte ${policyLink('de', 'unsere Cookie-Richtlinie')}.`,
+        },
+      ],
+    },
+  },
+  it: {
+    consentModal: {
+      title: 'Utilizziamo i cookie',
+      description:
+        'Utilizziamo i cookie per migliorare la tua esperienza e analizzare il traffico del sito. Puoi scegliere quali categorie consentire.',
+      acceptAllBtn: 'Accetta tutti',
+      acceptNecessaryBtn: 'Rifiuta tutti',
+      showPreferencesBtn: 'Gestisci preferenze',
+    },
+    preferencesModal: {
+      title: 'Preferenze Cookie',
+      acceptAllBtn: 'Accetta tutti',
+      acceptNecessaryBtn: 'Rifiuta tutti',
+      savePreferencesBtn: 'Salva preferenze',
+      closeIconLabel: 'Chiudi',
+      sections: [
+        {
+          title: 'Utilizzo dei cookie',
+          description:
+            'Utilizziamo i cookie per garantire le funzionalità di base del sito, per migliorare la tua esperienza e per scopi di analisi e marketing. Puoi gestire le tue preferenze per ogni categoria.',
+        },
+        {
+          title: 'Cookie essenziali',
+          description:
+            'Questi cookie sono necessari per il funzionamento del sito e non possono essere disattivati.',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: 'Cookie analitici',
+          description:
+            'Questi cookie ci aiutano a capire come i visitatori interagiscono con il sito raccogliendo informazioni anonime.',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: 'Cookie funzionali',
+          description:
+            'Questi cookie abilitano funzionalità personalizzate e ricordano le tue preferenze.',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: 'Cookie di marketing',
+          description:
+            'Questi cookie vengono utilizzati per tracciare i visitatori sui siti web e mostrare pubblicità pertinenti.',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: 'Maggiori informazioni',
+          description: `Per qualsiasi domanda sulla nostra politica dei cookie, ${policyLink('it', 'leggi la nostra informativa sui cookie')}.`,
+        },
+      ],
+    },
+  },
+  es: {
+    consentModal: {
+      title: 'Usamos cookies',
+      description:
+        'Usamos cookies para mejorar tu experiencia y analizar el tráfico del sitio. Puedes elegir qué categorías permitir.',
+      acceptAllBtn: 'Aceptar todas',
+      acceptNecessaryBtn: 'Rechazar todas',
+      showPreferencesBtn: 'Gestionar preferencias',
+    },
+    preferencesModal: {
+      title: 'Preferencias de cookies',
+      acceptAllBtn: 'Aceptar todas',
+      acceptNecessaryBtn: 'Rechazar todas',
+      savePreferencesBtn: 'Guardar preferencias',
+      closeIconLabel: 'Cerrar',
+      sections: [
+        {
+          title: 'Uso de cookies',
+          description:
+            'Usamos cookies para garantizar la funcionalidad básica del sitio web, mejorar tu experiencia y con fines de análisis y marketing. Puedes gestionar tus preferencias para cada categoría.',
+        },
+        {
+          title: 'Cookies esenciales',
+          description:
+            'Estas cookies son necesarias para el funcionamiento del sitio web y no se pueden desactivar.',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: 'Cookies analíticas',
+          description:
+            'Estas cookies nos ayudan a entender cómo los visitantes interactúan con el sitio web recopilando información anónima.',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: 'Cookies funcionales',
+          description:
+            'Estas cookies permiten funciones personalizadas y recuerdan tus preferencias.',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: 'Cookies de marketing',
+          description:
+            'Estas cookies se utilizan para rastrear visitantes en sitios web y mostrar anuncios relevantes.',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: 'Más información',
+          description: `Si tienes preguntas sobre nuestra política de cookies, ${policyLink('es', 'lee nuestra política de cookies')}.`,
+        },
+      ],
+    },
+  },
+  zh: {
+    consentModal: {
+      title: '我们使用 Cookie',
+      description: '我们使用 Cookie 来改善您的体验并分析网站流量。您可以选择允许哪些类别。',
+      acceptAllBtn: '全部接受',
+      acceptNecessaryBtn: '全部拒绝',
+      showPreferencesBtn: '管理偏好设置',
+    },
+    preferencesModal: {
+      title: 'Cookie 偏好设置',
+      acceptAllBtn: '全部接受',
+      acceptNecessaryBtn: '全部拒绝',
+      savePreferencesBtn: '保存偏好设置',
+      closeIconLabel: '关闭',
+      sections: [
+        {
+          title: 'Cookie 使用说明',
+          description: '我们使用 Cookie 来确保网站的基本功能、改善您的体验，以及用于分析和营销目的。您可以管理每个类别的偏好设置。',
+        },
+        {
+          title: '必要 Cookie',
+          description: '这些 Cookie 是网站运行所必需的，无法关闭。',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: '分析 Cookie',
+          description: '这些 Cookie 通过收集匿名信息帮助我们了解访问者如何与网站互动。',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: '功能 Cookie',
+          description: '这些 Cookie 启用个性化功能并记住您的偏好设置。',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: '营销 Cookie',
+          description: '这些 Cookie 用于跨网站跟踪访问者并展示相关广告。',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: '更多信息',
+          description: `如果您对我们的 Cookie 政策有任何疑问，请${policyLink('zh', '阅读我们的 Cookie 政策')}。`,
+        },
+      ],
+    },
+  },
+  ja: {
+    consentModal: {
+      title: 'Cookie を使用しています',
+      description:
+        '当サイトでは、エクスペリエンスの向上とサイトトラフィックの分析のために Cookie を使用しています。許可するカテゴリを選択できます。',
+      acceptAllBtn: 'すべて許可',
+      acceptNecessaryBtn: 'すべて拒否',
+      showPreferencesBtn: '設定を管理',
+    },
+    preferencesModal: {
+      title: 'Cookie 設定',
+      acceptAllBtn: 'すべて許可',
+      acceptNecessaryBtn: 'すべて拒否',
+      savePreferencesBtn: '設定を保存',
+      closeIconLabel: '閉じる',
+      sections: [
+        {
+          title: 'Cookie の使用について',
+          description:
+            '当サイトでは、基本機能の確保、エクスペリエンスの向上、分析およびマーケティング目的で Cookie を使用しています。各カテゴリの設定を管理できます。',
+        },
+        {
+          title: '必須 Cookie',
+          description: 'これらの Cookie はウェブサイトの機能に必要であり、オフにすることはできません。',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: '分析 Cookie',
+          description:
+            'これらの Cookie は、匿名情報を収集することで、訪問者がウェブサイトとどのようにやり取りしているかを理解するのに役立ちます。',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: '機能 Cookie',
+          description: 'これらの Cookie はパーソナライズされた機能を有効にし、お客様の設定を記憶します。',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: 'マーケティング Cookie',
+          description: 'これらの Cookie は、ウェブサイト間で訪問者を追跡し、関連性の高い広告を表示するために使用されます。',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: '詳細情報',
+          description: `Cookie ポリシーについてご質問がある場合は、${policyLink('ja', 'Cookie ポリシー')}をご覧ください。`,
+        },
+      ],
+    },
+  },
+  ru: {
+    consentModal: {
+      title: 'Мы используем файлы cookie',
+      description:
+        'Мы используем файлы cookie для улучшения вашего опыта и анализа трафика сайта. Вы можете выбрать, какие категории разрешить.',
+      acceptAllBtn: 'Принять все',
+      acceptNecessaryBtn: 'Отклонить все',
+      showPreferencesBtn: 'Управление настройками',
+    },
+    preferencesModal: {
+      title: 'Настройки cookie',
+      acceptAllBtn: 'Принять все',
+      acceptNecessaryBtn: 'Отклонить все',
+      savePreferencesBtn: 'Сохранить настройки',
+      closeIconLabel: 'Закрыть',
+      sections: [
+        {
+          title: 'Использование cookie',
+          description:
+            'Мы используем файлы cookie для обеспечения базовой функциональности сайта, улучшения вашего опыта, а также в аналитических и маркетинговых целях. Вы можете управлять настройками для каждой категории.',
+        },
+        {
+          title: 'Основные cookie',
+          description: 'Эти файлы cookie необходимы для работы сайта и не могут быть отключены.',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: 'Аналитические cookie',
+          description:
+            'Эти файлы cookie помогают нам понять, как посетители взаимодействуют с сайтом, собирая анонимную информацию.',
+          linkedCategory: 'analytics',
+        },
+        {
+          title: 'Функциональные cookie',
+          description: 'Эти файлы cookie обеспечивают персонализированные функции и запоминают ваши настройки.',
+          linkedCategory: 'functionality',
+        },
+        {
+          title: 'Маркетинговые cookie',
+          description:
+            'Эти файлы cookie используются для отслеживания посетителей на сайтах и отображения релевантной рекламы.',
+          linkedCategory: 'marketing',
+        },
+        {
+          title: 'Дополнительная информация',
+          description: `По вопросам о нашей политике cookie, пожалуйста, ${policyLink('ru', 'ознакомьтесь с нашей политикой cookie')}.`,
+        },
+      ],
+    },
+  },
+};
+
+export function CookieConsentBanner({ cookieDomain }: { cookieDomain?: string }) {
+  useEffect(() => {
+    CookieConsent.run({
+      guiOptions: {
+        consentModal: { layout: 'box inline', position: 'bottom left' },
+        preferencesModal: { layout: 'box' },
+      },
+
+      cookie: {
+        name: 'cc_cookie',
+        domain: cookieDomain || undefined,
+        path: '/',
+        sameSite: 'Lax',
+        expiresAfterDays: 182,
+      },
+
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: {
+          autoClear: {
+            cookies: [{ name: /^_ga/ }, { name: '_gid' }, { name: /^_gat/ }],
+          },
+        },
+        functionality: {},
+        marketing: {
+          autoClear: {
+            cookies: [{ name: /^_gcl/ }, { name: '_fbp' }, { name: /^_fbc/ }],
+          },
+        },
+      },
+
+      language: {
+        default: 'en',
+        autoDetect: 'browser',
+        translations,
+      },
+
+      onFirstConsent: updateGtagConsent,
+      onConsent: updateGtagConsent,
+      onChange: updateGtagConsent,
+    });
+  }, [cookieDomain]);
+
+  return null;
+}
+
+// Convenience to open the preferences modal from a footer link.
+export function openCookiePreferences() {
+  CookieConsent.showPreferences();
+}

--- a/packages/frontend/src/components/google-tag-manager.tsx
+++ b/packages/frontend/src/components/google-tag-manager.tsx
@@ -1,0 +1,81 @@
+import Script from 'next/script';
+
+// Mirrors the Consent Mode v2 + GTM setup on anythingmcp.com so both
+// properties report into the same container and respect the same
+// regional defaults. Activated only when GTM_ID is set at runtime —
+// keeps community self-hosted builds free of any tracking.
+
+const EEA_UK_CH = [
+  'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR',
+  'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL',
+  'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'IS', 'LI', 'NO',
+  'GB', 'CH',
+];
+
+export function GoogleTagManager() {
+  const gtmId = process.env.GTM_ID;
+  if (!gtmId) return null;
+
+  const consentDefault = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied',
+      functionality_storage: 'denied',
+      personalization_storage: 'denied',
+      security_storage: 'granted',
+      wait_for_update: 500,
+      region: ${JSON.stringify(EEA_UK_CH)}
+    });
+    gtag('consent', 'default', {
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+      analytics_storage: 'granted',
+      functionality_storage: 'granted',
+      personalization_storage: 'granted',
+      security_storage: 'granted'
+    });
+  `;
+
+  const gtmSnippet = `
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','${gtmId}');
+  `;
+
+  return (
+    <>
+      {/* beforeInteractive is required so Consent Mode defaults are set before GTM loads.
+          The lint rule targets pages/_document.js but App Router supports this in root layout. */}
+      {/* eslint-disable-next-line @next/next/no-before-interactive-script-outside-document */}
+      <Script id="gtm-consent-default" strategy="beforeInteractive">
+        {consentDefault}
+      </Script>
+      <Script id="gtm-script" strategy="afterInteractive">
+        {gtmSnippet}
+      </Script>
+    </>
+  );
+}
+
+export function GoogleTagManagerNoscript() {
+  const gtmId = process.env.GTM_ID;
+  if (!gtmId) return null;
+
+  return (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+        height="0"
+        width="0"
+        style={{ display: 'none', visibility: 'hidden' }}
+      />
+    </noscript>
+  );
+}


### PR DESCRIPTION
## Summary

Adds optional Google Tag Manager + cookie consent banner to the frontend, fully gated by runtime env vars so **community self-hosted builds ship no tracking**. The same Docker image works for both flavors.

- **GTM** loaded only when \`GTM_ID\` env is set. Consent Mode v2 region-aware defaults (EEA/UK/CH \`denied\`, rest of world \`granted\`) — identical to the marketing site so both properties report into the same container.
- **Cookie banner** via \`vanilla-cookieconsent\` v3 (MIT, ~30 KB, no runtime cost when disabled). Granular categories: necessary / analytics / functionality / marketing. 7 languages auto-detected from browser. Auto-clears \`_ga*\`, \`_gid\`, \`_gat*\`, \`_gcl*\`, \`_fbp\`, \`_fbc*\` on revoke.
- **Cross-subdomain consent**: \`COOKIE_DOMAIN=.anythingmcp.com\` makes the consent cookie shareable with anythingmcp.com (companion PR on the website repo sets the same domain there).
- **Server Component** for GTM so the env stays server-side (no \`NEXT_PUBLIC_*\` leakage), one image serves both cloud and self-hosted.

Production deploy plan: set \`GTM_ID=GTM-W63BPRN9\` and \`COOKIE_DOMAIN=.anythingmcp.com\` on the cloud droplet's \`.env\`, leave both empty everywhere else.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [x] \`next build\` completes (24 routes)
- [ ] Smoke test on staging with \`GTM_ID\` set: banner appears, accept → \`gtag('consent','update', granted)\` fires
- [ ] Smoke test with \`GTM_ID\` empty: no banner, no GTM script in DOM
- [ ] Verify \`cc_cookie\` has \`Domain: .anythingmcp.com\` and is reused across subdomains