### PR TITLE
feat(clockify): expand adapter to 18 tools (workspace users, tasks, reports)

### DIFF
--- a/packages/backend/src/adapters/intl/clockify.json
+++ b/packages/backend/src/adapters/intl/clockify.json
@@ -1,8 +1,8 @@
 {
   "slug": "clockify",
   "name": "Clockify",
-  "description": "Manage Clockify (time tracking, projects, clients, tags, reports) from any AI agent. 10 tools, X-Api-Key auth.",
-  "instructions": "This connector wraps the Clockify REST API v1 (api.clockify.me/api/v1).\n\n**Setup**:\n1. Sign in to https://clockify.me → bottom-left avatar → **Preferences → Advanced → API → Generate API key**.\n2. Set `CLOCKIFY_API_KEY`.\n\n**Authentication**: `X-Api-Key: ${CLOCKIFY_API_KEY}` on every request.\n\n**Workspace IDs**: Clockify is workspace-scoped. Use `clockify_get_user` first — its response contains `defaultWorkspace` and `activeWorkspace`. List workspaces with `clockify_list_workspaces`.\n\n**Time entry shape**: `start` + `end` are ISO 8601 UTC with the literal `Z` suffix (e.g. `2026-05-20T14:30:00Z`). For a running entry, OMIT `end` — the entry will be live until you call `clockify_stop_current_entry`.\n\n**Project / Task / Tag IDs**: every entity ID is a 24-char hex Mongo-style ID (e.g. `5b1e7b7b7e8d8e3a4c5d6f78`). Always look them up first via the list endpoints; user-facing names are not accepted.\n\n**Pagination**: `page` (1-based) + `page-size` (max 5000 but default 50). Some endpoints also support cursor pagination via `cursor`.\n\n**Rate limits**: 50 req/s per workspace; bursts tolerated. 429 with no Retry-After — back off 1s.\n\n**Out of scope here**: Reports endpoints (different base host `reports.api.clockify.me`, would be a sibling adapter), approval workflows, Pumble integration.",
+  "description": "Manage Clockify (time tracking, projects, tasks, clients, tags, workspace users, reports) from any AI agent. 18 tools, X-Api-Key auth.",
+  "instructions": "This connector wraps the Clockify REST API v1 (api.clockify.me/api/v1).\n\n**Setup**:\n1. Sign in to https://clockify.me → bottom-left avatar → **Preferences → Advanced → API → Generate API key**.\n2. Set `CLOCKIFY_API_KEY`.\n\n**Authentication**: `X-Api-Key: ${CLOCKIFY_API_KEY}` on every request.\n\n**Workspace IDs**: Clockify is workspace-scoped. Use `clockify_get_user` first — its response contains `defaultWorkspace` and `activeWorkspace`. List workspaces with `clockify_list_workspaces`.\n\n**Time entry shape**: `start` + `end` are ISO 8601 UTC with the literal `Z` suffix (e.g. `2026-05-20T14:30:00Z`). For a running entry, OMIT `end` — the entry will be live until you call `clockify_stop_current_entry`.\n\n**Project / Task / Tag IDs**: every entity ID is a 24-char hex Mongo-style ID (e.g. `5b1e7b7b7e8d8e3a4c5d6f78`). Always look them up first via the list endpoints; user-facing names are not accepted.\n\n**Deleting clients/tasks/projects**: Clockify forbids deleting an active client or project — archive it first (PUT with `archived:true`), then DELETE. Tasks must be set to `status:DONE` before deletion.\n\n**Reports**: the report tools (`clockify_detailed_report`, `clockify_summary_report`) hit a SEPARATE host — `reports.api.clockify.me/v1` — handled transparently here via absolute URLs. POST body needs `dateRangeStart`/`dateRangeEnd` (ISO 8601 with millis, e.g. `2026-05-01T00:00:00.000`). Detailed reports paginate via `detailedFilter.page`/`pageSize`; summary groups via `summaryFilter.groups` (e.g. `[\"PROJECT\",\"USER\"]`).\n\n**Regional workspaces**: workspaces hosted in EU/US regions use prefixed hosts (e.g. `euc1.clockify.me`, `reports.euc1.clockify.me`). This adapter targets the global host; regional accounts need a forked baseUrl.\n\n**Pagination**: `page` (1-based) + `page-size` (max 5000 but default 50). Some endpoints also support cursor pagination via `cursor`.\n\n**Rate limits**: ~10 req/s per API key. 429 with no Retry-After — back off 1s.\n\n**Out of scope here**: approval workflows, expenses, invoicing, webhooks, Pumble integration.",
   "region": "intl",
   "category": "time-tracking",
   "icon": "clockify",
@@ -30,6 +30,156 @@
       "description": "List workspaces the user belongs to.",
       "parameters": { "type": "object", "properties": {} },
       "endpointMapping": { "method": "GET", "path": "/workspaces" }
+    },
+    {
+      "name": "clockify_list_workspace_users",
+      "description": "List all users (members) of a workspace. Returns each user's id, email, name, status (ACTIVE/INACTIVE), and memberships. Filter by name/email/status.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "name": { "type": "string", "description": "Substring filter by name." },
+          "email": { "type": "string", "description": "Filter by email." },
+          "status": { "type": "string", "description": "ACTIVE, INACTIVE, PENDING, DECLINED, or ALL." },
+          "page": { "type": "integer", "description": "1-based." },
+          "page_size": { "type": "integer", "description": "Default 50, max 5000." }
+        },
+        "required": ["workspace_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/workspaces/{workspace_id}/users",
+        "queryParams": {
+          "name": "$name",
+          "email": "$email",
+          "status": "$status",
+          "page": "$page",
+          "page-size": "$page_size"
+        }
+      }
+    },
+    {
+      "name": "clockify_find_tasks",
+      "description": "List tasks within a project. Returns id, name, status (ACTIVE/DONE), assigneeIds, estimate, billable.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "project_id": { "type": "string", "description": "Project ID." },
+          "name": { "type": "string", "description": "Substring filter." },
+          "is_active": { "type": "boolean", "description": "true = only ACTIVE tasks." },
+          "page": { "type": "integer", "description": "1-based." },
+          "page_size": { "type": "integer", "description": "Default 50." }
+        },
+        "required": ["workspace_id", "project_id"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/workspaces/{workspace_id}/projects/{project_id}/tasks",
+        "queryParams": {
+          "name": "$name",
+          "is-active": "$is_active",
+          "page": "$page",
+          "page-size": "$page_size"
+        }
+      }
+    },
+    {
+      "name": "clockify_add_task",
+      "description": "Add a task to a project. Required: name. Optionally assign users, set an estimate, or mark billable.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "project_id": { "type": "string", "description": "Project ID." },
+          "name": { "type": "string", "description": "Task name." },
+          "assignee_ids": { "type": "array", "description": "Array of user ID strings to assign." },
+          "estimate": { "type": "string", "description": "ISO 8601 duration, e.g. PT2H30M." },
+          "billable": { "type": "boolean", "description": "Billable flag." }
+        },
+        "required": ["workspace_id", "project_id", "name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/workspaces/{workspace_id}/projects/{project_id}/tasks",
+        "bodyMapping": {
+          "name": "$name",
+          "assigneeIds": "$assignee_ids",
+          "estimate": "$estimate",
+          "billable": "$billable"
+        }
+      }
+    },
+    {
+      "name": "clockify_add_project",
+      "description": "Create a project in a workspace. Required: name. Optionally link a client, set color, billable, public, hourly rate.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "name": { "type": "string", "description": "Project name." },
+          "client_id": { "type": "string", "description": "Client ID to attach." },
+          "color": { "type": "string", "description": "Hex color, e.g. #03A9F4." },
+          "billable": { "type": "boolean", "description": "Billable by default." },
+          "is_public": { "type": "boolean", "description": "Visible to all workspace members." },
+          "note": { "type": "string", "description": "Free-text note." }
+        },
+        "required": ["workspace_id", "name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/workspaces/{workspace_id}/projects",
+        "bodyMapping": {
+          "name": "$name",
+          "clientId": "$client_id",
+          "color": "$color",
+          "billable": "$billable",
+          "isPublic": "$is_public",
+          "note": "$note"
+        }
+      }
+    },
+    {
+      "name": "clockify_add_client",
+      "description": "Create a client in a workspace. Required: name.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "name": { "type": "string", "description": "Client name." },
+          "email": { "type": "string", "description": "Client email." },
+          "address": { "type": "string", "description": "Client address." },
+          "note": { "type": "string", "description": "Free-text note." }
+        },
+        "required": ["workspace_id", "name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/workspaces/{workspace_id}/clients",
+        "bodyMapping": {
+          "name": "$name",
+          "email": "$email",
+          "address": "$address",
+          "note": "$note"
+        }
+      }
+    },
+    {
+      "name": "clockify_add_tag",
+      "description": "Create a tag in a workspace. Required: name.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "name": { "type": "string", "description": "Tag name." }
+        },
+        "required": ["workspace_id", "name"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/workspaces/{workspace_id}/tags",
+        "bodyMapping": { "name": "$name" }
+      }
     },
     {
       "name": "clockify_list_clients",
@@ -232,6 +382,60 @@
       "endpointMapping": {
         "method": "DELETE",
         "path": "/workspaces/{workspace_id}/time-entries/{time_entry_id}"
+      }
+    },
+    {
+      "name": "clockify_detailed_report",
+      "description": "Detailed report: line-by-line time entries for a workspace over a date range, with totals (time, billable time, earned amount). Served by the Reports API host. Filter/paginate via detailed_filter.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "date_range_start": { "type": "string", "description": "ISO 8601 with millis, e.g. 2026-05-01T00:00:00.000." },
+          "date_range_end": { "type": "string", "description": "ISO 8601 with millis, e.g. 2026-05-31T23:59:59.999." },
+          "detailed_filter": { "type": "object", "description": "{page:1, pageSize:50, sortColumn:'DATE'}. pageSize max 1000." },
+          "users": { "type": "object", "description": "User filter: {ids:[...], contains:'CONTAINS'}." },
+          "projects": { "type": "object", "description": "Project filter: {ids:[...], contains:'CONTAINS'}." }
+        },
+        "required": ["workspace_id", "date_range_start", "date_range_end"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "https://reports.api.clockify.me/v1/workspaces/{workspace_id}/reports/detailed",
+        "bodyMapping": {
+          "dateRangeStart": "$date_range_start",
+          "dateRangeEnd": "$date_range_end",
+          "detailedFilter": "$detailed_filter",
+          "users": "$users",
+          "projects": "$projects"
+        }
+      }
+    },
+    {
+      "name": "clockify_summary_report",
+      "description": "Summary report: aggregated time/earnings grouped by one or more dimensions (PROJECT, USER, CLIENT, TASK, TAG, DATE) for a workspace over a date range. Served by the Reports API host.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "workspace_id": { "type": "string", "description": "Workspace ID." },
+          "date_range_start": { "type": "string", "description": "ISO 8601 with millis." },
+          "date_range_end": { "type": "string", "description": "ISO 8601 with millis." },
+          "summary_filter": { "type": "object", "description": "{groups:['PROJECT','USER'], sortColumn:'GROUP'}. groups required for grouping." },
+          "users": { "type": "object", "description": "User filter: {ids:[...], contains:'CONTAINS'}." },
+          "projects": { "type": "object", "description": "Project filter: {ids:[...], contains:'CONTAINS'}." }
+        },
+        "required": ["workspace_id", "date_range_start", "date_range_end", "summary_filter"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "https://reports.api.clockify.me/v1/workspaces/{workspace_id}/reports/summary",
+        "bodyMapping": {
+          "dateRangeStart": "$date_range_start",
+          "dateRangeEnd": "$date_range_end",
+          "summaryFilter": "$summary_filter",
+          "users": "$users",
+          "projects": "$projects"
+        }
       }
     }
   ]

