### PR TITLE
fix(auth): resolve OAuth org by id OR email — fixes prod 403 lockout on /mcp/:serverId

### DIFF
--- a/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
@@ -26,7 +26,7 @@ describe('McpCombinedAuthGuard', () => {
     mockConfig = { get: jest.fn() };
     mockAuth = { verifyToken: jest.fn() };
     mockApiKeys = { resolveUserByKey: jest.fn() };
-    mockPrisma = { user: { findUnique: jest.fn() } };
+    mockPrisma = { user: { findUnique: jest.fn(), findFirst: jest.fn() } };
     guard = new McpCombinedAuthGuard(
       mockConfig,
       mockAuth,
@@ -53,7 +53,7 @@ describe('McpCombinedAuthGuard', () => {
       expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-A');
     });
 
-    it('resolves organizationId from the user record for an OAuth token that lacks it', async () => {
+    it('resolves organizationId from the user record for an OAuth token whose sub is a cuid', async () => {
       mockConfig.get.mockReturnValue(undefined);
       // OAuth access token shape: sub + user_data, NO organizationId claim.
       mockAuth.verifyToken.mockReturnValue({
@@ -61,7 +61,8 @@ describe('McpCombinedAuthGuard', () => {
         type: 'access',
         user_data: { id: 'u-finance', email: 'finance@helpcode.ai' },
       });
-      mockPrisma.user.findUnique.mockResolvedValue({
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'u-finance',
         organizationId: 'org-B',
         email: 'finance@helpcode.ai',
         role: 'ADMIN',
@@ -71,19 +72,52 @@ describe('McpCombinedAuthGuard', () => {
       const result = await guard.canActivate(ctx);
 
       expect(result).toBe(true);
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
-        where: { id: 'u-finance' },
-        select: { organizationId: true, email: true, role: true },
+      // Resolves by id OR email — the user_data.email is also a candidate.
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: {
+          OR: [{ id: 'u-finance' }, { email: 'finance@helpcode.ai' }],
+        },
+        select: { id: true, organizationId: true, email: true, role: true },
       });
-      // Without this resolution the org check downstream would be skipped,
-      // allowing cross-tenant access to /mcp/:serverId.
       expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-B');
+    });
+
+    it('resolves organizationId when the OAuth token sub IS the email (rekog/mcp-nest)', async () => {
+      // Regression test for the production 403 incident: rekog signs `sub`
+      // with the email, not the users.id cuid. The guard must still resolve
+      // the org (by email) so legitimate owners are not locked out.
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'jjstrick9@gmail.com',
+        type: 'access',
+        user_data: {},
+      });
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'cmpzj8mm9007j1ymn5mo2y3eq',
+        organizationId: 'cmpzj8mds007i1ymntpyjngdp',
+        email: 'jjstrick9@gmail.com',
+        role: 'ADMIN',
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer oauth-token' });
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      // sub is an email → matched via the email branch, not id.
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: { OR: [{ email: 'jjstrick9@gmail.com' }] },
+        select: { id: true, organizationId: true, email: true, role: true },
+      });
+      const u = ctx.switchToHttp().getRequest().user;
+      expect(u.organizationId).toBe('cmpzj8mds007i1ymntpyjngdp');
+      // sub is normalised back to the real cuid for downstream ownership checks.
+      expect(u.sub).toBe('cmpzj8mm9007j1ymn5mo2y3eq');
     });
 
     it('leaves organizationId undefined when the user cannot be resolved (fail closed downstream)', async () => {
       mockConfig.get.mockReturnValue(undefined);
       mockAuth.verifyToken.mockReturnValue({ sub: 'ghost', user_data: {} });
-      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.findFirst.mockResolvedValue(null);
 
       const ctx = mockContext({ authorization: 'Bearer oauth-token' });
       await guard.canActivate(ctx);

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -83,18 +83,41 @@ export class McpCombinedAuthGuard implements CanActivate {
         // allowing cross-organization access to any /mcp/:serverId endpoint.
         let organizationId: string | undefined =
           payload.organizationId ?? undefined;
-        const userId: string | undefined = payload.sub || payload.user_data?.id;
-        if (!organizationId && userId) {
-          const dbUser = await this.prisma.user.findUnique({
-            where: { id: userId },
-            select: { organizationId: true, email: true, role: true },
+        // The MCP OAuth flow (rekog/mcp-nest) signs `sub` with whatever
+        // identifier the auth code carried — in our integration that's the
+        // user's EMAIL, not the `users.id` cuid. App JWTs, by contrast, put
+        // the cuid in `sub`. So we can't assume `sub` is a primary key:
+        // resolve the user by id OR email, trying every identifier the token
+        // exposes. Without this, OAuth callers resolve to `organizationId ===
+        // undefined` and the downstream per-server tenant check fails closed
+        // with 403 — locking legitimate owners out of their own servers.
+        const subId: string | undefined = payload.sub || payload.user_data?.id;
+        const email: string | undefined =
+          payload.email ?? payload.user_data?.email ?? undefined;
+        if (!organizationId && (subId || email)) {
+          // `sub` may itself be an email; collect every candidate and match
+          // on id OR email in a single query.
+          const ids = [subId].filter(
+            (v): v is string => !!v && !v.includes('@'),
+          );
+          const emails = [email, subId].filter(
+            (v): v is string => !!v && v.includes('@'),
+          );
+          const dbUser = await this.prisma.user.findFirst({
+            where: {
+              OR: [
+                ...ids.map((id) => ({ id })),
+                ...emails.map((e) => ({ email: e })),
+              ],
+            },
+            select: { id: true, organizationId: true, email: true, role: true },
           });
           organizationId = dbUser?.organizationId ?? undefined;
           req.user = {
             ...payload,
-            sub: userId,
+            sub: dbUser?.id ?? subId,
             organizationId,
-            email: payload.email ?? payload.user_data?.email ?? dbUser?.email,
+            email: dbUser?.email ?? email,
             role: payload.role ?? dbUser?.role,
             authMethod: 'jwt',
           };


### PR DESCRIPTION
## Production incident

≥6 paying customers locked out of their **own** MCP servers with **403 `Access denied`** on `/mcp/:serverId` — including server owners in the correct org with ADMIN role. Surfaced by a customer email (Marco Keuthen) but the audit + request logs showed it's **systemic** across distinct users/servers.

## Root cause

The per-server tenant check (from #286) fails closed when `user.organizationId !== mcpServerConfig.organizationId`. For legit owners the orgs are identical → so `user.organizationId` was resolving to **undefined**.

The guard resolved org via `findUnique({ where: { id: payload.sub } })`, assuming `sub` = `users.id` cuid. But the MCP OAuth flow (rekog/mcp-nest) signs `sub` with the user's **email** in our integration → id lookup returns null → org undefined → 403.

Confirmed: `logger.module.ts` maps `userId ← req.user.sub`, and prod logs show the **email** there; rekog `jwt-token.service` signs `sub: userId` verbatim.

## Fix

Resolve the user by **id OR email** (single `findFirst`): `sub` may be a cuid (app JWT) or an email (OAuth); `user_data.email` is also a candidate. `req.user.sub` is normalised back to the real cuid so downstream ownership checks keep working.

**Tenant isolation preserved** — resolved org is the authenticated user's real org, still compared to the server's org. Genuine cross-org access still 403s.

## Tests
Guard spec covers cuid-sub, **email-sub (the regression)**, and unresolved-user fail-closed. 66/66 auth + mcp-endpoint specs pass; tsc clean.

## Note — separate issue for Marco
His **Problem 1** (`"type": "url"` rejected by Claude Desktop) is a client-config/doc issue (should be `"type": "http"` or the mcp-remote bridge) — tracked separately.

Auth-deploy override approved for this run.