### PR TITLE
feat(connectors): expose LOGIN_TOKEN auth and custom headers in the GUI

### DIFF
--- a/packages/backend/src/adapters/de/hrworks.json
+++ b/packages/backend/src/adapters/de/hrworks.json
@@ -2,19 +2,30 @@
   "slug": "hrworks",
   "name": "HR WORKS",
   "description": "Access HR WORKS, the German HR/payroll platform: employees, absences, sick leaves, remote work (home office), working times, projects, applicants, organization units, holidays and cost centers via the v2 REST API.",
-  "instructions": "This connector uses the HR WORKS v2 REST API (https://developers.hrworks.de).\n\n**Authentication model — IMPORTANT**: HR WORKS does not use a long-lived API key. Instead, you POST `{accessKey, secretAccessKey}` to `/v2/authentication` and receive a short-lived JWT (valid 15 minutes) which is then sent as `Authorization: Bearer <token>` on every subsequent call. This adapter stores a single bearer token (`HRWORKS_TOKEN`) supplied by you.\n\n**Getting a token** (run before importing the connector, then again whenever the token expires):\n\n```bash\ncurl -X POST https://api.hrworks.de/v2/authentication \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"accessKey\":\"YOUR_ACCESS_KEY\",\"secretAccessKey\":\"YOUR_SECRET_ACCESS_KEY\"}'\n```\n\nThe response contains `{\"token\": \"eyJ...\"}` — paste that JWT as `HRWORKS_TOKEN` when importing.\n\n**Token lifetime**: ~15 minutes. After expiration the API will reject calls with 401; you must mint a new token and re-import or update the connector. For long-running workflows, consider wrapping this adapter in a custom proxy that refreshes tokens automatically.\n\n**Sandbox**: HR WORKS provides a demo environment at `https://api.demo-hrworks.de`. Set `HRWORKS_BASE_URL=https://api.demo-hrworks.de` to test against demo data; otherwise the production endpoint `https://api.hrworks.de` is used.\n\n**Identifiers**: most person-related endpoints accept either the HR WORKS personnel number or the HR WORKS username. Use the optional `personIdentifierType` / `usePersonnelNumbers` parameters when the identifier you have on hand is not the default.\n\n**Date intervals**: most listing endpoints (absences, sick leaves, working times, remote work) require ISO `YYYY-MM-DD` `beginDate`/`endDate` — maximum span is one year (or 31 days if `interval=days`).\n\n**Pagination**: page size is 50; the API returns a `Link` header with next/prev URLs. Pass `page` to step through results.\n\n**Rate limit**: HR WORKS imposes per-tenant rate limits — see their developer portal for details.",
+  "instructions": "This connector uses the HR WORKS v2 REST API (https://developers.hrworks.de).\n\n**Authentication — automatic token refresh**: HR WORKS issues short-lived tokens (~15 minutes). This connector uses the `LOGIN_TOKEN` flow: it POSTs `{accessKey, secretAccessKey}` to `/v2/authentication`, reads the returned `token`, sends it as `Authorization: Bearer <token>`, and refreshes it automatically before expiry (and re-logs-in on a 401). You never handle tokens manually.\n\n**Setup**: create an API key pair in HR WORKS (Administration → API) and set:\n- `HRWORKS_ACCESS_KEY` = your access key\n- `HRWORKS_SECRET_ACCESS_KEY` = your secret access key\n\n**Sandbox**: HR WORKS provides a demo environment at `https://api.demo-hrworks.de`. To test against it, change the connector's Base URL and the `loginUrl` in the auth config to the demo host.\n\n**Identifiers**: most person-related endpoints accept either the HR WORKS personnel number or the HR WORKS username. Use the optional `personIdentifierType` / `usePersonnelNumbers` parameters when the identifier you have on hand is not the default.\n\n**Date intervals**: most listing endpoints (absences, sick leaves, working times, remote work) require ISO `YYYY-MM-DD` `beginDate`/`endDate` — maximum span is one year (or 31 days if `interval=days`).\n\n**Pagination**: page size is 50; the API returns a `Link` header with next/prev URLs. Pass `page` to step through results.\n\n**Rate limit**: HR WORKS imposes per-tenant rate limits — see their developer portal for details.",
   "region": "de",
   "category": "hr",
   "icon": "hrworks",
   "docsUrl": "https://developers.hrworks.de",
