### PR TITLE
fix(mcp): dedupe tool names so a duplicate connector can't 500 the server

### DIFF
--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
@@ -94,6 +94,41 @@ describe('McpEndpointController — tenant isolation', () => {
     expect(mcpServersService.getConnectorIds).not.toHaveBeenCalled();
   });
 
+  it('does not crash when two connectors expose the same tool name (dedup, no 500)', async () => {
+    // Regression: a server with two connectors that both expose
+    // "etsy_get_authenticated_user" made the MCP SDK throw
+    // "Tool ... is already registered", which 500'd every request.
+    const dupTool = (connectorId: string) => ({
+      id: `${connectorId}:etsy_get_authenticated_user`,
+      connectorId,
+      name: 'etsy_get_authenticated_user',
+      description: 'whoami',
+      parameters: { type: 'object', properties: {} },
+      connectorConfig: { envVars: {} },
+    });
+    mcpServersService.getConnectorIds.mockResolvedValue(['c1', 'c2']);
+    toolRegistry.getAllTools.mockReturnValue([dupTool('c1'), dupTool('c2')]);
+    const warnSpy = jest
+      .spyOn((controller as any).logger, 'warn')
+      .mockImplementation(() => undefined);
+
+    const req: any = {
+      user: { sub: 'u-a', organizationId: 'org-A', authMethod: 'jwt' },
+      headers: {},
+    };
+    const res = makeRes();
+
+    // Must resolve — the duplicate registration used to throw out of the
+    // handler (it runs before the transport try/catch).
+    await expect(
+      controller.handlePost('srv-A', req, res, {}),
+    ).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Duplicate tool name "etsy_get_authenticated_user"'),
+    );
+  });
+
   it('allows a user whose primary org matches the server (zero-query fast path)', async () => {
     const req: any = {
       user: { sub: 'u-a', organizationId: 'org-A', authMethod: 'jwt' },

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -179,11 +179,26 @@ export class McpEndpointController {
       connectorIds,
     };
 
+    // Dedupe by tool name. A server can have two connectors that expose the
+    // same tool name (e.g. the same connector assigned twice, or two configs
+    // of one provider). The MCP SDK throws "Tool X is already registered" on
+    // the second registration, which previously 500'd the ENTIRE request and
+    // took down every tool on the server. Register the first occurrence of
+    // each name and skip the rest, so one duplicate can't break the endpoint.
+    const registeredNames = new Set<string>();
     for (const tool of serverTools) {
       // Skip tools not allowed by role
       if (allowedToolIds !== null && !allowedToolIds.includes(tool.id)) {
         continue;
       }
+
+      if (registeredNames.has(tool.name)) {
+        this.logger.warn(
+          `Duplicate tool name "${tool.name}" on server ${serverId} — skipping the extra copy (check for duplicate connector assignments).`,
+        );
+        continue;
+      }
+      registeredNames.add(tool.name);
 
       const schema = this.stripEnvVarParams(tool.parameters, tool.connectorConfig.envVars);
       const zodShape = this.jsonSchemaToZodShape(schema);


### PR DESCRIPTION
Production: one customer's MCP server returned **HTTP 500 on every request** (193 in 48h). Root cause: two connectors on the server both expose the same tool names (the same Etsy connector assigned twice). The per-request registration loop calls `mcpServer.tool(name, …)` for each → the MCP SDK throws `Tool <name> is already registered` on the second. That throw is **before** the transport try/catch, so it 500s the **entire** request — every tool on the server, not just the duplicate.

**Fix:** track registered names in a Set, skip duplicates (first wins), log a warning pointing at the duplicate connector assignment. One misconfiguration can no longer break the whole endpoint.

Regression test added. tsc clean, 5/5 controller specs pass.

A separate data cleanup removes the duplicate Etsy connector from the affected server. Auto-deploy override approved for this run.