### PR TITLE
fix(weclapp): correct -notnull filter syntax + warn off non-existent customerName

### DIFF
--- a/packages/backend/src/adapters/de/weclapp.json
+++ b/packages/backend/src/adapters/de/weclapp.json
@@ -23,7 +23,7 @@
   "tools": [
     {
       "name": "weclapp_list_customers",
-      "description": "List parties (customers/suppliers/contacts) from weclapp ERP. In API v2 customers and suppliers are unified under /party — pass filter='customerNumber-notnull=true' to restrict to customers, or filter='supplierNumber-notnull=true' for suppliers. Use `properties` to limit returned fields (e.g. 'id,customerNumber,company,firstName,lastName,email') to reduce payload size.",
+      "description": "List parties (customers/suppliers/contacts) from weclapp ERP. In API v2 customers and suppliers are unified under /party — pass filter='customerNumber-notnull=' to restrict to customers, or filter='supplierNumber-notnull=' for suppliers (the -null/-notnull operators take an EMPTY value — NOT '=true'). Use `properties` to limit returned fields (e.g. 'id,customerNumber,company,firstName,lastName,email') to reduce payload size.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -41,7 +41,7 @@
           },
           "filter": {
             "type": "string",
-            "description": "weclapp v2 filter expression, e.g. 'customerNumber-notnull=true' or 'partyType-eq=ORGANIZATION'"
+            "description": "weclapp v2 filter expression. The property+operator IS the param name (no 'filter=' wrapper). Examples: 'partyType-eq=ORGANIZATION', 'customerNumber-notnull=' — note the -null/-notnull operators take an EMPTY value, not '=true'."
           },
           "sort": {
             "type": "string",
@@ -83,7 +83,7 @@
     },
     {
       "name": "weclapp_list_sales_orders",
-      "description": "List sales orders from weclapp ERP. Returns order numbers, customer info, amounts, and status. Use `properties` to limit fields and `filter` to narrow results (e.g. 'orderNumber-eq=SO-1042').",
+      "description": "List sales orders from weclapp ERP. Returns order numbers, amounts, status and the record address. NOTE: salesOrder has NO 'customerName' field — do not request it in `properties` (weclapp returns 400). The customer's name is in `recordAddress`; the customer link is `customerId`. Use `properties` to limit fields and `filter` to narrow results (e.g. 'orderNumber-eq=SO-1042'). Date fields are Unix epoch milliseconds (e.g. 'orderDate-gt=1767225600000').",
       "parameters": {
         "type": "object",
         "properties": {
@@ -123,7 +123,7 @@
     },
     {
       "name": "weclapp_list_invoices",
-      "description": "List sales invoices from weclapp ERP. Returns invoice numbers, amounts, due dates, and payment status. Use `filter` for queries like 'paid-eq=false' or 'invoiceDate-gt=2026-01-01'.",
+      "description": "List sales invoices from weclapp ERP. Returns invoice numbers, amounts, due dates, and payment status. NOTE: invoice has NO 'customerName' field — do not request it in `properties` (weclapp returns 400); the name is in `recordAddress`, the link is `customerId`. Use `filter` for queries like 'paid-eq=false'. Date fields are Unix epoch milliseconds (e.g. 'invoiceDate-gt=1767225600000' for 2026-01-01).",
       "parameters": {
         "type": "object",
         "properties": {
@@ -141,7 +141,7 @@
           },
           "filter": {
             "type": "string",
-            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull. Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
+            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull (the -null/-notnull operators take an EMPTY value, e.g. 'articleNumber-notnull='). Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
           },
           "sort": {
             "type": "string",
@@ -181,7 +181,7 @@
           },
           "filter": {
             "type": "string",
-            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull. Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
+            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull (the -null/-notnull operators take an EMPTY value, e.g. 'articleNumber-notnull='). Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
           },
           "sort": {
             "type": "string",


### PR DESCRIPTION
## Why
Diagnosing a trial customer's weclapp calls on cloud: alongside many **SUCCESS** invocations, a recurring **400 Bad Request** pattern. Comparing success vs failure inputs isolated two adapter-description bugs that make Claude build invalid weclapp requests:

**1. `-notnull` filter syntax.** weclapp's `-null`/`-notnull` operators take an **empty** value (`customerNumber-notnull=`). The tool descriptions gave the example `customerNumber-notnull=true`; the model copied it verbatim → 400. (Confirmed against [geccomedia/weclapp](https://github.com/geccomedia/weclapp), which shows `leadStatus-notnull=`.)

**2. Non-existent `customerName` property.** salesOrder/invoice have no `customerName` field — the name is in `recordAddress` (link via `customerId`). Descriptions said *'Returns … customer info'*, so the model requested a `customerName` property → 400. Proven by the data: identical calls succeeded with `recordAddress` and failed with `customerName`.

## Changes (`adapters/de/weclapp.json`, descriptions only)
- Every `-notnull=true` example → `-notnull=`, plus an explicit empty-value note on the operator list
- salesOrder/invoice descriptions now warn not to request `customerName` and point to `recordAddress`/`customerId`
- Documented that weclapp date filters are Unix epoch milliseconds

No engine/endpoint changes — purely guidance the AI consumes to build valid requests.

## Test plan
- [x] weclapp.json valid; catalog test suite passes (2259 tests)
- [x] No `-notnull=true` / 'customer info' strings remain