### PR TITLE
fix(connectors): client_secret_basic for OAuth token exchange — DATEV (v0.3.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -26957,7 +26957,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@nestjs/common": "^11.1.28",
@@ -27312,7 +27312,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/adapters/de/datev.json
+++ b/packages/backend/src/adapters/de/datev.json
@@ -18,6 +18,7 @@
       "clientSecret": "{{DATEV_CLIENT_SECRET}}",
       "authorizationUrl": "https://login.datev.de/openid/authorize",
       "tokenUrl": "https://api.datev.de/token",
+      "tokenAuthMethod": "basic",
       "scopes": "datev:accounting:clients accounting:clients:read accounting:documents"
     },
     "headers": {

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -722,6 +722,9 @@ export class ConnectorsController {
         clientId,
         clientSecret,
         tokenUrl: tokenEndpoint,
+        tokenAuthMethod: authConfig.tokenAuthMethod
+          ? String(authConfig.tokenAuthMethod)
+          : undefined,
         createdAt: Date.now(),
       });
 

--- a/packages/backend/src/connectors/engines/oauth2-token.service.ts
+++ b/packages/backend/src/connectors/engines/oauth2-token.service.ts
@@ -150,8 +150,21 @@ export class OAuth2TokenService {
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
         };
-        if (clientId) body.client_id = clientId;
-        if (clientSecret) body.client_secret = clientSecret;
+        const useBasic =
+          authConfig.tokenAuthMethod === 'basic' ||
+          authConfig.tokenAuthMethod === 'client_secret_basic';
+        if (useBasic && clientId && clientSecret) {
+          // client_secret_basic — credentials in the Authorization header.
+          // DATEV and other confidential-client providers reject body creds.
+          if (clientId) body.client_id = clientId;
+          const basic = Buffer.from(`${clientId}:${clientSecret}`).toString(
+            'base64',
+          );
+          headers.Authorization = `Basic ${basic}`;
+        } else {
+          if (clientId) body.client_id = clientId;
+          if (clientSecret) body.client_secret = clientSecret;
+        }
       }
 
       await assertSafeOutboundUrl(tokenUrl);

