### PR TITLE
Cloud v0.3.3: workspace-SMTP UX fixes + Stripe billing portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -467,7 +467,9 @@ export class AuthController {
       // User exists but not in this org — allow invitation for multi-org membership
     }
 
-    // Check for existing pending invitation to this org
+    // Reuse an existing pending invitation instead of rejecting: throwing a
+    // 409 here left admins stuck with no way to get the link after a failed
+    // email send (the response with the URL only comes with a NEW invite).
     const existingInvite = await this.prisma.invitationToken.findFirst({
       where: {
         email: dto.email,
@@ -476,25 +478,25 @@ export class AuthController {
         expiresAt: { gt: new Date() },
       },
     });
-    if (existingInvite) {
-      throw new ConflictException('An active invitation already exists for this email');
+
+    const inviteToken = existingInvite
+      ? existingInvite.token
+      : crypto.randomBytes(32).toString('hex');
+
+    if (!existingInvite) {
+      const expiresAt = new Date(Date.now() + 48 * 60 * 60 * 1000); // 48 hours
+      await this.prisma.invitationToken.create({
+        data: {
+          email: dto.email,
+          token: inviteToken,
+          role: dto.role,
+          mcpRoleId: dto.mcpRoleId || null,
+          invitedBy: req.user.sub,
+          organizationId: req.user.organizationId,
+          expiresAt,
+        },
+      });
     }
-
-    // Generate invitation token
-    const inviteToken = crypto.randomBytes(32).toString('hex');
-    const expiresAt = new Date(Date.now() + 48 * 60 * 60 * 1000); // 48 hours
-
-    await this.prisma.invitationToken.create({
-      data: {
-        email: dto.email,
-        token: inviteToken,
-        role: dto.role,
-        mcpRoleId: dto.mcpRoleId || null,
-        invitedBy: req.user.sub,
-        organizationId: req.user.organizationId,
-        expiresAt,
-      },
-    });
 
     // Link straight to the instance's accept-invite page. (The old
     // anythingmcp.com/accept-invite hop 404'd — that route is shadowed by the
@@ -523,10 +525,13 @@ export class AuthController {
       req.user.organizationId,
     );
 
+    const created = existingInvite ? 'A pending invitation already existed' : 'Invitation created';
     return {
       message: emailResult.sent
-        ? `Invitation sent to ${dto.email}`
-        : `Invitation created for ${dto.email}, but the email could not be sent. Share the link manually.`,
+        ? existingInvite
+          ? `${created} for ${dto.email} — the email was re-sent.`
+          : `Invitation sent to ${dto.email}`
+        : `${created} for ${dto.email}, but the email could not be sent. Share the link manually.`,
       inviteUrl,
       emailSent: emailResult.sent,
       ...(emailResult.error ? { emailError: emailResult.error } : {}),

--- a/packages/backend/src/license/license.controller.ts
+++ b/packages/backend/src/license/license.controller.ts
@@ -12,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
-import { IsString, Matches } from 'class-validator';
+import { IsString, IsOptional, Matches } from 'class-validator';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 import { LicenseService } from './license.service';
 import { LicenseGuardService } from './license-guard.service';
@@ -26,6 +26,12 @@ class SetLicenseKeyDto {
     message: 'Invalid license key format. Expected: AMCP-XXXX-XXXX-XXXX-XXXX',
   })
   licenseKey: string;
+}
+
+class BillingPortalDto {
+  @IsOptional()
+  @IsString()
+  returnUrl?: string;
 }
 
 @ApiTags('License')
@@ -130,6 +136,24 @@ export class LicenseController {
       return { message: 'License activated successfully', license };
     } catch (err: any) {
       throw new BadRequestException(err.message || 'Failed to activate license');
+    }
+  }
+
+  @Post('billing-portal')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('ADMIN')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Open the Stripe billing portal for the current subscription (ADMIN)',
+  })
+  async billingPortal(@Req() req: any, @Body() dto: BillingPortalDto) {
+    try {
+      return await this.licenseService.createBillingPortalSession(
+        req.user.organizationId,
+        dto?.returnUrl,
+      );
+    } catch (err: any) {
+      throw new BadRequestException(err.message || 'Failed to open billing portal');
     }
   }
 

