### PR TITLE
feat(mcp): optional per-tool responseMapping.followUp workflow hint

### DIFF
--- a/packages/backend/src/connectors/engines/engine-types.ts
+++ b/packages/backend/src/connectors/engines/engine-types.ts
@@ -70,6 +70,9 @@ export interface ResponseMapping {
   cacheTtl?: number;
   type?: string;
   fields?: string[];
+  // Optional workflow hint appended to the tool result (see DynamicMcpTools):
+  // tells the calling agent what to do next, to drive multi-step tool chains.
+  followUp?: string;
   [k: string]: unknown;
 }
 

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -264,7 +264,18 @@ export class DynamicMcpTools {
       // Grow the knowledge graph from this real call (debounced, fire-and-forget).
       void this.kgService.scheduleObservationalIngest(context?.organizationId);
 
-      const resultText = JSON.stringify(result, null, 2);
+      let resultText = JSON.stringify(result, null, 2);
+
+      // Optional per-tool workflow hint. When a tool's responseMapping.followUp
+      // is set, append it to the result so the calling agent sees — mid-workflow,
+      // inside the tool output it just received — what it should do next (e.g.
+      // "a complete answer also needs tools X and Y; call them before replying").
+      // This drives multi-step tool chains far more reliably than a pre-call
+      // description, which agents often read but don't act on. Purely additive
+      // and opt-in: tools without followUp are unaffected.
+      if (responseMapping?.followUp) {
+        resultText += `\n\n---\nWORKFLOW HINT (guidance for the assistant, not part of the API response): ${responseMapping.followUp}`;
+      }
 
       // Cache the response if cacheTtl is set
       if (cacheTtl && cacheTtl > 0) {


### PR DESCRIPTION
## What
Add an opt-in `followUp` string to a tool's `responseMapping`. When set, `DynamicMcpTools` appends it to the tool result as a `WORKFLOW HINT` line.

## Why
Agents (Claude, etc.) reliably read tool *results* but often ignore multi-step guidance in a tool *description*. When an analysis needs several tools (e.g. a "professional football prediction" = predictions + odds + lineups + player stats + injuries + h2h), the agent tends to stop after the first obviously-relevant call. Putting the "call X, Y next" directive **inside the result the agent just received** drives the full chain far more reliably.

## Scope
- `ResponseMapping.followUp?: string` (engine-types.ts).
- `DynamicMcpTools`: append it to `resultText` when present (cached with the response).
- Purely additive & opt-in: tools without `followUp` are byte-for-byte unchanged. No other engine or tool affected.