-  "requiredEnvVars": ["HRWORKS_TOKEN"],
+  "requiredEnvVars": ["HRWORKS_ACCESS_KEY", "HRWORKS_SECRET_ACCESS_KEY"],
   "connector": {
     "name": "HR WORKS",
     "type": "REST",
     "baseUrl": "https://api.hrworks.de",
-    "authType": "BEARER_TOKEN",
+    "authType": "LOGIN_TOKEN",
     "authConfig": {
-      "token": "{{HRWORKS_TOKEN}}"
+      "loginUrl": "https://api.hrworks.de/v2/authentication",
+      "loginMethod": "POST",
+      "loginBody": {
+        "accessKey": "${username}",
+        "secretAccessKey": "${password}"
+      },
+      "username": "{{HRWORKS_ACCESS_KEY}}",
+      "password": "{{HRWORKS_SECRET_ACCESS_KEY}}",
+      "tokenJsonPath": "token",
+      "tokenTTLSeconds": 900,
+      "proactiveRefreshSeconds": 120,
+      "refreshOn401": true
     }
   },
   "tools": [

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -8,6 +8,7 @@ import { findDemoByTool } from '@/lib/demo-connectors';
 import { ToolEditor } from '@/components/tool-editor';
 import { McpAssignModal } from '@/components/mcp-assign-modal';
 import { AppSelect } from '@/components/ui/select';
+import { HeadersEditor, headerRowsToObject, objectToHeaderRows, type HeaderRow } from '@/components/headers-editor';
 import { AppShell } from '@/components/app-shell';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -23,6 +24,8 @@ const IMPORT_SOURCES = [
   { id: 'json', label: 'JSON Definition', placeholder: '[\n  {\n    "name": "get_users",\n    "description": "Fetch users",\n    "parameters": { "type": "object", "properties": { "limit": { "type": "number" } } },\n    "endpointMapping": { "method": "GET", "path": "/users", "queryParams": { "limit": "$limit" } }\n  }\n]' },
   { id: 'mcp', label: 'MCP Discovery', placeholder: 'Enter MCP endpoint path (default: /mcp)' },
 ];
+
+const EDIT_DEFAULT_LOGIN_BODY = '{\n  "username": "${username}",\n  "password": "${password}"\n}';
 
 export default function ConnectorDetailPage() {
   const { token } = useAuth();
@@ -49,6 +52,16 @@ export default function ConnectorDetailPage() {
   const [editAuthType, setEditAuthType] = useState('NONE');
   const [editAuthKey, setEditAuthKey] = useState('');
   const [editAuthValue, setEditAuthValue] = useState('');
+  // LOGIN_TOKEN (credentials → short-lived token, auto-refreshed) fields
+  const [editLtLoginUrl, setEditLtLoginUrl] = useState('');
+  const [editLtMethod, setEditLtMethod] = useState('POST');
+  const [editLtUsername, setEditLtUsername] = useState('');
+  const [editLtPassword, setEditLtPassword] = useState('');
+  const [editLtLoginBody, setEditLtLoginBody] = useState(EDIT_DEFAULT_LOGIN_BODY);
+  const [editLtTokenPath, setEditLtTokenPath] = useState('token');
+  const [editLtTtl, setEditLtTtl] = useState('');
+  const [editLtRefreshOn401, setEditLtRefreshOn401] = useState(true);
+  const [editHeaderRows, setEditHeaderRows] = useState<HeaderRow[]>([]);
   const [editDbReadOnly, setEditDbReadOnly] = useState(true);
   const [editInstructions, setEditInstructions] = useState('');
   const [msg, setMsg] = useState('');
@@ -105,6 +118,10 @@ export default function ConnectorDetailPage() {
       // Don't pre-fill credentials — they are encrypted on the server
       setEditAuthKey('');
       setEditAuthValue('');
+      // authConfig is encrypted server-side, so LOGIN_TOKEN fields start empty;
+      // headers are stored in the clear and can be pre-filled for editing.
+      setEditLtPassword('');
+      setEditHeaderRows(objectToHeaderRows(c.headers as Record<string, string> | null));
       setEditDbReadOnly((c.config as any)?.readOnly !== false);
       setToolList(c.tools || []);
       // Load env vars
@@ -153,6 +170,30 @@ export default function ConnectorDetailPage() {
       case 'BASIC_AUTH':
         if (!editAuthKey && !editAuthValue) return undefined;
         return { username: editAuthKey, password: editAuthValue };
+      case 'LOGIN_TOKEN': {
+        // Re-entering the password is required to (re)write the whole config;
+        // leaving it empty keeps the existing encrypted credentials untouched.
+        if (!editLtPassword) return undefined;
+        let loginBody: unknown;
+        const raw = editLtLoginBody.trim();
+        if (raw) {
+          try {
+            loginBody = JSON.parse(raw);
+          } catch {
+            throw new Error('Login body must be valid JSON.');
+          }
+        }
+        return {
+          loginUrl: editLtLoginUrl,
+          loginMethod: editLtMethod || 'POST',
+          ...(loginBody !== undefined ? { loginBody } : {}),
+          username: editLtUsername,
+          password: editLtPassword,
+          tokenJsonPath: editLtTokenPath || 'token',
+          ...(editLtTtl.trim() ? { tokenTTLSeconds: Number(editLtTtl) } : {}),
+          refreshOn401: editLtRefreshOn401,
+        };
+      }
       default:
         return undefined;
     }
@@ -171,6 +212,11 @@ export default function ConnectorDetailPage() {
       };
       const authConfig = buildAuthConfig();
       if (authConfig) data.authConfig = authConfig;
+      if (connector.type !== 'DATABASE' && connector.type !== 'MCP') {
+        // Editor is pre-filled with current headers, so this round-trips
+        // untouched headers and applies any edits/removals the user made.
+        data.headers = headerRowsToObject(editHeaderRows);
+      }
       if (connector.type === 'DATABASE') {
         data.config = { readOnly: editDbReadOnly };
       }
@@ -659,7 +705,7 @@ export default function ConnectorDetailPage() {
                 <label className="block text-sm font-medium mb-1">Authentication</label>
                 <AppSelect
                   value={editAuthType}
-                  onValueChange={(v) => { setEditAuthType(v); setEditAuthKey(''); setEditAuthValue(''); }}
+                  onValueChange={(v) => { setEditAuthType(v); setEditAuthKey(''); setEditAuthValue(''); setEditLtPassword(''); }}
                   className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]"
                   options={[
                     { value: 'NONE', label: 'None' },
@@ -667,6 +713,7 @@ export default function ConnectorDetailPage() {
                     { value: 'BEARER_TOKEN', label: 'Bearer Token' },
                     { value: 'BASIC_AUTH', label: 'Basic Auth' },
                     { value: 'OAUTH2', label: 'OAuth 2.0' },
+                    { value: 'LOGIN_TOKEN', label: 'Login → Token (auto-refresh)' },
                   ]}
                 />
               </div>
@@ -717,10 +764,64 @@ export default function ConnectorDetailPage() {
                   </p>
                 </div>
               )}
-              {editAuthType !== 'NONE' && editAuthType !== 'OAUTH2' && (
+              {editAuthType === 'LOGIN_TOKEN' && (
+                <div className="space-y-3">
+                  <div className="rounded-[9px] border border-[var(--t-info-fg)]/20 bg-[var(--t-info-bg)] p-3 text-xs text-[var(--t-info-fg)]">
+                    For APIs with short-lived tokens (e.g. HRworks): we POST your credentials to the login endpoint, read the token from the response, send it as a Bearer token, and refresh it automatically before it expires. Re-enter the password/secret to change this configuration; leave it empty to keep the current one.
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Login URL</label>
+                    <input type="text" value={editLtLoginUrl} onChange={(e) => setEditLtLoginUrl(e.target.value)} placeholder="https://api.hrworks.de/v2/authentication" className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm font-mono bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]" />
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Username / Access key</label>
+                      <input type="text" value={editLtUsername} onChange={(e) => setEditLtUsername(e.target.value)} placeholder="access key" className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm font-mono bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Password / Secret</label>
+                      <input type="password" value={editLtPassword} onChange={(e) => setEditLtPassword(e.target.value)} placeholder="Leave empty to keep current" className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm font-mono bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]" />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Login request body (JSON)</label>
+                    <textarea value={editLtLoginBody} onChange={(e) => setEditLtLoginBody(e.target.value)} rows={4} className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm font-mono bg-[var(--surface)] resize-y focus:outline-none focus:border-[var(--border-strong)]" />
+                    <p className="text-xs text-[var(--text-3)] mt-1">
+                      Use <code>{'${username}'}</code> / <code>{'${password}'}</code> placeholders. HRworks uses <code>{'{ "accessKey": "${username}", "secretAccessKey": "${password}" }'}</code>.
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-3 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Method</label>
+                      <AppSelect
+                        value={editLtMethod}
+                        onValueChange={setEditLtMethod}
+                        className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]"
+                        options={[{ value: 'POST', label: 'POST' }, { value: 'GET', label: 'GET' }]}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Token JSON path</label>
+                      <input type="text" value={editLtTokenPath} onChange={(e) => setEditLtTokenPath(e.target.value)} placeholder="token" className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm font-mono bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Token TTL (s)</label>
+                      <input type="number" value={editLtTtl} onChange={(e) => setEditLtTtl(e.target.value)} placeholder="900" className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm font-mono bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]" />
+                    </div>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-[var(--text-2)]">
+                    <input type="checkbox" checked={editLtRefreshOn401} onChange={(e) => setEditLtRefreshOn401(e.target.checked)} />
+                    Re-login and retry automatically on a 401 response
+                  </label>
+                </div>
+              )}
+              {editAuthType !== 'NONE' && editAuthType !== 'OAUTH2' && editAuthType !== 'LOGIN_TOKEN' && (
                 <p className="text-xs text-[var(--text-3)]">
                   Leave credential fields empty to keep the current values.
                 </p>
+              )}
+              {connector.type !== 'DATABASE' && connector.type !== 'MCP' && (
+                <HeadersEditor rows={editHeaderRows} onChange={setEditHeaderRows} />
               )}
               <div>
                 <label className="block text-sm font-medium mb-1">Instructions</label>

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -8,7 +8,10 @@ import { AppShell } from '@/components/app-shell';
 import { Card } from '@/components/ui/card';
 import { McpAssignModal } from '@/components/mcp-assign-modal';
 import { AppSelect } from '@/components/ui/select';
+import { HeadersEditor, headerRowsToObject, type HeaderRow } from '@/components/headers-editor';
 import { cn } from '@/lib/utils';
+
+const DEFAULT_LOGIN_BODY = '{\n  "username": "${username}",\n  "password": "${password}"\n}';
 
 const CONNECTOR_TYPES = [
   { id: 'REST', name: 'REST API', description: 'Connect to any REST API. Import from OpenAPI/Swagger spec or configure manually.', tone: 'bg-[var(--t-info-bg)] text-[var(--t-info-fg)]' },
@@ -45,6 +48,16 @@ export default function NewConnectorPage() {
   const [oauthAuthUrl, setOauthAuthUrl] = useState('');
   const [oauthTokenUrl, setOauthTokenUrl] = useState('');
   const [oauthScopes, setOauthScopes] = useState('');
+  // LOGIN_TOKEN (credentials → short-lived token, auto-refreshed) fields
+  const [ltLoginUrl, setLtLoginUrl] = useState('');
+  const [ltMethod, setLtMethod] = useState('POST');
+  const [ltUsername, setLtUsername] = useState('');
+  const [ltPassword, setLtPassword] = useState('');
+  const [ltLoginBody, setLtLoginBody] = useState(DEFAULT_LOGIN_BODY);
+  const [ltTokenPath, setLtTokenPath] = useState('token');
+  const [ltTtl, setLtTtl] = useState('');
+  const [ltRefreshOn401, setLtRefreshOn401] = useState(true);
+  const [headerRows, setHeaderRows] = useState<HeaderRow[]>([]);
   const [dbReadOnly, setDbReadOnly] = useState(true);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -65,6 +78,27 @@ export default function NewConnectorPage() {
         return { token: authValue };
       case 'BASIC_AUTH':
         return { username: authKey, password: authValue };
+      case 'LOGIN_TOKEN': {
+        let loginBody: unknown;
+        const raw = ltLoginBody.trim();
+        if (raw) {
+          try {
+            loginBody = JSON.parse(raw);
+          } catch {
+            throw new Error('Login body must be valid JSON.');
+          }
+        }
+        return {
+          loginUrl: ltLoginUrl,
+          loginMethod: ltMethod || 'POST',
+          ...(loginBody !== undefined ? { loginBody } : {}),
+          username: ltUsername,
+          password: ltPassword,
+          tokenJsonPath: ltTokenPath || 'token',
+          ...(ltTtl.trim() ? { tokenTTLSeconds: Number(ltTtl) } : {}),
+          refreshOn401: ltRefreshOn401,
+        };
+      }
       case 'OAUTH2':
         if (selectedType !== 'MCP') {
           return {
@@ -96,6 +130,8 @@ export default function NewConnectorPage() {
       };
       const authConfig = buildAuthConfig();
       if (authConfig) data.authConfig = authConfig;
+      const headers = headerRowsToObject(headerRows);
+      if (Object.keys(headers).length > 0) data.headers = headers;
       if (specUrl) data.specUrl = specUrl;
       if (selectedType === 'DATABASE') {
         data.config = { readOnly: dbReadOnly };
@@ -134,6 +170,8 @@ export default function NewConnectorPage() {
       const data: any = { name: name || 'Test', type: selectedType, baseUrl, authType };
       const authConfig = buildAuthConfig();
       if (authConfig) data.authConfig = authConfig;
+      const headers = headerRowsToObject(headerRows);
+      if (Object.keys(headers).length > 0) data.headers = headers;
 
       const created = await connectors.create(data, token);
       const result = await connectors.test(created.id, token);
@@ -334,6 +372,7 @@ export default function NewConnectorPage() {
                     { value: 'BEARER_TOKEN', label: 'Bearer Token' },
                     { value: 'BASIC_AUTH', label: 'Basic Auth' },
                     { value: 'OAUTH2', label: 'OAuth 2.0' },
+                    { value: 'LOGIN_TOKEN', label: 'Login → Token (auto-refresh)' },
                   ]}
                 />
               </div>
@@ -406,6 +445,61 @@ export default function NewConnectorPage() {
                     <input type="password" value={authValue} onChange={(e) => setAuthValue(e.target.value)} className={inputClass} />
                   </div>
                 </div>
+              )}
+              {authType === 'LOGIN_TOKEN' && (
+                <div className="flex flex-col gap-3">
+                  <div className="rounded-[9px] border border-[var(--t-info-fg)]/20 bg-[var(--t-info-bg)] p-3 text-[12.5px] text-[var(--t-info-fg)]">
+                    For APIs with short-lived tokens (e.g. HRworks): we POST your credentials to the login endpoint, read the token from the response, send it as a Bearer token, and refresh it automatically before it expires.
+                  </div>
+                  <div>
+                    <label className={labelClass}>Login URL</label>
+                    <input type="text" value={ltLoginUrl} onChange={(e) => setLtLoginUrl(e.target.value)} placeholder="https://api.hrworks.de/v2/authentication" className={cn(inputClass, 'font-mono text-[13px]')} />
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className={labelClass}>Username / Access key</label>
+                      <input type="text" value={ltUsername} onChange={(e) => setLtUsername(e.target.value)} placeholder="access key" className={cn(inputClass, 'font-mono text-[13px]')} />
+                    </div>
+                    <div>
+                      <label className={labelClass}>Password / Secret</label>
+                      <input type="password" value={ltPassword} onChange={(e) => setLtPassword(e.target.value)} placeholder="secret" className={cn(inputClass, 'font-mono text-[13px]')} />
+                    </div>
+                  </div>
+                  <div>
+                    <label className={labelClass}>Login request body (JSON)</label>
+                    <textarea value={ltLoginBody} onChange={(e) => setLtLoginBody(e.target.value)} rows={4} className={cn(inputClass, 'h-auto py-2 font-mono text-[13px]')} />
+                    <p className="mt-1.5 text-[11.5px] text-[var(--text-3)]">
+                      Body sent to the login URL. Use <code>{'${username}'}</code> / <code>{'${password}'}</code> placeholders. HRworks uses <code>{'{ "accessKey": "${username}", "secretAccessKey": "${password}" }'}</code>.
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div>
+                      <label className={labelClass}>Method</label>
+                      <AppSelect
+                        value={ltMethod}
+                        onValueChange={setLtMethod}
+                        className={inputClass}
+                        options={[{ value: 'POST', label: 'POST' }, { value: 'GET', label: 'GET' }]}
+                      />
+                    </div>
+                    <div>
+                      <label className={labelClass}>Token JSON path</label>
+                      <input type="text" value={ltTokenPath} onChange={(e) => setLtTokenPath(e.target.value)} placeholder="token" className={cn(inputClass, 'font-mono text-[13px]')} />
+                    </div>
+                    <div>
+                      <label className={labelClass}>Token TTL (s)</label>
+                      <input type="number" value={ltTtl} onChange={(e) => setLtTtl(e.target.value)} placeholder="900" className={cn(inputClass, 'font-mono text-[13px]')} />
+                    </div>
+                  </div>
+                  <label className="flex items-center gap-2 text-[12.5px] text-[var(--text-2)]">
+                    <input type="checkbox" checked={ltRefreshOn401} onChange={(e) => setLtRefreshOn401(e.target.checked)} />
+                    Re-login and retry automatically on a 401 response
+                  </label>
+                </div>
+              )}
+
+              {selectedType !== 'DATABASE' && selectedType !== 'MCP' && (
+                <HeadersEditor rows={headerRows} onChange={setHeaderRows} />
               )}
 
               <div className="flex gap-[10px] pt-1">

--- a/packages/frontend/src/components/headers-editor.tsx
+++ b/packages/frontend/src/components/headers-editor.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export interface HeaderRow {
+  key: string;
+  value: string;
+}
+
+const inputClass =
+  'h-9 w-full rounded-[9px] border border-[var(--border)] bg-[var(--surface)] px-3 text-[13.5px] text-[var(--text)] placeholder:text-[var(--text-3)] outline-none focus:border-[var(--border-strong)]';
+const labelClass = 'mb-1.5 block text-[12.5px] font-medium text-[var(--text)]';
+
+/**
+ * Key/value editor for connector-level custom HTTP headers. The parent owns the
+ * `rows` array; empty rows are kept for editing and filtered out at submit time
+ * via {@link headerRowsToObject}. Values render as text (not password) so users
+ * can verify what they typed — connector headers are not necessarily secrets.
+ */
+export function HeadersEditor({
+  rows,
+  onChange,
+  label = 'Custom headers',
+  hint = 'Sent on every request to this API. Useful for APIs that require extra headers (e.g. Autotask: Username, Secret, ApiIntegrationCode).',
+}: {
+  rows: HeaderRow[];
+  onChange: (rows: HeaderRow[]) => void;
+  label?: string;
+  hint?: string;
+}) {
+  const update = (i: number, patch: Partial<HeaderRow>) =>
+    onChange(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+  const add = () => onChange([...rows, { key: '', value: '' }]);
+  const remove = (i: number) => onChange(rows.filter((_, idx) => idx !== i));
+
+  return (
+    <div>
+      <label className={labelClass}>{label}</label>
+      {rows.length > 0 && (
+        <div className="mb-2 flex flex-col gap-2">
+          {rows.map((row, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                type="text"
+                value={row.key}
+                onChange={(e) => update(i, { key: e.target.value })}
+                placeholder="Header-Name"
+                className={cn(inputClass, 'font-mono text-[13px]')}
+              />
+              <input
+                type="text"
+                value={row.value}
+                onChange={(e) => update(i, { value: e.target.value })}
+                placeholder="value"
+                className={cn(inputClass, 'font-mono text-[13px]')}
+              />
+              <button
+                type="button"
+                onClick={() => remove(i)}
+                aria-label="Remove header"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[9px] border border-[var(--border)] text-[var(--text-3)] hover:border-[var(--danger)] hover:text-[var(--danger)]"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={add}
+        className="rounded-[9px] border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-[12.5px] font-medium text-[var(--text-2)] hover:border-[var(--border-strong)]"
+      >
+        + Add header
+      </button>
+      {hint && <p className="mt-1.5 text-[11.5px] text-[var(--text-3)]">{hint}</p>}
+    </div>
+  );
+}
+
+/** Convert editor rows to a headers object, dropping rows with an empty key. */
+export function headerRowsToObject(rows: HeaderRow[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const { key, value } of rows) {
+    const k = key.trim();
+    if (k) out[k] = value;
+  }
+  return out;
+}
+
+/** Convert a stored headers object back into editor rows. */
+export function objectToHeaderRows(
+  headers: Record<string, string> | null | undefined,
+): HeaderRow[] {
+  if (!headers || typeof headers !== 'object') return [];
+  return Object.entries(headers).map(([key, value]) => ({
+    key,
+    value: String(value ?? ''),
+  }));
+}


### PR DESCRIPTION
## Why

Two connector auth capabilities already existed in the REST engine but were only reachable via catalog-adapter JSON or the connectors API — **not** from the connector create/edit UI. A customer evaluating the product hit exactly this gap:

- **HRworks** needs a credentials→short-lived-token flow with auto-refresh (tokens live ~15 min).
- **Autotask** needs 3 custom request headers (`Username`, `Secret`, `ApiIntegrationCode`).

This PR surfaces both in the interface (no backend changes needed — the DTO already accepts `authConfig` and `headers`).

## What

**Custom headers editor** (`headers-editor.tsx`, reusable)
- Key/value rows with add/remove on the **new** and **edit** connector forms, for REST/SOAP/GraphQL connectors.
- Existing headers are pre-filled on edit (they are stored in the clear) and round-trip cleanly (edits/removals applied, untouched headers preserved).

**`LOGIN_TOKEN` auth type** — "Login → Token (auto-refresh)"
- Dedicated form: Login URL, Username/Access key, Password/Secret, JSON login body (with `${username}`/`${password}` placeholders + HRworks hint), Method, Token JSON path, Token TTL, refresh-on-401.
- Edit keeps the existing "leave password empty to keep current credentials" semantics (authConfig is encrypted server-side, so fields start empty — same pattern as OAuth2).

**HR WORKS adapter migration**
- `de/hrworks.json` moved from `BEARER_TOKEN` (manual 15-min JWT paste) to `LOGIN_TOKEN` so it auto-refreshes out of the box, mirroring the existing SAP Business One `LOGIN_TOKEN` adapter.
- ⚠️ **Breaking for existing HR WORKS imports**: `requiredEnvVars` changes from `HRWORKS_TOKEN` → `HRWORKS_ACCESS_KEY` + `HRWORKS_SECRET_ACCESS_KEY`. Re-import / update credentials after deploy.

## Verification
- Frontend `tsc --noEmit` → clean.
- `eslint` on changed files → 0 errors (1 pre-existing unrelated `useEffect` deps warning).
- `hrworks.json` validated as JSON; no residual `HRWORKS_TOKEN` references in repo.
- Not exercised end-to-end (would need backend + DB + live HRworks/Autotask credentials).

## Follow-ups (not in this PR)
- Optionally return non-secret `authConfig` fields from the backend so LOGIN_TOKEN fields can pre-fill on edit (today you must re-enter the password to change loginUrl/body).
- Optional `autotask.json` catalog adapter.