### PR TITLE
fix(auth): OAuth consent screen + CSRF on MCP login (v0.3.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -26957,7 +26957,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@nestjs/common": "^11.1.28",
@@ -27312,7 +27312,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/auth/login.controller.spec.ts
+++ b/packages/backend/src/auth/login.controller.spec.ts
@@ -1,0 +1,215 @@
+import { LoginController } from './login.controller';
+import type { Request, Response } from 'express';
+import type { AuthService } from './auth.service';
+import type { PrismaService } from '../common/prisma.service';
+import type { ConfigService } from '@nestjs/config';
+import type { PrismaOAuthStore } from './prisma-oauth.store';
+
+interface FakeRes extends Response {
+  _cookies: Record<string, { value: string; options: any }>;
+  _cleared: string[];
+  _headers: Record<string, string>;
+  _sent?: string;
+  _redirect?: string;
+  _status: number;
+}
+
+function makeRes(): FakeRes {
+  const res: any = {
+    _cookies: {},
+    _cleared: [],
+    _headers: {},
+    _status: 200,
+    cookie(name: string, value: string, options: any) {
+      this._cookies[name] = { value, options };
+      return this;
+    },
+    clearCookie(name: string) {
+      this._cleared.push(name);
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this._headers[name] = value;
+      return this;
+    },
+    status(code: number) {
+      this._status = code;
+      return this;
+    },
+    send(payload: string) {
+      this._sent = payload;
+      return this;
+    },
+    redirect(url: string) {
+      this._redirect = url;
+      return this;
+    },
+  };
+  return res as FakeRes;
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {},
+    cookies: {},
+    signedCookies: {},
+    secure: false,
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('LoginController', () => {
+  let controller: LoginController;
+  let authService: jest.Mocked<Pick<AuthService, 'comparePassword'>>;
+  let prisma: { user: { findUnique: jest.Mock } };
+  let config: jest.Mocked<Pick<ConfigService, 'get'>>;
+  let store: jest.Mocked<
+    Pick<PrismaOAuthStore, 'getOAuthSession' | 'getClient'>
+  >;
+
+  beforeEach(() => {
+    authService = { comparePassword: jest.fn() };
+    prisma = { user: { findUnique: jest.fn() } };
+    config = { get: jest.fn().mockReturnValue(undefined) };
+    store = { getOAuthSession: jest.fn(), getClient: jest.fn() };
+
+    controller = new LoginController(
+      authService as unknown as AuthService,
+      prisma as unknown as PrismaService,
+      config as unknown as ConfigService,
+      store as unknown as PrismaOAuthStore,
+    );
+  });
+
+  describe('GET /auth/login (consent + CSRF)', () => {
+    it('renders the client name and redirect host for a pending OAuth session', async () => {
+      store.getOAuthSession.mockResolvedValue({
+        sessionId: 's1',
+        state: 'x',
+        clientId: 'client-abc',
+        redirectUri: 'https://evil.example.com/callback',
+        expiresAt: Date.now() + 60_000,
+      } as any);
+      store.getClient.mockResolvedValue({
+        client_id: 'client-abc',
+        client_name: 'Totally Legit App',
+        redirect_uris: ['https://evil.example.com/callback'],
+      } as any);
+
+      const res = makeRes();
+      await controller.showLoginPage(
+        undefined as unknown as string,
+        makeReq({ cookies: { oauth_session: 's1' } }),
+        res,
+      );
+
+      expect(res._sent).toContain('Totally Legit App');
+      expect(res._sent).toContain('evil.example.com');
+      // A signed CSRF cookie is issued and mirrored into the form.
+      const csrf = res._cookies['login_csrf'];
+      expect(csrf).toBeDefined();
+      expect(csrf.options.signed).toBe(true);
+      expect(csrf.options.httpOnly).toBe(true);
+      expect(res._sent).toContain(`name="csrf" value="${csrf.value}"`);
+    });
+
+    it('falls back to a generic form (no consent block) without a session', async () => {
+      const res = makeRes();
+      await controller.showLoginPage(
+        undefined as unknown as string,
+        makeReq({ cookies: {} }),
+        res,
+      );
+      expect(store.getOAuthSession).not.toHaveBeenCalled();
+      expect(res._sent).not.toContain('class="consent"');
+      expect(res._cookies['login_csrf']).toBeDefined();
+    });
+  });
+
+  describe('POST /auth/login (CSRF enforcement)', () => {
+    it('rejects when the CSRF field does not match the signed cookie', async () => {
+      const res = makeRes();
+      await controller.handleLogin(
+        makeReq({ signedCookies: { login_csrf: 'real-token' } }),
+        { email: 'a@b.com', password: 'pw', csrf: 'forged-token' },
+        res,
+      );
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+      expect(res._redirect).toContain('/auth/login?error=');
+      expect(res._cleared).toContain('login_csrf');
+    });
+
+    it('rejects when the CSRF cookie is missing entirely', async () => {
+      const res = makeRes();
+      await controller.handleLogin(
+        makeReq({ signedCookies: {} }),
+        { email: 'a@b.com', password: 'pw', csrf: 'anything' },
+        res,
+      );
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+      expect(res._redirect).toContain('/auth/login?error=');
+    });
+  });
+
+  describe('POST /auth/login (deny)', () => {
+    it('aborts the flow and drops OAuth cookies on explicit denial', async () => {
+      const res = makeRes();
+      await controller.handleLogin(
+        makeReq({ signedCookies: { login_csrf: 'tok' } }),
+        { email: '', password: '', csrf: 'tok', action: 'deny' },
+        res,
+      );
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+      expect(res._cleared).toEqual(
+        expect.arrayContaining(['oauth_session', 'oauth_state', 'login_csrf']),
+      );
+      expect(res._sent).toContain('Request Cancelled');
+    });
+  });
+
+  describe('POST /auth/login (credentials)', () => {
+    const okReq = () =>
+      makeReq({ signedCookies: { login_csrf: 'tok' }, headers: { host: 'mcp.test' } });
+
+    it('sets login_user and redirects to /callback on valid credentials', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u1',
+        email: 'a@b.com',
+        name: 'A',
+        passwordHash: 'hash',
+      });
+      authService.comparePassword.mockResolvedValue(true);
+
+      const res = makeRes();
+      await controller.handleLogin(
+        okReq(),
+        { email: 'a@b.com', password: 'pw', csrf: 'tok', action: 'approve' },
+        res,
+      );
+
+      expect(res._cookies['login_user']).toBeDefined();
+      expect(res._cookies['login_user'].options.signed).toBe(true);
+      expect(res._cleared).toContain('login_csrf');
+      expect(res._redirect).toBe('http://mcp.test/callback');
+    });
+
+    it('redirects with an error on wrong password (no login_user set)', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u1',
+        email: 'a@b.com',
+        passwordHash: 'hash',
+      });
+      authService.comparePassword.mockResolvedValue(false);
+
+      const res = makeRes();
+      await controller.handleLogin(
+        okReq(),
+        { email: 'a@b.com', password: 'bad', csrf: 'tok', action: 'approve' },
+        res,
+      );
+
+      expect(res._cookies['login_user']).toBeUndefined();
+      expect(res._redirect).toContain('/auth/login?error=');
+    });
+  });
+});

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -11,8 +11,23 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
+import { randomBytes, timingSafeEqual } from 'crypto';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../common/prisma.service';
+import { PrismaOAuthStore } from './prisma-oauth.store';
+
+/**
+ * Context describing the OAuth client that initiated the current authorize
+ * flow. Rendered on the login page so the user can see — and thereby approve —
+ * exactly which client and callback destination they are authorizing before
+ * they submit their credentials.
+ */
+interface ConsentContext {
+  clientName: string;
+  redirectUri: string;
+  redirectHost: string;
+  scopeText: string;
+}
 
 @Controller('auth')
 export class LoginController {
@@ -22,33 +37,81 @@ export class LoginController {
     private readonly authService: AuthService,
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
+    private readonly oauthStore: PrismaOAuthStore,
   ) {}
 
   @Get('login')
   async showLoginPage(
-    @Query('session') session: string,
     @Query('error') error: string,
+    @Req() req: Request,
     @Res() res: Response,
   ) {
     const serverName =
       this.configService.get<string>('MCP_SERVER_NAME') || 'AnythingMCP';
 
+    // Which client/redirect is this login authorizing? Read it from the OAuth
+    // session that @rekog/mcp-nest's /authorize handler stored (keyed by the
+    // httpOnly `oauth_session` cookie) so the user gives INFORMED consent.
+    const consent = await this.loadConsentContext(req);
+
+    // Issue a CSRF token bound to this render (double-submit, HMAC-signed
+    // cookie + matching hidden field). Prevents login CSRF / silent
+    // credential submission from a cross-site context.
+    const csrfToken = randomBytes(32).toString('base64url');
+    const isSecure = this.isSecureRequest(req);
+    res.cookie('login_csrf', csrfToken, {
+      httpOnly: true,
+      secure: isSecure,
+      maxAge: 10 * 60 * 1000, // 10 minutes — long enough to fill the form
+      sameSite: isSecure ? 'none' : 'lax',
+      signed: true,
+    });
+
     res.setHeader('Content-Type', 'text/html');
-    res.send(this.renderLoginPage(session, error, serverName));
+    res.send(this.renderLoginPage({ error, serverName, consent, csrfToken }));
   }
 
   @Post('login')
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
   async handleLogin(
     @Req() req: Request,
-    @Body() body: { email: string; password: string; session: string },
+    @Body()
+    body: {
+      email: string;
+      password: string;
+      csrf: string;
+      action?: string;
+    },
     @Res() res: Response,
   ) {
-    const { email, password, session } = body;
+    const serverName =
+      this.configService.get<string>('MCP_SERVER_NAME') || 'AnythingMCP';
+
+    // CSRF: the signed cookie must match the form field. Reject before doing
+    // anything with the submitted credentials.
+    if (!this.verifyCsrf(req, body.csrf)) {
+      this.logger.warn('Rejected login with missing/invalid CSRF token');
+      res.clearCookie('login_csrf');
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Your session expired. Please try again.')}`,
+      );
+    }
+
+    // The user explicitly declined on the consent screen: abort the flow and
+    // drop the OAuth session cookies so no authorization code can be issued.
+    if (body.action === 'deny') {
+      res.clearCookie('login_csrf');
+      res.clearCookie('oauth_session');
+      res.clearCookie('oauth_state');
+      res.setHeader('Content-Type', 'text/html');
+      return res.send(this.renderDeniedPage(serverName));
+    }
+
+    const { email, password } = body;
 
     if (!email || !password) {
       return res.redirect(
-        `/auth/login?session=${encodeURIComponent(session || '')}&error=${encodeURIComponent('Email and password are required')}`,
+        `/auth/login?error=${encodeURIComponent('Email and password are required')}`,
       );
     }
 
@@ -60,7 +123,7 @@ export class LoginController {
     if (!user) {
       this.logger.warn(`Login attempt for non-existent user: ${email}`);
       return res.redirect(
-        `/auth/login?session=${encodeURIComponent(session || '')}&error=${encodeURIComponent('Invalid email or password')}`,
+        `/auth/login?error=${encodeURIComponent('Invalid email or password')}`,
       );
     }
 
@@ -73,7 +136,7 @@ export class LoginController {
     if (!passwordValid) {
       this.logger.warn(`Failed login attempt for user: ${email}`);
       return res.redirect(
-        `/auth/login?session=${encodeURIComponent(session || '')}&error=${encodeURIComponent('Invalid email or password')}`,
+        `/auth/login?error=${encodeURIComponent('Invalid email or password')}`,
       );
     }
 
@@ -89,11 +152,7 @@ export class LoginController {
 
     const encoded = Buffer.from(JSON.stringify(profile)).toString('base64url');
 
-    // Detect if behind HTTPS proxy (ngrok, etc.)
-    const isSecure =
-      req.secure ||
-      req.headers['x-forwarded-proto'] === 'https' ||
-      this.configService.get<string>('NODE_ENV') === 'production';
+    const isSecure = this.isSecureRequest(req);
 
     res.cookie('login_user', encoded, {
       httpOnly: true,
@@ -103,9 +162,73 @@ export class LoginController {
       signed: true, // HMAC-signed: rejects forged cookies in the OAuth strategy
     });
 
+    // The consent decision has been made — the single-use CSRF token is done.
+    res.clearCookie('login_csrf');
+
     // Derive callback URL from the request origin (works behind proxy/tunnel)
     const baseUrl = this.getBaseUrl(req);
     res.redirect(`${baseUrl}/callback`);
+  }
+
+  /**
+   * Loads the client/redirect being authorized from the pending OAuth session.
+   * Returns null when there is no valid pending session (e.g. the login page was
+   * hit outside an authorize flow) — in that case a generic login form is shown,
+   * which is safe because /callback refuses to issue a code without a session.
+   */
+  private async loadConsentContext(
+    req: Request,
+  ): Promise<ConsentContext | null> {
+    const sessionId = req.cookies?.oauth_session;
+    if (!sessionId || typeof sessionId !== 'string') return null;
+
+    try {
+      const session = await this.oauthStore.getOAuthSession(sessionId);
+      if (!session?.clientId || !session.redirectUri) return null;
+
+      const client = await this.oauthStore.getClient(session.clientId);
+
+      let redirectHost = session.redirectUri;
+      try {
+        redirectHost = new URL(session.redirectUri).host || session.redirectUri;
+      } catch {
+        // Keep the raw value if it does not parse as a URL.
+      }
+
+      const scopeText = session.scope
+        ? session.scope
+        : "Access to your organization's MCP tools and connected servers.";
+
+      return {
+        clientName: client?.client_name || session.clientId,
+        redirectUri: session.redirectUri,
+        redirectHost,
+        scopeText,
+      };
+    } catch (e) {
+      this.logger.warn('Failed to load OAuth consent context', e as Error);
+      return null;
+    }
+  }
+
+  private verifyCsrf(req: Request, formToken: unknown): boolean {
+    const cookieToken = (req as Request & { signedCookies?: Record<string, unknown> })
+      .signedCookies?.login_csrf;
+    if (typeof cookieToken !== 'string' || typeof formToken !== 'string') {
+      return false;
+    }
+    const a = Buffer.from(cookieToken);
+    const b = Buffer.from(formToken);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  }
+
+  private isSecureRequest(req: Request): boolean {
+    return (
+      req.secure ||
+      req.headers['x-forwarded-proto'] === 'https' ||
+      this.configService.get<string>('NODE_ENV') === 'production'
+    );
   }
 
   private getBaseUrl(req: Request): string {
@@ -122,14 +245,37 @@ export class LoginController {
     );
   }
 
-  private renderLoginPage(
-    session: string,
-    error: string | undefined,
-    serverName: string,
-  ): string {
+  private renderLoginPage(params: {
+    error: string | undefined;
+    serverName: string;
+    consent: ConsentContext | null;
+    csrfToken: string;
+  }): string {
+    const { error, serverName, consent, csrfToken } = params;
+
     const errorHtml = error
       ? `<div class="error">${this.escapeHtml(error)}</div>`
       : '';
+
+    const consentHtml = consent
+      ? `
+    <div class="consent">
+      <p class="consent-lead">An application is requesting access to your
+        <strong>${this.escapeHtml(serverName)}</strong> account:</p>
+      <div class="consent-app">${this.escapeHtml(consent.clientName)}</div>
+      <p class="consent-redirect">After you sign in, your access will be sent to:</p>
+      <div class="consent-host">${this.escapeHtml(consent.redirectHost)}</div>
+      <p class="consent-scope">${this.escapeHtml(consent.scopeText)}</p>
+      <p class="consent-warn">Only continue if you started this and recognise the
+        destination above. If you did not, choose <strong>Cancel</strong>.</p>
+    </div>`
+      : '';
+
+    const denyButton = consent
+      ? `<button type="submit" name="action" value="deny" formnovalidate class="secondary">Cancel</button>`
+      : '';
+
+    const submitLabel = consent ? 'Sign In &amp; Authorize' : 'Sign In';
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -147,6 +293,7 @@ export class LoginController {
       justify-content: center;
       min-height: 100vh;
       color: #333;
+      padding: 20px;
     }
     .card {
       background: #fff;
@@ -176,6 +323,31 @@ export class LoginController {
       margin-bottom: 16px;
       font-size: 0.875rem;
     }
+    .consent {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 20px;
+      font-size: 0.875rem;
+    }
+    .consent-lead { color: #555; margin-bottom: 8px; }
+    .consent-app {
+      font-weight: 600;
+      font-size: 1rem;
+      color: #111;
+      margin-bottom: 12px;
+    }
+    .consent-redirect { color: #555; margin-bottom: 4px; }
+    .consent-host {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-weight: 600;
+      color: #b45309;
+      word-break: break-all;
+      margin-bottom: 12px;
+    }
+    .consent-scope { color: #666; font-size: 0.8rem; margin-bottom: 12px; }
+    .consent-warn { color: #92400e; font-size: 0.8rem; }
     label {
       display: block;
       font-size: 0.875rem;
@@ -212,6 +384,12 @@ export class LoginController {
     }
     button:hover { background: #1d4ed8; }
     button:active { background: #1e40af; }
+    button.secondary {
+      background: transparent;
+      color: #64748b;
+      margin-top: 8px;
+    }
+    button.secondary:hover { background: #f1f5f9; }
   </style>
 </head>
 <body>
@@ -219,14 +397,56 @@ export class LoginController {
     <h1>Sign In</h1>
     <p class="subtitle">Authorize access to ${this.escapeHtml(serverName)} MCP Server</p>
     ${errorHtml}
+    ${consentHtml}
     <form method="POST" action="/auth/login">
-      <input type="hidden" name="session" value="${this.escapeHtml(session || '')}">
+      <input type="hidden" name="csrf" value="${this.escapeHtml(csrfToken)}">
       <label for="email">Email</label>
       <input type="email" id="email" name="email" required autofocus placeholder="you@example.com">
       <label for="password">Password</label>
       <input type="password" id="password" name="password" required placeholder="Your password">
-      <button type="submit">Sign In</button>
+      <button type="submit" name="action" value="approve">${submitLabel}</button>
+      ${denyButton}
     </form>
+  </div>
+</body>
+</html>`;
+  }
+
+  private renderDeniedPage(serverName: string): string {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Request Cancelled — ${this.escapeHtml(serverName)}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      color: #333;
+      margin: 0;
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+      padding: 40px;
+      max-width: 400px;
+      text-align: center;
+    }
+    h1 { font-size: 1.25rem; margin-bottom: 12px; }
+    p { color: #666; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Request Cancelled</h1>
+    <p>The authorization request was declined. No access was granted. You can
+      safely close this window.</p>
   </div>
 </body>
 </html>`;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary

Closes a **consent-phishing** weakness in the MCP OAuth authorization flow, reported via external security disclosure and verified in-repo.

A client registered via open Dynamic Client Registration (`POST /register`) with an attacker-controlled `redirect_uri` could obtain a user's organization-scoped authorization code, because `@rekog/mcp-nest` performs **no consent step** at `/authorize` — the login page never told the user *which* client or callback destination they were authorizing.

Note on severity: this is **not** a zero-click hijack of an already-signed-in user. Our `LocalOAuthStrategy` keeps no ambient session — every `/authorize` forces a fresh login — so the real vector requires the victim to open the attacker's link **and** enter credentials on the legitimate login page. High, not Critical.

## Changes

- **Consent-in-login**: `/auth/login` now displays the requesting client name, the **redirect destination host**, and scope before credentials are entered, loaded from the pending OAuth session. Adds an explicit **Cancel/deny** action that drops the OAuth session cookies so no code is issued.
- **CSRF protection** on the login POST via double-submit (HMAC-signed cookie + hidden field), verified in constant time.
- Only active when `MCP_AUTH_MODE=oauth2`/`both`. **Inert in the default self-hosted `legacy` config**, where the OAuth module is not loaded — no behavior change for that path.

## Deliberately out of scope

Removing `plain` PKCE (enforced inside `@rekog/mcp-nest`; would need a library patch and does not stop this attack) and locking down DCR (open DCR is required by the MCP spec for client auto-registration; restricting loopback `redirect_uris` breaks desktop MCP clients). Neither prevents the attack; both would penalize cloud and self-hosted users.

## Verification

- Backend typecheck: clean.
- `src/auth` tests: 50/50 pass, incl. 7 new in `login.controller.spec.ts` (consent rendering, CSRF rejection, deny, valid/invalid login).
- Lint: clean.