### PR TITLE
fix(deploy): raise app healthcheck start_period to 120s

### DIFF
--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -104,7 +104,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      # The app needs ~100s on first boot (migrations + Next.js warmup); with
+      # 30s the v0.3.3 deploy hit "unhealthy" moments before the app came up.
+      start_period: 120s
     restart: unless-stopped
 
   # PostgreSQL Database


### PR DESCRIPTION
The v0.3.3 deploy was marked failed by the `--wait` health gate even though the rollout succeeded: the app needs ~100s on first boot (migrations + Next.js warmup) and the healthcheck only allowed ~80s (30s start_period + 5×10s retries). 120s gives it room without weakening the gate.