### PR TITLE
feat(connectors): GTIN/barcode lookup adapter + fix stale authConfig on env-var updates

### DIFF
--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -43,6 +43,16 @@ export class AdaptersService {
   ): Promise<{ connectorId: string; toolsCreated: number }> {
     const adapter = this.getBySlug(slug);
 
+    // Credentials arrive from the UI verbatim — a stray leading/trailing
+    // space (easy to pick up when pasting) would otherwise be encrypted into
+    // authConfig and break auth downstream (e.g. Basic Auth 401s that are
+    // invisible in the UI because the displayed env var looks correct).
+    if (credentials) {
+      for (const [k, v] of Object.entries(credentials)) {
+        if (typeof v === 'string') credentials[k] = v.trim();
+      }
+    }
+
     // Resolve {{VAR}} placeholders in authConfig with provided credentials
     const resolvedAuthConfig = adapter.connector.authConfig
       ? this.resolveTemplate(adapter.connector.authConfig, credentials)

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -48,12 +48,13 @@ export class AdaptersService {
     // authConfig and break auth downstream (e.g. Basic Auth 401s that are
     // invisible in the UI because the displayed env var looks correct).
     if (credentials) {
+      // Build onto a null-prototype object so user-controlled keys can't
+      // reach Object.prototype (prototype pollution).
+      const trimmed: Record<string, string> = Object.create(null);
       for (const [k, v] of Object.entries(credentials)) {
-        if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
-          continue;
-        }
-        if (typeof v === 'string') credentials[k] = v.trim();
+        trimmed[k] = typeof v === 'string' ? v.trim() : v;
       }
+      credentials = trimmed;
     }
 
     // Resolve {{VAR}} placeholders in authConfig with provided credentials

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -49,6 +49,9 @@ export class AdaptersService {
     // invisible in the UI because the displayed env var looks correct).
     if (credentials) {
       for (const [k, v] of Object.entries(credentials)) {
+        if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+          continue;
+        }
         if (typeof v === 'string') credentials[k] = v.trim();
       }
     }

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -48,13 +48,15 @@ export class AdaptersService {
     // authConfig and break auth downstream (e.g. Basic Auth 401s that are
     // invisible in the UI because the displayed env var looks correct).
     if (credentials) {
-      // Build onto a null-prototype object so user-controlled keys can't
-      // reach Object.prototype (prototype pollution).
-      const trimmed: Record<string, string> = Object.create(null);
-      for (const [k, v] of Object.entries(credentials)) {
-        trimmed[k] = typeof v === 'string' ? v.trim() : v;
-      }
-      credentials = trimmed;
+      // Rebuild via Object.fromEntries (no dynamic user-keyed property write)
+      // so a pasted leading/trailing space in a credential can't survive into
+      // the encrypted authConfig and break auth.
+      credentials = Object.fromEntries(
+        Object.entries(credentials).map(([k, v]) => [
+          k,
+          typeof v === 'string' ? v.trim() : v,
+        ]),
+      ) as Record<string, string>;
     }
 
     // Resolve {{VAR}} placeholders in authConfig with provided credentials

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -86,6 +86,7 @@ import * as gocardless from './intl/gocardless.json';
 import * as googleAnalytics4 from './intl/google-analytics-4.json';
 import * as gorgias from './intl/gorgias.json';
 import * as greenhouse from './intl/greenhouse.json';
+import * as gtinLookup from './intl/gtin-lookup.json';
 import * as hackernews from './intl/hackernews.json';
 import * as harvest from './intl/harvest.json';
 import * as heap from './intl/heap.json';
@@ -363,6 +364,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   googleAnalytics4 as unknown as AdapterDefinition,
   gorgias as unknown as AdapterDefinition,
   greenhouse as unknown as AdapterDefinition,
+  gtinLookup as unknown as AdapterDefinition,
   hackernews as unknown as AdapterDefinition,
   harvest as unknown as AdapterDefinition,
   heap as unknown as AdapterDefinition,

--- a/packages/backend/src/adapters/intl/gtin-lookup.json
+++ b/packages/backend/src/adapters/intl/gtin-lookup.json
@@ -1,0 +1,162 @@
+{
+  "slug": "gtin-lookup",
+  "name": "GTIN / Barcode Lookup",
+  "description": "Resolve a GTIN / EAN / UPC / ISBN barcode to product information using free public product databases (Open Food Facts, UPCitemdb, Open Beauty Facts, Google Books). No API key required. Covers food & CPG, general retail, cosmetics, and books.",
+  "instructions": "Turn a barcode (GTIN-13 / EAN / UPC-A / ISBN-13) into product details using several free, public, no-auth product databases. Pick the tool that matches the product domain — or try a few, since coverage differs per database.\n\n## Tools by domain\n- **Food, drinks & packaged consumer goods** → `gtin_lookup_food` (by barcode) and `gtin_lookup_search_food` (by name/brand). Backed by Open Food Facts: millions of products, multilingual (incl. German), rich fields (brands, categories, quantity, labels, Nutri-Score, image).\n- **General retail** (electronics, household, toys, tools…) → `gtin_lookup_retail` (by UPC/EAN) and `gtin_lookup_search_retail` (by keyword). Backed by UPCitemdb.\n- **Cosmetics / personal care** → `gtin_lookup_beauty` (by barcode). Backed by Open Beauty Facts.\n- **Books** → `gtin_lookup_book` (by ISBN-13; a book's GTIN is its ISBN). Backed by Google Books.\n\n## No credentials\nAll sources are public and require no API key, so this connector needs no setup.\n\n## Proxy & rate limits\nEvery tool routes through the instance proxy / web-unblocker (when configured) because these free databases rate-limit per client IP — UPCitemdb's trial tier allows only ~100 requests/day per IP, Google Books has a shared anonymous quota, and Open Food Facts asks callers to be gentle and identify themselves. Routing through the proxy spreads load and avoids IP bans. Look up one barcode at a time; cache results you reuse.\n\n## Tips\n- Barcodes are strings — keep leading zeros (UPC-A is 12 digits, EAN/GTIN-13 is 13). A UPC-A can be looked up as its GTIN-13 by prefixing a 0.\n- A `status` / `found` of 0 (Open Food/Beauty Facts) or an empty `items` array (UPCitemdb) means the product is not in that database — try another tool.\n- The food and beauty lookups already request a curated `fields` set to keep responses lean.",
+  "region": "intl",
+  "category": "data",
+  "icon": "barcode",
+  "docsUrl": "https://openfoodfacts.github.io/openfoodfacts-server/api/",
+  "requiredEnvVars": [],
+  "connector": {
+    "name": "GTIN / Barcode Lookup",
+    "type": "REST",
+    "baseUrl": "https://world.openfoodfacts.org",
+    "authType": "NONE",
+    "headers": {
+      "User-Agent": "AnythingMCP-GTIN-Lookup/1.0 (https://anythingmcp.com)",
+      "Accept": "application/json"
+    }
+  },
+  "tools": [
+    {
+      "name": "gtin_lookup_food",
+      "description": "Look up a food, drink or packaged consumer product by its barcode (GTIN-13 / EAN / UPC) in Open Food Facts. Returns name, brands, categories, quantity, labels, Nutri-Score and image URL. status=0 means not found.",
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "barcode": {
+            "type": "string",
+            "description": "The product barcode (GTIN-13 / EAN-13 / UPC-A digits, keep leading zeros)."
+          }
+        },
+        "required": ["barcode"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/v2/product/{barcode}.json",
+        "queryParams": {
+          "fields": "code,product_name,brands,quantity,categories,labels,nutriscore_grade,countries,image_url,ingredients_text"
+        }
+      }
+    },
+    {
+      "name": "gtin_lookup_search_food",
+      "description": "Search Open Food Facts by product name or brand (no barcode needed). Returns matching products with their barcode (code), name and brands — useful to find a GTIN from a description.",
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search terms, e.g. a product name or brand ('nutella', 'coca cola zero')."
+          },
+          "pageSize": {
+            "type": "number",
+            "description": "Number of results to return (default 10, max 50)."
+          }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/cgi/search.pl",
+        "queryParams": {
+          "search_terms": "$query",
+          "json": "1",
+          "page_size": "$pageSize",
+          "fields": "code,product_name,brands,quantity,categories,image_url"
+        }
+      }
+    },
+    {
+      "name": "gtin_lookup_retail",
+      "description": "Look up a general retail product (electronics, household, toys, tools, etc.) by UPC/EAN barcode in UPCitemdb. Returns title, description, brand, model, images and known marketplace offers. Empty items array means not found.",
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "barcode": {
+            "type": "string",
+            "description": "The product UPC-A (12 digits) or EAN/GTIN-13 (13 digits) barcode."
+          }
+        },
+        "required": ["barcode"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "https://api.upcitemdb.com/prod/trial/lookup",
+        "queryParams": {
+          "upc": "$barcode"
+        }
+      }
+    },
+    {
+      "name": "gtin_lookup_search_retail",
+      "description": "Search UPCitemdb by keyword to find general retail products and their UPC/EAN barcodes. Returns matching items with title, brand, barcode and images — useful to find a GTIN from a product name.",
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Keyword search, e.g. 'logitech mouse m100'."
+          }
+        },
+        "required": ["query"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "https://api.upcitemdb.com/prod/trial/search",
+        "queryParams": {
+          "s": "$query"
+        }
+      }
+    },
+    {
+      "name": "gtin_lookup_beauty",
+      "description": "Look up a cosmetics or personal-care product by its barcode (GTIN-13 / EAN) in Open Beauty Facts. Returns name, brands, ingredients and image URL. status=0 means not found.",
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "barcode": {
+            "type": "string",
+            "description": "The product barcode (GTIN-13 / EAN-13, keep leading zeros)."
+          }
+        },
+        "required": ["barcode"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "https://world.openbeautyfacts.org/api/v2/product/{barcode}.json",
+        "queryParams": {
+          "fields": "code,product_name,brands,image_url,ingredients_text,periods_after_opening"
+        }
+      }
+    },
+    {
+      "name": "gtin_lookup_book",
+      "description": "Look up a book by its ISBN-13 (which is the book's GTIN) via Google Books. Returns title, authors, publisher, published date, description and cover image.",
+      "useProxy": true,
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "isbn": {
+            "type": "string",
+            "description": "The book's ISBN-13 (13 digits, the EAN/GTIN printed on the back cover)."
+          }
+        },
+        "required": ["isbn"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "https://www.googleapis.com/books/v1/volumes",
+        "queryParams": {
+          "q": "isbn:${isbn}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/gtin-lookup.live.spec.ts
+++ b/packages/backend/src/adapters/intl/gtin-lookup.live.spec.ts
@@ -1,0 +1,97 @@
+import * as adapter from './gtin-lookup.json';
+import { RestEngine } from '../../connectors/engines/rest.engine';
+import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
+
+/**
+ * Two layers of verification for the GTIN / Barcode Lookup adapter:
+ *
+ *   1. Static — always runs. Asserts the adapter is auth-free, that EVERY tool
+ *      opts into the proxy/web-unblocker (useProxy:true) — these public barcode
+ *      databases rate-limit per IP, so proxy routing is the whole point — and
+ *      that the multi-host tools (UPCitemdb, Open Beauty Facts, Google Books)
+ *      use absolute per-tool URLs while the Open Food Facts tools stay on the
+ *      connector baseUrl.
+ *
+ *   2. Live — skipped unless RUN_GTIN_LIVE is set. Hits the real public APIs
+ *      (no key needed) and asserts a known barcode resolves. May be flaky under
+ *      the shared per-IP rate limits — that's exactly why the tools proxy.
+ *
+ *   Run live with:  RUN_GTIN_LIVE=1 npx jest src/adapters/intl/gtin-lookup.live.spec.ts
+ */
+
+describe('gtin-lookup adapter — static spec conformance', () => {
+  const a = adapter as unknown as {
+    connector: { baseUrl: string; authType: string };
+    tools: Array<{
+      name: string;
+      useProxy?: boolean;
+      endpointMapping: { method: string; path: string };
+    }>;
+  };
+
+  it('requires no authentication (all sources are public)', () => {
+    expect(a.connector.authType).toBe('NONE');
+    expect(a.connector.baseUrl).toBe('https://world.openfoodfacts.org');
+  });
+
+  it('routes EVERY tool through the proxy / web-unblocker', () => {
+    expect(a.tools.length).toBeGreaterThanOrEqual(6);
+    for (const tool of a.tools) {
+      expect(tool.useProxy).toBe(true);
+    }
+  });
+
+  it('uses absolute per-tool URLs for the non-Open-Food-Facts sources', () => {
+    const byName = Object.fromEntries(a.tools.map((t) => [t.name, t.endpointMapping.path]));
+    expect(byName['gtin_lookup_retail']).toBe('https://api.upcitemdb.com/prod/trial/lookup');
+    expect(byName['gtin_lookup_search_retail']).toBe('https://api.upcitemdb.com/prod/trial/search');
+    expect(byName['gtin_lookup_beauty']).toContain('https://world.openbeautyfacts.org/');
+    expect(byName['gtin_lookup_book']).toBe('https://www.googleapis.com/books/v1/volumes');
+    // Open Food Facts tools stay on the connector baseUrl (relative paths).
+    expect(byName['gtin_lookup_food']).toBe('/api/v2/product/{barcode}.json');
+    expect(byName['gtin_lookup_search_food']).toBe('/cgi/search.pl');
+  });
+
+  it('prefixes every tool name with gtin_lookup_', () => {
+    for (const tool of a.tools) {
+      expect(tool.name.startsWith('gtin_lookup_')).toBe(true);
+    }
+  });
+});
+
+const live = process.env.RUN_GTIN_LIVE ? describe : describe.skip;
+
+live('gtin-lookup adapter — live public API resolution', () => {
+  const oauth = {} as unknown as OAuth2TokenService;
+  const login = {} as unknown as LoginTokenService;
+  const engine = new RestEngine(oauth, login);
+  const config = { baseUrl: 'https://world.openfoodfacts.org', authType: 'NONE' };
+
+  it('resolves a known food barcode via Open Food Facts (Nutella)', async () => {
+    const res = (await engine.execute(
+      config,
+      {
+        method: 'GET',
+        path: '/api/v2/product/{barcode}.json',
+        queryParams: { fields: 'code,product_name,brands' },
+      },
+      { barcode: '3017620422003' },
+    )) as { status?: number; product?: { product_name?: string } };
+    expect(res).toBeDefined();
+    expect(res.status).toBe(1);
+    expect(String(res.product?.product_name || '')).toMatch(/nutella/i);
+  }, 30000);
+
+  it('resolves a general retail barcode via UPCitemdb', async () => {
+    const res = (await engine.execute(
+      { baseUrl: 'https://api.upcitemdb.com', authType: 'NONE' },
+      { method: 'GET', path: 'https://api.upcitemdb.com/prod/trial/lookup', queryParams: { upc: '$upc' } },
+      { upc: '0049000028911' },
+    )) as { code?: string; items?: unknown[] };
+    expect(res).toBeDefined();
+    expect(res.code).toBe('OK');
+    expect(Array.isArray(res.items)).toBe(true);
+    expect((res.items || []).length).toBeGreaterThan(0);
+  }, 30000);
+});

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -1060,12 +1060,15 @@ export class ConnectorsController {
     // Trim pasted values — a stray leading/trailing space would be stored
     // (and encrypted into authConfig below) verbatim and break auth with an
     // error the UI can't explain, since the displayed value looks correct.
-    // Null-prototype target so user-controlled keys can't pollute
-    // Object.prototype.
-    const envVars: Record<string, string> = Object.create(null);
-    for (const [rawKey, v] of Object.entries(body.envVars || {})) {
-      envVars[rawKey.trim()] = typeof v === 'string' ? v.trim() : v;
-    }
+    // Rebuild via Object.fromEntries (no dynamic user-keyed property write) so
+    // a stray leading/trailing space in a pasted value can't survive into the
+    // encrypted authConfig and produce a 401 the UI can't explain.
+    const envVars: Record<string, string> = Object.fromEntries(
+      Object.entries(body.envVars || {}).map(([k, v]) => [
+        k.trim(),
+        typeof v === 'string' ? v.trim() : v,
+      ]),
+    );
 
     const updateData: {
       envVars: Record<string, string>;

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -1061,8 +1061,12 @@ export class ConnectorsController {
     // (and encrypted into authConfig below) verbatim and break auth with an
     // error the UI can't explain, since the displayed value looks correct.
     const envVars: Record<string, string> = {};
-    for (const [k, v] of Object.entries(body.envVars || {})) {
-      envVars[k.trim()] = typeof v === 'string' ? v.trim() : v;
+    for (const [rawKey, v] of Object.entries(body.envVars || {})) {
+      const k = rawKey.trim();
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+        continue;
+      }
+      envVars[k] = typeof v === 'string' ? v.trim() : v;
     }
 
     const updateData: {

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -43,6 +43,11 @@ import { McpServerService } from '../mcp-server/mcp-server.service';
 import { LicenseGuardService } from '../license/license-guard.service';
 import { getRequiredSecret } from '../common/secrets.util';
 import { decrypt } from '../common/crypto/encryption.util';
+import { getAdapter } from '../adapters/catalog';
+import {
+  interpolateDeep,
+  interpolateString,
+} from '../common/env-interpolation.util';
 
 class CreateConnectorDto {
   @ApiProperty({
@@ -1051,9 +1056,50 @@ export class ConnectorsController {
   ) {
     const connector = await this.connectorsService.findById(id);
     this.assertCanWrite(connector, req);
-    const updated = await this.connectorsService.update(id, {
-      envVars: body.envVars,
-    });
+
+    // Trim pasted values — a stray leading/trailing space would be stored
+    // (and encrypted into authConfig below) verbatim and break auth with an
+    // error the UI can't explain, since the displayed value looks correct.
+    const envVars: Record<string, string> = {};
+    for (const [k, v] of Object.entries(body.envVars || {})) {
+      envVars[k.trim()] = typeof v === 'string' ? v.trim() : v;
+    }
+
+    const updateData: {
+      envVars: Record<string, string>;
+      authConfig?: Record<string, unknown>;
+      baseUrl?: string;
+      headers?: Record<string, string>;
+    } = { envVars };
+
+    // For catalog-installed connectors, authConfig/baseUrl/headers were
+    // resolved from the adapter template at import time and frozen (auth
+    // encrypted). Re-resolve them from the template here so editing env vars
+    // actually changes the credentials used for requests — otherwise the UI
+    // shows the new value while auth keeps using the old one.
+    const cfg = connector.config as { adapterSlug?: string } | null;
+    const adapter = cfg?.adapterSlug ? getAdapter(cfg.adapterSlug) : null;
+    if (adapter) {
+      const merged = {
+        ...((connector.envVars as Record<string, string> | null) || {}),
+        ...envVars,
+      };
+      if (adapter.connector.authConfig) {
+        updateData.authConfig = interpolateDeep(
+          adapter.connector.authConfig as Record<string, unknown>,
+          merged,
+        );
+      }
+      updateData.baseUrl = interpolateString(adapter.connector.baseUrl, merged);
+      const adapterHeaders = (
+        adapter.connector as { headers?: Record<string, string> }
+      ).headers;
+      if (adapterHeaders) {
+        updateData.headers = interpolateDeep(adapterHeaders, merged);
+      }
+    }
+
+    const updated = await this.connectorsService.update(id, updateData);
     await this.mcpServer.reloadConnectorTools(id);
     return updated;
   }

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -1060,13 +1060,11 @@ export class ConnectorsController {
     // Trim pasted values — a stray leading/trailing space would be stored
     // (and encrypted into authConfig below) verbatim and break auth with an
     // error the UI can't explain, since the displayed value looks correct.
-    const envVars: Record<string, string> = {};
+    // Null-prototype target so user-controlled keys can't pollute
+    // Object.prototype.
+    const envVars: Record<string, string> = Object.create(null);
     for (const [rawKey, v] of Object.entries(body.envVars || {})) {
-      const k = rawKey.trim();
-      if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
-        continue;
-      }
-      envVars[k] = typeof v === 'string' ? v.trim() : v;
+      envVars[rawKey.trim()] = typeof v === 'string' ? v.trim() : v;
     }
 
     const updateData: {


### PR DESCRIPTION
## 1. New adapter: GTIN / Barcode Lookup (`intl/gtin-lookup`)
Resolve GTIN / EAN / UPC / ISBN barcodes to product data via four free public databases — no API key needed:

| Tool | Source | Domain |
|---|---|---|
| `gtin_lookup_food` / `_search_food` | Open Food Facts | food & CPG (multilingual) |
| `gtin_lookup_retail` / `_search_retail` | UPCitemdb | general retail |
| `gtin_lookup_beauty` | Open Beauty Facts | cosmetics |
| `gtin_lookup_book` | Google Books | books (ISBN-13) |

Every tool sets `useProxy: true` — these sources rate-limit per client IP (UPCitemdb ~100/day/IP, Google Books shared anonymous quota), so proxy routing is the point. Verified live (Nutella EAN 3017620422003, Diet Coke UPC, keyword search). Ships `gtin-lookup.live.spec.ts`.

## 2. Credential fix (root-caused from an MFR 401 in production)
A user fixed a mistyped `MFR_USERNAME` (leading space) in the UI, but requests kept failing with 401 while Postman worked. Cause, verified by decrypting the prod record: `PUT /connectors/:id/env-vars` only writes `env_vars`, while BASIC_AUTH & co. authenticate from the **encrypted `auth_config` frozen at import** — the UI showed the corrected value, auth kept using the stale one (` 1demo@…`, hex `20` prefix).

- `updateEnvVars` now re-resolves `authConfig`/`baseUrl`/`headers` from the catalog adapter template with the merged env vars (catalog-installed connectors only; `update()` re-encrypts).
- Credential values are trimmed at adapter import and env-var update.

The affected prod record was already hot-fixed by re-encrypting `auth_config` with the trimmed username.