--- a/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
+++ b/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
@@ -64,6 +64,7 @@ export class McpOAuthCallbackController {
         clientId: flow.clientId,
         clientSecret: flow.clientSecret,
         codeVerifier: flow.codeVerifier,
+        tokenAuthMethod: flow.tokenAuthMethod,
       });
 
       this.logger.log(
@@ -80,6 +81,7 @@ export class McpOAuthCallbackController {
             tokenUrl: flow.tokenUrl,
             clientId: flow.clientId,
             clientSecret: flow.clientSecret,
+            tokenAuthMethod: flow.tokenAuthMethod,
             expiresIn: tokens.expiresIn,
             expiresAt: Date.now() + (tokens.expiresIn || 3600) * 1000,
             authorizedAt: new Date().toISOString(),

--- a/packages/backend/src/connectors/mcp-oauth.service.spec.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.spec.ts
@@ -1,0 +1,65 @@
+import { McpOAuthService } from './mcp-oauth.service';
+import axios from 'axios';
+
+jest.mock('axios');
+// assertSafeOutboundUrl performs DNS/SSRF checks — stub it out for unit tests.
+jest.mock('../common/ssrf.util', () => ({
+  assertSafeOutboundUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('McpOAuthService.exchangeCodeForTokens client authentication', () => {
+  let service: McpOAuthService;
+
+  beforeEach(() => {
+    service = new McpOAuthService();
+    mockedAxios.post.mockReset();
+    mockedAxios.post.mockResolvedValue({
+      data: { access_token: 'at', refresh_token: 'rt', expires_in: 3600 },
+    } as any);
+  });
+
+  const baseParams = {
+    tokenUrl: 'https://sandbox-api.datev.de/token',
+    code: 'authcode',
+    redirectUri: 'https://cloud.anythingmcp.com/api/mcp-oauth/callback',
+    clientId: 'cid',
+    clientSecret: 'secret',
+    codeVerifier: 'verifier',
+  };
+
+  it('defaults to client_secret_post (credentials in body, no Basic header)', async () => {
+    await service.exchangeCodeForTokens({ ...baseParams });
+
+    const [, body, config] = mockedAxios.post.mock.calls[0];
+    expect(String(body)).toContain('client_secret=secret');
+    expect((config as any).headers.Authorization).toBeUndefined();
+  });
+
+  it('uses client_secret_basic when tokenAuthMethod=basic (header, not body)', async () => {
+    await service.exchangeCodeForTokens({
+      ...baseParams,
+      tokenAuthMethod: 'basic',
+    });
+
+    const [, body, config] = mockedAxios.post.mock.calls[0];
+    // Secret must NOT be in the body...
+    expect(String(body)).not.toContain('client_secret=');
+    // ...but in the Authorization header as base64(client_id:client_secret).
+    const expected =
+      'Basic ' + Buffer.from('cid:secret').toString('base64');
+    expect((config as any).headers.Authorization).toBe(expected);
+    // client_id still present in the body per RFC 6749.
+    expect(String(body)).toContain('client_id=cid');
+  });
+
+  it("treats 'client_secret_basic' as an alias for basic", async () => {
+    await service.exchangeCodeForTokens({
+      ...baseParams,
+      tokenAuthMethod: 'client_secret_basic',
+    });
+    const [, , config] = mockedAxios.post.mock.calls[0];
+    expect((config as any).headers.Authorization).toMatch(/^Basic /);
+  });
+});

--- a/packages/backend/src/connectors/mcp-oauth.service.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.ts
@@ -20,6 +20,15 @@ interface PendingOAuthFlow {
   clientId: string;
   clientSecret?: string;
   tokenUrl: string;
+  /**
+   * How the client authenticates at the token endpoint:
+   *  - undefined / 'post' → client_id + client_secret in the request body
+   *    (RFC 6749 client_secret_post) — the historical default.
+   *  - 'basic'            → HTTP Basic Authorization header
+   *    (client_secret_basic). Required by providers like DATEV that reject
+   *    body credentials with 401 invalid_client.
+   */
+  tokenAuthMethod?: string;
   createdAt: number;
 }
 
@@ -151,11 +160,16 @@ export class McpOAuthService {
     clientId: string;
     clientSecret?: string;
     codeVerifier: string;
+    tokenAuthMethod?: string;
   }): Promise<{
     accessToken: string;
     refreshToken?: string;
     expiresIn?: number;
   }> {
+    const useBasic =
+      params.tokenAuthMethod === 'basic' ||
+      params.tokenAuthMethod === 'client_secret_basic';
+
     const body: Record<string, string> = {
       grant_type: 'authorization_code',
       code: params.code,
@@ -163,21 +177,35 @@ export class McpOAuthService {
       client_id: params.clientId,
       code_verifier: params.codeVerifier,
     };
-    if (params.clientSecret) {
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    };
+
+    if (useBasic && params.clientSecret) {
+      // client_secret_basic (RFC 6749 §2.3.1): credentials go in the
+      // Authorization header, NOT the body. Providers like DATEV reject a
+      // body-supplied client_secret for confidential clients with 401.
+      const basic = Buffer.from(
+        `${params.clientId}:${params.clientSecret}`,
+      ).toString('base64');
+      headers.Authorization = `Basic ${basic}`;
+    } else if (params.clientSecret) {
+      // client_secret_post (default): credentials in the body.
       body.client_secret = params.clientSecret;
     }
 
-    this.logger.debug(`Exchanging auth code at ${params.tokenUrl}`);
+    this.logger.debug(
+      `Exchanging auth code at ${params.tokenUrl} (auth=${useBasic ? 'basic' : 'post'})`,
+    );
 
     await assertSafeOutboundUrl(params.tokenUrl);
     const response = await axios.post(
       params.tokenUrl,
       new URLSearchParams(body).toString(),
       {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json',
-        },
+        headers,
         timeout: 10000,
       },
     );

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary

DATEV's token endpoint **requires HTTP Basic client authentication** — it returns `WWW-Authenticate: Basic` and rejects body-supplied credentials with `401 invalid_client`. The connector authorization_code exchange only ever sent `client_id`/`client_secret` in the request body (`client_secret_post`), so **every DATEV confidential client failed the token exchange** (observed on multiple live connectors).

Verified read-only against DATEV's sandbox token endpoint (`https://sandbox-api.datev.de/token`, confirmed correct via DATEV's own OIDC discovery): body-auth → `401 invalid_client` + `WWW-Authenticate: Basic`.

## Changes

- New per-connector `tokenAuthMethod` (`'basic'` | default `'post'`).
- `McpOAuthService.exchangeCodeForTokens`: sends `Authorization: Basic base64(id:secret)` and omits the secret from the body when method is `basic`.
- The pending OAuth flow carries `tokenAuthMethod`; the callback persists it into `authConfig` so token **refresh** uses the same method (`oauth2-token.service`).
- DATEV adapter (`adapters/de/datev.json`) sets `tokenAuthMethod: "basic"`.
- **Default behaviour unchanged** for every other connector (still `client_secret_post`).

## Verification

- Backend typecheck clean, lint clean.
- `src/connectors` OAuth tests 22/22 pass (3 new in `mcp-oauth.service.spec.ts` covering the basic/post branch).
- Live read-only probe confirmed DATEV requires Basic (`WWW-Authenticate: Basic`).

Note: a valid DATEV client secret is still required end-to-end — this change fixes the authentication *method*, which was blocking all DATEV token exchanges.