### PR TITLE
fix(cloud): org-aware SMTP + direct invite/verify links (v0.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -177,10 +177,10 @@ export class AuthController {
       data: { userId, token: linkToken, code, expiresAt },
     });
 
-    // Build verification link URL — route through anythingmcp.com so the
-    // link domain matches the Resend sending domain (avoids spam filters).
+    // Link straight to the instance's verify-email page (the anythingmcp.com
+    // hop 404s behind the marketing site's i18n middleware).
     const instanceUrl = this.getFrontendUrl(req);
-    const verifyUrl = `https://anythingmcp.com/verify-email?token=${linkToken}&instance=${encodeURIComponent(instanceUrl)}`;
+    const verifyUrl = `${instanceUrl}/verify-email?token=${linkToken}`;
 
     // Send email
     try {
@@ -496,10 +496,12 @@ export class AuthController {
       },
     });
 
-    // Build invitation URL — route through anythingmcp.com so the
-    // link domain matches the Resend sending domain (avoids spam filters).
+    // Link straight to the instance's accept-invite page. (The old
+    // anythingmcp.com/accept-invite hop 404'd — that route is shadowed by the
+    // marketing site's i18n middleware — and it isn't needed now that we send
+    // via the org's own SMTP.)
     const instanceUrl = this.getFrontendUrl(req);
-    const inviteUrl = `https://anythingmcp.com/accept-invite?token=${inviteToken}&instance=${encodeURIComponent(instanceUrl)}`;
+    const inviteUrl = `${instanceUrl}/accept-invite?token=${inviteToken}`;
 
     // Get inviter's name for the email
     const inviter = await this.usersService.findById(req.user.sub);
@@ -518,6 +520,7 @@ export class AuthController {
       inviteUrl,
       inviterName,
       roleName,
+      req.user.organizationId,
     );
 
     return {

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
 import axios from 'axios';
 import { SiteSettingsService } from './site-settings.service';
+import { OrgSettingsService } from './org-settings.service';
 import { PrismaService } from '../common/prisma.service';
 
 const LICENSE_API_URL =
@@ -16,8 +17,31 @@ export class EmailService {
 
   constructor(
     private readonly siteSettings: SiteSettingsService,
+    private readonly orgSettings: OrgSettingsService,
     private readonly prisma: PrismaService,
   ) {}
+
+  /**
+   * Resolve the SMTP config to use: the org's own SMTP when an
+   * organizationId is given (falling back to the global site config), else the
+   * global site config. This is what makes per-org SMTP entered in Settings →
+   * Admin actually get used by the sender/tester (previously everything read
+   * only the global site config, so org SMTP was saved but never applied).
+   */
+  private async resolveSmtp(organizationId?: string) {
+    const raw: any = organizationId
+      ? await this.orgSettings.getSmtpConfig(organizationId)
+      : await this.siteSettings.getSmtpConfig();
+    if (!raw || !raw.host) return null;
+    return {
+      host: String(raw.host),
+      port: Number(raw.port),
+      secure: !!raw.secure,
+      user: raw.user,
+      pass: raw.pass,
+      from: raw.from,
+    };
+  }
 
   // ── Password Reset (SMTP with external API fallback) ─────────────────────
 
@@ -95,8 +119,8 @@ export class EmailService {
 
   // ── Invitation Email (SMTP with external API fallback) ────────────────────
 
-  private async createTransporter() {
-    const smtp = await this.siteSettings.getSmtpConfig();
+  private async createTransporter(organizationId?: string) {
+    const smtp = await this.resolveSmtp(organizationId);
     if (!smtp) return null;
     return {
       transporter: nodemailer.createTransport({
@@ -114,8 +138,9 @@ export class EmailService {
     inviteUrl: string,
     invitedByName: string,
     roleName: string,
+    organizationId?: string,
   ): Promise<{ sent: boolean; error?: string }> {
-    const transport = await this.createTransporter();
+    const transport = await this.createTransporter(organizationId);
 
     if (transport) {
       try {
@@ -534,8 +559,8 @@ export class EmailService {
 
   // ── SMTP Test ─────────────────────────────────────────────────────────────
 
-  async testConnection(): Promise<{ ok: boolean; message: string }> {
-    const smtp = await this.siteSettings.getSmtpConfig();
+  async testConnection(organizationId?: string): Promise<{ ok: boolean; message: string }> {
+    const smtp = await this.resolveSmtp(organizationId);
     if (!smtp) {
       return { ok: false, message: 'SMTP not configured' };
     }

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -143,8 +143,8 @@ export class SiteSettingsAdminController {
 
   @Post('smtp/test')
   @ApiOperation({ summary: 'Test SMTP connection (ADMIN)' })
-  async testSmtp() {
-    return this.emailService.testConnection();
+  async testSmtp(@Req() req: any) {
+    return this.emailService.testConnection(req.user.organizationId);
   }
 
   @Get('footer-links')

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Hotfix for cloud email, surfaced by the first paying multi-user customer.

**1. Org SMTP never applied.** SMTP saved per-org (Settings → Admin) but sender/tester read only the global site config → 'SMTP not configured' on test, and invites fell back to the external API with an arbitrary active license key → 'Failed to send email — License revoked'. EmailService now resolves the org's SMTP first (OrgSettingsService already falls back to the global config); createTransporter/testConnection/sendInvitationEmail take an organizationId, threaded from the invite + smtp/test endpoints.

**2. Invite/verify links 404.** They routed through anythingmcp.com/accept-invite, which 404s behind the marketing site's i18n middleware. Now link straight to the instance (`${FRONTEND_URL}/accept-invite|/verify-email`).

tsc + auth/settings specs green.