### PR TITLE
feat(connectors): catalog re-sync — propagate adapter updates to installed connectors (PR1/3, backend core)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,14 @@ CORS_ORIGIN=http://localhost:3000
 # All other users must be invited by an admin. Set to true to allow open registration.
 ALLOW_OPEN_REGISTRATION=false
 
+# ── Catalog auto-sync ─────────────────────────────────────────────────────────
+# On startup, automatically applies "safe" catalog updates (tool
+# description/parameter fixes — no endpoint or tool add/remove changes) to
+# connectors installed from the catalog, so adapter improvements reach existing
+# connectors without manual action. Structural updates are left for explicit
+# review. Set to false to disable and pin installed connectors to their tools.
+# CATALOG_AUTOSYNC=true
+
 # ── MCP Server Auth (for external MCP clients like Claude Desktop) ───────────
 # Auth mode: none | legacy | oauth2 | both
 #   none    — No authentication (not recommended for production)

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -4,6 +4,7 @@ import { McpServerService } from '../mcp-server/mcp-server.service';
 import { encrypt } from '../common/crypto/encryption.util';
 import { ConfigService } from '@nestjs/config';
 import { listAdapters, getAdapter, AdapterMeta, AdapterDefinition } from './catalog';
+import { hashInstructions } from './catalog-fingerprint';
 import { getRequiredSecret } from '../common/secrets.util';
 
 @Injectable()
@@ -82,9 +83,15 @@ export class AdaptersService {
         headers: resolvedHeaders as any,
         envVars: envVarsToPersist as any,
         instructions: adapter.instructions || null,
-        // Persist the source adapter slug so the UI can resolve the brand
-        // logo (via resolveAdapterIcon) even after the connector is renamed.
-        config: { adapterSlug: slug },
+        // Persist the source adapter slug (brand-logo resolution survives a
+        // rename) plus the catalog version + instructions baseline at install
+        // time, so the catalog re-sync feature can later detect that the
+        // catalog has moved on and whether the user has edited instructions.
+        config: {
+          adapterSlug: slug,
+          adapterVersion: adapter.version,
+          instructionsBaseline: hashInstructions(adapter.instructions),
+        },
       },
     });
 

