### PR TITLE
fix(auth): membership-based tenant isolation for /mcp/:serverId (multi-org)

### DIFF
--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
@@ -33,6 +33,7 @@ describe('McpEndpointController — tenant isolation', () => {
       findById: jest.fn().mockResolvedValue(SERVER),
       getConnectorIds: jest.fn().mockResolvedValue([]),
       getComposedInstructions: jest.fn().mockResolvedValue(''),
+      isUserInOrganization: jest.fn().mockResolvedValue(false),
     };
     toolRegistry = { getAllTools: jest.fn().mockReturnValue([]) };
     toolExecutor = { executeTool: jest.fn() };
@@ -45,15 +46,42 @@ describe('McpEndpointController — tenant isolation', () => {
     );
   });
 
-  it('denies a user whose organization differs from the server (cross-tenant)', async () => {
-    const req: any = { user: { organizationId: 'org-B', authMethod: 'jwt' } };
+  it('denies a non-member whose org differs and has no membership (cross-tenant)', async () => {
+    // org-B user, NOT a member of org-A → isUserInOrganization returns false.
+    const req: any = {
+      user: { sub: 'u-b', organizationId: 'org-B', authMethod: 'jwt' },
+    };
     const res = makeRes();
 
     await controller.handlePost('srv-A', req, res, {});
 
+    expect(mcpServersService.isUserInOrganization).toHaveBeenCalledWith(
+      'u-b',
+      'org-A',
+    );
     expect(res.status).toHaveBeenCalledWith(403);
     // Must short-circuit before touching the server's connectors/tools.
     expect(mcpServersService.getConnectorIds).not.toHaveBeenCalled();
+  });
+
+  it('allows a multi-org user who is a MEMBER of the server org via membership', async () => {
+    // Primary org is org-B, but the user is also a member of org-A (the
+    // server's org) — must be allowed.
+    mcpServersService.isUserInOrganization.mockResolvedValue(true);
+    const req: any = {
+      user: { sub: 'u-multi', organizationId: 'org-B', authMethod: 'jwt' },
+      headers: {},
+    };
+    const res = makeRes();
+
+    await controller.handlePost('srv-A', req, res, {});
+
+    expect(mcpServersService.isUserInOrganization).toHaveBeenCalledWith(
+      'u-multi',
+      'org-A',
+    );
+    expect(mcpServersService.getConnectorIds).toHaveBeenCalledWith('srv-A');
+    expect(res.status).not.toHaveBeenCalledWith(403);
   });
 
   it('denies when the caller organization cannot be determined (fail closed)', async () => {
@@ -66,16 +94,17 @@ describe('McpEndpointController — tenant isolation', () => {
     expect(mcpServersService.getConnectorIds).not.toHaveBeenCalled();
   });
 
-  it('allows a user from the same organization as the server', async () => {
+  it('allows a user whose primary org matches the server (zero-query fast path)', async () => {
     const req: any = {
-      user: { organizationId: 'org-A', authMethod: 'jwt' },
+      user: { sub: 'u-a', organizationId: 'org-A', authMethod: 'jwt' },
       headers: {},
     };
     const res = makeRes();
 
     await controller.handlePost('srv-A', req, res, {});
 
-    // Passed isolation → proceeded to assemble the server's tools.
+    // Primary org matches → no membership query needed.
+    expect(mcpServersService.isUserInOrganization).not.toHaveBeenCalled();
     expect(mcpServersService.getConnectorIds).toHaveBeenCalledWith('srv-A');
     expect(res.status).not.toHaveBeenCalledWith(403);
   });

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -107,23 +107,39 @@ export class McpEndpointController {
     }
 
     // Tenant isolation: a request scoped to a specific server must come from a
-    // principal in that server's organization. Fail closed — deny when the
-    // caller's organization is unknown or does not match. Instance-level static
+    // principal who is a MEMBER of that server's organization. Fail closed —
+    // deny when membership can't be established. Instance-level static
     // credentials (self-host, not organization-scoped) are exempt.
+    //
+    // Membership is checked against organization_members, not just the user's
+    // primary `organizationId` column: a user who belongs to several
+    // workspaces must reach servers in any org they're a member of, while a
+    // non-member is still denied. The primary-org match is kept as a
+    // zero-query fast path for the common single-org case.
     const user = (req as any).user;
     const isInstanceLevel =
       user?.authMethod === 'static_api_key' ||
       user?.authMethod === 'static_bearer' ||
       user?.authMethod === 'none';
-    if (
-      !isInstanceLevel &&
-      mcpServerConfig.organizationId !== user?.organizationId
-    ) {
-      return res.status(403).json({
-        jsonrpc: '2.0',
-        error: { code: -32001, message: 'Access denied' },
-        id: null,
-      });
+    if (!isInstanceLevel) {
+      const serverOrg = mcpServerConfig.organizationId;
+      const primaryOrgMatches =
+        !!user?.organizationId && user.organizationId === serverOrg;
+      const isMember =
+        primaryOrgMatches ||
+        (!!user?.sub &&
+          !!serverOrg &&
+          (await this.mcpServersService.isUserInOrganization(
+            user.sub,
+            serverOrg,
+          )));
+      if (!isMember) {
+        return res.status(403).json({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Access denied' },
+          id: null,
+        });
+      }
     }
 
     // 2. Get connector IDs and composed instructions for this server

--- a/packages/backend/src/mcp-servers/mcp-servers.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.service.ts
@@ -32,6 +32,26 @@ export class McpServersService {
     });
   }
 
+  /**
+   * Tenant-isolation primitive: is the user a member of the organization?
+   *
+   * Authoritative membership check used by the per-server MCP endpoint. Unlike
+   * comparing the single `users.organizationId` column, this honours
+   * organization_members — so a user who belongs to multiple workspaces can
+   * reach servers in any org they're actually a member of, while a non-member
+   * is still denied (fail closed).
+   */
+  async isUserInOrganization(
+    userId: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    if (!userId || !organizationId) return false;
+    const count = await this.prisma.organizationMember.count({
+      where: { userId, organizationId },
+    });
+    return count > 0;
+  }
+
   async findById(id: string) {
     return this.prisma.mcpServerConfig.findUnique({
       where: { id },


### PR DESCRIPTION
Follow-up hardening to #309. The per-server tenant check compared the user's single primary `organizationId` column to the server's org — which **over-blocks multi-org users** (member of workspace B primary + workspace A would be denied A's servers). No leak, strictly over-restrictive.

**Fix:** authoritative membership check against `organization_members` (new `McpServersService.isUserInOrganization`). Allowed iff the user is a member of the server's org. Primary-org match kept as a **zero-query fast path** for the common single-org case → extra DB round-trip only for the multi-org edge.

**Fail-closed preserved:** no membership row → 403. Verified on prod data that no (user, server) pair passes without a genuine membership; cross-workspace users remain denied.

Tests: controller spec — non-member-with-sub denied, multi-org-member allowed, primary-org fast path issues no query. tsc clean.

Auto-deploy override approved for this run.