### PR TITLE
feat(users): onboarding state endpoint + columns

### DIFF
--- a/packages/backend/prisma/migrations/20260528100000_add_onboarding_columns/migration.sql
+++ b/packages/backend/prisma/migrations/20260528100000_add_onboarding_columns/migration.sql
@@ -1,0 +1,13 @@
+-- Onboarding state for the in-app welcome wizard and the email drip.
+-- Both gates read these columns; only the welcome wizard / drip cron
+-- writes to them.
+
+ALTER TABLE "users"
+  ADD COLUMN "onboarding_completed_at"   TIMESTAMP(3),
+  ADD COLUMN "onboarding_last_reminder_at" TIMESTAMP(3),
+  ADD COLUMN "onboarding_reminder_count" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "email_marketing_opt_out"   BOOLEAN  NOT NULL DEFAULT false;
+
+-- Used by the cron to select candidates efficiently.
+CREATE INDEX "users_onboarding_drip_idx"
+  ON "users" ("email_verified", "onboarding_completed_at", "email_marketing_opt_out", "created_at");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -85,6 +85,16 @@ model User {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  // Onboarding state — drives the welcome wizard and the email drip.
+  // null `onboardingCompletedAt` = wizard still pending or never seen.
+  // `onboardingReminderCount` is terminal at 2 (24h + 72h emails sent).
+  // `emailMarketingOptOut` hard-blocks drip emails; transactional emails
+  // (password reset, email verification) ignore it.
+  onboardingCompletedAt    DateTime? @map("onboarding_completed_at")
+  onboardingLastReminderAt DateTime? @map("onboarding_last_reminder_at")
+  onboardingReminderCount  Int       @default(0) @map("onboarding_reminder_count")
+  emailMarketingOptOut     Boolean   @default(false) @map("email_marketing_opt_out")
+
   // MCP tool governance — optional custom role for tool access control
   mcpRoleId String? @map("mcp_role_id")
   mcpRole   Role?   @relation(fields: [mcpRoleId], references: [id], onDelete: SetNull)

--- a/packages/backend/src/users/users.controller.ts
+++ b/packages/backend/src/users/users.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Put,
+  Patch,
   Delete,
   Body,
   Param,
@@ -11,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
-import { IsString, IsOptional, IsEmail, IsEnum, MinLength, Matches, Equals } from 'class-validator';
+import { IsString, IsOptional, IsEmail, IsEnum, IsBoolean, MinLength, Matches, Equals } from 'class-validator';
 import { UserRole } from '../generated/prisma/client';
 import { UsersService } from './users.service';
 import { AuthService } from '../auth/auth.service';
@@ -44,6 +45,24 @@ class ChangePasswordDto {
   @MinLength(8)
   @Matches(PASSWORD_REGEX, { message: PASSWORD_MESSAGE })
   newPassword: string;
+}
+
+class UpdateOnboardingStateDto {
+  @ApiPropertyOptional({
+    description:
+      'Mark onboarding as completed (sets onboardingCompletedAt = now). ' +
+      'Frontend calls this when the user finishes or explicitly skips the welcome wizard.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  completed?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Hard unsubscribe from drip emails. Transactional mail keeps flowing.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  emailMarketingOptOut?: boolean;
 }
 
 class UpdateUserRoleDto {
@@ -84,6 +103,29 @@ export class UsersController {
     if (!user) return { error: 'User not found' };
     const { passwordHash, ...profile } = user;
     return profile;
+  }
+
+  @Get('me/onboarding-state')
+  @ApiOperation({
+    summary: 'Get onboarding/wizard state for the current user',
+    description:
+      'Returns the fields used by the welcome wizard and the drip cron. ' +
+      'The frontend combines this with /api/license/status and /api/connectors ' +
+      'to decide whether to redirect to /welcome.',
+  })
+  async getOnboardingState(@Req() req: any) {
+    return this.usersService.getOnboardingState(req.user.sub);
+  }
+
+  @Patch('me/onboarding-state')
+  @ApiOperation({
+    summary: 'Update onboarding state (skip/finish the wizard, opt out of marketing emails)',
+  })
+  async updateOnboardingState(
+    @Req() req: any,
+    @Body() dto: UpdateOnboardingStateDto,
+  ) {
+    return this.usersService.updateOnboardingState(req.user.sub, dto);
   }
 
   @Put('me')

--- a/packages/backend/src/users/users.service.ts
+++ b/packages/backend/src/users/users.service.ts
@@ -55,6 +55,57 @@ export class UsersService {
   }
 
   /**
+   * Read the fields the welcome wizard + drip cron care about.
+   * Lightweight — picks only the relevant columns, no joins.
+   */
+  async getOnboardingState(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        emailVerified: true,
+        createdAt: true,
+        onboardingCompletedAt: true,
+        onboardingLastReminderAt: true,
+        onboardingReminderCount: true,
+        emailMarketingOptOut: true,
+      },
+    });
+    if (!user) throw new NotFoundException('User not found');
+    return user;
+  }
+
+  /**
+   * Mark the wizard finished/skipped or toggle the marketing opt-out flag.
+   * Both fields are idempotent: setting completed=true twice keeps the
+   * earliest timestamp (we don't overwrite a non-null value), so re-opening
+   * the wizard later won't reset analytics.
+   */
+  async updateOnboardingState(
+    userId: string,
+    patch: { completed?: boolean; emailMarketingOptOut?: boolean },
+  ) {
+    const current = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { onboardingCompletedAt: true },
+    });
+    if (!current) throw new NotFoundException('User not found');
+
+    const data: Partial<User> = {};
+    if (patch.completed === true && current.onboardingCompletedAt === null) {
+      data.onboardingCompletedAt = new Date();
+    }
+    if (patch.emailMarketingOptOut !== undefined) {
+      data.emailMarketingOptOut = patch.emailMarketingOptOut;
+    }
+
+    if (Object.keys(data).length === 0) return this.getOnboardingState(userId);
+
+    await this.prisma.user.update({ where: { id: userId }, data });
+    return this.getOnboardingState(userId);
+  }
+
+  /**
    * Update a user only if they belong to the given organization.
    * Returns null if no row matched. Use this from any admin endpoint
    * that takes a user id from the request URL.


### PR DESCRIPTION
Foundation PR for the new welcome wizard + email drip.

## Schema
Migration `20260528100000_add_onboarding_columns`:
- `users.onboarding_completed_at` — null = wizard pending or never seen
- `users.onboarding_last_reminder_at` — last drip touch
- `users.onboarding_reminder_count` — terminal at 2 (24h + 72h emails sent)
- `users.email_marketing_opt_out` — hard unsubscribe (transactional mail ignores)
- Composite index for the cron candidate query

## API
- `GET /api/users/me/onboarding-state`
- `PATCH /api/users/me/onboarding-state` — { completed?, emailMarketingOptOut? }

The composite gate is left to the frontend (combines this endpoint with /api/license/status + /api/connectors) to avoid pulling LicenseService into UsersService — see follow-up PR.

## Test plan
- [x] `npx nest build` passes
- [ ] After deploy: `curl /api/users/me/onboarding-state` returns the fields for an authenticated user
- [ ] PATCH with `{ completed: true }` stamps the timestamp; second call is idempotent