### PR TITLE
chore(release): v0.1.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "BUSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -24458,7 +24458,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "BUSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.1.21",
@@ -24913,7 +24913,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "BUSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Source-available (BSL-1.1 → Apache 2030).",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BUSL-1.1",


### PR DESCRIPTION
Bump to v0.1.32.

## Highlights
- **Proxy / web-unblocker** (#280–#282): per-tool routing through a proxy/unblocker (Zyte) — fixes Akamai-blocked connectors (Deutsche Bahn). Per-tool checkbox, cloud rate limit, adapter `useProxy` flag.
- **Help Scout** OAuth2 client-credentials with auto-refresh (#277)
- **Clockify** expanded to 18 tools (#279)
- **Onboarding**: /welcome wizard + email drip (#272/#273/#276)
- **Sendcloud** perf fix (#274), **audit** user_id resolution (#275), **license-wall** logout fix (#278)