--- a/packages/backend/src/license/license.service.ts
+++ b/packages/backend/src/license/license.service.ts
@@ -60,6 +60,40 @@ export class LicenseService implements OnModuleInit {
     return (await this.siteSettings.get('instance_id')) || (await this.ensureInstanceId());
   }
 
+  // ── Stripe Billing Portal ──────────────────────────────────────────────────
+
+  /**
+   * Create a Stripe Billing Portal session for the org's active license so the
+   * user can manage payment method, invoices, or cancel their subscription.
+   * We hold only the license key locally; the licensing site (which owns the
+   * Stripe customer/subscription mapping) mints the actual portal URL.
+   */
+  async createBillingPortalSession(
+    organizationId: string,
+    returnUrl?: string,
+  ): Promise<{ url: string }> {
+    const license = await this.getCurrentLicense(organizationId);
+    if (!license?.licenseKey) {
+      throw new Error('No active license for this organization.');
+    }
+    try {
+      const { data } = await axios.post(
+        `${this.apiBase}/api/billing/portal`,
+        { licenseKey: license.licenseKey, returnUrl },
+        { timeout: 15000 },
+      );
+      if (!data?.url) throw new Error('No portal URL returned.');
+      return { url: data.url as string };
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.error ||
+        err?.message ||
+        'Failed to open the billing portal.';
+      this.logger.warn(`Billing portal request failed: ${msg}`);
+      throw new Error(msg);
+    }
+  }
+
   // ── Community License Request (sends key via email) ───────────────────────
 
   async requestCommunityLicense(

--- a/packages/backend/src/settings/email.service.ts
+++ b/packages/backend/src/settings/email.service.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { SiteSettingsService } from './site-settings.service';
 import { OrgSettingsService } from './org-settings.service';
 import { PrismaService } from '../common/prisma.service';
+import { DeploymentService } from '../common/deployment.service';
 
 const LICENSE_API_URL =
   process.env.NODE_ENV === 'production'
@@ -19,7 +20,33 @@ export class EmailService {
     private readonly siteSettings: SiteSettingsService,
     private readonly orgSettings: OrgSettingsService,
     private readonly prisma: PrismaService,
+    private readonly deployment: DeploymentService,
   ) {}
+
+  /**
+   * Build a transport with aggressive timeouts. Cloud droplets black-hole the
+   * standard SMTP ports (25/465/587), and nodemailer's default connection
+   * timeout is 2 minutes — a misconfigured workspace SMTP made requests hang
+   * for many minutes (one real test clocked 16 min). 10s is plenty for any
+   * reachable server.
+   */
+  private buildTransport(smtp: {
+    host: string;
+    port: number;
+    secure: boolean;
+    user: string;
+    pass: string;
+  }) {
+    return nodemailer.createTransport({
+      host: smtp.host,
+      port: smtp.port,
+      secure: smtp.secure,
+      auth: { user: smtp.user, pass: smtp.pass },
+      connectionTimeout: 10_000,
+      greetingTimeout: 10_000,
+      socketTimeout: 20_000,
+    });
+  }
 
   private normalizeSmtp(raw: any) {
     if (!raw || !raw.host) return null;
@@ -56,19 +83,34 @@ export class EmailService {
   }
 
   /**
-   * Resolve the SMTP to send with: the ORG's own SMTP first (never the global
-   * site config — so operator credentials can't leak through the settings API),
-   * then the system/Resend fallback from ENV. Returns null if neither is set
-   * (callers then use the external-API fallback or skip).
+   * The org's own SMTP config, or null. Never falls back — callers decide
+   * what to do when the workspace hasn't configured (or has broken) SMTP.
+   */
+  private async orgSmtp(organizationId?: string) {
+    if (!organizationId) return null;
+    return this.normalizeSmtp(
+      await this.orgSettings.getJson<any>(organizationId, 'smtp_config'),
+    );
+  }
+
+  /**
+   * Operator/instance-level SMTP: the legacy site-settings config (self-hosted
+   * installs configured pre-multi-org), then the env-based system fallback
+   * (e.g. Resend/Mailgun on cloud). Read only server-side and never returned
+   * by any API, so operator credentials are never exposed to workspace admins.
+   */
+  private async instanceSmtp() {
+    const site = this.normalizeSmtp(await this.siteSettings.getSmtpConfig());
+    return site || this.systemSmtp();
+  }
+
+  /**
+   * Resolve the SMTP to send with: the ORG's own SMTP first, then the
+   * instance/system fallback. Returns null if neither is set (callers then
+   * use the external-API fallback or skip).
    */
   private async resolveSmtp(organizationId?: string) {
-    if (organizationId) {
-      const org = this.normalizeSmtp(
-        await this.orgSettings.getJson<any>(organizationId, 'smtp_config'),
-      );
-      if (org) return org;
-    }
-    return this.systemSmtp();
+    return (await this.orgSmtp(organizationId)) || this.instanceSmtp();
   }
 
   // ── Password Reset (SMTP with external API fallback) ─────────────────────
@@ -77,19 +119,11 @@ export class EmailService {
     to: string,
     resetUrl: string,
   ): Promise<boolean> {
-    const smtp = await this.siteSettings.getSmtpConfig();
+    const smtp = await this.instanceSmtp();
 
     if (smtp) {
       try {
-        const transporter = nodemailer.createTransport({
-          host: smtp.host,
-          port: smtp.port,
-          secure: smtp.secure,
-          auth: {
-            user: smtp.user,
-            pass: smtp.pass,
-          },
-        });
+        const transporter = this.buildTransport(smtp);
 
         await transporter.sendMail({
           from: smtp.from || `AnythingMCP <${smtp.user}>`,
@@ -151,14 +185,40 @@ export class EmailService {
     const smtp = await this.resolveSmtp(organizationId);
     if (!smtp) return null;
     return {
-      transporter: nodemailer.createTransport({
-        host: smtp.host,
-        port: smtp.port,
-        secure: smtp.secure,
-        auth: { user: smtp.user, pass: smtp.pass },
-      }),
+      transporter: this.buildTransport(smtp),
       from: smtp.from || `AnythingMCP <${smtp.user}>`,
     };
+  }
+
+  /**
+   * Transports to try in order for org-scoped mail: the workspace's own SMTP
+   * first, then the instance/system fallback. A broken workspace SMTP must
+   * never black-hole an invitation — the mail still goes out via the
+   * platform sender and the admin gets told their SMTP failed.
+   */
+  private async transportCandidates(organizationId?: string) {
+    const candidates: Array<{
+      transporter: nodemailer.Transporter;
+      from: string;
+      source: 'workspace' | 'system';
+    }> = [];
+    const org = await this.orgSmtp(organizationId);
+    if (org) {
+      candidates.push({
+        transporter: this.buildTransport(org),
+        from: org.from || `AnythingMCP <${org.user}>`,
+        source: 'workspace',
+      });
+    }
+    const instance = await this.instanceSmtp();
+    if (instance) {
+      candidates.push({
+        transporter: this.buildTransport(instance),
+        from: instance.from || `AnythingMCP <${instance.user}>`,
+        source: 'system',
+      });
+    }
+    return candidates;
   }
 
   async sendInvitationEmail(
@@ -168,9 +228,10 @@ export class EmailService {
     roleName: string,
     organizationId?: string,
   ): Promise<{ sent: boolean; error?: string }> {
-    const transport = await this.createTransporter(organizationId);
+    const candidates = await this.transportCandidates(organizationId);
+    let workspaceError: string | undefined;
 
-    if (transport) {
+    for (const transport of candidates) {
       try {
         await transport.transporter.sendMail({
           from: transport.from,
@@ -192,16 +253,28 @@ export class EmailService {
           text: `You're Invited!\n\n${invitedByName} has invited you to join AnythingMCP as ${roleName}.\n\nAccept your invitation: ${inviteUrl}\n\nThis link expires in 48 hours.`,
         });
 
-        this.logger.log(`Invitation email sent to ${to}`);
-        return { sent: true };
+        this.logger.log(`Invitation email sent to ${to} (via ${transport.source} SMTP)`);
+        return {
+          sent: true,
+          ...(workspaceError
+            ? {
+                error: `Your workspace SMTP failed (${workspaceError}) — the invitation was delivered by the platform mail service instead.`,
+              }
+            : {}),
+        };
       } catch (err: any) {
-        this.logger.error(`Failed to send invitation via SMTP to ${to}: ${err}`);
-        return { sent: false, error: err.message || 'SMTP delivery failed' };
+        this.logger.error(
+          `Failed to send invitation via ${transport.source} SMTP to ${to}: ${err}`,
+        );
+        if (transport.source === 'workspace') {
+          workspaceError = err.message || 'SMTP delivery failed';
+        } else {
+          return { sent: false, error: err.message || 'SMTP delivery failed' };
+        }
       }
     }
-
-    // Fallback: send via external API (requires active license)
-    // Try to find a valid license key: first any active license in DB, then site_settings
+    // No SMTP delivered it (none configured, or workspace SMTP failed with no
+    // system fallback) — try the external API (requires active license).
     let licenseKey = await this.siteSettings.get('license_key');
     if (!licenseKey) {
       const activeLicense = await this.prisma.license.findFirst({
@@ -212,14 +285,23 @@ export class EmailService {
       if (activeLicense) licenseKey = activeLicense.licenseKey;
     }
     this.logger.log(
-      `SMTP not configured, using external API fallback (licenseKey ${licenseKey ? 'present' : 'MISSING'})`,
+      `Using external API fallback for invitation (licenseKey ${licenseKey ? 'present' : 'MISSING'})`,
     );
-    return this.sendViaExternalApiWithError('/api/email/invite', {
+    const result = await this.sendViaExternalApiWithError('/api/email/invite', {
       email: to,
       inviterName: invitedByName,
       instanceUrl: inviteUrl,
       ...(licenseKey ? { licenseKey } : {}),
     });
+    if (workspaceError) {
+      return result.sent
+        ? {
+            sent: true,
+            error: `Your workspace SMTP failed (${workspaceError}) — the invitation was delivered by the platform mail service instead.`,
+          }
+        : { sent: false, error: workspaceError };
+    }
+    return result;
   }
 
   // ── Welcome Email (SMTP with external API fallback) ───────────────────────
@@ -588,26 +670,38 @@ export class EmailService {
   // ── SMTP Test ─────────────────────────────────────────────────────────────
 
   async testConnection(organizationId?: string): Promise<{ ok: boolean; message: string }> {
-    const smtp = await this.resolveSmtp(organizationId);
+    // Test the WORKSPACE config only — testing the hidden system fallback
+    // would report "successful" for settings the admin never entered.
+    const smtp = await this.orgSmtp(organizationId);
+    const hasFallback = !!(await this.instanceSmtp());
+
     if (!smtp) {
-      return { ok: false, message: 'SMTP not configured' };
+      return hasFallback
+        ? {
+            ok: true,
+            message:
+              'No workspace SMTP configured — emails are delivered by the platform mail service.',
+          }
+        : { ok: false, message: 'SMTP not configured' };
     }
 
     try {
-      const transporter = nodemailer.createTransport({
-        host: smtp.host,
-        port: smtp.port,
-        secure: smtp.secure,
-        auth: {
-          user: smtp.user,
-          pass: smtp.pass,
-        },
-      });
-
-      await transporter.verify();
+      await this.buildTransport(smtp).verify();
       return { ok: true, message: 'SMTP connection successful' };
     } catch (err: any) {
-      return { ok: false, message: err.message || 'Connection failed' };
+      let message = err.message || 'Connection failed';
+      if (
+        this.deployment.isCloud() &&
+        [25, 465, 587].includes(smtp.port) &&
+        /timeout|ETIMEDOUT|ECONNREFUSED/i.test(message)
+      ) {
+        message +=
+          ' — note: the cloud network blocks outbound SMTP ports 25/465/587. Use a provider that supports port 2525, or remove the workspace SMTP config to send via the platform mail service.';
+      } else if (hasFallback) {
+        message +=
+          ' — emails will fall back to the platform mail service until this is fixed.';
+      }
+      return { ok: false, message };
     }
   }
 }

--- a/packages/backend/src/settings/org-settings.service.ts
+++ b/packages/backend/src/settings/org-settings.service.ts
@@ -38,6 +38,12 @@ export class OrgSettingsService {
     await this.set(organizationId, key, JSON.stringify(value));
   }
 
+  async delete(organizationId: string, key: string): Promise<void> {
+    await this.prisma.orgSettings.deleteMany({
+      where: { organizationId, key },
+    });
+  }
+
   /**
    * Get SMTP config for an org, falling back to global SiteSettings if not configured.
    */

--- a/packages/backend/src/settings/site-settings.controller.ts
+++ b/packages/backend/src/settings/site-settings.controller.ts
@@ -3,9 +3,11 @@ import {
   Get,
   Put,
   Post,
+  Delete,
   Body,
   Req,
   UseGuards,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -30,9 +32,13 @@ class SmtpConfigDto {
   @IsString()
   user: string;
 
-  @ApiProperty({ description: 'SMTP password / API key.' })
+  @ApiPropertyOptional({
+    description:
+      'SMTP password / API key. Omit or leave empty to keep the currently stored password.',
+  })
+  @IsOptional()
   @IsString()
-  pass: string;
+  pass?: string;
 
   @ApiPropertyOptional({
     description: '"From" address used by outbound mail. Defaults to the SMTP user.',
@@ -132,15 +138,38 @@ export class SiteSettingsAdminController {
   @Put('smtp')
   @ApiOperation({ summary: 'Update SMTP configuration for current organization (ADMIN)' })
   async updateSmtpConfig(@Req() req: any, @Body() dto: SmtpConfigDto) {
+    // Empty password = keep the stored one, so admins can edit host/port
+    // without re-entering the secret (the GET never returns it).
+    let pass = dto.pass;
+    if (!pass) {
+      const existing = await this.orgSettings.getJson<any>(
+        req.user.organizationId,
+        'smtp_config',
+      );
+      pass = existing?.pass;
+      if (!pass) {
+        throw new BadRequestException('SMTP password is required');
+      }
+    }
     await this.orgSettings.setJson(req.user.organizationId, 'smtp_config', {
       host: dto.host,
       port: dto.port,
       user: dto.user,
-      pass: dto.pass,
+      pass,
       from: dto.from || '',
       secure: dto.secure ?? (dto.port === 465),
     });
     return { message: 'SMTP configuration saved' };
+  }
+
+  @Delete('smtp')
+  @ApiOperation({
+    summary:
+      'Remove the SMTP configuration for the current organization (ADMIN) — emails fall back to the platform mail service',
+  })
+  async deleteSmtpConfig(@Req() req: any) {
+    await this.orgSettings.delete(req.user.organizationId, 'smtp_config');
+    return { message: 'SMTP configuration removed' };
   }
 
   @Post('smtp/test')

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/src/app/admin/settings/page.tsx
+++ b/packages/frontend/src/app/admin/settings/page.tsx
@@ -93,8 +93,25 @@ export default function AdminSettingsPage() {
     setSmtpMsg('Testing connection...');
     try {
       const result = await adminSettings.testSmtp(token);
-      setSmtpMsg(result.ok ? 'Connection successful!' : `Error: ${result.message}`);
-      setTimeout(() => setSmtpMsg(''), 5000);
+      setSmtpMsg(result.ok ? result.message : `Error: ${result.message}`);
+    } catch (err: any) {
+      setSmtpMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleRemoveSmtp = async () => {
+    if (!token) return;
+    if (!confirm('Remove the workspace SMTP configuration? Emails will be sent by the platform mail service instead.')) return;
+    try {
+      await adminSettings.deleteSmtp(token);
+      setSmtpConfigured(false);
+      setSmtpHost('');
+      setSmtpPort(587);
+      setSmtpUser('');
+      setSmtpPass('');
+      setSmtpFrom('');
+      setSmtpSecure(false);
+      setSmtpMsg('SMTP configuration removed — emails now use the platform mail service');
     } catch (err: any) {
       setSmtpMsg(`Error: ${err.message}`);
     }
@@ -205,16 +222,22 @@ export default function AdminSettingsPage() {
               </p>
             )}
             <div className="flex gap-2">
+              {/* Existing config: password field may stay empty (kept server-side) */}
               <Button
                 onClick={handleSaveSmtp}
-                disabled={!smtpHost || !smtpUser || !smtpPass}
+                disabled={!smtpHost || !smtpUser || (!smtpPass && !smtpConfigured)}
               >
                 Save SMTP Config
               </Button>
               {smtpConfigured && (
-                <Button variant="secondary" onClick={handleTestSmtp}>
-                  Test Connection
-                </Button>
+                <>
+                  <Button variant="secondary" onClick={handleTestSmtp}>
+                    Test Connection
+                  </Button>
+                  <Button variant="ghost" onClick={handleRemoveSmtp} className="text-[var(--danger)] hover:text-[var(--danger)]">
+                    Remove
+                  </Button>
+                </>
               )}
             </div>
           </div>

--- a/packages/frontend/src/app/settings/admin/page.tsx
+++ b/packages/frontend/src/app/settings/admin/page.tsx
@@ -64,8 +64,25 @@ export default function SettingsAdminPage() {
     setSmtpMsg('Testing connection...');
     try {
       const result = await adminSettings.testSmtp(token);
-      setSmtpMsg(result.ok ? 'Connection successful!' : `Error: ${result.message}`);
-      setTimeout(() => setSmtpMsg(''), 5000);
+      setSmtpMsg(result.ok ? result.message : `Error: ${result.message}`);
+    } catch (err: any) {
+      setSmtpMsg(`Error: ${err.message}`);
+    }
+  };
+
+  const handleRemoveSmtp = async () => {
+    if (!token) return;
+    if (!confirm('Remove the workspace SMTP configuration? Emails will be sent by the platform mail service instead.')) return;
+    try {
+      await adminSettings.deleteSmtp(token);
+      setSmtpConfigured(false);
+      setSmtpHost('');
+      setSmtpPort(587);
+      setSmtpUser('');
+      setSmtpPass('');
+      setSmtpFrom('');
+      setSmtpSecure(false);
+      setSmtpMsg('SMTP configuration removed — emails now use the platform mail service');
     } catch (err: any) {
       setSmtpMsg(`Error: ${err.message}`);
     }
@@ -176,13 +193,19 @@ export default function SettingsAdminPage() {
             </p>
           )}
           <div className="flex gap-2">
-            <Button onClick={handleSaveSmtp} disabled={!smtpHost || !smtpUser || !smtpPass}>
+            {/* Existing config: password field may stay empty (kept server-side) */}
+            <Button onClick={handleSaveSmtp} disabled={!smtpHost || !smtpUser || (!smtpPass && !smtpConfigured)}>
               Save SMTP Config
             </Button>
             {smtpConfigured && (
-              <Button variant="secondary" onClick={handleTestSmtp}>
-                Test Connection
-              </Button>
+              <>
+                <Button variant="secondary" onClick={handleTestSmtp}>
+                  Test Connection
+                </Button>
+                <Button variant="ghost" onClick={handleRemoveSmtp} className="text-[var(--danger)] hover:text-[var(--danger)]">
+                  Remove
+                </Button>
+              </>
             )}
           </div>
         </div>

--- a/packages/frontend/src/app/settings/license/page.tsx
+++ b/packages/frontend/src/app/settings/license/page.tsx
@@ -26,8 +26,16 @@ export default function LicenseSettingsPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [verifying, setVerifying] = useState(false);
+  const [openingPortal, setOpeningPortal] = useState(false);
 
   const isCloud = deploymentMode === 'cloud';
+  // The Stripe billing portal only applies to a real paid subscription —
+  // not the free trial or a self-hosted community license.
+  const hasBillableSubscription =
+    isCloud &&
+    !!status?.plan &&
+    status.plan !== 'trial' &&
+    status.plan !== 'community';
 
   const loadStatus = async () => {
     try {
@@ -92,6 +100,23 @@ export default function LicenseSettingsPage() {
       setError(err.message || 'Failed to register community license');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleBillingPortal = async () => {
+    if (!token) return;
+    setError('');
+    setMessage('');
+    setOpeningPortal(true);
+    try {
+      const { url } = await license.billingPortal(
+        token,
+        typeof window !== 'undefined' ? window.location.href : undefined,
+      );
+      window.location.href = url;
+    } catch (err: any) {
+      setError(err.message || 'Failed to open the billing portal');
+      setOpeningPortal(false);
     }
   };
 
@@ -223,10 +248,15 @@ export default function LicenseSettingsPage() {
         )}
 
         {status?.plan && (
-          <div className="mt-4 pt-4 border-t border-[var(--border)]">
+          <div className="mt-4 pt-4 border-t border-[var(--border)] flex flex-wrap gap-3">
             <Button variant="secondary" onClick={handleVerify} disabled={verifying}>
               {verifying ? 'Verifying...' : 'Verify Now'}
             </Button>
+            {hasBillableSubscription && (
+              <Button onClick={handleBillingPortal} disabled={openingPortal}>
+                {openingPortal ? 'Opening…' : 'Manage subscription & billing'}
+              </Button>
+            )}
           </div>
         )}
       </Card>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -521,8 +521,10 @@ export const siteSettings = {
 export const adminSettings = {
   getSmtp: (token: string) =>
     request<{ configured: boolean; host?: string; port?: number; user?: string; from?: string; secure?: boolean }>('/api/admin/settings/smtp', { token }),
-  updateSmtp: (data: { host: string; port: number; user: string; pass: string; from?: string; secure?: boolean }, token: string) =>
+  updateSmtp: (data: { host: string; port: number; user: string; pass?: string; from?: string; secure?: boolean }, token: string) =>
     request<{ message: string }>('/api/admin/settings/smtp', { method: 'PUT', body: data, token }),
+  deleteSmtp: (token: string) =>
+    request<{ message: string }>('/api/admin/settings/smtp', { method: 'DELETE', token }),
   testSmtp: (token: string) =>
     request<{ ok: boolean; message: string }>('/api/admin/settings/smtp/test', { method: 'POST', token }),
   getFooterLinks: (token: string) =>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -596,6 +596,12 @@ export const license = {
       method: 'POST',
       token,
     }),
+  billingPortal: (token: string, returnUrl?: string) =>
+    request<{ url: string }>('/api/license/billing-portal', {
+      method: 'POST',
+      body: { returnUrl },
+      token,
+    }),
   getInstanceId: () =>
     request<{ instanceId: string }>('/api/license/instance-id'),
   getUsage: (token?: string) =>


### PR DESCRIPTION
## Email / SMTP fixes (customer-reported)

- **10s SMTP timeouts** everywhere — nodemailer's 2-min default + DO's blocked outbound 25/465/587 made smtp/test hang up to 16 minutes with no browser feedback.
- **Delivery fallback**: if the workspace SMTP fails, invitations are still delivered via the instance/system sender; the admin is told their SMTP failed.
- **Pending invitations are reused** instead of throwing 409 — the invite link is returned again and the email re-sent.
- **SMTP config editable again**: empty password keeps the stored one (GET never returns it); both admin pages fixed.
- **DELETE /api/admin/settings/smtp** + Remove button to drop a broken workspace config.
- **smtp/test** tests the workspace config only, with clear cloud port guidance.
- Password-reset mail now uses the same instance-SMTP resolution (site settings → env).

## Stripe billing portal (v0.3.3)

- `POST /api/license/billing-portal` (ADMIN) proxies to the licensing site which mints the Stripe customer portal URL — no Stripe secrets in the cloud app.
- "Manage subscription & billing" button on Settings → License for paid cloud plans.

Backend: 3300 tests green. Frontend: tsc + build green.