### PR TITLE
feat(onboarding): drip email cron + sendOnboardingReminderEmail

### DIFF
--- a/.github/workflows/onboarding-reminders.yml
+++ b/.github/workflows/onboarding-reminders.yml
@@ -1,0 +1,51 @@
+name: Onboarding reminders cron
+
+# Pings the cloud backend every 6 hours to send drip emails to users
+# who registered 24h+ ago but never created a connector. The endpoint
+# (`/api/cron/onboarding-reminders`) is idempotent — re-running within
+# a window won't double-send because per-user counters and timing
+# checks are persisted in the users table.
+#
+# Schedule: */6 means 00:00, 06:00, 12:00, 18:00 UTC. We don't tie this
+# to local business hours because the email itself isn't time-sensitive
+# (users register globally and the drip lands ~ a day later anyway).
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "Override the onboarding-reminders URL (used for staging / dry-run)"
+        required: false
+        default: "https://cloud.anythingmcp.com/api/cron/onboarding-reminders"
+
+jobs:
+  trigger:
+    name: Trigger onboarding drip
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Call cron endpoint
+        env:
+          CRON_SECRET: ${{ secrets.ONBOARDING_CRON_SECRET }}
+          TARGET_URL: ${{ inputs.target_url || 'https://cloud.anythingmcp.com/api/cron/onboarding-reminders' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CRON_SECRET:-}" ]; then
+            echo "::error::ONBOARDING_CRON_SECRET secret is not set on this repository."
+            exit 1
+          fi
+          response_file="$(mktemp)"
+          http_code=$(curl -sS -o "${response_file}" -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            -H "Content-Type: application/json" \
+            "${TARGET_URL}")
+          echo "HTTP ${http_code}"
+          cat "${response_file}"
+          echo
+          if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            echo "::error::Onboarding cron endpoint returned ${http_code}"
+            exit 1
+          fi

--- a/packages/backend/src/cloud/cloud.module.ts
+++ b/packages/backend/src/cloud/cloud.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
+import { SettingsModule } from '../settings/settings.module';
+import { OnboardingCronController } from './onboarding-cron.controller';
+import { OnboardingCronService } from './onboarding-cron.service';
 
 /**
  * CloudModule — loaded only when DEPLOYMENT_MODE=cloud.
  *
- * Groups cloud-specific providers and controllers. Future additions:
- * - Usage metering
- * - Multi-tenant routing
- * - Cloud-specific billing webhooks
+ * Groups cloud-specific providers and controllers:
+ * - Onboarding drip cron (sends nudge emails to users with 0 connectors)
+ * - Future: usage metering, multi-tenant routing, billing webhooks
  */
-@Module({})
+@Module({
+  imports: [SettingsModule],
+  controllers: [OnboardingCronController],
+  providers: [OnboardingCronService],
+})
 export class CloudModule {}

--- a/packages/backend/src/cloud/onboarding-cron.controller.ts
+++ b/packages/backend/src/cloud/onboarding-cron.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Post,
+  Headers,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { OnboardingCronService } from './onboarding-cron.service';
+
+/**
+ * POST /api/cron/onboarding-reminders
+ *
+ * Triggered by the `onboarding-reminders.yml` GitHub Actions workflow
+ * every 6 hours. Pings the cloud backend to run the drip pipeline.
+ *
+ * Auth: `Authorization: Bearer <CRON_SECRET>`. The secret is shared
+ * between the workflow and the cloud env. Self-host deployments
+ * normally don't set CRON_SECRET → the endpoint refuses anonymous
+ * calls there too, so the drip is effectively cloud-only.
+ */
+@ApiTags('Cron')
+@Controller('api/cron')
+export class OnboardingCronController {
+  private readonly logger = new Logger(OnboardingCronController.name);
+
+  constructor(private readonly cron: OnboardingCronService) {}
+
+  @Post('onboarding-reminders')
+  @ApiOperation({
+    summary:
+      'Send onboarding drip emails to users registered ≥24h ago with 0 connectors',
+  })
+  async run(@Headers('authorization') authHeader?: string) {
+    const expected = process.env.CRON_SECRET;
+    if (!expected) {
+      this.logger.warn(
+        'CRON_SECRET is not configured — refusing onboarding cron call.',
+      );
+      throw new UnauthorizedException('Cron not configured');
+    }
+    const provided =
+      authHeader?.startsWith('Bearer ') && authHeader.substring(7);
+    if (provided !== expected) {
+      throw new UnauthorizedException('Invalid cron token');
+    }
+
+    const result = await this.cron.run();
+    return { ok: true, ...result };
+  }
+}

--- a/packages/backend/src/cloud/onboarding-cron.service.ts
+++ b/packages/backend/src/cloud/onboarding-cron.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { EmailService } from '../settings/email.service';
+
+const HOURS = (n: number) => n * 60 * 60 * 1000;
+
+/**
+ * Onboarding drip — finds users who registered, verified their email,
+ * but never created a connector, and nudges them via email at two
+ * milestones:
+ *
+ *   day 1 (~24-48h after signup): first reminder
+ *   day 2 (~72-96h after signup, ≥48h after the first): second reminder
+ *
+ * Cap is 2 emails. After that we leave them alone — we'd rather lose
+ * an inactive trial than annoy someone enough to mark us as spam.
+ *
+ * State columns on users (migration 20260528100000):
+ *   onboarding_completed_at      — null = wizard not yet finished
+ *   onboarding_last_reminder_at  — last drip touch
+ *   onboarding_reminder_count    — terminal at 2
+ *   email_marketing_opt_out      — hard unsubscribe
+ *
+ * Idempotency: the cron is fine to re-run within a window — counters
+ * + timing checks prevent duplicate sends. Worst case a missed run
+ * sends a reminder a few hours late.
+ */
+@Injectable()
+export class OnboardingCronService {
+  private readonly logger = new Logger(OnboardingCronService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly email: EmailService,
+  ) {}
+
+  async run(): Promise<{
+    examined: number;
+    firstReminders: number;
+    secondReminders: number;
+    skipped: number;
+  }> {
+    const now = Date.now();
+    const out = {
+      examined: 0,
+      firstReminders: 0,
+      secondReminders: 0,
+      skipped: 0,
+    };
+
+    // Candidate set: verified, no completion, ≤2 reminders, not opted out,
+    // and registered between 24h and 14d ago. We bound at 14d so a user
+    // who signed up months ago doesn't suddenly get woken up if we ever
+    // backfill columns.
+    const candidates = await this.prisma.user.findMany({
+      where: {
+        emailVerified: true,
+        emailMarketingOptOut: false,
+        onboardingCompletedAt: null,
+        onboardingReminderCount: { lt: 2 },
+        createdAt: {
+          lte: new Date(now - HOURS(24)),
+          gte: new Date(now - HOURS(24 * 14)),
+        },
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        createdAt: true,
+        onboardingReminderCount: true,
+        onboardingLastReminderAt: true,
+        _count: { select: { connectors: true } },
+      },
+    });
+
+    for (const u of candidates) {
+      out.examined++;
+
+      // Race-safe: a user that created a connector between candidate
+      // pull and now should never receive a nudge.
+      if (u._count.connectors > 0) {
+        // Auto-stamp completion so we never see them again.
+        await this.prisma.user
+          .update({
+            where: { id: u.id },
+            data: { onboardingCompletedAt: new Date() },
+          })
+          .catch(() => {});
+        out.skipped++;
+        continue;
+      }
+
+      const age = now - u.createdAt.getTime();
+      const sinceLast = u.onboardingLastReminderAt
+        ? now - u.onboardingLastReminderAt.getTime()
+        : Infinity;
+
+      // First nudge: 24-72h after signup, count == 0.
+      if (u.onboardingReminderCount === 0 && age >= HOURS(24)) {
+        const ok = await this.email.sendOnboardingReminderEmail(
+          u.email,
+          u.name || 'there',
+          1,
+        );
+        if (ok) {
+          await this.prisma.user.update({
+            where: { id: u.id },
+            data: {
+              onboardingReminderCount: 1,
+              onboardingLastReminderAt: new Date(),
+            },
+          });
+          out.firstReminders++;
+        } else {
+          out.skipped++;
+        }
+        continue;
+      }
+
+      // Second nudge: count == 1, ≥72h after signup AND ≥48h since first.
+      if (
+        u.onboardingReminderCount === 1 &&
+        age >= HOURS(72) &&
+        sinceLast >= HOURS(48)
+      ) {
+        const ok = await this.email.sendOnboardingReminderEmail(
+          u.email,
+          u.name || 'there',
+          2,
+        );
+        if (ok) {
+          await this.prisma.user.update({
+            where: { id: u.id },
+            data: {
+              onboardingReminderCount: 2,
+              onboardingLastReminderAt: new Date(),
+            },
+          });
+          out.secondReminders++;
+        } else {
+          out.skipped++;
+        }
+        continue;
+      }
+
+      out.skipped++;
+    }
+
+    this.logger.log(
+      `Onboarding drip: examined=${out.examined} first=${out.firstReminders} second=${out.secondReminders} skipped=${out.skipped}`,
+    );
+    return out;
+  }
+}

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -280,6 +280,77 @@ export class EmailService {
     });
   }
 
