### PR TITLE
chore(release): v0.1.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -20,6 +20,9 @@
       "devDependencies": {
         "@types/cookie-parser": "^1.4.10",
         "concurrently": "^9.1.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -23821,7 +23824,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@nestjs/common": "^11.1.24",
@@ -24298,7 +24301,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Release **v0.1.34**. Version bump only (package.json ×3 + lockfile sync).

Changes since v0.1.33:
- fix(mcp): dedupe tool names so a duplicate connector can't 500 the server (#313)
- chore(license): migrate to AGPL-3.0 with commercial `ee/` split + GitHub detection fix (#314, #315)
- chore(selfhost): parameterize compose names, centralize Node version, fix license leftovers (#316)

Tag + GitHub Release + Docker image publish follow once this merges.