### PR TITLE
fix(cloud): default MCP responses to JSON for Copilot Studio compatibility

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -51,6 +51,15 @@ services:
       - SERVER_URL=https://${DOMAIN}
       - FRONTEND_URL=https://${DOMAIN}
       - MCP_AUTH_MODE=${MCP_AUTH_MODE:-oauth2}
+      # MCP Streamable HTTP response framing. `true` = single-shot
+      # `application/json` responses; `false` = SSE-framed `text/event-stream`.
+      # Microsoft Copilot Studio's MCP client cannot deserialize SSE-framed
+      # responses ("response could not be deserialized as JSON") and requires
+      # plain JSON, so the cloud defaults to JSON. This is spec-compliant and
+      # every compliant client (incl. Claude) handles it; combined with the
+      # default stateless mode (MCP_STATEFUL_SESSIONS unset) it also avoids the
+      # `-32001 Session not found` errors Copilot hits against stateful servers.
+      - MCP_STREAMABLE_JSON_RESPONSE=${MCP_STREAMABLE_JSON_RESPONSE:-true}
       - ALLOW_OPEN_REGISTRATION=${ALLOW_OPEN_REGISTRATION:-true}
       - LICENSE_API_URL=${LICENSE_API_URL:-https://anythingmcp.com}
       # Operator analytics — cloud build only. Leave unset on self-hosted.

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -90,9 +90,14 @@ export class McpEndpointController {
   ) {}
 
   // Streamable-HTTP response framing. Default: SSE-framed responses
-  // (`text/event-stream`), which is the spec-standard and what some clients
-  // (e.g. Microsoft Copilot Studio) require. Set MCP_STREAMABLE_JSON_RESPONSE=true
-  // to force the older single-shot `application/json` responses instead.
+  // (`text/event-stream`), the spec-standard envelope that also carries
+  // streaming and server-initiated notifications. Set
+  // MCP_STREAMABLE_JSON_RESPONSE=true for single-shot `application/json`
+  // responses instead — required by Microsoft Copilot Studio, whose MCP
+  // client cannot deserialize SSE-framed responses ("response could not be
+  // deserialized as JSON"). JSON is spec-compliant and handled by every
+  // compliant client (incl. Claude); the cloud deployment enables it by
+  // default (see docker-compose.cloud.yml).
   private jsonResponseEnabled(): boolean {
     return process.env.MCP_STREAMABLE_JSON_RESPONSE === 'true';
   }


### PR DESCRIPTION
## What

Default the cloud deployment to `MCP_STREAMABLE_JSON_RESPONSE=true` so the per-server MCP endpoints return single-shot `application/json` instead of SSE-framed `text/event-stream`.

## Why

Microsoft Copilot Studio's MCP client cannot consume SSE-framed Streamable HTTP responses — it fails with *"MCP server response could not be deserialized as JSON"*. It requires plain JSON-RPC responses. Combined with the existing default **stateless** mode (`MCP_STATEFUL_SESSIONS` unset), this also avoids the `-32001 "Session not found"` errors Copilot hits against stateful servers.

JSON single-shot responses are spec-compliant and handled by every compliant MCP client (verified against Claude.ai connectors), so this is safe as a cloud default.

## Scope

- One line in `docker-compose.cloud.yml` (cloud deployment only). No backend code change — the `MCP_STREAMABLE_JSON_RESPONSE` flag already exists in the shipped image.
- Self-hosted deployments are unaffected (flag stays opt-in via their own env).

## Verification

Already applied and verified live on the cloud droplet:
- Demo MCP endpoint → `200 application/json`, no `mcp-session-id` (stateless).
- `tools/list` returns tools as JSON.
- Existing Claude.ai cloud connectors still work (canary: live data returned).