### PR TITLE
fix(deploy): raise healthcheck start_period so live deploys stop false-failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,8 +124,12 @@ USER appuser
 EXPOSE 3000 4000
 
 # Health check — backend exposes /health on port 4000.
-# 30s interval, 5s timeout, 30s start period, 3 retries before unhealthy.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+# start-period must exceed cold-start time: the app loads the full connector/tool
+# catalog on boot (can be ~90s+ with a large catalog). During start-period a
+# failing probe keeps the container "starting" (not "unhealthy"), so orchestrators
+# that gate on health don't abort a deploy that is still legitimately coming up.
+# 30s interval, 5s timeout, 120s start period, 3 retries before unhealthy.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
   CMD wget --quiet --tries=1 --spider http://localhost:4000/health || exit 1
 
 CMD ["./start.sh"]

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -104,7 +104,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      # Cold start loads the full connector/tool catalog (~18.5k tools, ~90s).
+      # start_period must comfortably exceed that: during it, failing probes keep
+      # the container in "starting" (not "unhealthy"), so `docker compose --wait`
+      # in deploy-cloud.yml keeps waiting and the first healthy probe (~90s) turns
+      # the deploy green. Too short (was 30s) → the container flipped to unhealthy
+      # mid-boot and --wait aborted, failing a deploy that was actually coming up
+      # fine (false negative). A genuinely dead app never becomes healthy, so once
+      # start_period elapses it still goes unhealthy and the deploy fails for real.
+      start_period: 180s
     restart: unless-stopped
 
   # PostgreSQL Database


### PR DESCRIPTION
## Problem
`deploy-cloud.yml` recreates the `app` container with `docker compose up --wait`. The app loads the full connector/tool catalog on boot (~18.5k tools, ~90s). The app healthcheck used `start_period: 30s` with `interval: 10s` / `retries: 5`, so ~50s after the grace period it reached 5 consecutive failures and flipped to **unhealthy while still legitimately booting**. `--wait` aborts the moment a container reports unhealthy, so the job failed even though the app came up fine and served the new image — a **false negative** (observed 2026-07-10 while deploying #403; app was `healthy` seconds after the job errored).

## Fix
Raise `start_period` past real boot time:
- `docker-compose.cloud.yml` (cloud, heavy catalog): `30s → 180s`
- `Dockerfile` image default (also helps self-hosters with large catalogs): `30s → 120s`

During `start_period`, a failing probe keeps the container in `starting` (not `unhealthy`), so `--wait` keeps waiting up to its `--wait-timeout` (300s) and the first healthy probe (~90s) turns the deploy **green**. A genuinely dead app never becomes healthy and still flips to `unhealthy` once `start_period` elapses (~230s < 300s timeout), so **real** failures are still caught. Net: deploy job success/failure now reflects reality.

## Note
No app code change. The cloud healthcheck comes from compose (overrides the image), so the compose bump is what fixes the pipeline; the Dockerfile bump keeps the published image consistent. Effective on the next deploy (deploy-cloud scp's the compose file before `up`).