### PR TITLE
fix(ci): unblock Dependabot auto-merge (drop forbidden approval step)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -65,13 +65,20 @@ jobs:
           echo "auto=$AUTO" >> "$GITHUB_OUTPUT"
           echo "reason=$REASON" >> "$GITHUB_OUTPUT"
 
-      - name: Approve and enable auto-merge
+      - name: Enable auto-merge
         if: steps.decide.outputs.auto == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr review --approve "$PR_URL" --body "Auto-approved: ${{ steps.decide.outputs.reason }}"
+          # No review step: `main` requires 0 approving reviews, so approval is
+          # unnecessary — and GitHub forbids GITHUB_TOKEN-backed Actions from
+          # approving PRs ("GitHub Actions is not permitted to approve pull
+          # requests"), which previously failed this step under `set -e` and
+          # stopped the merge command from ever running.
+          # `gh pr merge --auto` enables auto-merge; GitHub completes it once
+          # the required Backend/Frontend checks pass and the branch is
+          # up to date (Dependabot keeps its PRs rebased).
           gh pr merge --auto --squash "$PR_URL"
 
       - name: Label as needs-review


### PR DESCRIPTION
## Problem
Every open Dependabot PR (#298–#307) has a failing `triage` check. The auto-merge workflow's step ran:
```
gh pr review --approve "$PR_URL" ...
gh pr merge --auto --squash "$PR_URL"
```
The first line fails with **"GitHub Actions is not permitted to approve pull requests"** (a repo/org security setting). GitHub Actions bash steps run with `set -e`, so the step aborts before the merge command runs — **nothing ever auto-merges**.

## Fix
`main` requires **0 approving reviews** (verified via branch protection API), so the approval is unnecessary. Drop it; keep `gh pr merge --auto --squash`. Auto-merge then completes once the required Backend/Frontend checks pass.

## Note on the current backlog
The 10 open Dependabot PRs are all npm patch/minor with green Backend+Frontend checks (only the broken `triage` job is red). They show `BEHIND` because `main` requires up-to-date branches (`strict: true`); Dependabot rebases keep them current going forward. This fix only re-runs on new PR events, so the existing 10 still need a nudge (rebase or manual merge) — handled separately.