### PR TITLE
chore(release): v0.1.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "BUSL-1.1",
       "workspaces": [
         "packages/backend",
@@ -23820,7 +23820,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "BUSL-1.1",
       "dependencies": {
         "@nestjs/common": "^11.1.24",
@@ -24297,7 +24297,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "BUSL-1.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Source-available (BSL-1.1 → Apache 2030).",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "BUSL-1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "BUSL-1.1",


### PR DESCRIPTION
Release v0.1.33. Bumps version across root + backend + frontend + lockfile.

Highlights since v0.1.32:
- **fix(auth):** membership-based tenant isolation for /mcp/:serverId — multi-org users reach all orgs they belong to; cross-org still denied (#311)
- **fix(auth):** resolve OAuth org by id OR email — fixes prod 403 lockout on /mcp/:serverId (#309)
- **fix(dashboard):** Claude Desktop config uses type "http" not "url" (#310)
- **weclapp:** fix filter 400s via __rawquery engine passthrough (#308)
- Plus: 8 reverse-engineered connectors live (playtomic, opentable, resy, vinted, untappd, idealista, trenitalia) + Etsy OAuth2 refresh migration.