### PR TITLE
fix(cloud): wire CRON_SECRET into app container for onboarding cron

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -29,10 +29,13 @@ jobs:
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
+        env:
+          CRON_SECRET: ${{ secrets.ONBOARDING_CRON_SECRET }}
         with:
           host: ${{ secrets.CLOUD_HOST }}
           username: root
           key: ${{ secrets.CLOUD_SSH_KEY }}
+          envs: CRON_SECRET
           script: |
             set -e
             cd /opt/anythingmcp-cloud
@@ -47,6 +50,16 @@ jobs:
             cp /tmp/anythingmcp-deploy/docker-compose.cloud.yml ./docker-compose.cloud.yml
             cp /tmp/anythingmcp-deploy/deploy/cloud/Caddyfile ./Caddyfile
             rm -rf /tmp/anythingmcp-deploy
+
+            # Keep CRON_SECRET in the server .env in sync with the repo
+            # secret so the onboarding-reminders cron can authenticate.
+            # Upsert (replace-or-append) without disturbing other vars.
+            touch .env
+            if grep -q '^CRON_SECRET=' .env; then
+              sed -i "s#^CRON_SECRET=.*#CRON_SECRET=${CRON_SECRET}#" .env
+            else
+              echo "CRON_SECRET=${CRON_SECRET}" >> .env
+            fi
 
             # Restart services (force-recreate to pick up new image and config)
             docker compose -f docker-compose.cloud.yml up -d --force-recreate --remove-orphans

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -43,6 +43,10 @@ services:
       - REDIS_URL=redis://redis:6379
       - JWT_SECRET=${JWT_SECRET}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      # Shared secret for the onboarding-reminders GitHub Actions cron.
+      # Must match the repo secret ONBOARDING_CRON_SECRET. Unset = cron
+      # endpoint refuses all calls (self-host default).
+      - CRON_SECRET=${CRON_SECRET:-}
       - CORS_ORIGIN=https://${DOMAIN}
       - SERVER_URL=https://${DOMAIN}
       - FRONTEND_URL=https://${DOMAIN}


### PR DESCRIPTION
## Problem
The scheduled **Onboarding reminders cron** workflow (`onboarding-reminders.yml`, every 6h) has been failing continuously. Two gaps:

1. The repo secret `ONBOARDING_CRON_SECRET` was never set → the workflow aborts at its first guard (`CRON_SECRET is not set on this repository`).
2. Even past that, `docker-compose.cloud.yml` never passed `CRON_SECRET` to the app container, so `OnboardingCronController` (which checks `process.env.CRON_SECRET`) would return 401 for every call.

## This change
Adds `CRON_SECRET=${CRON_SECRET:-}` to the cloud app service env. Defaults to empty so the self-host behaviour is unchanged (endpoint refuses anonymous calls → drip stays cloud-only by design).

## Remaining steps to fully enable (production — not done here)
- `ONBOARDING_CRON_SECRET` repo secret is **already set**.
- Add the **same value** as `CRON_SECRET=...` to `/opt/anythingmcp-cloud/.env` on the cloud droplet.
- Run the **Deploy Cloud** workflow so the app picks up the new env.

Until the server `.env` + redeploy are done, the cron will still fail (now with 401 instead of "secret not set").