### PR TITLE
fix(cloud): wire proxy env vars into app service

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -52,6 +52,10 @@ services:
       # Operator analytics — cloud build only. Leave unset on self-hosted.
       - GTM_ID=${GTM_ID:-}
       - COOKIE_DOMAIN=${COOKIE_DOMAIN:-}
+      # Proxy / web-unblocker (e.g. Zyte API proxy mode). Tools with
+      # use_proxy=true route through this; unset = feature off everywhere.
+      - CONNECTOR_PROXY_URL=${CONNECTOR_PROXY_URL:-}
+      - PROXY_RATE_LIMIT_DEFAULT=${PROXY_RATE_LIMIT_DEFAULT:-100}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
The cloud `app` service lists env vars explicitly under `environment:` (no `env_file`), so CONNECTOR_PROXY_URL / PROXY_RATE_LIMIT_DEFAULT added to the droplet .env never reached the container. Pass them through. Already applied live on the droplet; this keeps it across future deploys.