### PR TITLE
chore(selfhost): parameterize compose names, centralize Node version, fix license leftovers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,14 @@
 
 # ── General ──────────────────────────────────────────────────────────────────
 NODE_ENV=production
+# Internal backend port inside the container. The host-published port is set
+# separately via BACKEND_PORT (see the Ports section) — leave this at 4000.
 PORT=4000
+
+# Compose project name — also the prefix for the network, volumes and container
+# names (amcp-app, amcp-postgres, …). Override it to run more than one
+# AnythingMCP stack on the same host without name collisions.
+# COMPOSE_PROJECT_NAME=amcp
 
 # ── Database ─────────────────────────────────────────────────────────────────
 POSTGRES_PASSWORD=change-me-in-production

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
 url: "https://github.com/HelpCode-ai/anythingmcp"
 repository-code: "https://github.com/HelpCode-ai/anythingmcp"
 abstract: >
-  AnythingMCP is a source-available self-hosted Model Context Protocol (MCP)
+  AnythingMCP is an open-source self-hosted Model Context Protocol (MCP)
   server and API gateway. It converts REST, SOAP, GraphQL endpoints, databases,
   and other MCP servers into MCP tools consumable by AI clients such as
   Claude, ChatGPT, Google Gemini, GitHub Copilot, and Cursor. It ships with

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,14 @@
 # Container Registry, and other registries to display image metadata.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Node runtime version, declared once and reused by every stage below so the
+# image always builds on a single, consistent Node major. The supported minimum
+# for local development is Node 22 (see "engines" in package.json); the shipped
+# image tracks a newer release. Override with --build-arg NODE_VERSION=24-alpine.
+ARG NODE_VERSION=26-alpine
+
 # ── Stage 1: Install ALL dependencies ───────────────────────────────────────
-FROM node:26-alpine AS deps
+FROM node:${NODE_VERSION} AS deps
 RUN apk add --no-cache libc6-compat python3 make g++
 WORKDIR /app
 
@@ -25,7 +31,7 @@ COPY packages/frontend/package.json ./packages/frontend/
 RUN npm ci --network-timeout 600000
 
 # ── Stage 1b: Backend production deps only ────────────────────────────────
-FROM node:26-alpine AS backend-prod-deps
+FROM node:${NODE_VERSION} AS backend-prod-deps
 RUN apk add --no-cache libc6-compat python3 make g++
 WORKDIR /app
 
@@ -41,7 +47,7 @@ RUN npm install --omit=dev --network-timeout=600000 && \
     rm -rf node_modules/typescript node_modules/react-dom node_modules/react
 
 # ── Stage 2: Build Backend ──────────────────────────────────────────────────
-FROM node:26-alpine AS backend-builder
+FROM node:${NODE_VERSION} AS backend-builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -61,7 +67,7 @@ RUN npx prisma generate
 RUN npm run build
 
 # ── Stage 3: Build Frontend ─────────────────────────────────────────────────
-FROM node:26-alpine AS frontend-builder
+FROM node:${NODE_VERSION} AS frontend-builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -75,7 +81,7 @@ WORKDIR /app/packages/frontend
 RUN npm run build
 
 # ── Stage 4: Production ─────────────────────────────────────────────────────
-FROM node:26-alpine AS runner
+FROM node:${NODE_VERSION} AS runner
 RUN apk add --no-cache wget
 WORKDIR /app
 
@@ -112,7 +118,7 @@ LABEL org.opencontainers.image.title="AnythingMCP" \
       org.opencontainers.image.source="https://github.com/HelpCode-ai/anythingmcp" \
       org.opencontainers.image.documentation="https://github.com/HelpCode-ai/anythingmcp#readme" \
       org.opencontainers.image.vendor="helpcode.ai GmbH" \
-      org.opencontainers.image.licenses="BSL-1.1"
+      org.opencontainers.image.licenses="AGPL-3.0-only"
 
 USER appuser
 EXPOSE 3000 4000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@
 # MCP:    http://localhost:4000/mcp
 # =============================================================================
 
-name: amcp
+# Project name — also the prefix for the auto-created network and volumes.
+# Override COMPOSE_PROJECT_NAME (in .env or the environment) to run more than
+# one AnythingMCP stack on the same host without name collisions.
+name: ${COMPOSE_PROJECT_NAME:-amcp}
 
 services:
 
@@ -16,7 +19,7 @@ services:
   caddy:
     image: caddy:2-alpine
     profiles: ["proxy"]
-    container_name: amcp-caddy
+    container_name: ${COMPOSE_PROJECT_NAME:-amcp}-caddy
     ports:
       - "80:80"
       - "443:443"
