### PR TITLE
fix(license): make LICENSE pure AGPL text so GitHub detects AGPL-3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,3 @@
-AnythingMCP
-Copyright (c) 2026 helpcode.ai GmbH
-
-This software is licensed under the GNU Affero General Public License
-version 3 ("AGPL-3.0-only"), reproduced in full below — with the
-following exception:
-
-  All content that resides under any directory named "ee" (e.g.
-  packages/backend/src/ee/) is NOT licensed under the AGPL. It is
-  licensed under the AnythingMCP Commercial License — see the LICENSE
-  file inside that directory.
-
-Versions of AnythingMCP released before the adoption of this license
-remain governed by the Business Source License 1.1 under which they
-were published (converting to Apache 2.0 on their respective Change
-Dates).
-
-For commercial licensing inquiries: licensing@helpcode.ai
-
------------------------------------------------------------------------------
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,35 @@
+# Licensing
+
+AnythingMCP — Copyright (c) 2026 helpcode.ai GmbH
+
+This repository uses a dual-license structure:
+
+## AGPL-3.0 (everything except `ee/`)
+
+All code in this repository is licensed under the GNU Affero General
+Public License version 3 ("AGPL-3.0-only") — see [LICENSE](LICENSE) —
+**except** the contents of `ee/` directories described below.
+
+## AnythingMCP Commercial License (`ee/` directories)
+
+All content that resides under any directory named `ee` (e.g.
+[`packages/backend/src/ee/`](packages/backend/src/ee/)) is **not**
+licensed under the AGPL. It is licensed under the AnythingMCP
+Commercial License — see the [LICENSE](packages/backend/src/ee/LICENSE)
+file inside that directory. EE code contains operator-only
+functionality for the AnythingMCP Cloud offering and is inert in
+self-hosted deployments.
+
+## Earlier releases
+
+Versions of AnythingMCP released before the adoption of the AGPL
+remain governed by the Business Source License 1.1 under which they
+were published (converting to Apache 2.0 on their respective Change
+Dates).
+
+## Contributions
+
+Contributions are accepted under the [Contributor License
+Agreement](CLA.md) — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+For commercial licensing inquiries: licensing@helpcode.ai

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ AnythingMCP is **open source** under the [GNU Affero General Public License v3](
 - 🔄 **Copyleft** — if you modify AnythingMCP and offer it over a network, you must share your modified source with those users
 - 🏢 **`ee/` directories** — cloud-operator code under `ee/` is licensed under the [AnythingMCP Commercial License](packages/backend/src/ee/LICENSE) and is not required for self-hosting
 
-Releases published before the AGPL adoption remain under the Business Source License 1.1 (converting to Apache 2.0 on 2030-03-04). For commercial licensing: [licensing@helpcode.ai](mailto:licensing@helpcode.ai)
+See [LICENSING.md](LICENSING.md) for the full breakdown (including earlier BUSL releases). For commercial licensing: [licensing@helpcode.ai](mailto:licensing@helpcode.ai)
 
 > **Transparency note** — AnythingMCP makes optional network calls to `anythingmcp.com` for license verification and email delivery when SMTP is not configured. No API credentials or tool invocation data is ever sent. See [External services](docs/deployment.md#external-services) for full details.
 


### PR DESCRIPTION
GitHub's license detection reported Other/NOASSERTION because of the custom preamble in LICENSE (#314). This keeps LICENSE as the verbatim AGPL-3.0 text and moves the preamble — ee/ carve-out and the earlier-BUSL-releases note — to a new LICENSING.md, linked from the README license section. No legal change: the ee/ directories still carry their own commercial LICENSE file.