--- a/packages/backend/src/adapters/intl/clockify.live.spec.ts
+++ b/packages/backend/src/adapters/intl/clockify.live.spec.ts
@@ -1,12 +1,161 @@
 import * as adapter from './clockify.json';
+import { RestEngine } from '../../connectors/engines/rest.engine';
+import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
+
+/**
+ * Two-tier verification (pattern: pipedrive, weclapp).
+ *
+ *  1. Static — always runs in CI. Asserts the adapter shape matches Clockify
+ *     REST conventions: api.clockify.me/api/v1 base, API_KEY via X-Api-Key,
+ *     the workspace-scoped tool paths, and that the report tools escape to the
+ *     separate reports.api.clockify.me host via absolute URLs.
+ *
+ *  2. Live — opt-in. Runs the REAL RestEngine against production Clockify with
+ *     a real key supplied via env (never committed):
+ *       RUN_CLOCKIFY_LIVE=1 CLOCKIFY_API_KEY=xxx npx jest src/adapters/intl/clockify.live.spec.ts
+ *     Without a key it falls back to a bogus-key edge check (expects 401).
+ */
+
+interface Tool {
+  name: string;
+  endpointMapping: {
+    method: string;
+    path: string;
+    queryParams?: Record<string, string>;
+    bodyMapping?: Record<string, string>;
+  };
+}
+
 const a = adapter as unknown as {
-  connector: { baseUrl: string; authType: string; authConfig: { headerName: string } };
+  slug: string;
+  requiredEnvVars: string[];
+  connector: { baseUrl: string; authType: string; authConfig: Record<string, string> };
+  tools: Tool[];
 };