+  // ── Onboarding Reminder (SMTP only) ───────────────────────────────────
+  // Cloud-only drip. Self-hosted instances generally don't have SMTP set
+  // up and the external website API has no template for it, so we skip
+  // rather than throw.
+
+  async sendOnboardingReminderEmail(
+    to: string,
+    name: string,
+    dayNumber: 1 | 2,
+  ): Promise<boolean> {
+    const transport = await this.createTransporter();
+    if (!transport) {
+      this.logger.warn(
+        `Skipping onboarding-reminder email to ${to}: no SMTP configured`,
+      );
+      return false;
+    }
+
+    const cloudUrl =
+      process.env.CLOUD_PUBLIC_URL || 'https://cloud.anythingmcp.com';
+    const welcomeUrl = `${cloudUrl}/welcome`;
+    const unsubUrl = `${cloudUrl}/settings/profile`;
+
+    const subject =
+      dayNumber === 1
+        ? 'Connect your first tool in 60 seconds — AnythingMCP'
+        : 'Still here? Pick a tool to try — AnythingMCP';
+
+    const body =
+      dayNumber === 1
+        ? `<p>Hi ${name},</p>
+           <p>You signed up for AnythingMCP yesterday but haven't connected anything yet. The fastest path to your first AI superpower is picking a ready-made connector from the marketplace — Sendcloud, Stripe, GitHub, Slack, Help Scout… 180+ are pre-wired.</p>
+           <p><a href="${welcomeUrl}" style="display:inline-block;background:#d97757;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;">Open the welcome wizard →</a></p>
+           <p style="font-size:13px;color:#666;">Should take about a minute.</p>`
+        : `<p>Hi ${name},</p>
+           <p>Just checking in — your AnythingMCP account is still waiting for its first connector. If anything got in your way, hit reply and tell us what; we read every reply.</p>
+           <p><a href="${welcomeUrl}" style="display:inline-block;background:#d97757;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;">Pick a connector →</a></p>`;
+
+    try {
+      await transport.transporter.sendMail({
+        from: transport.from,
+        to,
+        subject,
+        html: `
+          <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
+            ${body}
+            <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 24px 0;" />
+            <p style="color: #a3a3a3; font-size: 11px;">
+              You're receiving this because you signed up at cloud.anythingmcp.com.
+              <a href="${unsubUrl}" style="color: #a3a3a3;">Unsubscribe from these nudges</a>.
+            </p>
+          </div>
+        `,
+        text: `Hi ${name},\n\n${
+          dayNumber === 1
+            ? "You signed up for AnythingMCP yesterday but haven't connected anything yet."
+            : 'Your AnythingMCP account is still waiting for its first connector.'
+        }\n\nOpen the wizard: ${welcomeUrl}\n\nUnsubscribe: ${unsubUrl}`,
+      });
+      this.logger.log(
+        `Onboarding-reminder email (day ${dayNumber}) sent to ${to}`,
+      );
+      return true;
+    } catch (err) {
+      this.logger.error(
+        `Failed to send onboarding-reminder email to ${to}: ${err}`,
+      );
+      return false;
+    }
+  }
+
   // ── External API Fallback ─────────────────────────────────────────────────
 
   private async sendViaExternalApi(


### PR DESCRIPTION
Closes the loop on the welcome wizard introduced in #272 + #273.

Users who skip the wizard or never log back in get nudged twice:
- **+24h**: 'connect your first tool in 60 seconds'
- **+72h** (≥48h after the first): 'still here? pick a tool to try'

After that we leave them alone — would rather lose an inactive trial than annoy someone into marking us as spam.

## What ships
- **`OnboardingCronService`** with the race-safe drip query (auto-stamps onboardingCompletedAt if connector count jumped > 0 between candidate pull and send)
- **`POST /api/cron/onboarding-reminders`** protected by `Authorization: Bearer $CRON_SECRET`. Refuses if the secret isn't set so self-host stays silent without configuration
- **`sendOnboardingReminderEmail`** — short templates, SMTP-only, includes unsubscribe link to /settings/profile
- **`.github/workflows/onboarding-reminders.yml`** — runs every 6h, workflow_dispatch for staging dry-runs

## Required ops setup (NOT automatic)
- Set repo secret `ONBOARDING_CRON_SECRET` (any random string)
- Set the same value as `CRON_SECRET` on the cloud droplet `.env`
- Optionally override `CLOUD_PUBLIC_URL` if it differs from `https://cloud.anythingmcp.com`

## Test plan
- [x] backend builds
- [ ] After deploy: POST with valid bearer → returns examined/firstReminders/secondReminders/skipped counts
- [ ] POST without bearer → 401
- [ ] Confirm at least one of our 12 dormant users gets the email