### PR TITLE
chore(release): v0.1.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "BUSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -24482,7 +24482,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "BUSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.1.21",
@@ -24936,7 +24936,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "BUSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Source-available (BSL-1.1 → Apache 2030).",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BUSL-1.1",


### PR DESCRIPTION
Bump to v0.1.31.

## Adapters
- **#250** 7 reverse-engineered adapters: OpenTable, Resy, Vinted, Untappd, idealista, Trenitalia, Trainline
- **#266** Remove Trainline (TOS / instability)
- **#267** Etsy → OAuth2 with refresh-token auto-rotation
- **#268** Deutsche Bahn → rewrite against bahn.de directly (drop the v6.db.transport.rest dependency)

## Fixes
- **#249** Playtomic logo: add fill style so the wordmark renders