### PR TITLE
fix(security): tenant isolation on per-server MCP endpoint + self-host hardening

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,14 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: amcp-app
+    # Bind published ports to loopback by default so the API/MCP endpoint is
+    # not exposed on every network interface out of the box. To reach it from
+    # the LAN or the public internet, set APP_BIND_IP=0.0.0.0 in .env (and put
+    # it behind the Caddy proxy / a firewall). The Caddy service talks to the
+    # app over the internal Docker network, so it is unaffected by this bind.
     ports:
-      - "${APP_BIND_IP:-0.0.0.0}:${FRONTEND_PORT:-3000}:3000"
-      - "${APP_BIND_IP:-0.0.0.0}:${BACKEND_PORT:-4000}:4000"
+      - "${APP_BIND_IP:-127.0.0.1}:${FRONTEND_PORT:-3000}:3000"
+      - "${APP_BIND_IP:-127.0.0.1}:${BACKEND_PORT:-4000}:4000"
     environment:
       - NODE_ENV=production
       - PORT=4000
@@ -50,9 +55,16 @@ services:
       - SERVER_URL=${SERVER_URL:-http://localhost:4000}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
       # MCP Authentication (oauth2 | legacy | both | none)
+      # In `legacy`/`both` mode the /mcp endpoint requires MCP_API_KEY or
+      # MCP_BEARER_TOKEN. If neither is set, requests are REFUSED (401) unless
+      # MCP_ALLOW_ANONYMOUS=true is set explicitly — this avoids silently
+      # exposing configured MCP tools to unauthenticated network clients.
       - MCP_AUTH_MODE=${MCP_AUTH_MODE:-legacy}
       - MCP_API_KEY=${MCP_API_KEY:-}
       - MCP_BEARER_TOKEN=${MCP_BEARER_TOKEN:-}
+      # Set to true ONLY for trusted local/dev use to allow unauthenticated
+      # /mcp access when no MCP credentials are configured (legacy mode).
+      - MCP_ALLOW_ANONYMOUS=${MCP_ALLOW_ANONYMOUS:-false}
       # Registration (false = invite-only after first admin, true = anyone can register)
       - ALLOW_OPEN_REGISTRATION=${ALLOW_OPEN_REGISTRATION:-false}
       # Uncomment to enable Redis (optional — used for response caching and rate limiting)

--- a/packages/backend/src/auth/mcp-auth.middleware.ts
+++ b/packages/backend/src/auth/mcp-auth.middleware.ts
@@ -48,10 +48,28 @@ export class McpAuthMiddleware implements NestMiddleware {
       // Invalid per-user key — fall through to 401
     }
 
-    // If no auth is configured, allow all (dev mode)
+    // If no MCP credentials are configured, refuse by default (fail closed).
+    // Anonymous access is allowed only when explicitly opted in via
+    // MCP_ALLOW_ANONYMOUS=true, for trusted local/dev use. This prevents a
+    // default deployment from silently exposing configured MCP tools to
+    // unauthenticated network clients.
     if (!configuredApiKey && !mcpBearerToken) {
-      (req as any).user = { authMethod: 'none' };
-      return next();
+      const allowAnonymous =
+        this.configService.get<string>('MCP_ALLOW_ANONYMOUS') === 'true';
+      if (allowAnonymous) {
+        (req as any).user = { authMethod: 'none' };
+        return next();
+      }
+      this.logger.warn(
+        'MCP request refused: no MCP_API_KEY/MCP_BEARER_TOKEN configured and MCP_ALLOW_ANONYMOUS is not enabled.',
+      );
+      res.setHeader('WWW-Authenticate', 'Bearer realm="AnythingMCP MCP Server"');
+      res.status(401).json({
+        statusCode: 401,
+        message:
+          'MCP authentication is not configured. Set MCP_API_KEY or MCP_BEARER_TOKEN, or set MCP_ALLOW_ANONYMOUS=true for trusted local use.',
+      });
+      return;
     }
 
     // Check static API key

--- a/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
@@ -1,0 +1,121 @@
+import { McpCombinedAuthGuard } from './mcp-combined-auth.guard';
+
+describe('McpCombinedAuthGuard', () => {
+  let guard: McpCombinedAuthGuard;
+  let mockConfig: any;
+  let mockAuth: any;
+  let mockApiKeys: any;
+  let mockPrisma: any;
+
+  const mockContext = (headers: Record<string, string> = {}) => {
+    const request = { headers, user: undefined as any };
+    const response = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as any;
+  };
+
+  beforeEach(() => {
+    mockConfig = { get: jest.fn() };
+    mockAuth = { verifyToken: jest.fn() };
+    mockApiKeys = { resolveUserByKey: jest.fn() };
+    mockPrisma = { user: { findUnique: jest.fn() } };
+    guard = new McpCombinedAuthGuard(
+      mockConfig,
+      mockAuth,
+      mockApiKeys,
+      mockPrisma,
+    );
+  });
+
+  describe('organization resolution for JWT/OAuth tokens', () => {
+    it('keeps organizationId from an app JWT without a DB lookup', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'u1',
+        email: 'a@b.com',
+        role: 'ADMIN',
+        organizationId: 'org-A',
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer app-jwt' });
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+      expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-A');
+    });
+
+    it('resolves organizationId from the user record for an OAuth token that lacks it', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+      // OAuth access token shape: sub + user_data, NO organizationId claim.
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'u-finance',
+        type: 'access',
+        user_data: { id: 'u-finance', email: 'finance@helpcode.ai' },
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        organizationId: 'org-B',
+        email: 'finance@helpcode.ai',
+        role: 'ADMIN',
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer oauth-token' });
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'u-finance' },
+        select: { organizationId: true, email: true, role: true },
+      });
+      // Without this resolution the org check downstream would be skipped,
+      // allowing cross-tenant access to /mcp/:serverId.
+      expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-B');
+    });
+
+    it('leaves organizationId undefined when the user cannot be resolved (fail closed downstream)', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({ sub: 'ghost', user_data: {} });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const ctx = mockContext({ authorization: 'Bearer oauth-token' });
+      await guard.canActivate(ctx);
+
+      expect(
+        ctx.switchToHttp().getRequest().user.organizationId,
+      ).toBeUndefined();
+    });
+  });
+
+  describe('legacy mode with no credentials (fail closed)', () => {
+    const legacyNoCreds = (allowAnon?: string) =>
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'MCP_AUTH_MODE') return 'legacy';
+        if (key === 'MCP_ALLOW_ANONYMOUS') return allowAnon;
+        return undefined; // MCP_API_KEY / MCP_BEARER_TOKEN unset
+      });
+
+    it('refuses anonymous access by default', async () => {
+      legacyNoCreds(undefined);
+      const ctx = mockContext({});
+      const result = await guard.canActivate(ctx);
+      expect(result).toBe(false);
+      expect(ctx.switchToHttp().getResponse().status).toHaveBeenCalledWith(401);
+    });
+
+    it('allows anonymous access only when MCP_ALLOW_ANONYMOUS=true', async () => {
+      legacyNoCreds('true');
+      const ctx = mockContext({});
+      const result = await guard.canActivate(ctx);
+      expect(result).toBe(true);
+      expect(ctx.switchToHttp().getRequest().user.authMethod).toBe('none');
+    });
+  });
+});

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -2,6 +2,7 @@ import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/commo
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { McpApiKeysService } from '../roles/mcp-api-keys.service';
+import { PrismaService } from '../common/prisma.service';
 
 /**
  * Combined auth guard for per-server MCP endpoints (/mcp/:serverId).
@@ -22,6 +23,7 @@ export class McpCombinedAuthGuard implements CanActivate {
     private readonly configService: ConfigService,
     private readonly authService: AuthService,
     private readonly mcpApiKeysService: McpApiKeysService,
+    private readonly prisma: PrismaService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -72,8 +74,33 @@ export class McpCombinedAuthGuard implements CanActivate {
 
       // JWT token (OAuth or legacy JWT)
       try {
-        const payload = this.authService.verifyToken(token);
-        req.user = { ...payload, authMethod: 'jwt' };
+        const payload = this.authService.verifyToken(token) as any;
+        // App JWTs carry `organizationId` in their claims. OAuth access tokens
+        // issued by the MCP OAuth flow only carry `sub` + `user_data` (no org).
+        // Resolve the organization from the user record so the per-server
+        // tenant-isolation check can be enforced — without this, OAuth clients
+        // would have `organizationId === undefined` and bypass isolation,
+        // allowing cross-organization access to any /mcp/:serverId endpoint.
+        let organizationId: string | undefined =
+          payload.organizationId ?? undefined;
+        const userId: string | undefined = payload.sub || payload.user_data?.id;
+        if (!organizationId && userId) {
+          const dbUser = await this.prisma.user.findUnique({
+            where: { id: userId },
+            select: { organizationId: true, email: true, role: true },
+          });
+          organizationId = dbUser?.organizationId ?? undefined;
+          req.user = {
+            ...payload,
+            sub: userId,
+            organizationId,
+            email: payload.email ?? payload.user_data?.email ?? dbUser?.email,
+            role: payload.role ?? dbUser?.role,
+            authMethod: 'jwt',
+          };
+        } else {
+          req.user = { ...payload, organizationId, authMethod: 'jwt' };
+        }
         return true;
       } catch {
         // Invalid JWT — continue
@@ -86,8 +113,15 @@ export class McpCombinedAuthGuard implements CanActivate {
       return true;
     }
 
-    // 5. If legacy mode but no credentials configured (dev mode), allow
-    if (!configuredApiKey && !mcpBearerToken && mode === 'legacy') {
+    // 5. Legacy mode with no credentials configured: refuse by default (fail
+    // closed). Allow anonymous access only when explicitly opted in via
+    // MCP_ALLOW_ANONYMOUS=true, for trusted local/dev use.
+    if (
+      mode === 'legacy' &&
+      !configuredApiKey &&
+      !mcpBearerToken &&
+      this.configService.get<string>('MCP_ALLOW_ANONYMOUS') === 'true'
+    ) {
       req.user = { authMethod: 'none' };
       return true;
     }

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
@@ -1,0 +1,82 @@
+import { McpEndpointController } from './mcp-endpoint.controller';
+
+/**
+ * Regression tests for cross-tenant isolation on the per-server MCP endpoint.
+ * A leak was confirmed where an OAuth token from org B could list/use org A's
+ * tools because the org check was skipped when organizationId was absent.
+ */
+describe('McpEndpointController — tenant isolation', () => {
+  let controller: McpEndpointController;
+  let mcpServersService: any;
+  let toolRegistry: any;
+  let toolExecutor: any;
+  let rolesService: any;
+
+  const SERVER = {
+    id: 'srv-A',
+    name: 'deutsch bahn',
+    version: '1.0.0',
+    isActive: true,
+    organizationId: 'org-A',
+  };
+
+  const makeRes = () => {
+    const res: any = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    res.headersSent = false;
+    return res;
+  };
+
+  beforeEach(() => {
+    mcpServersService = {
+      findById: jest.fn().mockResolvedValue(SERVER),
+      getConnectorIds: jest.fn().mockResolvedValue([]),
+      getComposedInstructions: jest.fn().mockResolvedValue(''),
+    };
+    toolRegistry = { getAllTools: jest.fn().mockReturnValue([]) };
+    toolExecutor = { executeTool: jest.fn() };
+    rolesService = { getAllowedToolIds: jest.fn().mockResolvedValue(null) };
+    controller = new McpEndpointController(
+      mcpServersService,
+      toolRegistry,
+      toolExecutor,
+      rolesService,
+    );
+  });
+
+  it('denies a user whose organization differs from the server (cross-tenant)', async () => {
+    const req: any = { user: { organizationId: 'org-B', authMethod: 'jwt' } };
+    const res = makeRes();
+
+    await controller.handlePost('srv-A', req, res, {});
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    // Must short-circuit before touching the server's connectors/tools.
+    expect(mcpServersService.getConnectorIds).not.toHaveBeenCalled();
+  });
+
+  it('denies when the caller organization cannot be determined (fail closed)', async () => {
+    const req: any = { user: { authMethod: 'jwt' } }; // no organizationId
+    const res = makeRes();
+
+    await controller.handlePost('srv-A', req, res, {});
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mcpServersService.getConnectorIds).not.toHaveBeenCalled();
+  });
+
+  it('allows a user from the same organization as the server', async () => {
+    const req: any = {
+      user: { organizationId: 'org-A', authMethod: 'jwt' },
+      headers: {},
+    };
+    const res = makeRes();
+
+    await controller.handlePost('srv-A', req, res, {});
+
+    // Passed isolation → proceeded to assemble the server's tools.
+    expect(mcpServersService.getConnectorIds).toHaveBeenCalledWith('srv-A');
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+});

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -106,9 +106,19 @@ export class McpEndpointController {
       });
     }
 