+
 describe('clockify adapter — static spec conformance', () => {
   it('api.clockify.me/api/v1 base URL', () =>
     expect(a.connector.baseUrl).toBe('https://api.clockify.me/api/v1'));
+
   it('X-Api-Key auth header', () => {
     expect(a.connector.authType).toBe('API_KEY');
     expect(a.connector.authConfig.headerName).toBe('X-Api-Key');
+    expect(a.connector.authConfig.apiKey).toBe('{{CLOCKIFY_API_KEY}}');
+    expect(a.requiredEnvVars).toEqual(['CLOCKIFY_API_KEY']);
   });
+
+  it('exposes the workspace-users tool that custom connectors were missing', () => {
+    const t = a.tools.find((x) => x.name === 'clockify_list_workspace_users');
+    expect(t).toBeDefined();
+    expect(t!.endpointMapping.method).toBe('GET');
+    expect(t!.endpointMapping.path).toBe('/workspaces/{workspace_id}/users');
+  });
+
+  it('covers tasks + create tools', () => {
+    const expected = [
+      ['clockify_find_tasks', 'GET', '/workspaces/{workspace_id}/projects/{project_id}/tasks'],
+      ['clockify_add_task', 'POST', '/workspaces/{workspace_id}/projects/{project_id}/tasks'],
+      ['clockify_add_project', 'POST', '/workspaces/{workspace_id}/projects'],
+      ['clockify_add_client', 'POST', '/workspaces/{workspace_id}/clients'],
+      ['clockify_add_tag', 'POST', '/workspaces/{workspace_id}/tags'],
+    ];
+    for (const [name, method, path] of expected) {
+      const t = a.tools.find((x) => x.name === name);
+      expect(t).toBeDefined();
+      expect(t!.endpointMapping.method).toBe(method);
+      expect(t!.endpointMapping.path).toBe(path);
+    }
+  });
+
+  it('routes report tools to the separate reports.api host via absolute URLs', () => {
+    for (const name of ['clockify_detailed_report', 'clockify_summary_report']) {
+      const t = a.tools.find((x) => x.name === name)!;
+      expect(t).toBeDefined();
+      expect(t.endpointMapping.method).toBe('POST');
+      expect(t.endpointMapping.path.startsWith('https://reports.api.clockify.me/v1/')).toBe(true);
+    }
+  });
+
+  it('ships 18 tools', () => {
+    expect(a.tools.length).toBe(18);
+  });
+});
+
+const live = process.env.RUN_CLOCKIFY_LIVE ? describe : describe.skip;
+
+live('clockify adapter — live (real RestEngine against production)', () => {
+  const oauth = {} as unknown as OAuth2TokenService;
+  const loginToken = {} as unknown as LoginTokenService;
+  const engine = new RestEngine(oauth, loginToken);
+  const apiKey = process.env.CLOCKIFY_API_KEY || 'bogus-key-for-edge-validation';
+  const hasRealKey = !!process.env.CLOCKIFY_API_KEY;
+  const authConfig = { headerName: 'X-Api-Key', apiKey };
+
+  it('GET /user reaches Clockify and (with a real key) returns the profile', async () => {
+    let res: any, err: any;
+    try {
+      res = await engine.execute(
+        { baseUrl: a.connector.baseUrl, authType: 'API_KEY', authConfig },
+        { method: 'GET', path: '/user' },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    if (hasRealKey) {
+      expect(err).toBeUndefined();
+      expect(res.id).toBeDefined();
+      expect(res.activeWorkspace).toBeDefined();
+    } else {
+      expect(err?.response?.status).toBe(401);
+    }
+  }, 30000);
+
+  it('GET workspace users path resolves (the tool Ram needed)', async () => {
+    if (!hasRealKey) return;
+    const me: any = await engine.execute(
+      { baseUrl: a.connector.baseUrl, authType: 'API_KEY', authConfig },
+      { method: 'GET', path: '/user' },
+      {},
+    );
+    const users: any = await engine.execute(
+      { baseUrl: a.connector.baseUrl, authType: 'API_KEY', authConfig },
+      {
+        method: 'GET',
+        path: '/workspaces/{workspace_id}/users',
+        queryParams: { 'page-size': '$page_size' },
+      },
+      { workspace_id: me.activeWorkspace, page_size: 5 },
+    );
+    expect(Array.isArray(users)).toBe(true);
+  }, 30000);
+
+  it('detailed report escapes to reports.api host through the engine', async () => {
+    if (!hasRealKey) return;
+    const me: any = await engine.execute(
+      { baseUrl: a.connector.baseUrl, authType: 'API_KEY', authConfig },
+      { method: 'GET', path: '/user' },
+      {},
+    );
+    const report: any = await engine.execute(
+      { baseUrl: a.connector.baseUrl, authType: 'API_KEY', authConfig },
+      {
+        method: 'POST',
+        path: 'https://reports.api.clockify.me/v1/workspaces/{workspace_id}/reports/detailed',
+        bodyMapping: {
+          dateRangeStart: '$date_range_start',
+          dateRangeEnd: '$date_range_end',
+          detailedFilter: '$detailed_filter',
+        },
+      },
+      {
+        workspace_id: me.activeWorkspace,
+        date_range_start: '2026-05-01T00:00:00.000',
+        date_range_end: '2026-05-31T23:59:59.999',
+        detailed_filter: { page: 1, pageSize: 5 },
+      },
+    );
+    expect(report.totals).toBeDefined();
+  }, 30000);
 });


### PR DESCRIPTION
## Summary

The Clockify pre-built adapter (#236) had 10 tools but was **missing `list workspace users`** — the exact endpoint a Cloud user (ram.ganapathi@fundmore.ai) kept hitting last week, which forced them to roll a broken custom connector (wrong base URL → 404s, visible in production telemetry). This expands the official adapter to **18 tools**.

### Added
- `clockify_list_workspace_users` — `GET /workspaces/{id}/users` (the missing tool)
- `clockify_find_tasks`, `clockify_add_task`
- `clockify_add_project`, `clockify_add_client`, `clockify_add_tag`
- `clockify_detailed_report`, `clockify_summary_report` — hit the **separate Reports host** `reports.api.clockify.me/v1`, handled in-adapter via absolute URLs (the REST engine lets a path starting with `http` escape the connector baseUrl).

### Fixed
- Rate limit corrected to ~10 req/s (was 50)
- Documented archive-before-delete (clients/projects), DONE-before-delete (tasks), regional-host caveat

## Test plan

Verified **live against production Clockify** (real key via env, never committed):
- [x] `npx jest src/adapters/intl/clockify.live.spec.ts` — **9/9 pass** (static + live)
- [x] Live tier runs the real `RestEngine.execute()`: `GET /user`, `GET /workspaces/{id}/users`, `POST` detailed report → confirmed report escapes to `reports.api.clockify.me`
- [x] All 18 endpoints probed against production; create tools tested via create→delete round-trip, zero residue

## Companion
Marketing-site marketplace card + SEO guides in `anythingmcp-website` (separate PR).