### PR TITLE
feat(proxy): per-tool proxy / web-unblocker routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,25 @@ SERVER_URL=http://localhost:4000
 # Max requests per minute per client (by API key or IP). Only enforced when Redis is available.
 MCP_RATE_LIMIT_PER_MINUTE=60
 
+# ── Proxy / Web-Unblocker (optional) ─────────────────────────────────────────
+# When set, tools whose `use_proxy` flag is on route their outbound HTTP
+# request through this proxy. Use a plain rotating proxy for IP/geo/rate-limit
+# cases, or a "web unblocker" (e.g. Zyte API proxy mode) for anti-bot targets
+# like Akamai / Cloudflare / DataDome.
+#
+#   Zyte API proxy mode:  http://<ZYTE_API_KEY>:@api.zyte.com:8011
+#   Generic proxy:        http://user:pass@host:port
+#
+# If unset, the feature is off everywhere: tools that opted in simply make a
+# direct request. Per-tool opt-in is a UI checkbox (shown only when this is
+# set) plus the adapter spec's `useProxy` field.
+# CONNECTOR_PROXY_URL=
+
+# Cloud only: default hourly cap on proxy-routed tool calls PER WORKSPACE.
+# Override per workspace by setting organizations.proxy_rate_limit in the DB
+# (admin-only; there is no API to change it). Defaults to 100 when unset.
+# PROXY_RATE_LIMIT_DEFAULT=100
+
 # ── Operator Analytics (cloud build only — leave empty on self-hosted) ──────
 # Loads Google Tag Manager + a Consent Mode v2 cookie banner. Self-hosted
 # builds must leave both empty so no tracking is shipped to community users.

--- a/docs/connectors/proxy.md
+++ b/docs/connectors/proxy.md
@@ -1,0 +1,91 @@
+# Proxy / Web-Unblocker
+
+Some upstream APIs block server-side requests — by IP reputation, geo, rate
+limits, or full anti-bot systems (Akamai Bot Manager, Cloudflare, DataDome).
+AnythingMCP can route a tool's outbound HTTP request through a proxy or a
+**web unblocker** so those connectors work from your server.
+
+## How it turns on
+
+Three things must line up for a request to be proxied:
+
+1. **`CONNECTOR_PROXY_URL` is set** on the instance (env). If it isn't, the
+   feature is off everywhere — a tool that opted in just makes a direct
+   request (no error).
+2. **The tool opted in** — `mcp_tools.use_proxy = true`. This is seeded from
+   the adapter spec's per-tool `useProxy` (default `false`) and can be toggled
+   per tool in the connector UI (the checkbox only appears when
+   `CONNECTOR_PROXY_URL` is set).
+3. **(Cloud only)** the workspace has an active license/trial and is under its
+   hourly proxy cap (see below). Self-hosted installs have no license gate and
+   no rate limit.
+
+If all three hold, the request goes through the proxy. Otherwise it goes out
+directly.
+
+## Configuring the proxy
+
+```bash
+# Zyte API "proxy mode" — defeats Akamai/Cloudflare/DataDome (recommended for
+# anti-bot targets). The API key is the proxy username, empty password.
+CONNECTOR_PROXY_URL=http://<ZYTE_API_KEY>:@api.zyte.com:8011
+
+# …or any rotating/residential proxy for IP/geo/rate-limit cases:
+CONNECTOR_PROXY_URL=http://user:pass@host:port
+```
+
+The credential lives only in this env var. It is never exposed to the
+frontend (the UI only learns a boolean "available") and never logged.
+
+Implementation note: the engine attaches an `HttpsProxyAgent` with
+`rejectUnauthorized: false`, which is required for unblockers like Zyte that
+intercept TLS.
+
+## Rate limit (cloud)
+
+Each workspace is capped at **`PROXY_RATE_LIMIT_DEFAULT`** proxy-routed tool
+calls per hour (default **100**). Over the cap, a proxied tool call returns an
+explicit error:
+
+> Proxy quota exceeded: this workspace is limited to N proxy/unblocker tool
+> calls per hour. Try again in ~M minute(s), or run this tool without the proxy.
+
+Only requests that actually use the proxy count toward the cap; direct
+requests don't.
+
+To raise or lower a single workspace's cap, a **service admin** sets
+`organizations.proxy_rate_limit` directly in the database — there is
+intentionally **no API** to change it:
+
+```sql
+UPDATE organizations SET proxy_rate_limit = 500 WHERE id = '<org_id>';
+-- NULL → fall back to PROXY_RATE_LIMIT_DEFAULT (or 100 if that is unset)
+```
+
+## Adapter authoring
+
+Set `useProxy: true` on a tool in the adapter JSON to recommend proxy routing
+by default. Use it for anti-bot, geo-restricted, reverse-engineered, or
+rate-limited APIs. Default is `false`.
+
+```jsonc
+{
+  "name": "db_get_departures",
+  "description": "…",
+  "useProxy": true,
+  "endpointMapping": { "method": "GET", "path": "/reiseloesung/abfahrten" }
+}
+```
+
+Adapters shipped with `useProxy: true` today: Deutsche Bahn, Playtomic
+(+ public), Sorare, OpenTable, Resy, Vinted, Untappd, idealista, Trenitalia,
+ImmobilienScout24, Etsy, Mercado Libre.
+
+For GraphQL adapters, if any tool opts in, the auto-injected
+`<slug>_graphql_query` / `_mutation` / `_subscription` helpers inherit the
+proxy preference too.
+
+## Scope
+
+Proxy routing is applied by the **REST** and **GraphQL** engines. SOAP,
+Database, and MCP-bridge connectors ignore the flag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24520,6 +24520,7 @@
         "graphql": "^16.14.0",
         "graphql-request": "^7.1.2",
         "helmet": "^8.1.0",
+        "https-proxy-agent": "^7.0.6",
         "ioredis": "^5.6.0",
         "js-yaml": "^4.1.1",
         "mongodb": "^7.1.0",
@@ -24931,6 +24932,28 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/backend/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/backend/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/backend/node_modules/undici-types": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -52,6 +52,7 @@
     "graphql": "^16.14.0",
     "graphql-request": "^7.1.2",
     "helmet": "^8.1.0",
+    "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.6.0",
     "js-yaml": "^4.1.1",
     "mongodb": "^7.1.0",