-    // Verify the authenticated user belongs to the same organization as the MCP server
+    // Tenant isolation: a request scoped to a specific server must come from a
+    // principal in that server's organization. Fail closed — deny when the
+    // caller's organization is unknown or does not match. Instance-level static
+    // credentials (self-host, not organization-scoped) are exempt.
     const user = (req as any).user;
-    if (user?.organizationId && mcpServerConfig.organizationId !== user.organizationId) {
+    const isInstanceLevel =
+      user?.authMethod === 'static_api_key' ||
+      user?.authMethod === 'static_bearer' ||
+      user?.authMethod === 'none';
+    if (
+      !isInstanceLevel &&
+      mcpServerConfig.organizationId !== user?.organizationId
+    ) {
       return res.status(403).json({
         jsonrpc: '2.0',
         error: { code: -32001, message: 'Access denied' },


### PR DESCRIPTION
## Summary
Closes a **confirmed cross-tenant authorization vulnerability** on the cloud per-server MCP endpoint, plus the two self-host hardening items from an external report.

## The vulnerability (confirmed live on cloud)
MCP OAuth access tokens (the normal auth path for clients like Claude Desktop) carry only `sub` + `user_data` — **no `organizationId`**. The per-server endpoint `/mcp/:serverId` only enforced org isolation `if (user.organizationId && …)`, so OAuth clients bypassed it.

Live test (two of the owner's own orgs A/B): an OAuth token for org B listed org A's tools:
| Caller | Target | Result |
|---|---|---|
| anonymous | org A server | 401 ✅ |
| app-JWT (org B) | org A server | 403 ✅ |
| **OAuth token (org B)** | **org A server** | **🔴 200 — tools leaked** |

Root cause compounders: `profileMapper` omits org from the OAuth profile, and `JwtModule` verifies no `audience`/`issuer`, so OAuth access tokens pass `authService.verifyToken`.

## Fixes
- **McpCombinedAuthGuard**: resolve `organizationId` from the user record when a verified bearer JWT lacks it (OAuth tokens), so every authenticated principal carries an org.
- **McpEndpointController**: org check is now **fail-closed** — deny when the caller's org is unknown or mismatched. Instance-level static creds (self-host) stay exempt.
- Regression tests: `mcp-combined-auth.guard.spec.ts`, `mcp-endpoint.controller.spec.ts`.

## Self-host hardening (cloud unaffected — runs `oauth2`)
- **Fail-closed legacy**: `legacy` mode with no `MCP_API_KEY`/`MCP_BEARER_TOKEN` now returns 401 instead of allowing all; opt back in with `MCP_ALLOW_ANONYMOUS=true` for trusted local use (middleware + guard).
- **Loopback bind**: `docker-compose.yml` binds app ports to `127.0.0.1` by default (`APP_BIND_IP=0.0.0.0` to expose). Caddy is unaffected (talks over the Docker network).

Note: placeholder JWT/ENCRYPTION secrets in compose are already rejected at boot by `validateRequiredSecretsAtStartup` — the app fails closed there too.

## Verification
- Local: backend lint (0 errors), `tsc --noEmit`, **3023 tests pass** (incl. new regression tests).
- Post-merge: rebuild image, deploy to cloud, re-run the live cross-tenant test (expect 403).

## Follow-ups (not in this PR)
- Unused `McpAuthGuard` still has a fail-open dev branch (not wired to any route) — recommend hardening or removing.
- Consider verifying `audience`/`issuer` on app JWTs to separate OAuth access tokens from app session tokens.