### PR TITLE
fix(cloud): allow SSRF guard to reach internal db-rest host

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -64,6 +64,10 @@ services:
       # connector's public base URL (v6.db.transport.rest) is transparently
       # routed here. Unset on self-host → connector uses the public API.
       - DB_REST_INTERNAL_URL=${DB_REST_INTERNAL_URL:-http://db-rest:3000}
+      # Allow the SSRF guard to reach the internal db-rest host (it resolves to
+      # a private docker IP, which the guard blocks by default). Harmless on
+      # self-host (no such host on their network).
+      - SSRF_ALLOWED_HOSTS=${SSRF_ALLOWED_HOSTS:-db-rest}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Follow-up to #338. The Deutsche Bahn host swap routes to `http://db-rest:3000` (private docker IP). The SSRF guard blocks private addresses by default, so the internal call failed with `SsrfBlockedError: hostname 'db-rest' resolves to non-public address`. Allowlist the db-rest host via `SSRF_ALLOWED_HOSTS` (compose default `db-rest`; harmless on self-host). Compose-only change — no image rebuild needed.