### PR TITLE
feat(onboarding): /welcome wizard + gate-aware redirect + dashboard nudge

### DIFF
--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -85,6 +85,28 @@ export default function DashboardPage() {
           <p className="text-[var(--muted-foreground)] mt-1 text-sm">Here&apos;s an overview of your MCP server.</p>
         </div>
 
+        {/* First-run nudge: user has zero connectors → softly point them
+            back to the welcome wizard. Disappears as soon as they have
+            one. Non-blocking; safe to dismiss by clicking the CTA. */}
+        {!dataLoading && stats.connectors === 0 && (
+          <div className="mb-8 rounded-xl border border-[var(--brand)]/30 bg-[var(--brand-light)] px-5 py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div>
+              <div className="font-medium text-sm">
+                You&apos;re 60 seconds from your first AI superpower
+              </div>
+              <div className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                Pick a pre-built connector from the marketplace or paste your own OpenAPI spec.
+              </div>
+            </div>
+            <Link
+              href="/welcome"
+              className="shrink-0 inline-flex items-center justify-center bg-[var(--brand)] text-white px-4 py-2 rounded-md text-sm font-medium hover:brightness-90"
+            >
+              Connect your first tool →
+            </Link>
+          </div>
+        )}
+
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
           <StatCard
             title="Active Connectors"

--- a/packages/frontend/src/app/providers.tsx
+++ b/packages/frontend/src/app/providers.tsx
@@ -3,12 +3,17 @@
 import { AuthProvider } from '@/lib/auth-context';
 import { ThemeProvider } from '@/lib/theme-context';
 import { ToastProvider } from '@/components/toast';
+import { OnboardingRedirect } from '@/components/onboarding-redirect';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider>
       <AuthProvider>
-        <ToastProvider>{children}</ToastProvider>
+        <ToastProvider>
+          {/* No DOM; runs the welcome-wizard gate on every navigation. */}
+          <OnboardingRedirect />
+          {children}
+        </ToastProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/packages/frontend/src/app/welcome/page.tsx
+++ b/packages/frontend/src/app/welcome/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth-context';
+import { adapters, users } from '@/lib/api';
+import { LogoIcon } from '@/components/nav-bar';
+
+// A small, curated subset of slugs known to actually work end-to-end
+// today, ordered by popularity from the production analytics
+// (Sendcloud + Playtomic lead, then GitHub/Twitter/Slack as broadly
+// useful starters). We don't fetch and re-rank: a stable list keeps
+// the wizard predictable, and the user can switch to the full
+// /connectors/store from the CTA below.
+const STARTER_SLUGS = [
+  'sendcloud',
+  'playtomic-public',
+  'github',
+  'twitter',
+  'slack',
+  'notion',
+  'stripe',
+  'help-scout',
+];
+
+export default function WelcomePage() {
+  const { token, user, isLoading } = useAuth();
+  const router = useRouter();
+  const [starters, setStarters] = useState<any[]>([]);
+  const [skipping, setSkipping] = useState(false);
+
+  useEffect(() => {
+    // Bounce to /login if the user landed here unauthenticated.
+    if (!isLoading && !token) router.replace('/login?redirect=/welcome');
+  }, [isLoading, token, router]);
+
+  useEffect(() => {
+    // Fetch the catalog so we can show real logos + descriptions for
+    // the starter set. If the catalog endpoint fails we degrade
+    // gracefully to the two empty CTA cards.
+    if (!token) return;
+    adapters
+      .list(token)
+      .then((all: any[]) => {
+        const bySlug = new Map(all.map((a) => [a.slug, a]));
+        setStarters(
+          STARTER_SLUGS.map((s) => bySlug.get(s)).filter(Boolean) as any[],
+        );
+      })
+      .catch(() => setStarters([]));
+  }, [token]);
+
+  const handleSkip = async () => {
+    if (!token || skipping) return;
+    setSkipping(true);
+    try {
+      await users.updateOnboardingState({ completed: true }, token);
+    } catch {
+      // Non-blocking: even if the PATCH fails, the redirect still
+      // happens; the gate will fire again next page load.
+    }
+    router.replace('/');
+  };
+
+  if (isLoading || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--background)]">
+        <div className="text-sm text-[var(--muted-foreground)]">Loading…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
+      <header className="border-b border-[var(--border)] bg-[var(--card)]">
+        <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <LogoIcon size={28} />
+            <span className="font-semibold">
+              Anything<span className="text-[var(--brand)]">MCP</span>
+            </span>
+          </div>
+          <button
+            onClick={handleSkip}
+            disabled={skipping}
+            className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] disabled:opacity-50"
+          >
+            {skipping ? 'Skipping…' : 'Skip for now'}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-6 py-12">
+        <div className="text-center mb-10">
+          <p className="text-xs uppercase tracking-[0.18em] text-[var(--brand)] font-mono mb-3">
+            Welcome
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+            Connect your first tool, {user.name?.split(' ')[0] || 'friend'}.
+          </h1>
+          <p className="text-[var(--muted-foreground)] max-w-xl mx-auto">
+            AnythingMCP turns any API into MCP tools your AI agent can call.
+            Pick a starter from the marketplace or paste your own OpenAPI
+            spec — should take about a minute.
+          </p>
+        </div>
+
+        {/* Two big paths — marketplace vs custom */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-10">
+          <Link
+            href="/connectors/store?from=welcome"
+            className="group border border-[var(--border)] rounded-xl p-6 bg-[var(--card)] hover:border-[var(--brand)] hover:bg-[var(--brand-light)] transition-colors text-left"
+          >
+            <div className="text-xs uppercase tracking-wider text-[var(--brand)] font-mono mb-2">
+              Recommended
+            </div>
+            <h2 className="text-lg font-semibold mb-1.5">
+              Browse the marketplace
+            </h2>
+            <p className="text-sm text-[var(--muted-foreground)] mb-4">
+              180+ pre-built connectors. OAuth, API keys, refresh-token
+              rotation — all wired up. Click → install → done.
+            </p>
+            <div className="text-sm font-medium text-[var(--brand)] group-hover:underline">
+              Open marketplace →
+            </div>
+          </Link>
+
+          <Link
+            href="/connectors/new?from=welcome"
+            className="group border border-[var(--border)] rounded-xl p-6 bg-[var(--card)] hover:border-[var(--brand)] hover:bg-[var(--brand-light)] transition-colors text-left"
+          >
+            <div className="text-xs uppercase tracking-wider text-[var(--muted-foreground)] font-mono mb-2">
+              Bring your own
+            </div>
+            <h2 className="text-lg font-semibold mb-1.5">Add your own API</h2>
+            <p className="text-sm text-[var(--muted-foreground)] mb-4">
+              Paste an OpenAPI URL or JSON spec and we generate MCP tools
+              for every endpoint. Works for REST, SOAP, GraphQL.
+            </p>
+            <div className="text-sm font-medium text-[var(--brand)] group-hover:underline">
+              Start from scratch →
+            </div>
+          </Link>
+        </div>
+
+        {/* Starter shortcuts — real logos + 1-click install */}
+        {starters.length > 0 && (
+          <div>
+            <h3 className="text-sm font-semibold mb-3 text-[var(--muted-foreground)]">
+              Popular starters
+            </h3>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {starters.map((a) => (
+                <Link
+                  key={a.slug}
+                  href={`/connectors/store?install=${encodeURIComponent(a.slug)}&from=welcome`}
+                  className="border border-[var(--border)] rounded-lg p-3 bg-[var(--card)] hover:border-[var(--brand)] hover:bg-[var(--brand-light)] transition-colors flex items-center gap-3"
+                >
+                  <div className="text-2xl shrink-0">
+                    {a.icon === 'sendcloud' && '📦'}
+                    {a.icon === 'playtomic' && '🎾'}
+                    {a.icon === 'github' && '🐙'}
+                    {a.icon === 'twitter' && '🐦'}
+                    {a.icon === 'slack' && '💬'}
+                    {a.icon === 'notion' && '📝'}
+                    {a.icon === 'stripe' && '💳'}
+                    {a.icon === 'helpscout' && '🛟'}
+                    {![
+                      'sendcloud',
+                      'playtomic',
+                      'github',
+                      'twitter',
+                      'slack',
+                      'notion',
+                      'stripe',
+                      'helpscout',
+                    ].includes(a.icon) && '🔌'}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium truncate">{a.name}</div>
+                    <div className="text-xs text-[var(--muted-foreground)] truncate">
+                      {a.toolCount} tools
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <p className="mt-10 text-center text-xs text-[var(--muted-foreground)]">
+          You can always come back and add more connectors from the dashboard.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/onboarding-redirect.tsx
+++ b/packages/frontend/src/components/onboarding-redirect.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth-context';
+import { connectors, license, users } from '@/lib/api';
+
+// Routes where we MUST NOT redirect, even if the wizard hasn't been
+// completed yet. Login + token-bound flows handle their own redirects,
+// the license/setup pages must stay reachable so admins can fix gating
+// problems without being bounced back to /welcome, and /welcome itself
+// is the destination so we shouldn't loop.
+const EXCLUDED_ROUTES = [
+  '/login',
+  '/verify-email',
+  '/forgot-password',
+  '/reset-password',
+  '/accept-invite',
+  '/settings/license',
+  '/welcome',
+];
+
+function isExcluded(pathname: string | null): boolean {
+  if (!pathname) return true;
+  return EXCLUDED_ROUTES.some(
+    (r) => pathname === r || pathname.startsWith(r + '/'),
+  );
+}
+
+/**
+ * Decides whether to show the new welcome wizard for the current user.
+ * Lives at provider scope so it runs on every route change.
+ *
+ * Gate precedence (matches LicenseWall + login multi-step flows):
+ *  1. Email must be verified — unverified users see verify prompts.
+ *  2. License must be active (cloud has a plan, or self-host community
+ *     personal-use already chosen). LicenseWall reads the same source.
+ *  3. Wizard not yet completed/skipped (onboardingCompletedAt === null).
+ *  4. User has zero connectors — once they own at least one, the wizard
+ *     is moot and we auto-stamp completion (so they don't re-see it).
+ *
+ * If all 4 hold and we're on the dashboard, redirect to /welcome.
+ * If 1-3 hold but they already have a connector, fire-and-forget the
+ * PATCH so we don't pester them again.
+ */
+export function OnboardingRedirect() {
+  const { token, user, isLoading, deploymentMode } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+  // Avoid duplicate evaluations on rapid route changes / re-renders.
+  const lastRun = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (isLoading || !token || !user) return;
+    if (isExcluded(pathname)) return;
+
+    // Dedupe per (path, userId) to avoid hammering the API on every render.
+    const key = `${user.id}:${pathname}`;
+    if (lastRun.current === key) return;
+    lastRun.current = key;
+
+    let cancelled = false;
+    const run = async () => {
+      try {
+        // Four lightweight calls; can race in parallel. We fetch the full
+        // /me ourselves because the auth-context User type doesn't expose
+        // emailVerified (an unverified user shouldn't reach this code path
+        // — the signup flow keeps them on /verify-email — but we guard
+        // anyway so a malformed session doesn't slip past the gate).
+        const [onboarding, lic, connList, me] = await Promise.all([
+          users.onboardingState(token),
+          license.getStatus(token),
+          connectors.list(token),
+          users.me(token),
+        ]);
+        if (cancelled) return;
+        if (me?.emailVerified === false) return;
+
+        // License gate — mirror LicenseWall's logic exactly so the two
+        // never disagree. Self-host with no plan = community tier OK.
+        const isCloud = deploymentMode === 'cloud';
+        const noPlan = !lic.plan;
+        const trialEnded =
+          lic.plan === 'trial' &&
+          typeof lic.trialDaysLeft === 'number' &&
+          lic.trialDaysLeft <= 0;
+        const expired = lic.status === 'expired' || lic.status === 'revoked';
+        const licenseBlocking = (isCloud && noPlan) || trialEnded || expired;
+        if (licenseBlocking) return;
+
+        const hasConnector = (connList?.length ?? 0) > 0;
+        const wizardDone = onboarding.onboardingCompletedAt !== null;
+
+        // User finished onboarding implicitly by creating a connector
+        // elsewhere — stamp it so the wizard never opens again.
+        if (!wizardDone && hasConnector) {
+          users
+            .updateOnboardingState({ completed: true }, token)
+            .catch(() => {});
+          return;
+        }
+
+        if (!wizardDone && !hasConnector && pathname === '/') {
+          router.replace('/welcome');
+        }
+      } catch {
+        // Network blip — don't surface to the user; we'll re-evaluate
+        // on the next navigation.
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, token, user, pathname, deploymentMode, router]);
+
+  return null;
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -103,9 +103,30 @@ export const auth = {
 };
 
 // Users
+export interface OnboardingState {
+  id: string;
+  emailVerified: boolean;
+  createdAt: string;
+  onboardingCompletedAt: string | null;
+  onboardingLastReminderAt: string | null;
+  onboardingReminderCount: number;
+  emailMarketingOptOut: boolean;
+}
+
 export const users = {
   me: (token: string) =>
     request<any>('/api/users/me', { token }),
+  onboardingState: (token: string) =>
+    request<OnboardingState>('/api/users/me/onboarding-state', { token }),
+  updateOnboardingState: (
+    data: { completed?: boolean; emailMarketingOptOut?: boolean },
+    token: string,
+  ) =>
+    request<OnboardingState>('/api/users/me/onboarding-state', {
+      method: 'PATCH',
+      body: data,
+      token,
+    }),
   updateProfile: (data: { name?: string; email?: string }, token: string) =>
     request('/api/users/me', { method: 'PUT', body: data, token }),
   changePassword: (data: { currentPassword: string; newPassword: string }, token: string) =>


### PR DESCRIPTION
Follow-up to #272 — the user-visible piece.

## What ships
- `components/onboarding-redirect.tsx` — provider-scoped client gate that fetches `/api/users/me/onboarding-state` + `/api/license/status` + `/api/connectors` + `/api/users/me` in parallel and redirects to `/welcome` when all four point to a first-run user. Mirrors LicenseWall's blocking logic exactly so the two gates can't disagree.
- `app/welcome/page.tsx` — minimal 1-page wizard with two big choices (Browse marketplace / Add your own API) plus 8 popular starters as one-click shortcuts (Sendcloud, Playtomic, GitHub, Twitter, Slack, Notion, Stripe, Help Scout — the ones with real production usage).
- `app/page.tsx` — small first-run banner on the dashboard for users who skipped the wizard, pointing them back at /welcome.
- Auto-stamps `onboardingCompletedAt` if the user already has a connector (e.g. created via API directly).

## Excluded routes
The gate does NOT redirect from: `/login`, `/verify-email`, `/forgot-password`, `/reset-password`, `/accept-invite`, `/settings/license/*`, `/welcome` — protects every existing onboarding flow (LicenseWall, login multi-step `license-choice`, accept-invite) from being overruled.

## Test plan
- [x] frontend tsc passes
- [ ] After deploy: new user lands on /welcome instead of empty dashboard
- [ ] Skip button stamps completedAt → user goes back to /, no re-redirect on next page load
- [ ] Existing user with ≥1 connector is not affected
- [ ] License-blocked user (Cloud no plan, trial expired) sees LicenseWall, NOT /welcome
- [ ] Self-host first-admin in license-choice flow is not interrupted