--- a/packages/backend/prisma/migrations/20260531100000_add_proxy_support/migration.sql
+++ b/packages/backend/prisma/migrations/20260531100000_add_proxy_support/migration.sql
@@ -1,0 +1,11 @@
+-- Per-tool proxy/unblocker preference. Seeded from the adapter spec on
+-- import; user-toggleable in the UI. No effect when CONNECTOR_PROXY_URL
+-- is unset.
+ALTER TABLE "mcp_tools"
+  ADD COLUMN "use_proxy" BOOLEAN NOT NULL DEFAULT false;
+
+-- Per-workspace hourly cap on proxy-routed tool calls (cloud only).
+-- null = use the PROXY_RATE_LIMIT_DEFAULT env (default 100). Editable
+-- only by a service admin directly in the DB.
+ALTER TABLE "organizations"
+  ADD COLUMN "proxy_rate_limit" INTEGER;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -20,6 +20,12 @@ model Organization {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  // Hourly cap on proxy/unblocker-routed tool calls for this workspace
+  // (cloud only). null = fall back to the PROXY_RATE_LIMIT_DEFAULT env
+  // (which itself defaults to 100). Editable ONLY by a service admin
+  // directly in the DB — there is intentionally no API to change it.
+  proxyRateLimit Int? @map("proxy_rate_limit")
+
   users            User[]
   members          OrganizationMember[]
   connectors       Connector[]
@@ -344,6 +350,13 @@ model McpTool {
   name        String
   description String    @db.Text
   isEnabled   Boolean   @default(true) @map("is_enabled")
+
+  // Route this tool's outbound HTTP request through the configured
+  // proxy / web-unblocker (CONNECTOR_PROXY_URL). Seeded from the
+  // adapter spec's per-tool `useProxy` (default false); the user can
+  // toggle it per tool in the UI. Has no effect when CONNECTOR_PROXY_URL
+  // is unset — the request then goes out directly.
+  useProxy    Boolean   @default(false) @map("use_proxy")
 
   // OpenAPI operationId, when the tool was generated from an OpenAPI spec.
   // Used as the primary key for re-imports so that responseMapping and role

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -98,6 +98,8 @@ export class AdaptersService {
             name: tool.name,
             description: tool.description,
             isEnabled: true,
+            // Seed the proxy preference from the adapter spec (default off).
+            useProxy: tool.useProxy === true,
             parameters: tool.parameters as any,
             endpointMapping: tool.endpointMapping as any,
             responseMapping: tool.responseMapping as any,

--- a/packages/backend/src/adapters/br/mercado-libre.json
+++ b/packages/backend/src/adapters/br/mercado-libre.json
@@ -7,7 +7,10 @@
   "category": "ecommerce",
   "icon": "mercado-libre",
   "docsUrl": "https://developers.mercadolibre.com/en_us/api-docs-en",
-  "requiredEnvVars": ["MERCADO_LIBRE_CLIENT_ID", "MERCADO_LIBRE_CLIENT_SECRET"],
+  "requiredEnvVars": [
+    "MERCADO_LIBRE_CLIENT_ID",
+    "MERCADO_LIBRE_CLIENT_SECRET"
+  ],
   "connector": {
     "name": "Mercado Libre",
     "type": "REST",
@@ -25,6 +28,7 @@
     {
       "name": "mercado_libre_search_items",
       "description": "Search items in a Mercado Libre site (country marketplace). Returns matches with item id (e.g. 'MLB1234567890'), title, price, currency, condition (new/used), thumbnail, seller id, available_quantity, and permalink to the listing.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -49,7 +53,10 @@
             "description": "Offset for pagination (max 1000)."
           }
         },
-        "required": ["site_id", "q"]
+        "required": [
+          "site_id",
+          "q"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -65,6 +72,7 @@
     {
       "name": "mercado_libre_get_item",
       "description": "Fetch full details for a Mercado Libre item by id. Returns title, description, price, currency, listing type, all attributes (brand, model, condition, …), pictures, available_quantity, sold_quantity, warranty, seller_id, and shipping options.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -73,7 +81,9 @@
             "description": "Mercado Libre item id including site prefix (e.g. 'MLB1234567890')."
           }
         },
-        "required": ["item_id"]
+        "required": [
+          "item_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -83,6 +93,7 @@
     {
       "name": "mercado_libre_get_user",
       "description": "Get a user's public profile (typically used to inspect a seller). Returns id, nickname, country_id, registration_date, seller_reputation (level_id, transactions completed/canceled, ratings positive/neutral/negative), and listing site.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -91,7 +102,9 @@
             "description": "Mercado Libre user/seller id (numeric, e.g. '123456789')."
           }
         },
-        "required": ["user_id"]
+        "required": [
+          "user_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -101,6 +114,7 @@
     {
       "name": "mercado_libre_list_orders",
       "description": "List orders for an authenticated seller. Requires an OAuth2 token belonging to the seller. Returns order id, status (paid/cancelled/confirmed), date_created, total amount, buyer summary, order items, and shipping details.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -125,7 +139,9 @@
             "description": "Offset for pagination."
           }
         },
-        "required": ["seller"]
+        "required": [
+          "seller"
+        ]
       },
       "endpointMapping": {
         "method": "GET",

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -216,6 +216,11 @@ export interface AdapterDefinition extends AdapterMeta {
     parameters: Record<string, unknown>;
     endpointMapping: Record<string, unknown>;
     responseMapping?: Record<string, unknown>;
+    // Adapter author's recommendation to route this tool through the
+    // proxy / web-unblocker by default (anti-bot, geo, or rate-limited
+    // APIs). Default false. Seeds mcp_tools.use_proxy on import; the user
+    // can still toggle it per tool afterwards.
+    useProxy?: boolean;
   }>;
 }
 
@@ -237,11 +242,17 @@ export interface AdapterDefinition extends AdapterMeta {
  */
 function withGraphqlBuiltins(adapter: AdapterDefinition): AdapterDefinition {
   if (adapter.connector.type !== 'GRAPHQL') return adapter;
+  // If the adapter's own tools opt into the proxy, the generic
+  // query/mutation helpers should too (same upstream host, same anti-bot).
+  const adapterUsesProxy = adapter.tools.some(
+    (t) => (t as { useProxy?: boolean }).useProxy === true,
+  );
   const builtins = buildGraphqlBuiltinTools({
     prefix: adapter.slug,
     displayName: adapter.name,
     baseUrl: adapter.connector.baseUrl,
     schemaUrl: (adapter.connector as { schemaUrl?: string }).schemaUrl,
+    useProxy: adapterUsesProxy,
   }) as unknown as AdapterDefinition['tools'];
 
   return { ...adapter, tools: [...builtins, ...adapter.tools] };

--- a/packages/backend/src/adapters/de/deutsche-bahn.json
+++ b/packages/backend/src/adapters/de/deutsche-bahn.json
@@ -22,6 +22,7 @@
     {
       "name": "db_search_locations",
       "description": "Search Deutsche Bahn stops/stations by name. Returns an array of matches, each with `extId` (the stable IBNR id used everywhere else), `name`, `lat`, `lon`, and `products` (list of services that call at this stop: ICE, EC_IC, IR, REGIONAL, SBAHN, BUS, TRAM, …). Use the returned `extId` as the `id` parameter for db_get_departures, db_get_arrivals, db_get_stop, and as `from`/`to` for db_get_journeys.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -35,7 +36,9 @@
             "default": 10
           }
         },
-        "required": ["query"]
+        "required": [
+          "query"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -50,6 +53,7 @@
     {
       "name": "db_get_stop",
       "description": "Retrieve a single Deutsche Bahn stop by its `extId` (IBNR), returning `name`, `lat`, `lon`, and the list of `products` that call there (ICE, EC_IC, IR, REGIONAL, SBAHN, BUS, TRAM, …). Useful when you already have the id but need the station metadata.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -58,7 +62,9 @@
             "description": "The stop's IBNR / extId from db_search_locations (e.g. '8000105' = Frankfurt(Main)Hbf, '8000107' = Freiburg(Breisgau) Hbf, '8011160' = Berlin Hbf)."
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -72,6 +78,7 @@
     {
       "name": "db_get_departures",
       "description": "List upcoming departures from a DB stop with live delays. Returns `entries[]` — each entry has `journeyId` (use with `db_get_journey_detail`-equivalent), `zeit` (planned ISO time), `ezZeit` (real/estimated time if delayed), `gleis` (platform), `terminus` (direction = where the train is heading), `verkehrmittel` (line info: name, product type, line number), and `meldungen` (disruption messages, if any). If `ezZeit` is absent the train is on time. Delay in seconds = `(ezZeit - zeit)`.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -88,7 +95,9 @@
             "description": "Optional reference time in HH:mm format (local Berlin time, 24h). Omit for 'now'. Example: '08:30'."
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -103,6 +112,7 @@
     {
       "name": "db_get_arrivals",
       "description": "List upcoming arrivals at a DB stop with live delays. Same response shape as db_get_departures (`entries[]`), but each entry's `terminus` is the train's *origin* and `zeit`/`ezZeit` are arrival times.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -119,7 +129,9 @@
             "description": "Optional reference time in HH:mm format (local Berlin time, 24h). Omit for 'now'."
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -134,6 +146,7 @@
     {
       "name": "db_get_journeys",
       "description": "Plan one or more itineraries between two DB stops. Returns `verbindungen[]` — each itinerary has `verbindungsAbschnitte[]` (the legs), `tripId`, and `ctxRecon` (opaque continuation token). Each leg includes `startHalt`/`zielHalt` (`extId`, `name`, `abfahrt.sollzeit`/`istzeit`, `ankunft.sollzeit`/`istzeit`, `gleis`), `verkehrsmittel` (line name, product, kategorie), `risNotizen`/`himMeldungen` (alerts), and `halte[]` (intermediate stops, when available). Use `extId` (IBNR) for `from` and `to`. The `when` parameter is the departure or arrival time depending on `direction`.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -151,7 +164,10 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["ABFAHRT", "ANKUNFT"],
+            "enum": [
+              "ABFAHRT",
+              "ANKUNFT"
+            ],
             "description": "ABFAHRT = depart-at (default) — when is the departure time. ANKUNFT = arrive-by — when is the latest acceptable arrival time.",
             "default": "ABFAHRT"
           },
@@ -166,7 +182,11 @@
             "default": false
           }
         },
-        "required": ["from", "to", "when"]
+        "required": [
+          "from",
+          "to",
+          "when"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -182,7 +202,18 @@
           "sitzplatzOnly": false,
           "deutschlandTicketVorhanden": false,
           "nurDeutschlandTicketVerbindungen": false,
-          "produktgattungen": ["ICE", "EC_IC", "IR", "REGIONAL", "SBAHN", "BUS", "SCHIFF", "UBAHN", "TRAM", "ANRUFPFLICHTIG"],
+          "produktgattungen": [
+            "ICE",
+            "EC_IC",
+            "IR",
+            "REGIONAL",
+            "SBAHN",
+            "BUS",
+            "SCHIFF",
+            "UBAHN",
+            "TRAM",
+            "ANRUFPFLICHTIG"
+          ],
           "klasse": "KLASSE_2",
           "reisende": [
             {
@@ -190,7 +221,10 @@
               "anzahl": 1,
               "alter": [],
               "ermaessigungen": [
-                { "art": "KEINE_ERMAESSIGUNG", "klasse": "KLASSENLOS" }
+                {
+                  "art": "KEINE_ERMAESSIGUNG",
+                  "klasse": "KLASSENLOS"
+                }
               ]
             }
           ]

--- a/packages/backend/src/adapters/de/immobilienscout24.json
+++ b/packages/backend/src/adapters/de/immobilienscout24.json
@@ -26,6 +26,7 @@
     {
       "name": "is24_search_properties",
       "description": "Search for real estate listings on ImmobilienScout24 by location and filters. Returns property titles, prices, sizes, and listing IDs.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -84,6 +85,7 @@
     {
       "name": "is24_search_locations",
       "description": "Search for ImmobilienScout24 GeoCode IDs by location name. Use this to find the geocode parameter needed for property searches.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -110,6 +112,7 @@
     {
       "name": "is24_get_property",
       "description": "Get detailed information about a specific real estate listing by its expose ID. Returns full property details including description, equipment, energy certificate, and contact info.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {

--- a/packages/backend/src/adapters/intl/etsy.json
+++ b/packages/backend/src/adapters/intl/etsy.json
@@ -7,7 +7,11 @@
   "category": "e-commerce",
   "icon": "etsy",
   "docsUrl": "https://developers.etsy.com/documentation/",
-  "requiredEnvVars": ["ETSY_CLIENT_ID", "ETSY_CLIENT_SECRET", "ETSY_REFRESH_TOKEN"],
+  "requiredEnvVars": [
+    "ETSY_CLIENT_ID",
+    "ETSY_CLIENT_SECRET",
+    "ETSY_REFRESH_TOKEN"
+  ],
   "connector": {
     "name": "Etsy Open API v3",
     "type": "REST",
@@ -28,47 +32,93 @@
     {
       "name": "etsy_get_authenticated_user",
       "description": "Return the user the OAuth token belongs to. Returns user_id, login_name, primary_email.",
-      "parameters": { "type": "object", "properties": {} },
-      "endpointMapping": { "method": "GET", "path": "/users/me" }
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/users/me"
+      }
     },
     {
       "name": "etsy_get_user_shops",
       "description": "List shops owned by the user. Returns shop_id, shop_name, currency_code, languages, login_name, last_updated_tsz, listing_active_count.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "user_id": { "type": "integer", "description": "User ID." }
+          "user_id": {
+            "type": "integer",
+            "description": "User ID."
+          }
         },
-        "required": ["user_id"]
+        "required": [
+          "user_id"
+        ]
       },
-      "endpointMapping": { "method": "GET", "path": "/users/{user_id}/shops" }
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/users/{user_id}/shops"
+      }
     },
     {
       "name": "etsy_get_shop",
       "description": "Fetch one shop by shop_id with full details (announcement, sale message, etc.).",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "shop_id": { "type": "integer", "description": "Shop ID." }
+          "shop_id": {
+            "type": "integer",
+            "description": "Shop ID."
+          }
         },
-        "required": ["shop_id"]
+        "required": [
+          "shop_id"
+        ]
       },
-      "endpointMapping": { "method": "GET", "path": "/shops/{shop_id}" }
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/shops/{shop_id}"
+      }
     },
     {
       "name": "etsy_get_shop_listings_active",
       "description": "List active listings in a shop.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "shop_id": { "type": "integer", "description": "Shop ID." },
-          "limit": { "type": "integer", "description": "Per page (max 100)." },
-          "offset": { "type": "integer", "description": "Pagination offset." },
-          "sort_on": { "type": "string", "description": "created, price, updated, score." },
-          "sort_order": { "type": "string", "description": "asc, ascending, desc, descending, up, down." },
-          "keywords": { "type": "string", "description": "Substring search on title." }
+          "shop_id": {
+            "type": "integer",
+            "description": "Shop ID."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Per page (max 100)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Pagination offset."
+          },
+          "sort_on": {
+            "type": "string",
+            "description": "created, price, updated, score."
+          },
+          "sort_order": {
+            "type": "string",
+            "description": "asc, ascending, desc, descending, up, down."
+          },
+          "keywords": {
+            "type": "string",
+            "description": "Substring search on title."
+          }
         },
-        "required": ["shop_id"]
+        "required": [
+          "shop_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -85,39 +135,86 @@
     {
       "name": "etsy_get_listing",
       "description": "Fetch one listing by listing_id with full details.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "listing_id": { "type": "integer", "description": "Listing ID." },
-          "includes": { "type": "string", "description": "Comma-separated: Shipping, Images, Shop, User, Translations, Inventory, Videos." }
+          "listing_id": {
+            "type": "integer",
+            "description": "Listing ID."
+          },
+          "includes": {
+            "type": "string",
+            "description": "Comma-separated: Shipping, Images, Shop, User, Translations, Inventory, Videos."
+          }
         },
-        "required": ["listing_id"]
+        "required": [
+          "listing_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/listings/{listing_id}",
-        "queryParams": { "includes": "$includes" }
+        "queryParams": {
+          "includes": "$includes"
+        }
       }
     },
     {
       "name": "etsy_get_shop_receipts",
       "description": "List orders (receipts) for the shop.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "shop_id": { "type": "integer", "description": "Shop ID." },
-          "min_created": { "type": "integer", "description": "Unix timestamp." },
-          "max_created": { "type": "integer", "description": "Unix timestamp." },
-          "min_last_modified": { "type": "integer", "description": "Unix timestamp." },
-          "max_last_modified": { "type": "integer", "description": "Unix timestamp." },
-          "limit": { "type": "integer", "description": "Per page (max 100)." },
-          "offset": { "type": "integer", "description": "Offset." },
-          "sort_on": { "type": "string", "description": "created, updated, receipt_id." },
-          "sort_order": { "type": "string", "description": "asc, desc." },
-          "was_paid": { "type": "boolean", "description": "Filter paid status." },
-          "was_shipped": { "type": "boolean", "description": "Filter shipped status." }
+          "shop_id": {
+            "type": "integer",
+            "description": "Shop ID."
+          },
+          "min_created": {
+            "type": "integer",
+            "description": "Unix timestamp."
+          },
+          "max_created": {
+            "type": "integer",
+            "description": "Unix timestamp."
+          },
+          "min_last_modified": {
+            "type": "integer",
+            "description": "Unix timestamp."
+          },
+          "max_last_modified": {
+            "type": "integer",
+            "description": "Unix timestamp."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Per page (max 100)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset."
+          },
+          "sort_on": {
+            "type": "string",
+            "description": "created, updated, receipt_id."
+          },
+          "sort_order": {
+            "type": "string",
+            "description": "asc, desc."
+          },
+          "was_paid": {
+            "type": "boolean",
+            "description": "Filter paid status."
+          },
+          "was_shipped": {
+            "type": "boolean",
+            "description": "Filter shipped status."
+          }
         },
-        "required": ["shop_id"]
+        "required": [
+          "shop_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -139,13 +236,23 @@
     {
       "name": "etsy_get_shop_receipt",
       "description": "Fetch one receipt with buyer info, transactions[], shipping address.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "shop_id": { "type": "integer", "description": "Shop ID." },
-          "receipt_id": { "type": "integer", "description": "Receipt ID." }
+          "shop_id": {
+            "type": "integer",
+            "description": "Shop ID."
+          },
+          "receipt_id": {
+            "type": "integer",
+            "description": "Receipt ID."
+          }
         },
-        "required": ["shop_id", "receipt_id"]
+        "required": [
+          "shop_id",
+          "receipt_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -155,15 +262,30 @@
     {
       "name": "etsy_get_shop_reviews",
       "description": "List reviews (transactions with feedback) for the shop.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "shop_id": { "type": "integer", "description": "Shop ID." },
-          "limit": { "type": "integer", "description": "Per page." },
-          "offset": { "type": "integer", "description": "Offset." },
-          "min_created": { "type": "integer", "description": "Unix timestamp lower bound." }
+          "shop_id": {
+            "type": "integer",
+            "description": "Shop ID."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Per page."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset."
+          },
+          "min_created": {
+            "type": "integer",
+            "description": "Unix timestamp lower bound."
+          }
         },
-        "required": ["shop_id"]
+        "required": [
+          "shop_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -178,15 +300,31 @@
     {
       "name": "etsy_get_listings_by_shop_section",
       "description": "List listings filtered by a shop section.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "shop_id": { "type": "integer", "description": "Shop ID." },
-          "shop_section_ids": { "type": "string", "description": "Comma-separated section IDs." },
-          "limit": { "type": "integer", "description": "Per page." },
-          "offset": { "type": "integer", "description": "Offset." }
+          "shop_id": {
+            "type": "integer",
+            "description": "Shop ID."
+          },
+          "shop_section_ids": {
+            "type": "string",
+            "description": "Comma-separated section IDs."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Per page."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset."
+          }
         },
-        "required": ["shop_id", "shop_section_ids"]
+        "required": [
+          "shop_id",
+          "shop_section_ids"
+        ]
       },
       "endpointMapping": {
         "method": "GET",

--- a/packages/backend/src/adapters/intl/idealista.json
+++ b/packages/backend/src/adapters/intl/idealista.json
@@ -21,21 +21,61 @@
     {
       "name": "idealista_search",
       "description": "Search Idealista listings with filters. Returns paginated results with listing id, price, m², rooms, address, photos, energy class.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it", "description": "Market locale." },
-          "operation": { "type": "string", "enum": ["sale", "rent"], "default": "sale" },
-          "propertyType": { "type": "string", "description": "homes, garages, premises, offices, lands, storages." },
-          "locationId": { "type": "string", "description": "Idealista location code (use `idealista_search_locations` to discover)." },
-          "minPrice": { "type": "number" },
-          "maxPrice": { "type": "number" },
-          "minSize": { "type": "number", "description": "Minimum square meters." },
-          "maxSize": { "type": "number" },
-          "rooms": { "type": "integer", "description": "Minimum number of rooms." },
-          "page": { "type": "integer", "default": 1 }
+          "locale": {
+            "type": "string",
+            "enum": [
+              "it",
+              "es",
+              "pt"
+            ],
+            "default": "it",
+            "description": "Market locale."
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "sale",
+              "rent"
+            ],
+            "default": "sale"
+          },
+          "propertyType": {
+            "type": "string",
+            "description": "homes, garages, premises, offices, lands, storages."
+          },
+          "locationId": {
+            "type": "string",
+            "description": "Idealista location code (use `idealista_search_locations` to discover)."
+          },
+          "minPrice": {
+            "type": "number"
+          },
+          "maxPrice": {
+            "type": "number"
+          },
+          "minSize": {
+            "type": "number",
+            "description": "Minimum square meters."
+          },
+          "maxSize": {
+            "type": "number"
+          },
+          "rooms": {
+            "type": "integer",
+            "description": "Minimum number of rooms."
+          },
+          "page": {
+            "type": "integer",
+            "default": 1
+          }
         },
-        "required": ["locale"]
+        "required": [
+          "locale"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -56,13 +96,28 @@
     {
       "name": "idealista_get_listing",
       "description": "Full detail of one Idealista listing by ID — full description, all photos, agency, contact, geocoordinate, energy class, characteristics.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it" },
-          "listing_id": { "type": "integer", "description": "Idealista listing ID." }
+          "locale": {
+            "type": "string",
+            "enum": [
+              "it",
+              "es",
+              "pt"
+            ],
+            "default": "it"
+          },
+          "listing_id": {
+            "type": "integer",
+            "description": "Idealista listing ID."
+          }
         },
-        "required": ["locale", "listing_id"]
+        "required": [
+          "locale",
+          "listing_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -72,35 +127,86 @@
     {
       "name": "idealista_search_locations",
       "description": "Search for Idealista location IDs (cities, neighborhoods, districts). Required to filter by area in `idealista_search`.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it" },
-          "query": { "type": "string", "description": "Location text (e.g. 'Navigli', 'Salamanca', 'Lisboa Centro')." }
+          "locale": {
+            "type": "string",
+            "enum": [
+              "it",
+              "es",
+              "pt"
+            ],
+            "default": "it"
+          },
+          "query": {
+            "type": "string",
+            "description": "Location text (e.g. 'Navigli', 'Salamanca', 'Lisboa Centro')."
+          }
         },
-        "required": ["locale", "query"]
+        "required": [
+          "locale",
+          "query"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/api/3/{locale}/locations",
-        "queryParams": { "q": "$query" }
+        "queryParams": {
+          "q": "$query"
+        }
       }
     },
     {
       "name": "idealista_map_search",
       "description": "Search Idealista listings within a geo bounding box (map-driven search). Returns clusters and individual listings.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "locale": { "type": "string", "enum": ["it", "es", "pt"], "default": "it" },
-          "north": { "type": "number", "description": "Northern latitude of bounding box." },
-          "south": { "type": "number" },
-          "east": { "type": "number" },
-          "west": { "type": "number" },
-          "operation": { "type": "string", "enum": ["sale", "rent"], "default": "sale" },
-          "propertyType": { "type": "string", "default": "homes" }
+          "locale": {
+            "type": "string",
+            "enum": [
+              "it",
+              "es",
+              "pt"
+            ],
+            "default": "it"
+          },
+          "north": {
+            "type": "number",
+            "description": "Northern latitude of bounding box."
+          },
+          "south": {
+            "type": "number"
+          },
+          "east": {
+            "type": "number"
+          },
+          "west": {
+            "type": "number"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "sale",
+              "rent"
+            ],
+            "default": "sale"
+          },
+          "propertyType": {
+            "type": "string",
+            "default": "homes"
+          }
         },
-        "required": ["locale", "north", "south", "east", "west"]
+        "required": [
+          "locale",
+          "north",
+          "south",
+          "east",
+          "west"
+        ]
       },
       "endpointMapping": {
         "method": "POST",

--- a/packages/backend/src/adapters/intl/opentable.json
+++ b/packages/backend/src/adapters/intl/opentable.json
@@ -21,24 +21,59 @@
     {
       "name": "opentable_search_restaurants",
       "description": "Search OpenTable restaurants near a coordinate, with optional filters for party size, date/time, cuisine, and price. Returns a ranked list of restaurants with id, name, cuisine, neighborhood, price band, and ratings.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "latitude": { "type": "number", "description": "Center latitude (e.g. 48.0707)" },
-          "longitude": { "type": "number", "description": "Center longitude (e.g. 7.8674)" },
-          "covers": { "type": "integer", "description": "Party size (1-12).", "default": 2, "minimum": 1, "maximum": 12 },
-          "dateTime": { "type": "string", "description": "Naive ISO-8601 local time, e.g. '2026-05-24T19:30'. If omitted, uses 'now'." },
-          "leadTime": { "type": "integer", "description": "Days ahead to allow (default 14).", "default": 14 },
-          "size": { "type": "integer", "description": "Max restaurants to return (default 30).", "default": 30, "minimum": 1, "maximum": 100 },
-          "cuisine": { "type": "string", "description": "Optional cuisine filter (e.g. 'Italian', 'French', 'Japanese')." }
+          "latitude": {
+            "type": "number",
+            "description": "Center latitude (e.g. 48.0707)"
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Center longitude (e.g. 7.8674)"
+          },
+          "covers": {
+            "type": "integer",
+            "description": "Party size (1-12).",
+            "default": 2,
+            "minimum": 1,
+            "maximum": 12
+          },
+          "dateTime": {
+            "type": "string",
+            "description": "Naive ISO-8601 local time, e.g. '2026-05-24T19:30'. If omitted, uses 'now'."
+          },
+          "leadTime": {
+            "type": "integer",
+            "description": "Days ahead to allow (default 14).",
+            "default": 14
+          },
+          "size": {
+            "type": "integer",
+            "description": "Max restaurants to return (default 30).",
+            "default": 30,
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cuisine": {
+            "type": "string",
+            "description": "Optional cuisine filter (e.g. 'Italian', 'French', 'Japanese')."
+          }
         },
-        "required": ["latitude", "longitude"]
+        "required": [
+          "latitude",
+          "longitude"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
         "path": "/api/v5/personalize/search/1",
         "bodyMapping": {
-          "location": { "latitude": "$latitude", "longitude": "$longitude" },
+          "location": {
+            "latitude": "$latitude",
+            "longitude": "$longitude"
+          },
           "covers": "$covers",
           "dateTime": "$dateTime",
           "leadTime": "$leadTime",
@@ -54,12 +89,18 @@
     {
       "name": "opentable_get_restaurant",
       "description": "Full detail of one OpenTable restaurant — name, address, cuisine, hours, menu URL, photos, reviews summary, price band, dress code, parking, neighborhood.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "restaurant_id": { "type": "integer", "description": "OpenTable restaurant ID (numeric, e.g. 12213). Get it from `opentable_search_restaurants`." }
+          "restaurant_id": {
+            "type": "integer",
+            "description": "OpenTable restaurant ID (numeric, e.g. 12213). Get it from `opentable_search_restaurants`."
+          }
         },
-        "required": ["restaurant_id"]
+        "required": [
+          "restaurant_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -69,14 +110,28 @@
     {
       "name": "opentable_check_availability",
       "description": "Check live table availability at one or more OpenTable restaurants for a given party size and date/time. Returns time slots available with their booking URL.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "restaurant_id": { "type": "integer", "description": "Restaurant ID." },
-          "covers": { "type": "integer", "description": "Party size.", "default": 2 },
-          "dateTime": { "type": "string", "description": "Naive ISO-8601, e.g. '2026-05-24T19:30'." }
+          "restaurant_id": {
+            "type": "integer",
+            "description": "Restaurant ID."
+          },
+          "covers": {
+            "type": "integer",
+            "description": "Party size.",
+            "default": 2
+          },
+          "dateTime": {
+            "type": "string",
+            "description": "Naive ISO-8601, e.g. '2026-05-24T19:30'."
+          }
         },
-        "required": ["restaurant_id", "dateTime"]
+        "required": [
+          "restaurant_id",
+          "dateTime"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
@@ -91,21 +146,36 @@
     {
       "name": "opentable_autocomplete",
       "description": "Autocomplete restaurant or location names. Useful before search — when the user says 'find me a sushi place in Mayfair', resolve 'Mayfair' to a coordinate first.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "query": { "type": "string", "description": "Partial restaurant or location name." },
-          "latitude": { "type": "number", "description": "User location latitude for ranking." },
-          "longitude": { "type": "number", "description": "User location longitude for ranking." }
+          "query": {
+            "type": "string",
+            "description": "Partial restaurant or location name."
+          },
+          "latitude": {
+            "type": "number",
+            "description": "User location latitude for ranking."
+          },
+          "longitude": {
+            "type": "number",
+            "description": "User location longitude for ranking."
+          }
         },
-        "required": ["query"]
+        "required": [
+          "query"
+        ]
       },
       "endpointMapping": {
         "method": "PUT",
         "path": "/api/v4/personalize/autocompleteInterspersed",
         "bodyMapping": {
           "query": "$query",
-          "location": { "latitude": "$latitude", "longitude": "$longitude" }
+          "location": {
+            "latitude": "$latitude",
+            "longitude": "$longitude"
+          }
         }
       }
     }

--- a/packages/backend/src/adapters/intl/playtomic-public.json
+++ b/packages/backend/src/adapters/intl/playtomic-public.json
@@ -21,6 +21,7 @@
     {
       "name": "playtomic_search_tenants",
       "description": "Search Playtomic clubs (tenants) — typically by geo coordinate + radius. Returns active clubs with their courts (`resources[]`), address, timezone, and images. Use this first to find clubs near a city, then pass the `tenant_id` values into `playtomic_get_availability` to check free slots.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -35,7 +36,11 @@
           },
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "description": "Sport filter. Most clubs are PADEL."
           },
           "size": {
@@ -51,7 +56,9 @@
             "default": 0
           }
         },
-        "required": ["coordinate"]
+        "required": [
+          "coordinate"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -69,6 +76,7 @@
     {
       "name": "playtomic_get_tenant",
       "description": "Get full detail of a single Playtomic club by `tenant_id` — including all courts (`resources[]` with indoor/outdoor, single/double, surface), opening info, contact, gallery. Use this after `playtomic_search_tenants` to drill into a specific club, or to enrich availability results (join `availability.resource_id` → `tenant.resources[].name`).",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -77,7 +85,9 @@
             "description": "Tenant UUID from `playtomic_search_tenants` (e.g. `7176a7b5-757e-46c0-8f04-e42ff7219563`)."
           }
         },
-        "required": ["tenant_id"]
+        "required": [
+          "tenant_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -87,12 +97,17 @@
     {
       "name": "playtomic_get_availability",
       "description": "Read free court slots for a given day at one or more clubs. Returns an array, one entry per court (`resource_id`), each with `slots[]` of `{ start_time, duration (min), price (string like \"48 EUR\") }`. The same `start_time` may appear with multiple durations (60/90/120) — those are alternative bookings, not separate slots.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "description": "Sport.",
             "default": "PADEL"
           },
@@ -109,7 +124,11 @@
             "description": "Naive ISO-8601 upper bound, same-day end e.g. `2026-05-23T23:59:59`."
           }
         },
-        "required": ["tenant_id", "local_start_min", "local_start_max"]
+        "required": [
+          "tenant_id",
+          "local_start_min",
+          "local_start_max"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -125,6 +144,7 @@
     {
       "name": "playtomic_get_sport_configuration",
       "description": "Read Playtomic's canonical sport configuration — enums for allowed durations, court properties (indoor/outdoor/roofed, single/double, wall/crystal/panoramic), and supported sports. Useful to validate filters before calling other tools.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {}

--- a/packages/backend/src/adapters/intl/playtomic.json
+++ b/packages/backend/src/adapters/intl/playtomic.json
@@ -9,7 +9,10 @@
   "docsUrl": "https://playtomic.io",
   "featured": true,
   "priority": 90,
-  "requiredEnvVars": ["PLAYTOMIC_EMAIL", "PLAYTOMIC_PASSWORD"],
+  "requiredEnvVars": [
+    "PLAYTOMIC_EMAIL",
+    "PLAYTOMIC_PASSWORD"
+  ],
   "connector": {
     "name": "Playtomic",
     "type": "REST",
@@ -19,7 +22,9 @@
       "loginUrl": "https://app.playtomic.io/api/v3/auth/login",
       "loginMethod": "POST",
       "loginBody": {
-        "requested_user_roles": ["ROLE_CUSTOMER"],
+        "requested_user_roles": [
+          "ROLE_CUSTOMER"
+        ],
         "email": "${username}",
         "password": "${password}"
       },
@@ -38,6 +43,7 @@
     {
       "name": "playtomic_search_tenants",
       "description": "Search Playtomic clubs (tenants) — typically by geo coordinate + radius. Returns active clubs with their courts (`resources[]`), address, timezone, images. Use this first to find clubs near a city; pass `tenant_id` values into `playtomic_get_availability` to check free slots.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -52,7 +58,11 @@
           },
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "description": "Sport filter."
           },
           "size": {
@@ -68,7 +78,9 @@
             "default": 0
           }
         },
-        "required": ["coordinate"]
+        "required": [
+          "coordinate"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -86,12 +98,18 @@
     {
       "name": "playtomic_get_tenant",
       "description": "Get full detail of a single Playtomic club by `tenant_id` (UUID) — including all courts, opening info, contact, gallery. Use after `playtomic_search_tenants` or to join availability rows to court metadata.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "tenant_id": { "type": "string", "description": "Tenant UUID." }
+          "tenant_id": {
+            "type": "string",
+            "description": "Tenant UUID."
+          }
         },
-        "required": ["tenant_id"]
+        "required": [
+          "tenant_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -101,12 +119,17 @@
     {
       "name": "playtomic_get_availability",
       "description": "Read free court slots for a given day at one or more clubs. With this connector pricing reflects your account (member discounts if any). Returns an array, one entry per court, each with `slots[]` of `{ start_time, duration (min), price (string e.g. \"48 EUR\") }`.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "default": "PADEL"
           },
           "tenant_id": {
@@ -122,7 +145,11 @@
             "description": "Naive ISO-8601 upper bound, e.g. `2026-05-23T23:59:59`."
           }
         },
-        "required": ["tenant_id", "local_start_min", "local_start_max"]
+        "required": [
+          "tenant_id",
+          "local_start_min",
+          "local_start_max"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -139,18 +166,33 @@
     {
       "name": "playtomic_get_sport_configuration",
       "description": "Read Playtomic's canonical sport configuration — enums for allowed durations, court properties (indoor/outdoor/roofed, single/double, wall/crystal/panoramic), supported sports. Reference data; rarely changes.",
-      "parameters": { "type": "object", "properties": {} },
-      "endpointMapping": { "method": "GET", "path": "/api/v2/configuration" }
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v2/configuration"
+      }
     },
     {
       "name": "playtomic_get_my_profile",
       "description": "Full profile of the authenticated user — name, email, phone, communications language, `linked_accounts` per club, accepted commercial/privacy flags. Useful as a health check.",
-      "parameters": { "type": "object", "properties": {} },
-      "endpointMapping": { "method": "GET", "path": "/api/v2/users/me" }
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v2/users/me"
+      }
     },
     {
       "name": "playtomic_get_my_level",
       "description": "Your Playtomic skill level per sport — `level_value` (typically 0–7), `level_confidence` (matches-based confidence), `status`. Pass `with_history=true` to include historical level changes.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -173,12 +215,17 @@
     {
       "name": "playtomic_get_my_stats",
       "description": "Lifetime match results for the authenticated user in a given sport — `played`, `won`, `lost`, `drawn`, `validating`, `rejected`.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "default": "PADEL"
           }
         }
@@ -195,12 +242,17 @@
     {
       "name": "playtomic_get_top_clubs",
       "description": "Clubs where the authenticated user plays most often (all-time or last 3 months). Returns `[{ tenant_id, count }]` ordered by frequency. Enrich with `playtomic_get_tenant` to get names.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "default": "PADEL"
           },
           "size": {
@@ -228,6 +280,7 @@
     {
       "name": "playtomic_find_open_matches",
       "description": "Search open matches in a date window (people looking for partners). Filter by `match_status` and `join_request_status`. Useful with phrases like 'show me open padel matches this weekend at my level'.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -252,7 +305,10 @@
             "maximum": 100
           }
         },
-        "required": ["after_end_date", "before_end_date"]
+        "required": [
+          "after_end_date",
+          "before_end_date"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -270,12 +326,18 @@
     {
       "name": "playtomic_get_match",
       "description": "Full detail of a single match by `match_id` — teams, players, location/tenant, lock_id, status.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "match_id": { "type": "string", "description": "Match UUID." }
+          "match_id": {
+            "type": "string",
+            "description": "Match UUID."
+          }
         },
-        "required": ["match_id"]
+        "required": [
+          "match_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -285,6 +347,7 @@
     {
       "name": "playtomic_match_recommendations",
       "description": "Playtomic's algorithmic match recommendations for the authenticated user, given a geo center. Returns open matches at the user's level near the coordinate. Empty array = no recommendations right now.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -299,9 +362,14 @@
             "minimum": 1,
             "maximum": 50
           },
-          "page": { "type": "integer", "default": 0 }
+          "page": {
+            "type": "integer",
+            "default": 0
+          }
         },
-        "required": ["coordinate"]
+        "required": [
+          "coordinate"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -318,6 +386,7 @@
     {
       "name": "playtomic_list_tournaments",
       "description": "List tournaments visible to the authenticated user, filtered by start date and status.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -330,9 +399,14 @@
             "description": "Comma-separated statuses.",
             "default": "PENDING,IN_PROGRESS"
           },
-          "size": { "type": "integer", "default": 20 }
+          "size": {
+            "type": "integer",
+            "default": 20
+          }
         },
-        "required": ["to_start_date"]
+        "required": [
+          "to_start_date"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -349,23 +423,39 @@
     {
       "name": "playtomic_list_leagues",
       "description": "List open leagues near a coordinate, optionally for a sport and skill level.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "coordinate": { "type": "string", "description": "`lat,lon`." },
-          "radius": { "type": "integer", "default": 50000 },
+          "coordinate": {
+            "type": "string",
+            "description": "`lat,lon`."
+          },
+          "radius": {
+            "type": "integer",
+            "default": 50000
+          },
           "sport_id": {
             "type": "string",
-            "enum": ["PADEL", "TENNIS", "FUTSAL"],
+            "enum": [
+              "PADEL",
+              "TENNIS",
+              "FUTSAL"
+            ],
             "default": "PADEL"
           },
           "for_level": {
             "type": "number",
             "description": "Your level (e.g. 3.5) — Playtomic filters leagues you're eligible for."
           },
-          "size": { "type": "integer", "default": 10 }
+          "size": {
+            "type": "integer",
+            "default": 10
+          }
         },
-        "required": ["coordinate"]
+        "required": [
+          "coordinate"
+        ]
       },
       "endpointMapping": {
         "method": "GET",

--- a/packages/backend/src/adapters/intl/resy.json
+++ b/packages/backend/src/adapters/intl/resy.json
@@ -21,41 +21,94 @@
     {
       "name": "resy_search_venues",
       "description": "Geo search Resy venues near a coordinate, with optional party size and date filters. Returns venues with id, name, neighborhood, cuisine, price band, and available time slots.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "latitude": { "type": "number", "description": "Search center latitude." },
-          "longitude": { "type": "number", "description": "Search center longitude." },
-          "party_size": { "type": "integer", "description": "Party size.", "default": 2, "minimum": 1, "maximum": 20 },
-          "day": { "type": "string", "description": "Date in YYYY-MM-DD, e.g. '2026-05-24'." }
+          "latitude": {
+            "type": "number",
+            "description": "Search center latitude."
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Search center longitude."
+          },
+          "party_size": {
+            "type": "integer",
+            "description": "Party size.",
+            "default": 2,
+            "minimum": 1,
+            "maximum": 20
+          },
+          "day": {
+            "type": "string",
+            "description": "Date in YYYY-MM-DD, e.g. '2026-05-24'."
+          }
         },
-        "required": ["latitude", "longitude"]
+        "required": [
+          "latitude",
+          "longitude"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
         "path": "/3/venuesearch/search",
         "bodyMapping": {
-          "venue_filter": { "venue_id": [] },
+          "venue_filter": {
+            "venue_id": []
+          },
           "availability": true,
-          "slot_filter": { "party_size": "$party_size", "day": "$day" },
-          "geo": { "user": { "latitude": "$latitude", "longitude": "$longitude" } }
+          "slot_filter": {
+            "party_size": "$party_size",
+            "day": "$day"
+          },
+          "geo": {
+            "user": {
+              "latitude": "$latitude",
+              "longitude": "$longitude"
+            }
+          }
         }
       }
     },
     {
       "name": "resy_find_availability",
       "description": "Find available slots at one or more venues on a given day for a party size, optionally near a coordinate. Returns slots with start time, table type, and configuration token for booking.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "day": { "type": "string", "description": "Date in YYYY-MM-DD." },
-          "party_size": { "type": "integer", "default": 2, "minimum": 1, "maximum": 20 },
-          "location": { "type": "string", "description": "City code (e.g. 'ny', 'la', 'lon', 'mia', 'ath')." },
-          "venue_id": { "type": "integer", "description": "Optional: limit to one venue." },
-          "lat": { "type": "number", "description": "Search center latitude." },
-          "long": { "type": "number", "description": "Search center longitude." }
+          "day": {
+            "type": "string",
+            "description": "Date in YYYY-MM-DD."
+          },
+          "party_size": {
+            "type": "integer",
+            "default": 2,
+            "minimum": 1,
+            "maximum": 20
+          },
+          "location": {
+            "type": "string",
+            "description": "City code (e.g. 'ny', 'la', 'lon', 'mia', 'ath')."
+          },
+          "venue_id": {
+            "type": "integer",
+            "description": "Optional: limit to one venue."
+          },
+          "lat": {
+            "type": "number",
+            "description": "Search center latitude."
+          },
+          "long": {
+            "type": "number",
+            "description": "Search center longitude."
+          }
         },
-        "required": ["day", "party_size"]
+        "required": [
+          "day",
+          "party_size"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -73,31 +126,56 @@
     {
       "name": "resy_get_venue",
       "description": "Full venue detail — name, address, cuisine, photos, menu, hours, descriptions. Pass venue_id from search or find.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer", "description": "Venue ID." }
+          "id": {
+            "type": "integer",
+            "description": "Venue ID."
+          }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/3/venue",
-        "queryParams": { "id": "$id" }
+        "queryParams": {
+          "id": "$id"
+        }
       }
     },
     {
       "name": "resy_get_venue_calendar",
       "description": "Get the booking calendar for one venue across a date range — which days have availability for a given party size.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "venue_id": { "type": "integer" },
-          "num_seats": { "type": "integer", "description": "Party size.", "default": 2 },
-          "start_date": { "type": "string", "description": "YYYY-MM-DD." },
-          "end_date": { "type": "string", "description": "YYYY-MM-DD." }
+          "venue_id": {
+            "type": "integer"
+          },
+          "num_seats": {
+            "type": "integer",
+            "description": "Party size.",
+            "default": 2
+          },
+          "start_date": {
+            "type": "string",
+            "description": "YYYY-MM-DD."
+          },
+          "end_date": {
+            "type": "string",
+            "description": "YYYY-MM-DD."
+          }
         },
-        "required": ["venue_id", "start_date", "end_date"]
+        "required": [
+          "venue_id",
+          "start_date",
+          "end_date"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -113,13 +191,23 @@
     {
       "name": "resy_get_city_list",
       "description": "Get a Resy editorial list for a city — e.g. 'top-rated', 'new-on-resy', 'most-bookmarked'. Returns the curated venues.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "city": { "type": "string", "description": "City code, e.g. 'ny', 'la', 'lon', 'ath'." },
-          "list": { "type": "string", "description": "List slug, e.g. 'top-rated', 'new-on-resy', 'climbing' (city-specific lists vary)." }
+          "city": {
+            "type": "string",
+            "description": "City code, e.g. 'ny', 'la', 'lon', 'ath'."
+          },
+          "list": {
+            "type": "string",
+            "description": "List slug, e.g. 'top-rated', 'new-on-resy', 'climbing' (city-specific lists vary)."
+          }
         },
-        "required": ["city", "list"]
+        "required": [
+          "city",
+          "list"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -129,6 +217,7 @@
     {
       "name": "resy_get_location_config",
       "description": "Get Resy's configuration for available cities, neighborhoods, and cuisines. Use first to discover what's queryable.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {}

--- a/packages/backend/src/adapters/intl/sorare.json
+++ b/packages/backend/src/adapters/intl/sorare.json
@@ -8,7 +8,10 @@
   "docsUrl": "https://github.com/sorare/api",
   "featured": true,
   "priority": 100,
-  "requiredEnvVars": ["SORARE_EMAIL", "SORARE_PASSWORD"],
+  "requiredEnvVars": [
+    "SORARE_EMAIL",
+    "SORARE_PASSWORD"
+  ],
   "instructions": "## Authentication (handled automatically)\n\nSorare uses a custom two-step login the AnythingMCP `LOGIN_TOKEN` engine performs for you:\n\n1. `GET https://api.sorare.com/api/v1/users/{email}` returns the account's bcrypt salt.\n2. Your plain password is hashed locally with `bcrypt.hashSync(password, salt)`.\n3. The hash is sent through Sorare's `signIn` GraphQL mutation; Sorare returns a JWT valid for ~30 days, tagged with the audience claim `anythingmcp` (managed for you).\n4. Every subsequent call adds `Authorization: Bearer <jwt>` and `JWT-AUD: anythingmcp` headers.\n\nThe token is cached in-memory and in the encrypted `connector_auth_cache` table, then proactively re-issued ~24 h before expiry and on any 401. You never need to refresh manually.\n\n## Credentials\n\n- `SORARE_EMAIL` — your Sorare account email.\n- `SORARE_PASSWORD` — your plain account password (never stored or transmitted in plain text after the first login; only the bcrypt hash leaves your server).\n\n## 2FA\n\nIf your account has 2FA enabled, the `signIn` mutation will fail until you provide a fresh `otpAttempt`. For headless/server use we recommend creating a dedicated read-only Sorare account without 2FA. Set `SORARE_PASSWORD` to that account's password.\n\n## Money & pricing conventions — READ THIS FIRST\n\nSorare exposes amounts in **four parallel scales** on every `MonetaryAmount`:\n- `wei` → raw on-chain unit (1 ETH = 10^18 wei). String to avoid precision loss.\n- `eurCents`, `usdCents`, `gbpCents` → **integers in cents, divide by 100 for the currency unit.** Example: `eurCents: 354` means **€3.54**, not €354.\n- These can be `null` when the card is listed only in crypto (no fiat conversion exposed). When you see `eurCents: null`, fall back to `wei` (roughly: `wei * 1e-18 * <ETH/EUR>` for an EUR estimate; the live ETH/EUR rate is not provided by the API).\n\n### TokenOffer sides — easy to get wrong\n\nFor a **single-sale offer** (someone selling a card):\n- `senderSide.anyCards` = the cards being sold (sender = seller, sending the card).\n- `receiverSide.amounts` = the price the buyer pays (receiver = buyer, receiving the card).\n\nIf you query `senderSide.amounts` on a sale offer you'll get **zeros** because the seller isn't sending money. Always read prices from `receiverSide.amounts`.\n\n## When dedicated tools are not enough\n\nThe purpose-built tools below cover the most common workflows. For anything else use the generic helpers:\n- `sorare_graphql_schema` (no args) → compact summary of Query/Mutation + a flat index of every type.\n- `sorare_graphql_schema(type: \"TypeName\")` → just one type's definition.\n- `sorare_graphql_schema(search: \"keyword\")` → every type whose name or a field name matches.\n- `sorare_graphql_query` / `_mutation` / `_subscription` → execute arbitrary documents.\n\n**GraphQL introspection (`__schema` / `__type`) is disabled on Sorare's production endpoint.** Use `sorare_graphql_schema(type: \"…\")` instead.\n\n## Useful field paths the schema search won't surface obviously\n\n- `Player.lowestPriceAnyCard(rarity, inSeason)` → floor card for a player at a rarity. (Wrapped by `sorare_player_floor_price`.)\n- `Player.so5Scores(last, position?)` → recent So5 scores for form analysis. (Wrapped by `sorare_player_recent_scores`.)\n- `tokens.tokenPrices(playerSlug, rarity, first, season?)` → recent sale history for a player+rarity, in fiat + wei. (Wrapped by `sorare_token_prices`.)\n- `tokens.liveSingleSaleOffers(playerSlug?, sport?, first)` → current secondary market. (Wrapped by `sorare_live_sale_offers`.)\n- `currentUser.cards(first, rarities, sport)` → your inventory. NOT `currentUser.football.myCards` (that path doesn't exist).\n- `currentUser.availableBalances` → wallet in wei + EUR + USD + GBP. (Wrapped by `sorare_wallet_balance`.)\n- For free-text player search use the root `searchPlayers(query, pageSize)` then drill via `commonPlayerHits { anyPlayer { ... on Player { ... } } }`. There is no `football.players(search:…)` — that path doesn't exist.\n\n## Sport / season / rarity enum quirks\n\n- `Sport` is upper-snake: `FOOTBALL`, `BASEBALL`, `NBA`.\n- `Rarity` is lowercase: `common`, `limited`, `rare`, `super_rare`, `unique`, `custom_series` (not the upper-snake form).\n- `season` arguments are season **start years**: 2024 means the 2024-25 season.\n- Older-vintage cards (pre-current-season) still score normally in So5 Classic competitions; the vintage mainly matters for the Captain Bonus and for season-eligibility tournaments.\n\n## Rate limits\n\nSorare enforces per-IP and per-token rate limits (`429`). Heavy bulk-export workflows should batch and back-off. Very large GraphQL responses (hundreds of items × deep selection) may also time out — split the request.\n\n## Useful starter prompts\n\n- \"What's my Sorare wallet balance?\" → `sorare_wallet_balance`\n- \"What's the floor price for a Limited Calafiori right now?\" → `sorare_player_floor_price(playerSlug, rarity:\"limited\")`\n- \"What did Messi rare cards sell for in the last month?\" → `sorare_token_prices(playerSlug, rarity:\"rare\", first:30)`\n- \"Show me my Limited cards for Top-5-league players.\" → `sorare_list_my_cards(rarities:[\"limited\"])`\n- \"Is this player in form?\" → `sorare_player_recent_scores(playerSlug, last:10)`\n- \"How am I doing in So5 overall?\" → `sorare_my_trophies_summary(sport:\"FOOTBALL\")`",
   "connector": {
     "name": "Sorare",
@@ -57,6 +60,7 @@
     {
       "name": "sorare_current_user",
       "description": "Get the authenticated Sorare user's profile (slug, email, nickname). Use this first to confirm the connection is healthy.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {},
@@ -70,6 +74,7 @@
     {
       "name": "sorare_get_card_by_slug",
       "description": "Fetch a single Sorare football card by slug (e.g. 'lionel-messi-2023-rare-1'). Returns player, rarity, season, current owner, and the live single-sale offer if any. For richer data use sorare_graphql_query with the relevant slice from sorare_graphql_schema.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -78,7 +83,9 @@
             "description": "The card's unique slug from a card URL."
           }
         },
-        "required": ["slug"],
+        "required": [
+          "slug"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -92,6 +99,7 @@
     {
       "name": "sorare_search_player",
       "description": "Search football players by name (full-text). Returns up to `pageSize` matches with slug, display name, country, and current club. Use the returned slug with sorare_list_player_cards or sorare_get_card_by_slug.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -107,7 +115,9 @@
             "description": "Max hits to return (1–20)."
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -122,6 +132,7 @@
     {
       "name": "sorare_list_player_cards",
       "description": "List cards minted for a given football player slug, with their rarity, season, and current owner.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -137,7 +148,9 @@
             "description": "Max cards to return (1–50)."
           }
         },
-        "required": ["playerSlug"],
+        "required": [
+          "playerSlug"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -152,6 +165,7 @@
     {
       "name": "sorare_list_my_cards",
       "description": "List football cards owned by the authenticated user with rarity, player, and season. Pass `rarities` to filter (e.g. ['rare']).",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -166,7 +180,14 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["common", "limited", "rare", "super_rare", "unique", "custom_series"]
+              "enum": [
+                "common",
+                "limited",
+                "rare",
+                "super_rare",
+                "unique",
+                "custom_series"
+              ]
             },
             "description": "Optional list of rarity tiers to keep."
           }
@@ -185,6 +206,7 @@
     {
       "name": "sorare_get_lineup",
       "description": "Fetch a Sorare So5 lineup by id. Returns lineup metadata (name, draft/confirmable flags) and owning user. For appearance scores and bonuses use sorare_graphql_query with a fragment on So5Appearance.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -193,7 +215,9 @@
             "description": "The So5 lineup id."
           }
         },
-        "required": ["lineupId"],
+        "required": [
+          "lineupId"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -207,6 +231,7 @@
     {
       "name": "sorare_wallet_balance",
       "description": "Get the authenticated user's wallet balances in ETH (wei) and the three fiat reference currencies (EUR, USD, GBP). Useful before recommending a purchase.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {},
@@ -220,6 +245,7 @@
     {
       "name": "sorare_user_by_slug",
       "description": "Fetch another Sorare user's public profile by slug — nickname, status, and So5 lineup count. Use sorare_graphql_query with currentUser/cards for richer data.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -228,7 +254,9 @@
             "description": "The user's slug (from the URL, e.g. 'harrypottah')."
           }
         },
-        "required": ["slug"],
+        "required": [
+          "slug"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -242,6 +270,7 @@
     {
       "name": "sorare_player_recent_scores",
       "description": "Return the most recent So5 scores for a football player slug, with position and game date. Use this to assess current form before composing a lineup or evaluating a card purchase.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -257,7 +286,9 @@
             "description": "Number of most-recent scores to return (1–20)."
           }
         },
-        "required": ["playerSlug"],
+        "required": [
+          "playerSlug"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -272,6 +303,7 @@
     {
       "name": "sorare_token_prices",
       "description": "Recent sale history for cards of a specific player + rarity. Returns an array of completed sales with date and amounts in wei / EUR / USD / GBP. Use to gauge fair market value.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -281,7 +313,14 @@
           },
           "rarity": {
             "type": "string",
-            "enum": ["common", "limited", "rare", "super_rare", "unique", "custom_series"],
+            "enum": [
+              "common",
+              "limited",
+              "rare",
+              "super_rare",
+              "unique",
+              "custom_series"
+            ],
             "description": "Card rarity (lowercase per Sorare's enum)."
           },
           "first": {
@@ -296,7 +335,10 @@
             "description": "Optional: filter by season start year (e.g. 2024 for the 2024-25 season)."
           }
         },
-        "required": ["playerSlug", "rarity"],
+        "required": [
+          "playerSlug",
+          "rarity"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -313,6 +355,7 @@
     {
       "name": "sorare_get_auction",
       "description": "Get a specific Sorare auction by id, including cards on auction, current price, best bid, and end date.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -321,7 +364,9 @@
             "description": "The auction id."
           }
         },
-        "required": ["auctionId"],
+        "required": [
+          "auctionId"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -335,12 +380,17 @@
     {
       "name": "sorare_my_trophies_summary",
       "description": "Summary of the authenticated user's So5 results: total final rankings, podium finishes, and lifetime card / monetary rewards. Optionally filter by sport.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
           "sport": {
             "type": "string",
-            "enum": ["FOOTBALL", "BASEBALL", "NBA"],
+            "enum": [
+              "FOOTBALL",
+              "BASEBALL",
+              "NBA"
+            ],
             "description": "Optional sport filter (default: all sports)."
           }
         },
@@ -357,6 +407,7 @@
     {
       "name": "sorare_player_floor_price",
       "description": "Get the cheapest currently-listed card for a player at a given rarity. Returns the card slug + the live single-sale offer price in wei + EUR/USD/GBP cents. Optionally restrict to in-season cards only. Far cheaper (1 round-trip) than scanning live_sale_offers when you just want 'what does this player's rarity X cost right now?'.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -366,7 +417,14 @@
           },
           "rarity": {
             "type": "string",
-            "enum": ["common", "limited", "rare", "super_rare", "unique", "custom_series"],
+            "enum": [
+              "common",
+              "limited",
+              "rare",
+              "super_rare",
+              "unique",
+              "custom_series"
+            ],
             "description": "Card rarity (lowercase per Sorare's enum)."
           },
           "inSeasonOnly": {
@@ -375,7 +433,10 @@
             "description": "If true, only consider cards eligible for in-season tournaments."
           }
         },
-        "required": ["playerSlug", "rarity"],
+        "required": [
+          "playerSlug",
+          "rarity"
+        ],
         "additionalProperties": false
       },
       "endpointMapping": {
@@ -391,6 +452,7 @@
     {
       "name": "sorare_live_sale_offers",
       "description": "List currently-live single-sale offers on the secondary market (Sorare's 'transfer market'). Optionally filter by player slug or sport. For rarity / max-price filters use sorare_graphql_query.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
@@ -400,7 +462,11 @@
           },
           "sport": {
             "type": "string",
-            "enum": ["FOOTBALL", "BASEBALL", "NBA"],
+            "enum": [
+              "FOOTBALL",
+              "BASEBALL",
+              "NBA"
+            ],
             "description": "Optional: filter by sport."
           },
           "limit": {

--- a/packages/backend/src/adapters/intl/trenitalia.json
+++ b/packages/backend/src/adapters/intl/trenitalia.json
@@ -21,18 +21,46 @@
     {
       "name": "trenitalia_search_trips",
       "description": "Search Trenitalia trains between two stations on a date. Returns trips with departure/arrival time, train type (Frecciarossa, Frecciargento, Intercity, regional), duration, transfers, available fares and prices.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "from_name": { "type": "string", "description": "Origin station name (e.g. 'Milano Centrale', 'Roma Termini')." },
-          "to_name": { "type": "string", "description": "Destination station name." },
-          "departure_date": { "type": "string", "description": "Departure date/time, naive ISO-8601 (e.g. '2026-05-24T08:00:00')." },
-          "return_date": { "type": "string", "description": "Optional return date/time for round-trip." },
-          "adults": { "type": "integer", "default": 1, "minimum": 1, "maximum": 9 },
-          "children": { "type": "integer", "default": 0 },
-          "page": { "type": "integer", "default": 1 }
+          "from_name": {
+            "type": "string",
+            "description": "Origin station name (e.g. 'Milano Centrale', 'Roma Termini')."
+          },
+          "to_name": {
+            "type": "string",
+            "description": "Destination station name."
+          },
+          "departure_date": {
+            "type": "string",
+            "description": "Departure date/time, naive ISO-8601 (e.g. '2026-05-24T08:00:00')."
+          },
+          "return_date": {
+            "type": "string",
+            "description": "Optional return date/time for round-trip."
+          },
+          "adults": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1,
+            "maximum": 9
+          },
+          "children": {
+            "type": "integer",
+            "default": 0
+          },
+          "page": {
+            "type": "integer",
+            "default": 1
+          }
         },
-        "required": ["from_name", "to_name", "departure_date"]
+        "required": [
+          "from_name",
+          "to_name",
+          "departure_date"
+        ]
       },
       "endpointMapping": {
         "method": "POST",
@@ -51,6 +79,7 @@
     {
       "name": "trenitalia_get_home_alerts",
       "description": "Get current service alerts and mobility info from Trenitalia's home feed — strikes, delays, line-wide notices.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {}
@@ -63,6 +92,7 @@
     {
       "name": "trenitalia_get_mobility_info",
       "description": "Get general mobility info — strikes (`scioperi`), planned outages, network status — from Trenitalia's home info feed.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {}

--- a/packages/backend/src/adapters/intl/untappd.json
+++ b/packages/backend/src/adapters/intl/untappd.json
@@ -7,7 +7,10 @@
   "category": "food",
   "icon": "untappd",
   "docsUrl": "https://untappd.com/api/docs",
-  "requiredEnvVars": ["UNTAPPD_CLIENT_ID", "UNTAPPD_CLIENT_SECRET"],
+  "requiredEnvVars": [
+    "UNTAPPD_CLIENT_ID",
+    "UNTAPPD_CLIENT_SECRET"
+  ],
   "connector": {
     "name": "Untappd API v4",
     "type": "REST",
@@ -19,15 +22,38 @@
     {
       "name": "untappd_search_beer",
       "description": "Search Untappd for beers by free-text query (name, brewery, style). Returns a paginated list with beer id, name, brewery, style, ABV, IBU, rating, label image.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "q": { "type": "string", "description": "Search query (e.g. 'Hazy IPA', 'Westvleteren 12')." },
-          "limit": { "type": "integer", "default": 25, "minimum": 1, "maximum": 50 },
-          "offset": { "type": "integer", "default": 0 },
-          "sort": { "type": "string", "enum": ["checkin", "name", "count", "all"], "default": "checkin" }
+          "q": {
+            "type": "string",
+            "description": "Search query (e.g. 'Hazy IPA', 'Westvleteren 12')."
+          },
+          "limit": {
+            "type": "integer",
+            "default": 25,
+            "minimum": 1,
+            "maximum": 50
+          },
+          "offset": {
+            "type": "integer",
+            "default": 0
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "checkin",
+              "name",
+              "count",
+              "all"
+            ],
+            "default": "checkin"
+          }
         },
-        "required": ["q"]
+        "required": [
+          "q"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -45,12 +71,18 @@
     {
       "name": "untappd_get_beer",
       "description": "Full detail of one beer by ID — brewery, style, ABV, IBU, ratings, recent check-ins, label.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "bid": { "type": "integer", "description": "Untappd beer ID." }
+          "bid": {
+            "type": "integer",
+            "description": "Untappd beer ID."
+          }
         },
-        "required": ["bid"]
+        "required": [
+          "bid"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -64,13 +96,21 @@
     {
       "name": "untappd_search_brewery",
       "description": "Search Untappd for breweries by free-text query.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "q": { "type": "string" },
-          "offset": { "type": "integer", "default": 0 }
+          "q": {
+            "type": "string"
+          },
+          "offset": {
+            "type": "integer",
+            "default": 0
+          }
         },
-        "required": ["q"]
+        "required": [
+          "q"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -86,12 +126,17 @@
     {
       "name": "untappd_get_brewery",
       "description": "Full detail of one brewery by ID — location, beer list, social stats.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "brewery_id": { "type": "integer" }
+          "brewery_id": {
+            "type": "integer"
+          }
         },
-        "required": ["brewery_id"]
+        "required": [
+          "brewery_id"
+        ]
       },
       "endpointMapping": {
         "method": "GET",

--- a/packages/backend/src/adapters/intl/vinted.json
+++ b/packages/backend/src/adapters/intl/vinted.json
@@ -21,22 +21,66 @@
     {
       "name": "vinted_search_items",
       "description": "Free-text search across Vinted's catalog. Returns a paginated list of items with id, title, price, currency, brand, size, condition, photos, seller info.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "search_text": { "type": "string", "description": "Free-text query (e.g. 'Stone Island jacket', 'Carhartt WIP trousers')." },
-          "currency": { "type": "string", "description": "Currency code: EUR, GBP, PLN, CZK, USD.", "default": "EUR" },
-          "order": { "type": "string", "enum": ["relevance", "newest_first", "price_low_to_high", "price_high_to_low"], "default": "relevance" },
-          "page": { "type": "integer", "default": 1, "minimum": 1 },
-          "per_page": { "type": "integer", "default": 24, "minimum": 1, "maximum": 96 },
-          "catalog_ids": { "type": "string", "description": "Optional comma-separated Vinted catalog (category) IDs." },
-          "brand_ids": { "type": "string", "description": "Optional comma-separated brand IDs." },
-          "size_ids": { "type": "string", "description": "Optional comma-separated size IDs." },
-          "status_ids": { "type": "string", "description": "Optional condition filter: '6' new with tags, '1' new without tags, '2' very good, '3' good, '4' satisfactory." },
-          "price_from": { "type": "number" },
-          "price_to": { "type": "number" }
+          "search_text": {
+            "type": "string",
+            "description": "Free-text query (e.g. 'Stone Island jacket', 'Carhartt WIP trousers')."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Currency code: EUR, GBP, PLN, CZK, USD.",
+            "default": "EUR"
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "relevance",
+              "newest_first",
+              "price_low_to_high",
+              "price_high_to_low"
+            ],
+            "default": "relevance"
+          },
+          "page": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          "per_page": {
+            "type": "integer",
+            "default": 24,
+            "minimum": 1,
+            "maximum": 96
+          },
+          "catalog_ids": {
+            "type": "string",
+            "description": "Optional comma-separated Vinted catalog (category) IDs."
+          },
+          "brand_ids": {
+            "type": "string",
+            "description": "Optional comma-separated brand IDs."
+          },
+          "size_ids": {
+            "type": "string",
+            "description": "Optional comma-separated size IDs."
+          },
+          "status_ids": {
+            "type": "string",
+            "description": "Optional condition filter: '6' new with tags, '1' new without tags, '2' very good, '3' good, '4' satisfactory."
+          },
+          "price_from": {
+            "type": "number"
+          },
+          "price_to": {
+            "type": "number"
+          }
         },
-        "required": ["search_text"]
+        "required": [
+          "search_text"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -59,21 +103,28 @@
     {
       "name": "vinted_get_filters",
       "description": "Get the available filter options for Vinted catalog search — categories, brands, sizes, colors, conditions. Useful before search to know what filter IDs are queryable.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {
-          "catalog_ids": { "type": "string", "description": "Optional: limit filter discovery to a specific catalog (e.g. one category)." }
+          "catalog_ids": {
+            "type": "string",
+            "description": "Optional: limit filter discovery to a specific catalog (e.g. one category)."
+          }
         }
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/api/v2/catalog/filters",
-        "queryParams": { "catalog_ids": "$catalog_ids" }
+        "queryParams": {
+          "catalog_ids": "$catalog_ids"
+        }
       }
     },
     {
       "name": "vinted_homepage",
       "description": "Get Vinted's curated homepage feed — featured items, promoted closets, banners. Useful for editorial discovery.",
+      "useProxy": true,
       "parameters": {
         "type": "object",
         "properties": {}

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -487,6 +487,17 @@ export class ConnectorsController {
     return connector;
   }
 
+  @Get('proxy-availability')
+  @ApiOperation({
+    summary: 'Whether the proxy / web-unblocker is configured on this instance',
+    description:
+      'Returns { available: true } only when CONNECTOR_PROXY_URL is set. ' +
+      'The UI uses this to show or hide the per-tool "Use proxy" checkbox.',
+  })
+  async proxyAvailability() {
+    return { available: !!process.env.CONNECTOR_PROXY_URL };
+  }
+
   @Get('health-check')
   @ApiOperation({
     summary: 'Test connectivity of all active connectors',

--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosError } from 'axios';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { OAuth2TokenService } from './oauth2-token.service';
 import {
   LoginTokenService,
@@ -29,6 +30,7 @@ export class GraphqlEngine {
       authConfig?: Record<string, unknown>;
       headers?: Record<string, string>;
       connectorId?: string;
+      proxyUrl?: string;
     },
     endpointMapping: {
       method: string; // "query" | "mutation" | "subscription" | "static"
@@ -164,11 +166,22 @@ export class GraphqlEngine {
       variables,
     };
 
-    try {
-      const response = await axios.post(config.baseUrl, requestConfig, {
-        headers,
-        timeout: 30000,
+    // Shared axios options. When the caller passes a proxyUrl, route every
+    // request (incl. the 401-refresh retries below) through the
+    // proxy / web-unblocker. rejectUnauthorized:false supports unblockers
+    // (e.g. Zyte) that intercept TLS.
+    const axiosOpts: Record<string, unknown> = { headers, timeout: 30000 };
+    if (config.proxyUrl) {
+      const agent = new HttpsProxyAgent(config.proxyUrl, {
+        rejectUnauthorized: false,
       });
+      axiosOpts.httpsAgent = agent;
+      axiosOpts.httpAgent = agent;
+      axiosOpts.proxy = false;
+    }
+
+    try {
+      const response = await axios.post(config.baseUrl, requestConfig, axiosOpts);
 
       if (response.data.errors) {
         throw new Error(
@@ -198,7 +211,7 @@ export class GraphqlEngine {
           const retryResponse = await axios.post(
             config.baseUrl,
             requestConfig,
-            { headers, timeout: 30000 },
+            { ...axiosOpts, headers },
           );
 
           if (retryResponse.data.errors) {
@@ -226,8 +239,8 @@ export class GraphqlEngine {
         );
         applyLoginTokenHeaders(headers, auth, bundle.token, bundle.aud);
         const retry = await axios.post(config.baseUrl, requestConfig, {
+          ...axiosOpts,
           headers,
-          timeout: 30000,
         });
         if (retry.data.errors) {
           throw new Error(

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
 import FormData from 'form-data';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { OAuth2TokenService } from './oauth2-token.service';
 import {
   LoginTokenService,
@@ -30,6 +31,11 @@ export class RestEngine {
       authConfig?: Record<string, unknown>;
       headers?: Record<string, string>;
       connectorId?: string;
+      // When set, route this request through the proxy / web-unblocker.
+      // The caller (DynamicMcpTools) decides whether a proxy applies
+      // (env present, tool opted in, license + rate-limit ok) and passes
+      // the URL here, or omits it for a direct request.
+      proxyUrl?: string;
     },
     endpointMapping: {
       method: string;
@@ -143,7 +149,21 @@ export class RestEngine {
       }
     }
 
-    this.logger.debug(`REST call: ${axiosConfig.method} ${url}`);
+    // Route through the proxy / web-unblocker when the caller asked for it.
+    // `rejectUnauthorized: false` is required for unblockers like Zyte that
+    // intercept the TLS connection (equivalent to curl's --proxy-insecure).
+    // We disable axios' native proxy handling so the agent owns the tunnel.
+    if (config.proxyUrl) {
+      const agent = new HttpsProxyAgent(config.proxyUrl, {
+        rejectUnauthorized: false,
+      });
+      axiosConfig.httpsAgent = agent;
+      axiosConfig.httpAgent = agent;
+      axiosConfig.proxy = false;
+      this.logger.debug(`REST call via proxy: ${axiosConfig.method} ${url}`);
+    } else {
+      this.logger.debug(`REST call: ${axiosConfig.method} ${url}`);
+    }
 
     try {
       const response = await axios(axiosConfig);

--- a/packages/backend/src/connectors/graphql-builtins.ts
+++ b/packages/backend/src/connectors/graphql-builtins.ts
@@ -19,6 +19,7 @@ export interface GraphqlBuiltinTool {
   description: string;
   parameters: Record<string, unknown>;
   endpointMapping: Record<string, unknown>;
+  useProxy?: boolean;
 }
 
 export interface GraphqlBuiltinOptions {
@@ -30,6 +31,13 @@ export interface GraphqlBuiltinOptions {
   baseUrl: string;
   /** Optional override for the SDL URL. Defaults to `${baseUrl}/schema`. */
   schemaUrl?: string;
+  /**
+   * When true, the generated query/mutation/subscription helpers route
+   * through the proxy/unblocker by default (the static/schema helpers
+   * never make a normal HTTP call so they're left off). Set by the
+   * catalog when the adapter's own tools opt into proxy.
+   */
+  useProxy?: boolean;
 }
 
 /**
@@ -89,6 +97,7 @@ export function buildGraphqlBuiltinTools(
       path: `$${op}`,
       variablesFromParam: 'variables',
     },
+    useProxy: !!opts.useProxy,
   });
 
   return [

--- a/packages/backend/src/connectors/tools.controller.ts
+++ b/packages/backend/src/connectors/tools.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Put,
+  Patch,
   Delete,
   Body,
   Param,
@@ -128,6 +129,15 @@ class BulkCreateToolsDto {
   @ValidateNested({ each: true })
   @Type(() => CreateToolDto)
   tools: CreateToolDto[];
+}
+
+class SetToolProxyDto {
+  @ApiProperty({
+    description:
+      'Whether this tool should route its request through the configured proxy / web-unblocker.',
+  })
+  @IsBoolean()
+  useProxy: boolean;
 }
 
 class TestToolDto {
@@ -289,6 +299,32 @@ export class ToolsController {
       throw new ForbiddenException('Tool not found');
     }
 
+    await this.mcpServer.reloadConnectorTools(connectorId);
+    return this.prisma.mcpTool.findUnique({ where: { id: toolId } });
+  }
+
+  @Patch(':toolId/proxy')
+  @ApiOperation({
+    summary: 'Toggle proxy / web-unblocker routing for a single tool',
+    description:
+      'Sets mcp_tools.use_proxy. Takes effect only when CONNECTOR_PROXY_URL ' +
+      'is configured on the instance; otherwise the request still goes out ' +
+      'directly. Does not change the workspace rate limit (DB/admin only).',
+  })
+  async setProxy(
+    @Req() req: any,
+    @Param('toolId') toolId: string,
+    @Param('connectorId') connectorId: string,
+    @Body() dto: SetToolProxyDto,
+  ) {
+    await this.assertCanWriteConnector(connectorId, req);
+    const result = await this.prisma.mcpTool.updateMany({
+      where: { id: toolId, connectorId },
+      data: { useProxy: dto.useProxy },
+    });
+    if (result.count === 0) {
+      throw new ForbiddenException('Tool not found');
+    }
     await this.mcpServer.reloadConnectorTools(connectorId);
     return this.prisma.mcpTool.findUnique({ where: { id: toolId } });
   }

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -10,7 +10,10 @@ import { DatabaseEngine } from '../connectors/engines/database.engine';
 import { AuditService } from '../audit/audit.service';
 import { RedisService } from '../common/redis.service';
 import { LicenseGuardService } from '../license/license-guard.service';
+import { DeploymentService } from '../common/deployment.service';
+import { PrismaService } from '../common/prisma.service';
 import { interpolateConnectorConfig } from '../common/env-interpolation.util';
+import type { RegisteredTool } from './tool-registry';
 
 /**
  * ToolExecutor — executes dynamically registered MCP tools.
@@ -27,12 +30,77 @@ export class DynamicMcpTools {
     private readonly auditService: AuditService,
     private readonly redisService: RedisService,
     private readonly licenseGuard: LicenseGuardService,
+    private readonly deployment: DeploymentService,
+    private readonly prisma: PrismaService,
     private readonly restEngine: RestEngine,
     private readonly graphqlEngine: GraphqlEngine,
     private readonly soapEngine: SoapEngine,
     private readonly mcpClientEngine: McpClientEngine,
     private readonly databaseEngine: DatabaseEngine,
   ) {}
+
+  /**
+   * Decide whether this tool call should be routed through the
+   * proxy / web-unblocker, and return the proxy URL when it should.
+   *
+   * Rules:
+   *  - No CONNECTOR_PROXY_URL env  → never proxy (request goes direct,
+   *    even if the tool opted in — graceful degradation).
+   *  - Tool must opt in (mcp_tools.use_proxy = true).
+   *  - Cloud only: the workspace must be under its hourly proxy cap.
+   *    The license/trial gate is already enforced at the top of
+   *    executeTool (checkLicenseActive throws), so reaching here in
+   *    cloud means the workspace is licensed/trialing.
+   *  - Over the cap → throw (choice B: explicit error to the caller).
+   *
+   * Self-hosted installs get no rate limit and no license gate.
+   */
+  private async resolveProxy(
+    tool: RegisteredTool,
+    organizationId?: string,
+  ): Promise<string | null> {
+    const proxyUrl = process.env.CONNECTOR_PROXY_URL;
+    if (!proxyUrl) return null; // env absent → direct request
+    if (tool.useProxy !== true) return null; // tool didn't opt in
+
+    if (this.deployment.isCloud() && organizationId) {
+      const limit = await this.getProxyLimit(organizationId);
+      const key = `proxy_rl:${organizationId}`;
+      const count = await this.redisService.incr(key);
+      if (count === 1) {
+        await this.redisService.expire(key, 3600);
+      }
+      if (count > limit) {
+        const ttl = await this.redisService.ttl(key);
+        const mins = ttl > 0 ? Math.ceil(ttl / 60) : 60;
+        throw new Error(
+          `Proxy quota exceeded: this workspace is limited to ${limit} ` +
+            `proxy/unblocker tool calls per hour. Try again in ~${mins} minute(s), ` +
+            `or run this tool without the proxy.`,
+        );
+      }
+    }
+
+    return proxyUrl;
+  }
+
+  /**
+   * Effective hourly proxy cap for a workspace:
+   * organizations.proxy_rate_limit (DB, admin-only) ?? PROXY_RATE_LIMIT_DEFAULT
+   * env ?? 100. There is intentionally no API to change the per-workspace
+   * value — only a service admin via the database.
+   */
+  private async getProxyLimit(organizationId: string): Promise<number> {
+    const org = await this.prisma.organization.findUnique({
+      where: { id: organizationId },
+      select: { proxyRateLimit: true },
+    });
+    if (org?.proxyRateLimit != null && org.proxyRateLimit >= 0) {
+      return org.proxyRateLimit;
+    }
+    const envDefault = parseInt(process.env.PROXY_RATE_LIMIT_DEFAULT || '', 10);
+    return Number.isFinite(envDefault) && envDefault >= 0 ? envDefault : 100;
+  }
 
   /**
    * Execute a tool by name with the given parameters.
@@ -125,6 +193,10 @@ export class DynamicMcpTools {
         envVars,
       );
 
+      // Decide proxy routing (env present + tool opted in + cloud rate-limit).
+      // Throws on over-quota (choice B). Returns null → direct request.
+      const proxyUrl = await this.resolveProxy(tool, context?.organizationId);
+
       const engineConfig = {
         baseUrl: interpolatedConfig.baseUrl,
         authType: tool.connectorConfig.authType,
@@ -133,6 +205,7 @@ export class DynamicMcpTools {
           : undefined,
         headers: interpolatedConfig.headers,
         specUrl: (tool.connectorConfig as any).specUrl,
+        ...(proxyUrl ? { proxyUrl } : {}),
       };
 
       // Inject env vars as parameter defaults (env var values fill in params

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -62,6 +62,7 @@ export class McpServerService implements OnModuleInit {
           description: tool.description,
           parameters: tool.parameters as Record<string, unknown>,
           connectorType: connector.type,
+          useProxy: tool.useProxy,
           connectorConfig: {
             baseUrl: connector.baseUrl,
             authType: connector.authType,
@@ -131,6 +132,7 @@ export class McpServerService implements OnModuleInit {
           description: tool.description,
           parameters: tool.parameters as Record<string, unknown>,
           connectorType: connector.type,
+          useProxy: tool.useProxy,
           connectorConfig: {
             baseUrl: connector.baseUrl,
             authType: connector.authType,

--- a/packages/backend/src/mcp-server/tool-registry.ts
+++ b/packages/backend/src/mcp-server/tool-registry.ts
@@ -20,6 +20,10 @@ export interface RegisteredTool {
   description: string;
   parameters: Record<string, unknown>;
   connectorType: string;
+  // Per-tool preference to route the outbound request through the
+  // proxy / web-unblocker. Mirrors mcp_tools.use_proxy. The actual
+  // decision (env present, license, rate-limit) is made at call time.
+  useProxy?: boolean;
   connectorConfig: {
     baseUrl: string;
     authType: string;

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -30,6 +30,9 @@ export default function ConnectorDetailPage() {
   const [connector, setConnector] = useState<any>(null);
   const [toolList, setToolList] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  // Whether CONNECTOR_PROXY_URL is configured on this instance — drives
+  // visibility of the per-tool "Use proxy" checkbox.
+  const [proxyAvailable, setProxyAvailable] = useState(false);
 
   // OAuth + MCP discovery
   const [authorizing, setAuthorizing] = useState(false);
@@ -82,6 +85,11 @@ export default function ConnectorDetailPage() {
   const fetchConnector = async () => {
     if (!token) return;
     try {
+      // Cheap, instance-wide flag — drives the per-tool proxy checkbox.
+      connectors
+        .proxyAvailability(token)
+        .then((r) => setProxyAvailable(!!r.available))
+        .catch(() => setProxyAvailable(false));
       const c = await connectors.get(id, token);
       setConnector(c);
       setEditName(c.name);
@@ -266,6 +274,22 @@ export default function ConnectorDetailPage() {
         prev.map((t) => (t.id === toolId ? { ...t, isEnabled: !isEnabled } : t)),
       );
     } catch (err: any) {
+      setMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleToggleProxy = async (toolId: string, useProxy: boolean) => {
+    if (!token) return;
+    // Optimistic flip; revert on error.
+    setToolList((prev) =>
+      prev.map((t) => (t.id === toolId ? { ...t, useProxy: !useProxy } : t)),
+    );
+    try {
+      await tools.setProxy(id, toolId, !useProxy, token);
+    } catch (err: any) {
+      setToolList((prev) =>
+        prev.map((t) => (t.id === toolId ? { ...t, useProxy } : t)),
+      );
       setMsg(`Error: ${err.message}`);
     }
   };
@@ -1039,6 +1063,20 @@ export default function ConnectorDetailPage() {
                           >
                             {tool.isEnabled ? 'Disable' : 'Enable'}
                           </button>
+                          {proxyAvailable && (
+                            <label
+                              className="flex items-center gap-1 border border-[var(--border)] px-2 py-1 rounded text-xs cursor-pointer hover:bg-[var(--accent)]"
+                              title="Route this tool's request through the configured proxy / web-unblocker. Recommended for anti-bot, geo-restricted, or rate-limited APIs."
+                            >
+                              <input
+                                type="checkbox"
+                                checked={!!tool.useProxy}
+                                onChange={() => handleToggleProxy(tool.id, !!tool.useProxy)}
+                                className="accent-[var(--brand)]"
+                              />
+                              Proxy
+                            </label>
+                          )}
                           <button
                             onClick={() => handleDeleteTool(tool.id)}
                             className="border border-[var(--destructive)] text-[var(--destructive)] px-2 py-1 rounded text-xs hover:bg-[var(--destructive-bg)]"

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -179,6 +179,8 @@ export const organizations = {
 export const connectors = {
   list: (token: string) =>
     request<any[]>('/api/connectors', { token }),
+  proxyAvailability: (token: string) =>
+    request<{ available: boolean }>('/api/connectors/proxy-availability', { token }),
   create: (data: unknown, token: string) =>
     request<any>('/api/connectors', { method: 'POST', body: data, token }),
   get: (id: string, token: string) =>
@@ -251,6 +253,12 @@ export const tools = {
     ),
   update: (connectorId: string, toolId: string, data: unknown, token: string) =>
     request(`/api/connectors/${connectorId}/tools/${toolId}`, { method: 'PUT', body: data, token }),
+  setProxy: (connectorId: string, toolId: string, useProxy: boolean, token: string) =>
+    request<any>(`/api/connectors/${connectorId}/tools/${toolId}/proxy`, {
+      method: 'PATCH',
+      body: { useProxy },
+      token,
+    }),
   delete: (connectorId: string, toolId: string, token: string) =>
     request(`/api/connectors/${connectorId}/tools/${toolId}`, { method: 'DELETE', token }),
   test: (connectorId: string, toolId: string, params: Record<string, unknown>, token: string) =>


### PR DESCRIPTION
Adds optional routing of a tool's HTTP request through a proxy / web-unblocker (e.g. Zyte API proxy mode). Fixes the Deutsche Bahn connector that 403s on Akamai-protected endpoints (a paying customer is affected).

## Activation (all three required)
1. `CONNECTOR_PROXY_URL` env set — else feature off, opted-in tools go direct (no error).
2. Tool opted in (`mcp_tools.use_proxy`, seeded from adapter spec, per-tool UI checkbox shown only when env set).
3. Cloud only: active license/trial + workspace under hourly proxy cap.

## Rate limit (cloud)
`PROXY_RATE_LIMIT_DEFAULT` (default 100) per workspace/hour, overridable via `organizations.proxy_rate_limit` (DB/admin only — **no API**). Over cap → explicit `Proxy quota exceeded` error.

## Engine
REST + GraphQL attach `HttpsProxyAgent` (`rejectUnauthorized:false` for TLS-intercepting unblockers). SOAP/DB/MCP ignore it.

## Schema
`mcp_tools.use_proxy`, `organizations.proxy_rate_limit` (migration `20260531100000_add_proxy_support`).

## Adapters with useProxy=true
deutsche-bahn, playtomic(+public), sorare, opentable, resy, vinted, untappd, idealista, trenitalia, immobilienscout24, etsy, mercado-libre.

## Test plan
- [x] backend + frontend build/typecheck
- [ ] Migration applies on deploy
- [ ] Set Zyte CONNECTOR_PROXY_URL on cloud droplet
- [ ] Backfill use_proxy=true on the customer's existing DB connector tools
- [ ] Customer's db_get_departures returns 200 via proxy
- [ ] Over-cap returns explicit error