### PR TITLE
docs: Glama score badge + official MCP registry server.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://github.com/HelpCode-ai/anythingmcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-2563eb?labelColor=0b1220" alt="License"></a>
   <a href="https://hub.docker.com/r/helpcodeai/anythingmcp"><img src="https://img.shields.io/badge/docker-ready-2563eb?logo=docker&logoColor=white&labelColor=0b1220" alt="Docker Ready"></a>
   <a href="https://github.com/HelpCode-ai/anythingmcp/commits/main"><img src="https://img.shields.io/github/last-commit/HelpCode-ai/anythingmcp?color=2563eb&labelColor=0b1220" alt="Last Commit"></a>
+  <a href="https://glama.ai/mcp/servers/HelpCode-ai/anythingmcp"><img src="https://glama.ai/mcp/servers/HelpCode-ai/anythingmcp/badges/score.svg" alt="anythingmcp MCP server"></a>
 </p>
 
 <p align="center">

--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.keysersoft/anythingmcp",
+  "description": "Self-hosted MCP gateway: turn any API, database or MCP server into AI connectors — no code.",
+  "repository": {
+    "url": "https://github.com/HelpCode-ai/anythingmcp",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "websiteUrl": "https://anythingmcp.com",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://cloud.anythingmcp.com/mcp/demo"
+    }
+  ]
+}


### PR DESCRIPTION
- Adds the **Glama quality-score badge** to the README badges row (also required for the awesome-mcp-servers listing, PR #6191).
- Adds **`server.json`** — the manifest for the **official MCP Registry**, with the remote (streamable-http) pointing at the public read-only demo endpoint `https://cloud.anythingmcp.com/mcp/demo`.

Published to the registry as `io.github.keysersoft/anythingmcp` v1.0.0 (interim personal namespace; will move to `io.github.helpcode-ai` once org membership is made public on GitHub).