### PR TITLE
fix(license-wall): hide on logout + auth routes, clear stale block state

### DIFF
--- a/packages/frontend/src/components/license-wall.tsx
+++ b/packages/frontend/src/components/license-wall.tsx
@@ -17,7 +17,14 @@ export function LicenseWall() {
   const isCloud = deploymentMode === 'cloud';
 
   useEffect(() => {
-    if (!token) return;
+    // Logged out (or logging out) — clear any stale block so the wall
+    // doesn't keep covering the login page. Without this reset the modal
+    // stays mounted after Logout because we'd only ever *set* `reason`,
+    // never unset it.
+    if (!token) {
+      setReason(null);
+      return;
+    }
 
     license.getStatus(token).then((status) => {
       // Cloud: no license at all means the org is not allowed to use the
@@ -25,6 +32,7 @@ export function LicenseWall() {
       // community tier", which is permitted.
       if (!status.plan) {
         if (isCloud) setReason('no-license');
+        else setReason(null);
         return;
       }
       // Block when trial is expired
@@ -35,12 +43,29 @@ export function LicenseWall() {
       // Block when any license is expired/revoked
       if (status.status === 'expired' || status.status === 'revoked') {
         setReason('expired');
+        return;
       }
+      // Active/valid license — make sure no stale block lingers.
+      setReason(null);
     }).catch(() => {});
   }, [token, isCloud]);
 
-  // Don't block the license settings page so users can enter a license key
-  if (!reason || pathname === '/settings/license' || pathname?.startsWith('/settings/license/')) return null;
+  // Routes where the wall must never appear: unauthenticated/auth flows
+  // (you can't fix a license problem while logged out) and the license
+  // settings page itself (so users can enter a key / start a trial).
+  const isExemptRoute =
+    !pathname ||
+    pathname === '/login' ||
+    pathname === '/verify-email' ||
+    pathname === '/forgot-password' ||
+    pathname === '/reset-password' ||
+    pathname.startsWith('/accept-invite') ||
+    pathname === '/settings/license' ||
+    pathname.startsWith('/settings/license/');
+
+  // Don't block when logged out, when there's no active block, or on an
+  // exempt route.
+  if (!token || !reason || isExemptRoute) return null;
 
   const title =
     reason === 'no-license'


### PR DESCRIPTION
## Bug
A user with no license/trial who clicks **Logout** still sees the 'License Required' modal covering the `/login` page (screenshot in thread). Logging out should dismiss it.

## Causes
1. The effect only ever *set* `reason`, never reset it. On logout `token` → null, the effect early-returned, and the stale `reason='no-license'` kept the modal mounted over the login page.
2. `/login` (and the other auth routes) weren't exempt — only `/settings/license` was.

## Fix
- Reset `reason` to null when `!token`, on the active-license path, and on the self-host-no-plan path (so stale blocks can't linger across logout / org-switch / re-auth).
- Exempt `/login`, `/verify-email`, `/forgot-password`, `/reset-password`, `/accept-invite` in addition to `/settings/license`.
- Guard short-circuits on `!token` directly so a render race can't flash the modal.

## Test plan
- [x] frontend tsc (license-wall clean)
- [ ] After deploy: log in as a no-license cloud user → wall shows on dashboard → click Logout → lands on /login with NO modal
- [ ] /settings/license still reachable to enter a key / start trial