### PR TITLE
fix(connectors): restore all proxied connectors — disable TLS verify on upstream unblocker hop

### DIFF
--- a/packages/backend/src/connectors/engines/graphql.engine.ts
+++ b/packages/backend/src/connectors/engines/graphql.engine.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosError } from 'axios';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import { createUnblockerProxyAgent } from './unblocker-proxy-agent';
 import { OAuth2TokenService } from './oauth2-token.service';
 import {
   LoginTokenService,
@@ -168,13 +168,11 @@ export class GraphqlEngine {
 
     // Shared axios options. When the caller passes a proxyUrl, route every
     // request (incl. the 401-refresh retries below) through the
-    // proxy / web-unblocker. rejectUnauthorized:false supports unblockers
-    // (e.g. Zyte) that intercept TLS.
+    // proxy / web-unblocker. The unblocker agent disables upstream TLS
+    // verification (e.g. Zyte intercepts TLS) — see createUnblockerProxyAgent.
     const axiosOpts: Record<string, unknown> = { headers, timeout: 30000 };
     if (config.proxyUrl) {
-      const agent = new HttpsProxyAgent(config.proxyUrl, {
-        rejectUnauthorized: false,
-      });
+      const agent = createUnblockerProxyAgent(config.proxyUrl);
       axiosOpts.httpsAgent = agent;
       axiosOpts.httpAgent = agent;
       axiosOpts.proxy = false;

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
 import FormData from 'form-data';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import { createUnblockerProxyAgent } from './unblocker-proxy-agent';
 import { OAuth2TokenService } from './oauth2-token.service';
 import {
   LoginTokenService,
@@ -164,13 +164,12 @@ export class RestEngine {
     }
 
     // Route through the proxy / web-unblocker when the caller asked for it.
-    // `rejectUnauthorized: false` is required for unblockers like Zyte that
-    // intercept the TLS connection (equivalent to curl's --proxy-insecure).
-    // We disable axios' native proxy handling so the agent owns the tunnel.
+    // The unblocker agent disables upstream TLS verification (Zyte and friends
+    // MITM the connection) — see createUnblockerProxyAgent. Equivalent to
+    // curl's --proxy-insecure. We disable axios' native proxy handling so the
+    // agent owns the tunnel.
     if (config.proxyUrl) {
-      const agent = new HttpsProxyAgent(config.proxyUrl, {
-        rejectUnauthorized: false,
-      });
+      const agent = createUnblockerProxyAgent(config.proxyUrl);
       axiosConfig.httpsAgent = agent;
       axiosConfig.httpAgent = agent;
       axiosConfig.proxy = false;

--- a/packages/backend/src/connectors/engines/unblocker-proxy-agent.spec.ts
+++ b/packages/backend/src/connectors/engines/unblocker-proxy-agent.spec.ts
@@ -1,0 +1,42 @@
+import { createUnblockerProxyAgent } from './unblocker-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+/**
+ * Regression: every connector with useProxy=true went down for ~8 days because
+ * the Zyte web-unblocker MITMs the upstream TLS, and `rejectUnauthorized:false`
+ * passed to the HttpsProxyAgent constructor only covers the hop to the proxy —
+ * not the upstream TLS upgrade (https-proxy-agent@7 builds that from the
+ * per-request opts). Node then threw UNABLE_TO_VERIFY_LEAF_SIGNATURE.
+ *
+ * The fix injects rejectUnauthorized:false into the per-request opts via a
+ * connect() override. These tests pin that behaviour.
+ */
+describe('createUnblockerProxyAgent', () => {
+  it('returns an HttpsProxyAgent', () => {
+    const agent = createUnblockerProxyAgent('http://user:@proxy.example:8011');
+    expect(agent).toBeInstanceOf(HttpsProxyAgent);
+  });
+
+  it('injects rejectUnauthorized:false into the UPSTREAM connect opts', async () => {
+    const agent = createUnblockerProxyAgent('http://user:@proxy.example:8011');
+
+    // Capture the opts the override forwards to the base connect (the upstream
+    // TLS path), without actually opening a socket.
+    const proto = Object.getPrototypeOf(Object.getPrototypeOf(agent));
+    const superConnect = jest
+      .spyOn(proto, 'connect')
+      .mockResolvedValue({} as never);
+
+    const reqOpts: any = { host: 'int.bahn.de', port: 443, secureEndpoint: true };
+    await (agent as any).connect({} as any, reqOpts);
+
+    expect(superConnect).toHaveBeenCalledTimes(1);
+    const forwarded = superConnect.mock.calls[0][1] as Record<string, unknown>;
+    expect(forwarded.rejectUnauthorized).toBe(false);
+    // Original opts must be preserved (host/port still routed upstream).
+    expect(forwarded.host).toBe('int.bahn.de');
+    expect(forwarded.port).toBe(443);
+
+    superConnect.mockRestore();
+  });
+});

--- a/packages/backend/src/connectors/engines/unblocker-proxy-agent.ts
+++ b/packages/backend/src/connectors/engines/unblocker-proxy-agent.ts
@@ -1,0 +1,41 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+/**
+ * Proxy agent for TLS-intercepting web unblockers (e.g. Zyte).
+ *
+ * Web unblockers MITM the upstream TLS connection and present their own leaf
+ * certificate, so the upstream handshake cannot be verified against the system
+ * CA store. We must therefore connect with `rejectUnauthorized: false`.
+ *
+ * The catch: passing `rejectUnauthorized: false` to the `HttpsProxyAgent`
+ * constructor only applies it to the hop *to the proxy*. In
+ * `https-proxy-agent@7`, the upstream TLS upgrade (after the CONNECT tunnel) is
+ * built from the per-request `opts`, NOT from the constructor options — so the
+ * flag never reaches the upstream socket and Node throws
+ * `UNABLE_TO_VERIFY_LEAF_SIGNATURE` on the unblocker's MITM cert.
+ *
+ * This subclass injects `rejectUnauthorized: false` into the per-request opts
+ * so it actually applies to the upstream TLS connection. Equivalent to curl's
+ * `--proxy-insecure`. Only used for explicitly proxied connector calls.
+ */
+type ConnectArgs = Parameters<HttpsProxyAgent<string>['connect']>;
+
+class UnblockerProxyAgent extends HttpsProxyAgent<string> {
+  async connect(req: ConnectArgs[0], opts: ConnectArgs[1]) {
+    // `rejectUnauthorized` only exists on the HTTPS branch of AgentConnectOpts;
+    // cast through the param type so the merge stays well-typed.
+    const insecure = { ...opts, rejectUnauthorized: false } as ConnectArgs[1];
+    return super.connect(req, insecure);
+  }
+}
+
+/**
+ * Build a proxy agent for a TLS-intercepting web unblocker. The returned agent
+ * disables upstream certificate verification (see UnblockerProxyAgent) — use it
+ * only for calls deliberately routed through the unblocker proxy.
+ */
+export function createUnblockerProxyAgent(proxyUrl: string): HttpsProxyAgent<string> {
+  // rejectUnauthorized:false on the constructor covers the proxy hop; the
+  // subclass covers the upstream hop. Both are needed.
+  return new UnblockerProxyAgent(proxyUrl, { rejectUnauthorized: false });
+}


### PR DESCRIPTION
## Severity: P1 — all proxied connectors down ~8 days

Production data (`tool_invocations`):
- **Last successful tool invocation of any kind: 2026-06-03 09:39**
- First TLS failure: 2026-06-04 05:00 — continuous since
- **13 adapters / 239 prod tool rows** use the proxy: Deutsche Bahn, Sorare, Etsy, Playtomic (+public), Vinted, Idealista, OpenTable, Resy, Untappd, Trenitalia, ImmobilienScout24, Mercado Libre

Every proxied call failed with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` ("unable to verify the first certificate").

## Root cause

Reverse-engineered connectors route through the **Zyte web-unblocker** (`CONNECTOR_PROXY_URL`) — required, because the upstreams block datacenter IPs (direct call = `403 OPS_BLOCKED`). Zyte **MITMs the upstream TLS** and presents its own leaf cert, so the upstream handshake can't verify against the system CA.

We passed `rejectUnauthorized:false` to the `HttpsProxyAgent` constructor, but in **`https-proxy-agent@7`** that flag only applies to the hop *to the proxy*. The upstream TLS upgrade (after the CONNECT tunnel) is built from the per-request `opts` (`dist/index.js` L132-135), so the flag never reached the upstream socket → Node rejected Zyte's MITM cert.

## Fix

Shared `UnblockerProxyAgent` subclass overrides `connect()` to inject `rejectUnauthorized:false` into the per-request opts — so it reaches the actual upstream TLS connection (≈ curl `--proxy-insecure`). Wired into both **REST** and **GraphQL** engines via `createUnblockerProxyAgent()`.

## Verification

- `tsc --noEmit` clean; `jest` engines + new helper spec → **16/16 pass**
- **Live in the prod container**: the exact proxied request that returned `UNABLE_TO_VERIFY_LEAF_SIGNATURE` now returns **`200` with real bahn.de data**
- Post-deploy: will confirm a real end-to-end proxied invocation lands as `SUCCESS` in `tool_invocations`

Scope limited to proxied connector calls; non-proxied paths unchanged.
