### PR TITLE
fix(cloud): Resend/system SMTP fallback + robust deploy (v0.3.2)

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -61,8 +61,18 @@ jobs:
               echo "CRON_SECRET=${CRON_SECRET}" >> .env
             fi
 
-            # Restart services (force-recreate to pick up new image and config)
-            docker compose -f docker-compose.cloud.yml up -d --force-recreate --remove-orphans
+            # Recreate ONLY the app to pick up the new image/config (postgres,
+            # redis and db-rest keep running — no data churn, no needless
+            # downtime), and wait until it reports healthy. The old command
+            # force-recreated the whole stack with no health gate, so a
+            # crash-on-start went unnoticed and could take the DB down with it.
+            docker compose -f docker-compose.cloud.yml up -d \
+              --no-deps --force-recreate --wait --wait-timeout 300 app
+
+            # Ensure the proxy + any other services are up (caddy waits for the
+            # app to be healthy, which it now is).
+            docker compose -f docker-compose.cloud.yml up -d --remove-orphans
+
             docker image prune -f
 
             echo "Deployment complete"

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -85,6 +85,15 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - KG_LLM_REDACT_INTENTS=${KG_LLM_REDACT_INTENTS:-true}
+      # System (operator) transactional-email fallback — used when a workspace
+      # hasn't set its own SMTP (e.g. Resend). Read only by the email sender,
+      # never exposed to workspace admins. Set these in the droplet .env.
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-587}
+      - SMTP_USER=${SMTP_USER:-}
+      - SMTP_PASS=${SMTP_PASS:-}
+      - SMTP_FROM=${SMTP_FROM:-}
+      - SMTP_SECURE=${SMTP_SECURE:-false}
     depends_on:
       postgres:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -21,26 +21,54 @@ export class EmailService {
     private readonly prisma: PrismaService,
   ) {}
 
-  /**
-   * Resolve the SMTP config to use: the org's own SMTP when an
-   * organizationId is given (falling back to the global site config), else the
-   * global site config. This is what makes per-org SMTP entered in Settings →
-   * Admin actually get used by the sender/tester (previously everything read
-   * only the global site config, so org SMTP was saved but never applied).
-   */
-  private async resolveSmtp(organizationId?: string) {
-    const raw: any = organizationId
-      ? await this.orgSettings.getSmtpConfig(organizationId)
-      : await this.siteSettings.getSmtpConfig();
+  private normalizeSmtp(raw: any) {
     if (!raw || !raw.host) return null;
     return {
       host: String(raw.host),
-      port: Number(raw.port),
+      port: Number(raw.port) || 587,
       secure: !!raw.secure,
-      user: raw.user,
-      pass: raw.pass,
+      user: raw.user ?? '',
+      pass: raw.pass ?? '',
       from: raw.from,
     };
+  }
+
+  /**
+   * System (operator) SMTP from ENV — the transactional fallback (e.g. Resend)
+   * used when an org hasn't configured its own SMTP. Read ONLY here and never
+   * returned by any API, so our credentials are never exposed to workspace
+   * admins. Configure on the server via SMTP_HOST/PORT/USER/PASS/FROM/SECURE.
+   */
+  private systemSmtp() {
+    const host = process.env.SMTP_HOST;
+    if (!host) return null;
+    const port = Number(process.env.SMTP_PORT) || 587;
+    return this.normalizeSmtp({
+      host,
+      port,
+      secure: process.env.SMTP_SECURE === 'true' || port === 465,
+      user: process.env.SMTP_USER || '',
+      pass: process.env.SMTP_PASS || '',
+      from:
+        process.env.SMTP_FROM ||
+        (process.env.SMTP_USER ? `AnythingMCP <${process.env.SMTP_USER}>` : 'AnythingMCP'),
+    });
+  }
+
+  /**
+   * Resolve the SMTP to send with: the ORG's own SMTP first (never the global
+   * site config — so operator credentials can't leak through the settings API),
+   * then the system/Resend fallback from ENV. Returns null if neither is set
+   * (callers then use the external-API fallback or skip).
+   */
+  private async resolveSmtp(organizationId?: string) {
+    if (organizationId) {
+      const org = this.normalizeSmtp(
+        await this.orgSettings.getJson<any>(organizationId, 'smtp_config'),
+      );
+      if (org) return org;
+    }
+    return this.systemSmtp();
   }
 
   // ── Password Reset (SMTP with external API fallback) ─────────────────────

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -115,8 +115,10 @@ export class SiteSettingsAdminController {
   @Get('smtp')
   @ApiOperation({ summary: 'Get SMTP configuration for current organization (ADMIN)' })
   async getSmtpConfig(@Req() req: any) {
-    const config = await this.orgSettings.getSmtpConfig(req.user.organizationId);
-    if (!config) return { configured: false };
+    // Org-only — never fall back to the global/system config, so operator
+    // credentials are never exposed to workspace admins.
+    const config = await this.orgSettings.getJson<any>(req.user.organizationId, 'smtp_config');
+    if (!config?.host) return { configured: false };
     return {
       configured: true,
       host: config.host,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Follow-up to v0.3.1 (org-aware SMTP).

- **System SMTP fallback (env, never exposed).** The sender resolves the org's own SMTP first, else a system SMTP from ENV (`SMTP_*`, e.g. Resend/Mailgun). It no longer reads the global site config, and GET /smtp is org-only — so operator credentials are never exposed to workspace admins. An org without its own SMTP now gets invites/verification via the system provider instead of the broken external-API-with-license-key fallback ('License revoked').
- **compose:** pass `SMTP_*` through to the app from the droplet .env.
- **deploy-cloud.yml:** recreate only the app with a 300s health wait (then bring the proxy up), instead of force-recreating the whole stack with no health gate.