### PR TITLE
fix(dashboard): Claude Desktop config uses type "http" not "url"

### DIFF
--- a/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
@@ -26,7 +26,7 @@ describe('McpCombinedAuthGuard', () => {
     mockConfig = { get: jest.fn() };
     mockAuth = { verifyToken: jest.fn() };
     mockApiKeys = { resolveUserByKey: jest.fn() };
-    mockPrisma = { user: { findUnique: jest.fn() } };
+    mockPrisma = { user: { findUnique: jest.fn(), findFirst: jest.fn() } };
     guard = new McpCombinedAuthGuard(
       mockConfig,
       mockAuth,
@@ -53,7 +53,7 @@ describe('McpCombinedAuthGuard', () => {
       expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-A');
     });
 
-    it('resolves organizationId from the user record for an OAuth token that lacks it', async () => {
+    it('resolves organizationId from the user record for an OAuth token whose sub is a cuid', async () => {
       mockConfig.get.mockReturnValue(undefined);
       // OAuth access token shape: sub + user_data, NO organizationId claim.
       mockAuth.verifyToken.mockReturnValue({
@@ -61,7 +61,8 @@ describe('McpCombinedAuthGuard', () => {
         type: 'access',
         user_data: { id: 'u-finance', email: 'finance@helpcode.ai' },
       });
-      mockPrisma.user.findUnique.mockResolvedValue({
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'u-finance',
         organizationId: 'org-B',
         email: 'finance@helpcode.ai',
         role: 'ADMIN',
@@ -71,19 +72,52 @@ describe('McpCombinedAuthGuard', () => {
       const result = await guard.canActivate(ctx);
 
       expect(result).toBe(true);
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
-        where: { id: 'u-finance' },
-        select: { organizationId: true, email: true, role: true },
+      // Resolves by id OR email — the user_data.email is also a candidate.
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: {
+          OR: [{ id: 'u-finance' }, { email: 'finance@helpcode.ai' }],
+        },
+        select: { id: true, organizationId: true, email: true, role: true },
       });
-      // Without this resolution the org check downstream would be skipped,
-      // allowing cross-tenant access to /mcp/:serverId.
       expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-B');
+    });
+
+    it('resolves organizationId when the OAuth token sub IS the email (rekog/mcp-nest)', async () => {
+      // Regression test for the production 403 incident: rekog signs `sub`
+      // with the email, not the users.id cuid. The guard must still resolve
+      // the org (by email) so legitimate owners are not locked out.
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'jjstrick9@gmail.com',
+        type: 'access',
+        user_data: {},
+      });
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'cmpzj8mm9007j1ymn5mo2y3eq',
+        organizationId: 'cmpzj8mds007i1ymntpyjngdp',
+        email: 'jjstrick9@gmail.com',
+        role: 'ADMIN',
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer oauth-token' });
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      // sub is an email → matched via the email branch, not id.
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
+        where: { OR: [{ email: 'jjstrick9@gmail.com' }] },
+        select: { id: true, organizationId: true, email: true, role: true },
+      });
+      const u = ctx.switchToHttp().getRequest().user;
+      expect(u.organizationId).toBe('cmpzj8mds007i1ymntpyjngdp');
+      // sub is normalised back to the real cuid for downstream ownership checks.
+      expect(u.sub).toBe('cmpzj8mm9007j1ymn5mo2y3eq');
     });
 
     it('leaves organizationId undefined when the user cannot be resolved (fail closed downstream)', async () => {
       mockConfig.get.mockReturnValue(undefined);
       mockAuth.verifyToken.mockReturnValue({ sub: 'ghost', user_data: {} });
-      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.findFirst.mockResolvedValue(null);
 
       const ctx = mockContext({ authorization: 'Bearer oauth-token' });
       await guard.canActivate(ctx);

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -83,18 +83,41 @@ export class McpCombinedAuthGuard implements CanActivate {
         // allowing cross-organization access to any /mcp/:serverId endpoint.
         let organizationId: string | undefined =
           payload.organizationId ?? undefined;
-        const userId: string | undefined = payload.sub || payload.user_data?.id;
-        if (!organizationId && userId) {
-          const dbUser = await this.prisma.user.findUnique({
-            where: { id: userId },
-            select: { organizationId: true, email: true, role: true },
+        // The MCP OAuth flow (rekog/mcp-nest) signs `sub` with whatever
+        // identifier the auth code carried — in our integration that's the
+        // user's EMAIL, not the `users.id` cuid. App JWTs, by contrast, put
+        // the cuid in `sub`. So we can't assume `sub` is a primary key:
+        // resolve the user by id OR email, trying every identifier the token
+        // exposes. Without this, OAuth callers resolve to `organizationId ===
+        // undefined` and the downstream per-server tenant check fails closed
+        // with 403 — locking legitimate owners out of their own servers.
+        const subId: string | undefined = payload.sub || payload.user_data?.id;
+        const email: string | undefined =
+          payload.email ?? payload.user_data?.email ?? undefined;
+        if (!organizationId && (subId || email)) {
+          // `sub` may itself be an email; collect every candidate and match
+          // on id OR email in a single query.
+          const ids = [subId].filter(
+            (v): v is string => !!v && !v.includes('@'),
+          );
+          const emails = [email, subId].filter(
+            (v): v is string => !!v && v.includes('@'),
+          );
+          const dbUser = await this.prisma.user.findFirst({
+            where: {
+              OR: [
+                ...ids.map((id) => ({ id })),
+                ...emails.map((e) => ({ email: e })),
+              ],
+            },
+            select: { id: true, organizationId: true, email: true, role: true },
           });
           organizationId = dbUser?.organizationId ?? undefined;
           req.user = {
             ...payload,
-            sub: userId,
+            sub: dbUser?.id ?? subId,
             organizationId,
-            email: payload.email ?? payload.user_data?.email ?? dbUser?.email,
+            email: dbUser?.email ?? email,
             role: payload.role ?? dbUser?.role,
             authMethod: 'jwt',
           };

--- a/packages/frontend/src/app/mcp-server/[id]/page.tsx
+++ b/packages/frontend/src/app/mcp-server/[id]/page.tsx
@@ -210,10 +210,15 @@ export default function McpServerDetailPage() {
 
   const slug = server.slug || 'my-server';
 
+  // Claude Desktop's config schema accepts "stdio" (local command) or "http"
+  // (remote streamable HTTP). "url" is NOT a valid type — Claude Desktop
+  // silently skips entries with it ("not valid MCP server configurations").
+  // For remote OAuth servers use "http"; Claude triggers the OAuth flow off
+  // the WWW-Authenticate header our endpoint returns on 401.
   const claudeConfigOAuth = `{
   "mcpServers": {
     "${slug}": {
-      "type": "url",
+      "type": "http",
       "url": "${endpointUrl}"
     }
   }
@@ -222,7 +227,7 @@ export default function McpServerDetailPage() {
   const claudeConfigApiKey = `{
   "mcpServers": {
     "${slug}": {
-      "type": "url",
+      "type": "http",
       "url": "${endpointUrl}",
       "headers": {
         "X-API-Key": "YOUR_MCP_API_KEY"


### PR DESCRIPTION
The per-server **Connect to Claude Desktop** modal generated a config with `"type": "url"`, which Claude Desktop does not accept — it silently skips the entry ("not valid MCP server configurations and were skipped"). Reported by customer Marco Keuthen (his Problem 1).

Valid types: `stdio` (local) / `http` (remote streamable HTTP). Changed both generated snippets (OAuth + API-key) to `"type": "http"`. For OAuth, Claude Desktop triggers the flow off the `WWW-Authenticate` header our endpoint returns on 401.

Other clients in the modal were already correct (Windsurf `serverUrl`, VS Code deep link `type: http`).

Frontend-only; ships via the same docker-publish + deploy-cloud pipeline. Auto-deploy override approved for this run.

Note: Marco also hit the systemic 403 (fixed separately in #309). His server-id `cmpyammdi...` is not in mcp_server_configs — likely recreated; he should copy the current URL from the dashboard.