### PR TITLE
fix(kg): page observational ingest + container self-heal (prod OOM)

### DIFF
--- a/packages/backend/src/knowledge-graph/kg-observational.service.ts
+++ b/packages/backend/src/knowledge-graph/kg-observational.service.ts
@@ -63,24 +63,8 @@ export class KgObservationalService {
         ? new Date(0)
         : new Date(Math.min(...watermarkTimes));
 
-    const invocations = await this.prisma.toolInvocation.findMany({
-      where: {
-        organizationId,
-        connectorId: { not: null },
-        createdAt: { gt: floor },
-      },
-      select: {
-        id: true,
-        connectorId: true,
-        createdAt: true,
-        input: true,
-        output: true,
-        intent: true,
-        tool: { select: { name: true } },
-      },
-      orderBy: { createdAt: 'asc' },
-      take: MAX_INVOCATIONS_PER_RUN,
-    });
+    // Invocations are streamed in pages inside the loop below (see CHUNK) so we
+    // never hold thousands of full input/output payloads in memory at once.
 
     // Existing entities per connector, so we can link a response field name to a
     // known entity (FK rule applied to the response shape, not just values).
@@ -116,7 +100,31 @@ export class KgObservationalService {
     const intentGroups = new Map<string, Set<string>>();
     const maxTsByConnector = new Map<string, Date>();
 
-    for (const inv of invocations) {
+    // Page through invocations so we never hold more than CHUNK full input/output
+    // payloads in memory at once. A busy org's payloads can be megabytes each;
+    // loading thousands together previously OOM'd the backend.
+    const CHUNK = 200;
+    let processed = 0;
+    while (processed < MAX_INVOCATIONS_PER_RUN) {
+      const page = await this.prisma.toolInvocation.findMany({
+        where: { organizationId, connectorId: { not: null }, createdAt: { gt: floor } },
+        select: {
+          id: true,
+          connectorId: true,
+          createdAt: true,
+          input: true,
+          output: true,
+          intent: true,
+          tool: { select: { name: true } },
+        },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        skip: processed,
+        take: Math.min(CHUNK, MAX_INVOCATIONS_PER_RUN - processed),
+      });
+      if (page.length === 0) break;
+      processed += page.length;
+
+      for (const inv of page) {
       const connectorId = inv.connectorId!;
       // Skip invocations already covered by this connector's watermark.
       const wm = watermark.get(connectorId);
@@ -176,7 +184,9 @@ export class KgObservationalService {
           }
         }
       }
-    }
+      } // for (const inv of page)
+      if (page.length < CHUNK) break;
+    } // while pages
 
     if (valueRows.length) {
       await this.prisma.kgValueSeen.createMany({ data: valueRows });
@@ -239,9 +249,9 @@ export class KgObservationalService {
     }
 
     this.logger.debug(
-      `KG observational ${organizationId}: ${invocations.length} invocations, ${edges} edges`,
+      `KG observational ${organizationId}: ${processed} invocations, ${edges} edges`,
     );
-    return { invocations: invocations.length, edges };
+    return { invocations: processed, edges };
   }
 
   /** Correlate value occurrences into produces_consumes + same_identity edges. */

--- a/start.sh
+++ b/start.sh
@@ -18,7 +18,10 @@ cd /app/backend
 npx prisma migrate deploy
 
 echo "==> Starting backend (port 4000)..."
-node dist/src/main.js &
+# Cap the V8 heap so a runaway allocation fails *this* process (caught by the
+# liveness loop below → container restart) instead of OOM-killing the whole host.
+# Override via NODE_MAX_OLD_SPACE_MB; default 2048 suits a ~4GB host.
+node --max-old-space-size="${NODE_MAX_OLD_SPACE_MB:-2048}" dist/src/main.js &
 BACKEND_PID=$!
 
 echo "==> Starting frontend (port 3000)..."
@@ -29,7 +32,13 @@ FRONTEND_PID=$!
 
 echo "==> AnythingMCP running — backend PID=$BACKEND_PID, frontend PID=$FRONTEND_PID"
 
-# Wait for both processes — if either exits, the wait returns and we shut down
-wait "$BACKEND_PID" "$FRONTEND_PID"
-echo "==> A process exited unexpectedly, shutting down..."
+# If EITHER process dies (e.g. the backend is OOM-killed), exit so Docker's
+# `restart: unless-stopped` brings the container back — instead of leaving a
+# half-broken container up (a dead backend behind a live frontend serving 502s,
+# which previously needed a manual restart). POSIX `wait pid1 pid2` waits for
+# BOTH to exit, so we poll liveness instead.
+while kill -0 "$BACKEND_PID" 2>/dev/null && kill -0 "$FRONTEND_PID" 2>/dev/null; do
+  sleep 5
+done
+echo "==> A process exited unexpectedly, shutting down so the container restarts..."
 cleanup


### PR DESCRIPTION
Root-cause fix for the production outage: the kg-discovery cron loaded up to 2000 tool_invocations **with full input/output JSON** at once → ~3GB → OOM-kill on the cloud host; start.sh then left a dead backend behind a live frontend (502s) with no restart.

- **kg-observational**: stream invocations in pages of 200 (offset paging) — only a small window of payloads in memory at a time; derived signals still accumulate across pages. Behaviour unchanged.
- **start.sh**: exit (→ Docker restart) as soon as either process dies (was waiting on both); cap backend V8 heap (NODE_MAX_OLD_SPACE_MB, default 2048).

Full backend suite green (3274). After merge+deploy the kg-discovery cron will be re-enabled.