@@ -35,7 +38,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: amcp-app
+    container_name: ${COMPOSE_PROJECT_NAME:-amcp}-app
     # Bind published ports to loopback by default so the API/MCP endpoint is
     # not exposed on every network interface out of the box. To reach it from
     # the LAN or the public internet, set APP_BIND_IP=0.0.0.0 in .env (and put
@@ -47,7 +50,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=4000
-      - NEXT_PUBLIC_API_URL=http://localhost:4000
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:4000}
       - DATABASE_URL=postgresql://amcp:${POSTGRES_PASSWORD:-amcp}@postgres:5432/anythingmcp
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production-min-32-chars}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-change-me-in-production-exactly-32}
@@ -84,7 +87,7 @@ services:
   # PostgreSQL Database
   postgres:
     image: postgres:17-alpine
-    container_name: amcp-postgres
+    container_name: ${COMPOSE_PROJECT_NAME:-amcp}-postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -101,7 +104,7 @@ services:
   # Redis Cache (optional — uncomment to enable response caching and rate limiting)
   # redis:
   #   image: redis:7-alpine
-  #   container_name: amcp-redis
+  #   container_name: ${COMPOSE_PROJECT_NAME:-amcp}-redis
   #   volumes:
   #     - redis_data:/data
   #   healthcheck:

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "anythingmcp",
   "version": "0.1.33",
-  "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Source-available (BSL-1.1 → Apache 2030).",
+  "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",
+  "engines": {
+    "node": ">=22"
+  },
   "workspaces": [
     "packages/backend",
     "packages/frontend"

--- a/packages/backend/src/common/secrets.util.ts
+++ b/packages/backend/src/common/secrets.util.ts
@@ -8,8 +8,8 @@ const MIN_SECRET_LENGTH = 32;
  * Returns a required secret from the environment.
  * Throws on startup if the value is missing or shorter than the minimum length.
  *
- * Never falls back to a hardcoded default: a known default key on a
- * source-available product is equivalent to having no encryption at all.
+ * Never falls back to a hardcoded default: a known default key on an
+ * open-source product is equivalent to having no encryption at all.
  */
 export function getRequiredSecret(
   name: string,


### PR DESCRIPTION
Follow-ups from a real end-to-end `setup.sh` self-host test (clone → docker build → boot → browser login). The flow works; these are the rough edges it surfaced.

## Changes

**Multi-instance friendly compose** — `name:` and every `container_name:` now derive from `COMPOSE_PROJECT_NAME` (default `amcp`, so existing docs and `docker exec amcp-postgres …` commands are unchanged). Setting `COMPOSE_PROJECT_NAME=foo` namespaces the project, network, volumes **and** container names, so a second stack can run on the same host without the hardcoded-name collision. `NEXT_PUBLIC_API_URL` is now overridable too.

**Centralized Node version** — the Dockerfile repeated `node:26-alpine` in all 5 stages; now declared once via `ARG NODE_VERSION=26-alpine` (kept at 26, per the deliberate bump in #155) and reused. Future bumps are one line; overridable with `--build-arg NODE_VERSION=24-alpine`.

**Explicit Node floor** — added `engines.node >=22` to root package.json so the supported minimum (already stated in setup.sh / CONTRIBUTING) is machine-readable and consistent with the image.

**License-migration leftovers** missed by #314/#315:
- Dockerfile OCI label `org.opencontainers.image.licenses`: `BSL-1.1` → `AGPL-3.0-only`
- `package.json` description: dropped `Source-available (BSL-1.1 → Apache 2030)` → `Open source (AGPL-3.0)`
- `CITATION.cff` abstract and a `secrets.util.ts` comment: `source-available` → `open-source`

**Docs** — `.env.example` now documents `COMPOSE_PROJECT_NAME` and the internal-`PORT` vs host-`BACKEND_PORT` distinction.

No default-behaviour change: with no `COMPOSE_PROJECT_NAME` set, names/volumes/network are byte-identical to before.

## Test plan

- [x] `docker compose config` resolves to `amcp-*` by default and `<name>-*` when `COMPOSE_PROJECT_NAME` is set
- [x] Full `docker compose up --build` from the working tree on an isolated project (`COMPOSE_PROJECT_NAME=amcptest`, ports 3100/4100): image builds on Node 26, app+postgres healthy, **runs side-by-side with the existing `amcp-*` stack** (no collision)
- [x] Built image's OCI license label = `AGPL-3.0-only`; admin registration → role ADMIN; `ee/` cloud module inert (onboarding route 404, `DEPLOYMENT_MODE` unset)
- [x] Backend suite: 173 suites / 3028 tests pass
- [x] Repo-wide sweep: no `BSL`/`source-available` references remain outside the intentional 'earlier BUSL releases' license notes