### PR TITLE
fix(connectors): hoist generic-call params to top-level form body (bitrix24_call) — v0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/adapters/intl/bitrix24.json
+++ b/packages/backend/src/adapters/intl/bitrix24.json
@@ -18,12 +18,12 @@
   "tools": [
     {
       "name": "bitrix24_call",
-      "description": "Generic Bitrix24 method invoker — pass any `method` name and `params` object. Use this for any method not covered by the typed wrappers below.",
+      "description": "Generic Bitrix24 method invoker. Pass the `method` name and a `params` object holding the method's NATIVE top-level arguments (they are sent at the body root, NOT wrapped under a `params` key). Examples: tasks.task.get → {taskId: 123}; tasks.task.add → {fields: {TITLE: '...', RESPONSIBLE_ID: 1}}; crm.deal.list → {select: ['*'], filter: {STAGE_ID: 'NEW'}, start: 0}; crm.timeline.comment.add → {fields: {ENTITY_ID: 42, ENTITY_TYPE: 'deal', COMMENT: '...'}}. Use the method's exact argument names from the Bitrix REST docs.",
       "parameters": {
         "type": "object",
         "properties": {
           "method": { "type": "string", "description": "Bitrix method name, e.g. 'crm.deal.list', 'tasks.task.get'." },
-          "params": { "type": "object", "description": "Free-form parameters object — engine form-encodes nested keys as Bitrix expects (e.g. {select:[...], filter:{...}})." }
+          "params": { "type": "object", "description": "The method's native arguments, keyed exactly as Bitrix expects them at the top level (e.g. {taskId: 1} or {fields: {...}, filter: {...}}). The engine bracket-encodes nested objects/arrays as Bitrix's PHP-style form body requires." }
         },
         "required": ["method"]
       },
@@ -31,7 +31,7 @@
         "method": "POST",
         "path": "/{method}",
         "bodyEncoding": "form-urlencoded",
-        "bodyMapping": { "params": "$params" }
+        "bodyMapping": { "__spread": "$params" }
       }
     },
     {

--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -514,6 +514,70 @@ describe('RestEngine', () => {
       expect(decoded).toContain('select[0]=ID');
       expect(decoded).toContain('select[1]=TITLE');
     });
+
+    it('hoists a __spread object to top-level form params (no params[] wrapper)', async () => {
+      mockedAxios.mockResolvedValue({ data: {} });
+
+      await engine.execute(
+        { baseUrl: 'https://example.bitrix24.com/rest/1/token', authType: 'NONE' },
+        {
+          method: 'POST',
+          path: '/tasks.task.add',
+          bodyEncoding: 'form-urlencoded',
+          bodyMapping: { __spread: '$params' },
+        },
+        { params: { fields: { TITLE: 'Call', RESPONSIBLE_ID: 1 } } },
+      );
+
+      const decoded = decodeURIComponent(
+        (mockedAxios.mock.calls[0][0] as unknown as { data: string }).data,
+      );
+      // Native arg names land at the body root, NOT under params[...].
+      expect(decoded).toContain('fields[TITLE]=Call');
+      expect(decoded).toContain('fields[RESPONSIBLE_ID]=1');
+      expect(decoded).not.toContain('params[fields]');
+      expect(decoded).not.toContain('__spread');
+    });
+
+    it('hoists a scalar __spread arg (e.g. taskId) to the top level', async () => {
+      mockedAxios.mockResolvedValue({ data: {} });
+
+      await engine.execute(
+        { baseUrl: 'https://example.bitrix24.com/rest/1/token', authType: 'NONE' },
+        {
+          method: 'POST',
+          path: '/tasks.task.get',
+          bodyEncoding: 'form-urlencoded',
+          bodyMapping: { __spread: '$params' },
+        },
+        { params: { taskId: 123 } },
+      );
+
+      const decoded = decodeURIComponent(
+        (mockedAxios.mock.calls[0][0] as unknown as { data: string }).data,
+      );
+      expect(decoded).toContain('taskId=123');
+      expect(decoded).not.toContain('params[taskId]');
+    });
+
+    it('omits __spread entirely when no params object is supplied', async () => {
+      mockedAxios.mockResolvedValue({ data: {} });
+
+      await engine.execute(
+        { baseUrl: 'https://example.bitrix24.com/rest/1/token', authType: 'NONE' },
+        {
+          method: 'POST',
+          path: '/profile',
+          bodyEncoding: 'form-urlencoded',
+          bodyMapping: { __spread: '$params' },
+        },
+        {},
+      );
+
+      const sent = (mockedAxios.mock.calls[0][0] as unknown as { data: string })
+        .data;
+      expect(sent).not.toContain('__spread');
+    });
   });
 
   describe('baseUrl / path joining', () => {

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -146,7 +146,7 @@ export class RestEngine {
 
           if (encoding === 'form-urlencoded') {
             const urlParams = new URLSearchParams();
-            for (const [k, v] of Object.entries(mapped)) {
+            for (const [k, v] of spreadFormEntries(mapped)) {
               appendFormParam((key, val) => urlParams.append(key, val), k, v);
             }
             axiosConfig.data = urlParams.toString();
@@ -156,7 +156,7 @@ export class RestEngine {
             };
           } else if (encoding === 'form-data') {
             const form = new FormData();
-            for (const [k, v] of Object.entries(mapped)) {
+            for (const [k, v] of spreadFormEntries(mapped)) {
               appendFormParam((key, val) => form.append(key, val), k, v);
             }
             axiosConfig.data = form;
@@ -512,6 +512,35 @@ function joinBaseAndPath(baseUrl: string, path: string): string {
  * "value does not match parameter" error. Primitives are emitted as-is;
  * null/undefined are skipped so absent optional fields don't send empty keys.
  */
+/**
+ * Yield top-level (key, value) entries for a form body, expanding a special
+ * `__spread` key: its object value's own entries are hoisted to the top level
+ * instead of being nested under the literal `__spread` key.
+ *
+ * This lets a generic, method-agnostic tool (e.g. Bitrix24's `bitrix24_call`)
+ * forward an arbitrary caller-supplied params object as the request body's
+ * top-level fields — `{filter:{...}, taskId:1}` becomes `filter[...]=` and
+ * `taskId=1`, NOT `params[filter][...]` / `params[taskId]` which the previous
+ * `{params:$params}` mapping produced and the upstream API rejected
+ * ("Could not find value for parameter {fields}", "Param #0 (taskId)").
+ */
+function* spreadFormEntries(
+  mapped: Record<string, unknown>,
+): Generator<[string, unknown]> {
+  for (const [k, v] of Object.entries(mapped)) {
+    if (
+      k === '__spread' &&
+      v !== null &&
+      typeof v === 'object' &&
+      !Array.isArray(v)
+    ) {
+      yield* Object.entries(v as Record<string, unknown>);
+    } else {
+      yield [k, v];
+    }
+  }
+}
+
 function appendFormParam(
   sink: (key: string, value: string) => void,
   key: string,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Problem
A 48h production usage analysis showed `bitrix24_call` (the generic Bitrix24 invoker) as the dominant source of errors. Post-deploy of v0.2.2 the `[object Object]` bug is gone, but the generic call still failed with:
- `Could not find value for parameter {fields}`
- `Param #0 (taskId)` / `Argument "entityid" is required`

## Root cause
`bitrix24_call` mapped the caller's params under a literal `params` key (`bodyMapping: {params: $params}`), so the PHP-bracket form encoder produced `params[fields][TITLE]=` / `params[taskId]=` instead of the top-level `fields[TITLE]=` / `taskId=` that Bitrix expects.

## Fix
- **rest.engine**: new `__spread` bodyMapping directive — hoists an object's own entries to the top level of a form body (urlencoded / form-data) instead of nesting under the literal key. Reusable by any generic, method-agnostic tool.
- **bitrix24.json**: `bitrix24_call` → `{__spread: $params}` + sharper description with per-method examples.
- **tests**: 3 new cases (nested object, scalar arg, empty params) — all 27 rest.engine tests green.

Other connectors from the analysis (Etsy 520, N26 404, Salesflare/CoinGecko 401) had **no errors post-deploy** or are **per-tenant config** — tracked separately, not code bugs.

Release **v0.2.3**.