### PR TITLE
fix(connectors): apply db-rest host swap to in-app Run Test

### DIFF
--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -349,7 +349,10 @@ export class ConnectorsService {
       : undefined;
 
     const config = {
-      baseUrl: connector.baseUrl,
+      // Apply the cloud db-rest host swap so the in-app "Run Test" hits the
+      // real (internal) endpoint, same as MCP tool execution — otherwise it
+      // calls the public base URL and hangs/times out.
+      baseUrl: resolveInternalDbRestUrl(connector.baseUrl),
       authType: connector.authType,
       authConfig,
       headers: connector.headers as Record<string, string>,


### PR DESCRIPTION
Follow-up to #338/#340/#341. The per-tool 'Run Test' (`POST /connectors/:id/tools/:toolId/test` → `executeConnectorCall`) built the engine config from the raw `connector.baseUrl` (public `v6.db.transport.rest`), so in cloud it hit the unreachable public instance and hung until the 30s timeout ('Running...' forever). Route it through `resolveInternalDbRestUrl` like the MCP execution and Test-connection paths.