--- a/packages/backend/src/adapters/catalog-fingerprint.ts
+++ b/packages/backend/src/adapters/catalog-fingerprint.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Content-addressed versioning for catalog adapters.
+ *
+ * A connector installed from a catalog adapter stores a copy of the adapter's
+ * tools in `mcp_tools`. To detect later that the catalog moved on (so the
+ * connector is stale — see the catalog re-sync feature), we fingerprint the
+ * parts of an adapter that are copied into a connector and compare hashes.
+ *
+ * The hash is deterministic (keys sorted, tools ordered by name) so the same
+ * adapter content always yields the same version, with no manual bumping.
+ */
+
+/** Stable JSON: object keys sorted recursively so key order never affects the hash. */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = canonicalize(obj[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function hashContent(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+type FingerprintTool = {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+  endpointMapping?: unknown;
+  responseMapping?: unknown;
+  useProxy?: boolean;
+};
+
+type FingerprintAdapter = {
+  instructions?: string;
+  connector?: { name?: string; type?: string; baseUrl?: string; authType?: string };
+  tools: FingerprintTool[];
+};
+
+/**
+ * The canonical per-tool shape used both for the adapter version and for the
+ * connector ↔ catalog diff. Only fields we actually copy into `mcp_tools`.
+ */
+export function toolFingerprint(tool: FingerprintTool) {
+  return {
+    name: tool.name,
+    description: tool.description ?? '',
+    parameters: tool.parameters ?? {},
+    endpointMapping: tool.endpointMapping ?? {},
+    responseMapping: tool.responseMapping ?? null,
+    useProxy: tool.useProxy === true,
+  };
+}
+
+/** Stable version string for an adapter's installable content. */
+export function computeAdapterVersion(adapter: FingerprintAdapter): string {
+  const tools = [...adapter.tools]
+    .map(toolFingerprint)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return hashContent({
+    instructions: adapter.instructions ?? '',
+    connector: {
+      name: adapter.connector?.name ?? '',
+      type: adapter.connector?.type ?? '',
+      baseUrl: adapter.connector?.baseUrl ?? '',
+      authType: adapter.connector?.authType ?? '',
+    },
+    tools,
+  });
+}
+
+/** Baseline hash for an adapter's instructions, to detect later user edits. */
+export function hashInstructions(instructions: string | null | undefined): string {
+  return hashContent({ instructions: instructions ?? '' });
+}

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -180,6 +180,7 @@ import * as lineMessaging from './jp/line-messaging.json';
 import * as paystack from './ng/paystack.json';
 // === AUTOGEN-IMPORTS-END ===
 import { buildGraphqlBuiltinTools } from '../connectors/graphql-builtins';
+import { computeAdapterVersion } from './catalog-fingerprint';
 
 export interface AdapterMeta {
   slug: string;
@@ -192,6 +193,11 @@ export interface AdapterMeta {
   docsUrl: string;
   requiredEnvVars: string[];
   toolCount: number;
+  /** Content-addressed version of the adapter's installable content (tools +
+   *  connector meta + instructions). Stamped onto a connector at install
+   *  (config.adapterVersion) so the catalog re-sync feature can detect when
+   *  the catalog has moved on. Computed at load — never hand-bumped. */
+  version: string;
   /** Surfaced on cards so the UI can render an auth-type chip without an
    *  extra round-trip to /api/adapters/:slug. */
   authType?: string;
@@ -446,7 +452,14 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
 ];
 // === AUTOGEN-ARRAY-END ===
 
-const ALL_ADAPTERS: AdapterDefinition[] = RAW_ADAPTERS.map(withGraphqlBuiltins);
+const ALL_ADAPTERS: AdapterDefinition[] = RAW_ADAPTERS.map(
+  withGraphqlBuiltins,
+).map((adapter) => ({
+  ...adapter,
+  // Computed after withGraphqlBuiltins so generated GraphQL helper tools are
+  // included in the fingerprint.
+  version: computeAdapterVersion(adapter),
+}));
 
 export function listAdapters(): AdapterMeta[] {
   return ALL_ADAPTERS.map((adapter) => ({
@@ -460,6 +473,7 @@ export function listAdapters(): AdapterMeta[] {
     docsUrl: adapter.docsUrl,
     requiredEnvVars: adapter.requiredEnvVars,
     toolCount: adapter.tools.length,
+    version: adapter.version,
     authType: adapter.connector.authType,
     featured: adapter.featured,
     priority: adapter.priority,

--- a/packages/backend/src/connectors/catalog-reconciler.service.ts
+++ b/packages/backend/src/connectors/catalog-reconciler.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../common/prisma.service';
+import { getAdapter } from '../adapters/catalog';
+import { CatalogResyncService } from './catalog-resync.service';
+
+/**
+ * On startup, auto-applies the **safe class** of catalog updates (description /
+ * parameters only — no endpoint change, no tool added/removed) to every
+ * catalog-installed connector. Structural updates are left for an explicit
+ * user/operator action (surfaced as "update available").
+ *
+ * This is what makes adapter fixes like the weclapp filter/description bug
+ * self-heal across the fleet without manual DB surgery. Gated by
+ * CATALOG_AUTOSYNC (default on); a self-hoster can set it to "false".
+ */
+@Injectable()
+export class CatalogReconciler implements OnApplicationBootstrap {
+  private readonly logger = new Logger(CatalogReconciler.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly resync: CatalogResyncService,
+    private readonly config: ConfigService,
+  ) {}
+
+  onApplicationBootstrap() {
+    if (this.config.get<string>('CATALOG_AUTOSYNC') === 'false') {
+      this.logger.log('Catalog auto-sync disabled (CATALOG_AUTOSYNC=false).');
+      return;
+    }
+    // Fire-and-forget so a slow scan never blocks boot.
+    void this.reconcile().catch((err) =>
+      this.logger.error(`Catalog auto-sync failed: ${err?.message ?? err}`),
+    );
+  }
+
+  async reconcile(): Promise<{
+    scanned: number;
+    autoSynced: number;
+    structuralPending: number;
+  }> {
+    const connectors = await this.prisma.connector.findMany({
+      select: { id: true, name: true, config: true },
+    });
+
+    let scanned = 0;
+    let autoSynced = 0;
+    let structuralPending = 0;
+
+    for (const connector of connectors) {
+      const slug = this.resync.resolveSlug(connector);
+      if (!slug) continue;
+      const adapter = getAdapter(slug);
+      if (!adapter) continue;
+      scanned++;
+
+      // Cheap pre-filter: skip connectors already on the current catalog
+      // version (the common case) without loading their tools.
+      const cfg = (connector.config ?? {}) as Record<string, unknown>;
+      if (cfg.adapterVersion === adapter.version) continue;
+
+      try {
+        const diff = await this.resync.computeDiff(connector.id);
+        if (!diff || diff.isUpToDate) {
+          // Up to date by content but version unstamped (e.g. backfill or a
+          // connector synced by hand) — stamp it so we skip it next boot.
+          await this.stampVersion(connector.id, adapter.version, cfg);
+          continue;
+        }
+        if (diff.isSafeClass) {
+          await this.resync.resync(connector.id, 'safe');
+          autoSynced++;
+        } else {
+          structuralPending++;
+        }
+      } catch (err: any) {
+        this.logger.warn(
+          `Catalog auto-sync skipped connector ${connector.id}: ${err?.message ?? err}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Catalog auto-sync: ${scanned} catalog connectors scanned, ` +
+        `${autoSynced} auto-synced (safe), ${structuralPending} with structural ` +
+        `updates pending review.`,
+    );
+    return { scanned, autoSynced, structuralPending };
+  }
+
+  /** Stamp the current catalog version on a connector already in sync by content. */
+  private async stampVersion(
+    connectorId: string,
+    version: string,
+    cfg: Record<string, unknown>,
+  ) {
+    await this.prisma.connector.update({
+      where: { id: connectorId },
+      data: { config: { ...cfg, adapterVersion: version } as any },
+    });
+  }
+}

--- a/packages/backend/src/connectors/catalog-resync.service.spec.ts
+++ b/packages/backend/src/connectors/catalog-resync.service.spec.ts
@@ -1,0 +1,152 @@
+import { CatalogResyncService } from './catalog-resync.service';
+import { getAdapter } from '../adapters/catalog';
+import {
+  computeAdapterVersion,
+  hashInstructions,
+} from '../adapters/catalog-fingerprint';
+
+const SLUG = 'weclapp';
+
+function connectorFromCatalog(mutate?: (tools: any[]) => void) {
+  const adapter = getAdapter(SLUG)!;
+  const tools = adapter.tools.map((t: any, i: number) => ({
+    id: `tool${i}`,
+    name: t.name,
+    description: t.description,
+    parameters: t.parameters,
+    endpointMapping: t.endpointMapping,
+    responseMapping: t.responseMapping ?? null,
+    useProxy: t.useProxy === true,
+    isEnabled: true,
+    deprecatedAt: null,
+  }));
+  if (mutate) mutate(tools);
+  return {
+    id: 'c1',
+    name: adapter.connector.name,
+    instructions: adapter.instructions ?? null,
+    config: {
+      adapterSlug: SLUG,
+      adapterVersion: adapter.version,
+      instructionsBaseline: hashInstructions(adapter.instructions),
+    },
+    tools,
+  };
+}
+
+function serviceFor(connector: any) {
+  const prisma = {
+    connector: { findUnique: jest.fn().mockResolvedValue(connector) },
+  } as any;
+  return new CatalogResyncService(prisma);
+}
+
+describe('catalog fingerprint', () => {
+  it('adapter version is deterministic and 12 hex chars', () => {
+    const a = getAdapter(SLUG)!;
+    expect(a.version).toMatch(/^[0-9a-f]{12}$/);
+    expect(computeAdapterVersion(a)).toBe(a.version);
+  });
+
+  it('version changes when a tool description changes', () => {
+    const a = getAdapter(SLUG)!;
+    const mutated = {
+      ...a,
+      tools: a.tools.map((t: any, i: number) =>
+        i === 0 ? { ...t, description: t.description + ' (changed)' } : t,
+      ),
+    };
+    expect(computeAdapterVersion(mutated as any)).not.toBe(a.version);
+  });
+});
+
+describe('CatalogResyncService.computeDiff', () => {
+  it('reports up-to-date when the connector matches the catalog', async () => {
+    const svc = serviceFor(connectorFromCatalog());
+    const diff = await svc.computeDiff('c1');
+    expect(diff).not.toBeNull();
+    expect(diff!.isUpToDate).toBe(true);
+    expect(diff!.isSafeClass).toBe(false);
+    expect(diff!.updated).toHaveLength(0);
+  });
+
+  it('classifies a description-only change as safe', async () => {
+    const svc = serviceFor(
+      connectorFromCatalog((tools) => {
+        tools[0].description = 'stale description';
+      }),
+    );
+    const diff = await svc.computeDiff('c1');
+    expect(diff!.isUpToDate).toBe(false);
+    expect(diff!.isSafeClass).toBe(true);
+    expect(diff!.updated).toEqual([
+      { name: tools0Name(), kind: 'safe' },
+    ]);
+  });
+
+  it('classifies a parameters-only change as safe', async () => {
+    const svc = serviceFor(
+      connectorFromCatalog((tools) => {
+        tools[0].parameters = { type: 'object', properties: {} };
+      }),
+    );
+    const diff = await svc.computeDiff('c1');
+    expect(diff!.isSafeClass).toBe(true);
+    expect(diff!.updated[0].kind).toBe('safe');
+  });
+
+  it('classifies an endpoint change as structural', async () => {
+    const svc = serviceFor(
+      connectorFromCatalog((tools) => {
+        tools[0].endpointMapping = { method: 'GET', path: '/changed' };
+      }),
+    );
+    const diff = await svc.computeDiff('c1');
+    expect(diff!.isSafeClass).toBe(false);
+    expect(diff!.updated[0].kind).toBe('structural');
+  });
+
+  it('treats a missing catalog tool as a structural addition', async () => {
+    const svc = serviceFor(
+      connectorFromCatalog((tools) => {
+        tools.shift(); // connector is missing the first catalog tool
+      }),
+    );
+    const diff = await svc.computeDiff('c1');
+    expect(diff!.added.length).toBe(1);
+    expect(diff!.isSafeClass).toBe(false);
+  });
+
+  it('treats an extra connector tool as a structural removal', async () => {
+    const svc = serviceFor(
+      connectorFromCatalog((tools) => {
+        tools.push({
+          id: 'extra',
+          name: 'weclapp_unknown_tool',
+          description: 'x',
+          parameters: {},
+          endpointMapping: { method: 'GET', path: '/x' },
+          responseMapping: null,
+          useProxy: false,
+          isEnabled: true,
+          deprecatedAt: null,
+        });
+      }),
+    );
+    const diff = await svc.computeDiff('c1');
+    expect(diff!.removed).toContain('weclapp_unknown_tool');
+    expect(diff!.isSafeClass).toBe(false);
+  });
+
+  it('returns null for a connector with no resolvable catalog slug', async () => {
+    const c = connectorFromCatalog();
+    c.config = {} as any;
+    c.name = 'Totally Custom Connector';
+    const svc = serviceFor(c);
+    expect(await svc.computeDiff('c1')).toBeNull();
+  });
+});
+
+function tools0Name(): string {
+  return getAdapter(SLUG)!.tools[0].name;
+}

--- a/packages/backend/src/connectors/catalog-resync.service.ts
+++ b/packages/backend/src/connectors/catalog-resync.service.ts
@@ -1,0 +1,304 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { getAdapter, AdapterDefinition } from '../adapters/catalog';
+import {
+  hashContent,
+  hashInstructions,
+} from '../adapters/catalog-fingerprint';
+
+/**
+ * Re-sync of catalog-installed connectors with the current catalog.
+ *
+ * Tool definitions (description/parameters/endpointMapping) are copied into
+ * `mcp_tools` at install, so later catalog fixes do not reach existing
+ * connectors. This service computes the connector ↔ catalog diff and applies
+ * it, matching by tool NAME (the stable identity for catalog adapters, and
+ * unique per connector) and preserving operator customisations
+ * (responseMapping, role access, manual enable/disable, useProxy).
+ *
+ * Change classes:
+ *   - safe       — only description/parameters changed. Non-breaking guidance;
+ *                  eligible for automatic (boot-time) application.
+ *   - structural — endpointMapping changed, or a tool was added/removed.
+ *                  Requires an explicit user/operator action.
+ */
+
+export type ToolChangeKind = 'safe' | 'structural';
+
+export interface CatalogDiff {
+  connectorId: string;
+  slug: string;
+  catalogVersion: string;
+  connectorVersion: string | null;
+  updated: Array<{ name: string; kind: ToolChangeKind }>;
+  added: string[];
+  removed: string[];
+  /** instructions changed upstream AND the user has not edited theirs. */
+  instructionsRefreshable: boolean;
+  isUpToDate: boolean;
+  /** Has changes, and every change is safe (no structural). */
+  isSafeClass: boolean;
+}
+
+type CatalogTool = AdapterDefinition['tools'][number] & {
+  responseMapping?: unknown;
+  useProxy?: boolean;
+};
+
+@Injectable()
+export class CatalogResyncService {
+  private readonly logger = new Logger(CatalogResyncService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Resolve the source adapter slug for a connector (explicit, else name match). */
+  resolveSlug(connector: {
+    name: string;
+    config?: unknown;
+  }): string | null {
+    const cfg = connector.config as Record<string, unknown> | null | undefined;
+    const explicit =
+      cfg && typeof cfg.adapterSlug === 'string' ? cfg.adapterSlug : null;
+    if (explicit && getAdapter(explicit)) return explicit;
+    return null;
+  }
+
+  /**
+   * Compute the diff between a connector and its catalog adapter.
+   * Returns null when the connector is not catalog-managed (no resolvable slug).
+   */
+  async computeDiff(connectorId: string): Promise<CatalogDiff | null> {
+    const connector = await this.prisma.connector.findUnique({
+      where: { id: connectorId },
+      include: { tools: true },
+    });
+    if (!connector) return null;
+
+    const slug = this.resolveSlug(connector);
+    if (!slug) return null;
+    const adapter = getAdapter(slug);
+    if (!adapter) return null;
+
+    const catalogTools = adapter.tools as CatalogTool[];
+    const catalogByName = new Map(catalogTools.map((t) => [t.name, t]));
+    const existingByName = new Map(connector.tools.map((t) => [t.name, t]));
+
+    const updated: CatalogDiff['updated'] = [];
+    const added: string[] = [];
+
+    for (const ct of catalogTools) {
+      const et = existingByName.get(ct.name);
+      if (!et) {
+        added.push(ct.name);
+        continue;
+      }
+      const endpointChanged =
+        hashContent(ct.endpointMapping ?? {}) !==
+        hashContent(et.endpointMapping ?? {});
+      const descParamsChanged =
+        (ct.description ?? '') !== (et.description ?? '') ||
+        hashContent(ct.parameters ?? {}) !== hashContent(et.parameters ?? {});
+      if (endpointChanged) {
+        updated.push({ name: ct.name, kind: 'structural' });
+      } else if (descParamsChanged) {
+        updated.push({ name: ct.name, kind: 'safe' });
+      }
+    }
+
+    // Existing, non-deprecated tools no longer present upstream.
+    const removed: string[] = [];
+    for (const et of connector.tools) {
+      if (et.deprecatedAt) continue;
+      if (!catalogByName.has(et.name)) removed.push(et.name);
+    }
+
+    const cfg = (connector.config ?? {}) as Record<string, unknown>;
+    const connectorVersion =
+      typeof cfg.adapterVersion === 'string' ? cfg.adapterVersion : null;
+    const baseline =
+      typeof cfg.instructionsBaseline === 'string'
+        ? cfg.instructionsBaseline
+        : null;
+    const instructionsChanged =
+      hashInstructions(adapter.instructions) !==
+      hashInstructions(connector.instructions);
+    const userEditedInstructions =
+      baseline !== null &&
+      baseline !== hashInstructions(connector.instructions);
+    const instructionsRefreshable = instructionsChanged && !userEditedInstructions;
+
+    const isUpToDate =
+      updated.length === 0 &&
+      added.length === 0 &&
+      removed.length === 0 &&
+      !instructionsRefreshable;
+    const isSafeClass =
+      !isUpToDate &&
+      added.length === 0 &&
+      removed.length === 0 &&
+      updated.every((u) => u.kind === 'safe');
+
+    return {
+      connectorId,
+      slug,
+      catalogVersion: adapter.version,
+      connectorVersion,
+      updated,
+      added,
+      removed,
+      instructionsRefreshable,
+      isUpToDate,
+      isSafeClass,
+    };
+  }
+
+  /**
+   * Apply the catalog to a connector. `mode: 'safe'` applies only
+   * description/parameters updates (and instructions-if-untouched), refusing if
+   * the diff has any structural change. `mode: 'full'` applies everything,
+   * including endpoint changes, new tools, and soft-deprecating removed tools.
+   *
+   * Always preserves responseMapping, role access, manual enable/disable and
+   * useProxy. Never touches auth/baseUrl/envVars/headers.
+   */
+  async resync(
+    connectorId: string,
+    mode: 'safe' | 'full' = 'full',
+  ): Promise<{ applied: boolean; diff: CatalogDiff; snapshot: unknown }> {
+    const diff = await this.computeDiff(connectorId);
+    if (!diff) {
+      throw new Error('Connector is not catalog-managed');
+    }
+    if (diff.isUpToDate) {
+      return { applied: false, diff, snapshot: null };
+    }
+    if (mode === 'safe' && !diff.isSafeClass) {
+      // Safe-mode caller must not apply structural changes.
+      return { applied: false, diff, snapshot: null };
+    }
+
+    const adapter = getAdapter(diff.slug) as AdapterDefinition;
+    const catalogTools = adapter.tools as CatalogTool[];
+    const catalogByName = new Map(catalogTools.map((t) => [t.name, t]));
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      const connector = await tx.connector.findUnique({
+        where: { id: connectorId },
+        include: { tools: true },
+      });
+      if (!connector) throw new Error('Connector vanished mid-resync');
+
+      // Pre-image snapshot for rollback / audit.
+      const snapshot = {
+        connectorId,
+        slug: diff.slug,
+        at: new Date().toISOString(),
+        tools: connector.tools.map((t) => ({
+          id: t.id,
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+          endpointMapping: t.endpointMapping,
+          deprecatedAt: t.deprecatedAt,
+          isEnabled: t.isEnabled,
+        })),
+        instructions: connector.instructions,
+        config: connector.config,
+      };
+
+      const existingByName = new Map(connector.tools.map((t) => [t.name, t]));
+      let updatedCount = 0;
+      let createdCount = 0;
+      let deprecatedCount = 0;
+
+      for (const ct of catalogTools) {
+        const et = existingByName.get(ct.name);
+        if (et) {
+          const endpointChanged =
+            hashContent(ct.endpointMapping ?? {}) !==
+            hashContent(et.endpointMapping ?? {});
+          // In safe mode never touch endpointMapping.
+          if (mode === 'safe' && endpointChanged) continue;
+          await tx.mcpTool.update({
+            where: { id: et.id },
+            data: {
+              description: ct.description,
+              parameters: ct.parameters as any,
+              endpointMapping:
+                mode === 'safe'
+                  ? (et.endpointMapping as any)
+                  : (ct.endpointMapping as any),
+              // Un-deprecate a tool the catalog brought back; never flip a
+              // user's manual disable.
+              deprecatedAt: null,
+              isEnabled: et.deprecatedAt ? true : et.isEnabled,
+              // responseMapping / useProxy / roleAccess preserved.
+            },
+          });
+          updatedCount++;
+        } else if (mode === 'full') {
+          await tx.mcpTool.create({
+            data: {
+              connectorId,
+              name: ct.name,
+              description: ct.description,
+              parameters: ct.parameters as any,
+              endpointMapping: ct.endpointMapping as any,
+              responseMapping: (ct.responseMapping as any) ?? undefined,
+              useProxy: ct.useProxy === true,
+            },
+          });
+          createdCount++;
+        }
+      }
+
+      // Soft-deprecate tools no longer in the catalog (full mode only).
+      if (mode === 'full') {
+        const now = new Date();
+        for (const et of connector.tools) {
+          if (et.deprecatedAt) continue;
+          if (catalogByName.has(et.name)) continue;
+          await tx.mcpTool.update({
+            where: { id: et.id },
+            data: { deprecatedAt: now, isEnabled: false },
+          });
+          deprecatedCount++;
+        }
+      }
+
+      // Refresh instructions only if the user hasn't edited them.
+      let newInstructions = connector.instructions;
+      if (diff.instructionsRefreshable) {
+        newInstructions = adapter.instructions ?? null;
+      }
+
+      // Bump the stored version only when the connector is now fully in sync
+      // with the catalog (full mode, or safe mode on a pure safe-class diff).
+      const fullySynced = mode === 'full' || diff.isSafeClass;
+      const cfg = ((connector.config ?? {}) as Record<string, unknown>) || {};
+      const newConfig = {
+        ...cfg,
+        ...(fullySynced ? { adapterVersion: adapter.version } : {}),
+        instructionsBaseline: hashInstructions(newInstructions),
+      };
+
+      await tx.connector.update({
+        where: { id: connectorId },
+        data: {
+          instructions: newInstructions,
+          config: newConfig as any,
+        },
+      });
+
+      return { snapshot, updatedCount, createdCount, deprecatedCount };
+    });
+
+    this.logger.log(
+      `Re-synced connector ${connectorId} (${diff.slug}, mode=${mode}): ` +
+        `${result.updatedCount} updated, ${result.createdCount} added, ` +
+        `${result.deprecatedCount} deprecated → ${adapter.version}`,
+    );
+
+    return { applied: true, diff, snapshot: result.snapshot };
+  }
+}

--- a/packages/backend/src/connectors/connectors.controller.spec.ts
+++ b/packages/backend/src/connectors/connectors.controller.spec.ts
@@ -33,6 +33,7 @@ function buildController(overrides: {
     {} as any, // curlParser
     {} as any, // mcpClientEngine
     {} as any, // mcpOAuthService
+    {} as any, // catalogResync
     prisma as any,
     mcpServer as any,
     configService as any,

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -37,6 +37,7 @@ import { PostmanParser } from './parsers/postman.parser';
 import { CurlParser } from './parsers/curl.parser';
 import { McpClientEngine } from './engines/mcp-client.engine';
 import { McpOAuthService } from './mcp-oauth.service';
+import { CatalogResyncService } from './catalog-resync.service';
 import { PrismaService } from '../common/prisma.service';
 import { McpServerService } from '../mcp-server/mcp-server.service';
 import { LicenseGuardService } from '../license/license-guard.service';
@@ -375,6 +376,7 @@ export class ConnectorsController {
     private readonly curlParser: CurlParser,
     private readonly mcpClientEngine: McpClientEngine,
     private readonly mcpOAuthService: McpOAuthService,
+    private readonly catalogResync: CatalogResyncService,
     private readonly prisma: PrismaService,
     private readonly mcpServer: McpServerService,
     private readonly configService: ConfigService,
@@ -1040,6 +1042,40 @@ export class ConnectorsController {
     });
     await this.mcpServer.reloadConnectorTools(id);
     return updated;
+  }
+
+  @Get(':id/catalog-diff')
+  @ApiOperation({
+    summary:
+      'Preview catalog updates for a connector installed from the catalog. ' +
+      'Returns the tool diff (safe vs structural) without applying anything.',
+  })
+  async catalogDiff(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id);
+    this.assertCanWrite(connector, req);
+    const diff = await this.catalogResync.computeDiff(id);
+    if (!diff) {
+      return { catalogManaged: false };
+    }
+    return { catalogManaged: true, ...diff };
+  }
+
+  @Post(':id/resync-catalog')
+  @ApiOperation({
+    summary:
+      'Re-sync a catalog-installed connector with the current catalog. ' +
+      'Updates tool descriptions/parameters/endpoints from the catalog while ' +
+      'preserving response customisations, role access and manual disables. ' +
+      'Never touches credentials, base URL or env vars.',
+  })
+  async resyncCatalog(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id);
+    this.assertCanWrite(connector, req);
+    const { applied, diff } = await this.catalogResync.resync(id, 'full');
+    if (applied) {
+      await this.mcpServer.reloadConnectorTools(id);
+    }
+    return { applied, ...diff };
   }
 
   /**

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -18,6 +18,8 @@ import { PostmanParser } from './parsers/postman.parser';
 import { CurlParser } from './parsers/curl.parser';
 import { McpOAuthService } from './mcp-oauth.service';
 import { McpOAuthCallbackController } from './mcp-oauth-callback.controller';
+import { CatalogResyncService } from './catalog-resync.service';
+import { CatalogReconciler } from './catalog-reconciler.service';
 import { LicenseModule } from '../license/license.module';
 
 const ENGINES = [
@@ -36,6 +38,8 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
   providers: [
     ConnectorsService,
     McpOAuthService,
+    CatalogResyncService,
+    CatalogReconciler,
     OAuth2TokenService,
     LoginTokenService,
     GraphqlSchemaService,
@@ -45,6 +49,7 @@ const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlPa
   exports: [
     ConnectorsService,
     McpOAuthService,
+    CatalogResyncService,
     OAuth2TokenService,
     LoginTokenService,
     GraphqlSchemaService,


### PR DESCRIPTION
## Why
Adapter fixes in the catalog don't reach connectors that are already installed — tools are **copied** into `mcp_tools` at install and nothing propagates later. A recent weclapp description/filter fix had to be applied to all 5 installed connectors by hand via prod SQL. This PR adds the mechanism so future fixes self-heal.

Design doc: `.context/catalog-resync-plan.md` (decisions locked there).

## What's in PR1 (backend core)
- **Content-hash versioning** (`catalog-fingerprint.ts`): deterministic per-adapter `version` (tools + connector meta + instructions), computed at load — never hand-bumped. Exposed on `AdapterMeta.version`; stamped onto `config.adapterVersion` + an instructions baseline at install.
- **`CatalogResyncService`**: connector↔catalog diff classified **safe** (description/parameters only) vs **structural** (endpoint change / tool add / remove); apply matches by tool name, **preserves** responseMapping / role access / manual enable-disable / useProxy, refreshes `instructions` only if the user hasn't edited them, soft-deprecates removed tools, **never** touches auth / baseUrl / envVars. Transactional + pre-image snapshot.
- **Endpoints**: `GET :id/catalog-diff` (preview), `POST :id/resync-catalog` (apply).
- **`CatalogReconciler`** (boot): flag `CATALOG_AUTOSYNC` (default on) auto-applies the **safe class** fleet-wide and stamps versions on already-synced connectors (**doubles as the backfill**). Structural updates wait for explicit review.

## Decisions (from the plan, approved)
1. Auto-apply the safe class on boot (non-breaking; consistent with the existing 'catalog owns descriptions' re-import semantics). Structural needs a click.
2. Refresh `instructions` only if untouched (install-time baseline).
3. Both layers: boot reconciler for safe + (PR2) operator endpoint for structural/bulk.

## Test plan
- [x] `tsc --noEmit` clean; `nest build` produces the new dist artifacts
- [x] Unit tests: fingerprint determinism + sensitivity; diff classification (safe / structural / add / remove / not-catalog-managed)
- [x] Full backend suite: 177 suites / 3055 tests pass
- [x] Deterministic version verified identical under ts-node and compiled dist

## Follow-ups
- **PR2** (`ee/`): operator bulk re-sync `/admin/catalog/resync?slug=&dryRun=&includeStructural=` + fleet report.
- **PR3** (frontend): 'Update available' badge + review modal (structural only) + 7-locale i18n.