### PR TITLE
fix(audit): resolve user_id from JWT email so cloud analytics aren't always NULL

### DIFF
--- a/packages/backend/src/audit/audit.service.spec.ts
+++ b/packages/backend/src/audit/audit.service.spec.ts
@@ -11,6 +11,12 @@ describe('AuditService', () => {
         findMany: jest.fn().mockResolvedValue([]),
         count: jest.fn().mockResolvedValue(0),
       },
+      // resolveUserId consults users to satisfy the FK before insert.
+      // Default: the test user exists. Individual tests override
+      // findUnique to simulate missing-row or email-fallback paths.
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'user-1' }),
+      },
     };
     service = new AuditService(mockPrisma);
   });

--- a/packages/backend/src/audit/audit.service.ts
+++ b/packages/backend/src/audit/audit.service.ts
@@ -11,6 +11,16 @@ export class AuditService {
   async logInvocation(data: {
     toolId: string;
     userId?: string;
+    /**
+     * Email from the JWT (OAuth or app-token). When `userId` doesn't
+     * resolve to a real users row — common for MCP OAuth JWTs whose
+     * `sub` is an external subject like `claude:user:xxx` rather than
+     * our cuid — we look the user up by email and stamp `userId`
+     * before persisting. Until this was added, 90% of cloud
+     * tool_invocations were saved with `user_id = NULL` even though
+     * the user was clearly authenticated.
+     */
+    userEmail?: string;
     mcpServerId?: string;
     input: Record<string, unknown>;
     output?: Record<string, unknown>;
@@ -19,11 +29,13 @@ export class AuditService {
     error?: string;
     clientInfo?: string;
   }): Promise<void> {
+    const resolvedUserId = await this.resolveUserId(data.userId, data.userEmail);
+
     try {
       await this.prisma.toolInvocation.create({
         data: {
           toolId: data.toolId,
-          userId: data.userId,
+          userId: resolvedUserId,
           mcpServerId: data.mcpServerId,
           input: data.input as any,
           output: data.output as any,
@@ -34,8 +46,10 @@ export class AuditService {
         },
       });
     } catch (error: any) {
-      // FK violation on userId — retry without userId (user info is still in clientInfo)
-      if (error.message?.includes('user_id_fkey') && data.userId) {
+      // FK violation should be impossible after resolveUserId, but
+      // keep the safety net: if it still trips, retry without user_id
+      // so we at least keep the row for aggregate metrics.
+      if (error.message?.includes('user_id_fkey') && resolvedUserId) {
         try {
           await this.prisma.toolInvocation.create({
             data: {
@@ -64,6 +78,45 @@ export class AuditService {
     this.logger.debug(
       `Tool invocation: ${data.toolId} [${data.status}] ${data.durationMs ?? 0}ms`,
     );
+  }
+
+  /**
+   * Return a `user_id` that is guaranteed to satisfy the FK constraint,
+   * or `undefined`. Order of preference:
+   *   1. The `userId` we were given, IF it exists in users.
+   *   2. A user matched by `userEmail` (case-insensitive, single row).
+   *   3. undefined (genuinely anonymous — e.g. static bearer token).
+   *
+   * Small in-memory cache on email so the hot MCP path doesn't issue
+   * a SELECT on every single tool invocation.
+   */
+  private emailToIdCache = new Map<string, string>();
+
+  private async resolveUserId(
+    userId: string | undefined,
+    userEmail: string | undefined,
+  ): Promise<string | undefined> {
+    if (userId) {
+      const exists = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true },
+      });
+      if (exists) return userId;
+    }
+
+    if (!userEmail) return undefined;
+    const key = userEmail.toLowerCase();
+    const cached = this.emailToIdCache.get(key);
+    if (cached) return cached;
+
+    const byEmail = await this.prisma.user.findUnique({
+      where: { email: key },
+      select: { id: true },
+    });
+    if (!byEmail) return undefined;
+
+    this.emailToIdCache.set(key, byEmail.id);
+    return byEmail.id;
   }
 
   private orgScope(organizationId?: string): any {

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -155,6 +155,7 @@ export class DynamicMcpTools {
       await this.auditService.logInvocation({
         toolId: tool.id,
         userId: context?.userId,
+        userEmail: context?.userEmail,
         mcpServerId: context?.mcpServerId,
         input: params,
         output: result as Record<string, unknown>,
@@ -189,6 +190,7 @@ export class DynamicMcpTools {
       await this.auditService.logInvocation({
         toolId: tool.id,
         userId: context?.userId,
+        userEmail: context?.userEmail,
         mcpServerId: context?.mcpServerId,
         input: params,
         status: 'ERROR',


### PR DESCRIPTION
## Bug
90% of `tool_invocations` were persisted with `user_id = NULL` even when `client_info.userEmail` clearly identified an authenticated user. Top-user dashboards / drip-cron queries / 'who broke prod' lookups all read garbage.

## Root cause
OAuth JWTs from MCP clients set `sub` to an external subject like `claude:user:xxx`, not our database cuid. The FK constraint refused the row, the existing retry path stripped `user_id` entirely, and we lost the signal.

## Fix
`audit.service.ts` gets a new `resolveUserId(userId, userEmail)`:
1. Trust `userId` if it actually exists in users.
2. Otherwise look up by email (case-insensitive, single-row).
3. Otherwise undefined (genuine anonymous — static bearer tokens etc).

Small in-memory `emailToIdCache` keeps the hot MCP path cheap (one SELECT per email per process lifetime).

`dynamic-mcp-tools.ts` now forwards `context.userEmail` to the audit call — already in client_info but not in the audit signature until now.

## Backfill
One-off SQL to recover historical rows (not in this PR — apply after deploy):
```sql
UPDATE tool_invocations ti
SET user_id = u.id
FROM users u
WHERE ti.user_id IS NULL
  AND ti.client_info IS NOT NULL
  AND lower(u.email) = lower(ti.client_info::jsonb->>'userEmail');
```

## Test plan
- [x] backend builds
- [ ] After deploy: new MCP invocation from a Claude-OAuth user → check user_id is set in tool_invocations