### PR TITLE
feat(catalog): Amazon Seller Central (SP-API) connector + OAuth2 custom token header

### DIFF
--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -40,6 +40,7 @@ import * as acuityScheduling from './intl/acuity-scheduling.json';
 import * as adyen from './intl/adyen.json';
 import * as agilecrm from './intl/agilecrm.json';
 import * as amadeus from './intl/amadeus.json';
+import * as amazonSeller from './intl/amazon-seller.json';
 import * as apiFootball from './intl/api-football.json';
 import * as apollo from './intl/apollo.json';
 import * as attio from './intl/attio.json';
@@ -319,6 +320,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   adyen as unknown as AdapterDefinition,
   agilecrm as unknown as AdapterDefinition,
   amadeus as unknown as AdapterDefinition,
+  amazonSeller as unknown as AdapterDefinition,
   apiFootball as unknown as AdapterDefinition,
   apollo as unknown as AdapterDefinition,
   attio as unknown as AdapterDefinition,

--- a/packages/backend/src/adapters/intl/amazon-seller.json
+++ b/packages/backend/src/adapters/intl/amazon-seller.json
@@ -1,0 +1,451 @@
+{
+  "slug": "amazon-seller",
+  "name": "Amazon Seller Central (SP-API)",
+  "description": "Query your Amazon Seller Central account through the official Selling Partner API: orders, order items, product catalog, FBA inventory, buy-box offers, fee estimates, financial events and reports. Read-focused v1 across all Amazon marketplaces (US, EU, FE).",
+  "instructions": "This connector wraps Amazon's **Selling Partner API (SP-API)** — the official successor of MWS — using Login-with-Amazon (LWA) OAuth2. No AWS keys or SigV4 signing are needed (Amazon removed that requirement).\n\n## Setup (one-time, ~15 min + Amazon approval)\n\n1. **Register as a developer**: Seller Central → Apps & Services → *Develop Apps* (you may first need to complete the developer profile in the Solution Provider Portal; Amazon reviews it manually, allow a few days).\n2. **Create a private app**: *Develop Apps* → **Add new app client** → type *Sellers* → select the roles you need (e.g. \"Inventory and Order Tracking\", \"Pricing\", \"Amazon Fulfillment\", \"Finance and Accounting\", \"Selling Partner Insights\"). PII roles (buyer names/addresses) are restricted and NOT required for this connector.\n3. **Get LWA credentials**: on the app row choose *View* → copy **Client ID** (`amzn1.application-oa2-client.…`) and **Client Secret** (`amzn1.oa2-cs.v1.…`).\n4. **Self-authorize**: on the app row choose **Authorize** → Amazon shows the **Refresh Token** (`Atzr|…`). This token is long-lived; the connector exchanges it automatically for 1-hour access tokens (sent in the `x-amz-access-token` header — handled for you).\n5. Fill the env vars:\n   - `SPAPI_CLIENT_ID`, `SPAPI_CLIENT_SECRET`, `SPAPI_REFRESH_TOKEN` — from steps 3-4.\n   - `SPAPI_ENDPOINT` — your region's API host:\n     - Europe (DE/UK/IT/FR/ES/NL/SE/PL/TR/AE/IN/…): `https://sellingpartnerapi-eu.amazon.com`\n     - North America (US/CA/MX/BR): `https://sellingpartnerapi-na.amazon.com`\n     - Far East (JP/AU/SG): `https://sellingpartnerapi-fe.amazon.com`\n   - `SPAPI_MARKETPLACE_ID` — the marketplace you sell in (call `amazon_marketplace_ids` for the full table; e.g. DE `A1PA6795UKMFR9`, US `ATVPDKIKX0DER`, IT `APJ6JRA9NG5V4`).\n   - `SPAPI_SELLER_ID` — your merchant token (Seller Central → Account Info → *Merchant Token*). Only needed for `amazon_get_listings_item`; set any placeholder otherwise.\n\n**First call**: run `amazon_marketplace_participations` — it needs no parameters and confirms auth + region are correct.\n\n## Sandbox\n\nSet `SPAPI_ENDPOINT` to `https://sandbox.sellingpartnerapi-eu.amazon.com` (or `-na`/`-fe`) to hit the **static sandbox**: it returns canned responses when requests match predefined parameter patterns (e.g. Orders requires `CreatedAfter=TEST_CASE_200`). Same LWA credentials work; a draft app's refresh token may be sandbox-only (production returns 403 until the authorization is production-grade).\n\n## Marketplace scoping\n\nAll tools are pinned to `SPAPI_MARKETPLACE_ID`. To work across multiple marketplaces of the same region, create one connector per marketplace (cheap) — the underlying seller account and credentials can be identical.\n\n## What v1 deliberately does NOT do\n\n- **Buyer PII** (names, shipping addresses, phone numbers): requires a Restricted Data Token and an Amazon-approved restricted role. Order data returned here is the non-PII view (IDs, status, totals, SKUs, quantities).\n- **Writes** (price updates, listings edits, feeds): planned for a later version once the read workflows are proven.\n\n## Pagination & rate limits\n\nList endpoints return a `NextToken`/`pageToken` — pass it back to fetch the next page. SP-API rate limits are per-endpoint (typically 0.0055–2 req/s with small bursts); on `429` the connector retries automatically with backoff, but space out heavy report loops.\n\n## Reports flow (3 steps)\n\n1. `amazon_create_report` (e.g. `reportType: \"GET_FLAT_FILE_OPEN_LISTINGS_DATA\"`) → returns `reportId`.\n2. Poll `amazon_get_report` until `processingStatus` = `DONE` → gives `reportDocumentId`.\n3. `amazon_get_report_document` → returns a **pre-signed download `url`** (valid ~5 min; document may be gzip). Fetch that URL yourself to read the content.",
+  "region": "intl",
+  "category": "e-commerce",
+  "icon": "amazon-seller",
+  "docsUrl": "https://developer-docs.amazon.com/sp-api/docs/welcome",
+  "requiredEnvVars": [
+    "SPAPI_CLIENT_ID",
+    "SPAPI_CLIENT_SECRET",
+    "SPAPI_REFRESH_TOKEN",
+    "SPAPI_ENDPOINT",
+    "SPAPI_MARKETPLACE_ID",
+    "SPAPI_SELLER_ID"
+  ],
+  "connector": {
+    "name": "Amazon Seller Central (SP-API)",
+    "type": "REST",
+    "baseUrl": "{{SPAPI_ENDPOINT}}",
+    "authType": "OAUTH2",
+    "authConfig": {
+      "grant": "refresh_token",
+      "tokenUrl": "https://api.amazon.com/auth/o2/token",
+      "clientId": "{{SPAPI_CLIENT_ID}}",
+      "clientSecret": "{{SPAPI_CLIENT_SECRET}}",
+      "refreshToken": "{{SPAPI_REFRESH_TOKEN}}",
+      "headerName": "x-amz-access-token"
+    }
+  },
+  "tools": [
+    {
+      "name": "amazon_marketplace_ids",
+      "description": "Reference table of Amazon marketplace IDs and the regional SP-API endpoint that serves each. Use it to pick SPAPI_MARKETPLACE_ID / SPAPI_ENDPOINT or to interpret marketplace IDs found in responses. No API call is made.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "static",
+        "path": "SP-API marketplace IDs by region.\n\nEUROPE — endpoint https://sellingpartnerapi-eu.amazon.com\n  DE A1PA6795UKMFR9 | UK A1F83G8C2ARO7P | IT APJ6JRA9NG5V4 | FR A13V1IB3VIYZZH | ES A1RKKUPIHCS9HS | NL A1805IZSGTT6HS | SE A2NODRKZP88ZB9 | PL A1C3SOZRARQ6R3 | BE AMEN7PMS3EDWL | TR A33AVAJ2PDY3EV | AE A2VIGQ35RCS4UG | SA A17E79C6D8DWNP | EG ARBP9OOSHTCHU | IN A21TJRUUN4KGV | ZA AE08WJ6YKNBMC\n\nNORTH AMERICA — endpoint https://sellingpartnerapi-na.amazon.com\n  US ATVPDKIKX0DER | CA A2EUQ1WTGCTBG2 | MX A1AM78C64UM0Y8 | BR A2Q3Y263D00KWC\n\nFAR EAST — endpoint https://sellingpartnerapi-fe.amazon.com\n  JP A1VC38T7YXB528 | AU A39IBJ37TRP1C6 | SG A19VAU5U5O7RUS\n\nSandbox endpoints: prepend `sandbox.` to the regional host (e.g. https://sandbox.sellingpartnerapi-eu.amazon.com).",
+        "staticResponse": "SP-API marketplace IDs by region.\n\nEUROPE — endpoint https://sellingpartnerapi-eu.amazon.com\n  DE A1PA6795UKMFR9 | UK A1F83G8C2ARO7P | IT APJ6JRA9NG5V4 | FR A13V1IB3VIYZZH | ES A1RKKUPIHCS9HS | NL A1805IZSGTT6HS | SE A2NODRKZP88ZB9 | PL A1C3SOZRARQ6R3 | BE AMEN7PMS3EDWL | TR A33AVAJ2PDY3EV | AE A2VIGQ35RCS4UG | SA A17E79C6D8DWNP | EG ARBP9OOSHTCHU | IN A21TJRUUN4KGV | ZA AE08WJ6YKNBMC\n\nNORTH AMERICA — endpoint https://sellingpartnerapi-na.amazon.com\n  US ATVPDKIKX0DER | CA A2EUQ1WTGCTBG2 | MX A1AM78C64UM0Y8 | BR A2Q3Y263D00KWC\n\nFAR EAST — endpoint https://sellingpartnerapi-fe.amazon.com\n  JP A1VC38T7YXB528 | AU A39IBJ37TRP1C6 | SG A19VAU5U5O7RUS\n\nSandbox endpoints: prepend `sandbox.` to the regional host (e.g. https://sandbox.sellingpartnerapi-eu.amazon.com)."
+      }
+    },
+    {
+      "name": "amazon_marketplace_participations",
+      "description": "List the marketplaces this seller account participates in (id, country, currency, store name). Takes no parameters — use it as the FIRST call to verify credentials, region endpoint and marketplace setup.",
+      "parameters": { "type": "object", "properties": {} },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/sellers/v1/marketplaceParticipations"
+      }
+    },
+    {
+      "name": "amazon_list_orders",
+      "description": "List orders in the configured marketplace. Provide at least ONE of createdAfter / lastUpdatedAfter (ISO 8601, e.g. 2026-07-01T00:00:00Z). Returns non-PII order data: AmazonOrderId, status, purchase date, order totals, fulfillment channel. Paginate with nextToken.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "createdAfter": {
+            "type": "string",
+            "description": "ISO 8601 date-time; orders created at or after this time. In the static sandbox pass `TEST_CASE_200`."
+          },
+          "lastUpdatedAfter": {
+            "type": "string",
+            "description": "ISO 8601 date-time; orders last updated at or after this time. Alternative to createdAfter."
+          },
+          "orderStatuses": {
+            "type": "string",
+            "description": "Optional comma-separated statuses: Pending, Unshipped, PartiallyShipped, Shipped, Canceled, Unfulfillable, InvoiceUnconfirmed, PendingAvailability."
+          },
+          "fulfillmentChannels": {
+            "type": "string",
+            "description": "Optional comma-separated: AFN (fulfilled by Amazon), MFN (fulfilled by seller)."
+          },
+          "maxResultsPerPage": {
+            "type": "integer",
+            "description": "Page size 1-100 (default 100)."
+          },
+          "nextToken": {
+            "type": "string",
+            "description": "Pagination token from the previous response."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/v0/orders",
+        "queryParams": {
+          "MarketplaceIds": "{{SPAPI_MARKETPLACE_ID}}",
+          "CreatedAfter": "$createdAfter",
+          "LastUpdatedAfter": "$lastUpdatedAfter",
+          "OrderStatuses": "$orderStatuses",
+          "FulfillmentChannels": "$fulfillmentChannels",
+          "MaxResultsPerPage": "$maxResultsPerPage",
+          "NextToken": "$nextToken"
+        }
+      }
+    },
+    {
+      "name": "amazon_get_order",
+      "description": "Fetch a single order by its AmazonOrderId (format 3-7-7, e.g. 902-3159896-1390916). Returns the non-PII order header: status, totals, dates, channel, number of items.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": {
+            "type": "string",
+            "description": "The AmazonOrderId. In the static sandbox use `TEST_CASE_200`."
+          }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/v0/orders/{orderId}"
+      }
+    },
+    {
+      "name": "amazon_get_order_items",
+      "description": "List the line items of an order: SellerSKU, ASIN, title, quantity ordered/shipped, item price, taxes, promotion discounts. Paginate with nextToken for very large orders.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "orderId": {
+            "type": "string",
+            "description": "The AmazonOrderId."
+          },
+          "nextToken": {
+            "type": "string",
+            "description": "Pagination token from the previous response."
+          }
+        },
+        "required": ["orderId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/orders/v0/orders/{orderId}/orderItems",
+        "queryParams": {
+          "NextToken": "$nextToken"
+        }
+      }
+    },
+    {
+      "name": "amazon_search_catalog",
+      "description": "Search the Amazon product catalog of the configured marketplace by keywords or identifiers (ASIN/EAN/GTIN/UPC/ISBN). Returns matching items with ASIN and summary data (title, brand, classification). Max 20 results per page; paginate with pageToken.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "keywords": {
+            "type": "string",
+            "description": "Comma-separated keywords to search for (e.g. 'espresso,machine'). Use either this OR identifiers."
+          },
+          "identifiers": {
+            "type": "string",
+            "description": "Comma-separated product identifiers (max 20). Use with identifiersType. Use either this OR keywords."
+          },
+          "identifiersType": {
+            "type": "string",
+            "description": "Type of the identifiers: ASIN, EAN, GTIN, ISBN, JAN, MINSAN, SKU, UPC."
+          },
+          "includedData": {
+            "type": "string",
+            "description": "Comma-separated data sets: summaries (default), attributes, classifications, dimensions, identifiers, images, productTypes, relationships, salesRanks."
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "Results per page, max 20 (default 10)."
+          },
+          "pageToken": {
+            "type": "string",
+            "description": "Pagination token from the previous response."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/catalog/2022-04-01/items",
+        "queryParams": {
+          "marketplaceIds": "{{SPAPI_MARKETPLACE_ID}}",
+          "keywords": "$keywords",
+          "identifiers": "$identifiers",
+          "identifiersType": "$identifiersType",
+          "includedData": "$includedData",
+          "pageSize": "$pageSize",
+          "pageToken": "$pageToken"
+        }
+      }
+    },
+    {
+      "name": "amazon_get_catalog_item",
+      "description": "Fetch a single catalog item by ASIN with the requested data sets (summaries, attributes, images, salesRanks, dimensions…).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "asin": {
+            "type": "string",
+            "description": "The Amazon Standard Identification Number, e.g. B08N5WRWNW."
+          },
+          "includedData": {
+            "type": "string",
+            "description": "Comma-separated data sets: summaries (default), attributes, classifications, dimensions, identifiers, images, productTypes, relationships, salesRanks."
+          }
+        },
+        "required": ["asin"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/catalog/2022-04-01/items/{asin}",
+        "queryParams": {
+          "marketplaceIds": "{{SPAPI_MARKETPLACE_ID}}",
+          "includedData": "$includedData"
+        }
+      }
+    },
+    {
+      "name": "amazon_fba_inventory",
+      "description": "FBA inventory summaries for the configured marketplace: fulfillable, inbound, reserved, unfulfillable and researching quantities per SKU/ASIN. Filter with sellerSkus or startDateTime; set details=true for the full quantity breakdown.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "details": {
+            "type": "boolean",
+            "description": "true returns the detailed quantity breakdown (inbound/reserved/unfulfillable buckets). Default false."
+          },
+          "sellerSkus": {
+            "type": "string",
+            "description": "Optional comma-separated list of seller SKUs (max 50) to fetch."
+          },
+          "startDateTime": {
+            "type": "string",
+            "description": "Optional ISO 8601; only items updated after this time."
+          },
+          "nextToken": {
+            "type": "string",
+            "description": "Pagination token from the previous response."
+          }
+        }
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/fba/inventory/v1/summaries",
+        "queryParams": {
+          "granularityType": "Marketplace",
+          "granularityId": "{{SPAPI_MARKETPLACE_ID}}",
+          "marketplaceIds": "{{SPAPI_MARKETPLACE_ID}}",
+          "details": "$details",
+          "sellerSkus": "$sellerSkus",
+          "startDateTime": "$startDateTime",
+          "nextToken": "$nextToken"
+        }
+      }
+    },
+    {
+      "name": "amazon_get_item_offers",
+      "description": "Current offers for an ASIN in the configured marketplace: buy-box winner, lowest prices by fulfillment channel, offer counts, shipping. Use it to check your buy-box position and price competitiveness.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "asin": {
+            "type": "string",
+            "description": "The ASIN to get offers for."
+          },
+          "itemCondition": {
+            "type": "string",
+            "description": "Condition filter: New, Used, Collectible, Refurbished, Club. Default New."
+          }
+        },
+        "required": ["asin"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/products/pricing/v0/items/{asin}/offers",
+        "queryParams": {
+          "MarketplaceId": "{{SPAPI_MARKETPLACE_ID}}",
+          "ItemCondition": "$itemCondition"
+        }
+      }
+    },
+    {
+      "name": "amazon_get_fees_estimate",
+      "description": "Estimate the Amazon fees (referral fee, FBA fulfillment fee…) you would pay for an ASIN at a given selling price. Essential for margin calculations before (re)pricing.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "asin": {
+            "type": "string",
+            "description": "The ASIN to estimate fees for."
+          },
+          "price": {
+            "type": "number",
+            "description": "The intended listing price (item price only, e.g. 29.99)."
+          },
+          "currencyCode": {
+            "type": "string",
+            "description": "ISO 4217 currency of the price, e.g. EUR, USD, GBP."
+          },
+          "isAmazonFulfilled": {
+            "type": "boolean",
+            "description": "true to include FBA fulfillment fees, false for merchant-fulfilled. Default true."
+          }
+        },
+        "required": ["asin", "price", "currencyCode"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/products/fees/v0/items/{asin}/feesEstimate",
+        "bodyMapping": {
+          "FeesEstimateRequest": {
+            "MarketplaceId": "{{SPAPI_MARKETPLACE_ID}}",
+            "IsAmazonFulfilled": "$isAmazonFulfilled",
+            "Identifier": "anythingmcp-fees-estimate",
+            "PriceToEstimateFees": {
+              "ListingPrice": {
+                "CurrencyCode": "$currencyCode",
+                "Amount": "$price"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "amazon_list_financial_events",
+      "description": "Financial events (shipments settlements, refunds, fees, service charges, adjustments) posted in a date window. The money-side view of your account — use it for revenue/fee reconciliation. Paginate with nextToken.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "postedAfter": {
+            "type": "string",
+            "description": "ISO 8601 date-time; events posted at or after this time. In the static sandbox pass `TEST_CASE_200`."
+          },
+          "postedBefore": {
+            "type": "string",
+            "description": "Optional ISO 8601 upper bound."
+          },
+          "maxResultsPerPage": {
+            "type": "integer",
+            "description": "Page size 1-100 (default 100)."
+          },
+          "nextToken": {
+            "type": "string",
+            "description": "Pagination token from the previous response."
+          }
+        },
+        "required": ["postedAfter"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/finances/v0/financialEvents",
+        "queryParams": {
+          "PostedAfter": "$postedAfter",
+          "PostedBefore": "$postedBefore",
+          "MaxResultsPerPage": "$maxResultsPerPage",
+          "NextToken": "$nextToken"
+        }
+      }
+    },
+    {
+      "name": "amazon_get_listings_item",
+      "description": "Fetch one of YOUR listings by seller SKU: summaries, attributes, issues (quality/compliance problems), offers and fulfillment availability. The seller id is taken from SPAPI_SELLER_ID configured on this connector.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sku": {
+            "type": "string",
+            "description": "Your seller SKU (as shown in Manage Inventory)."
+          },
+          "includedData": {
+            "type": "string",
+            "description": "Comma-separated data sets: summaries (default), attributes, issues, offers, fulfillmentAvailability, procurement."
+          }
+        },
+        "required": ["sku"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/listings/2021-08-01/items/{{SPAPI_SELLER_ID}}/{sku}",
+        "queryParams": {
+          "marketplaceIds": "{{SPAPI_MARKETPLACE_ID}}",
+          "includedData": "$includedData"
+        }
+      }
+    },
+    {
+      "name": "amazon_create_report",
+      "description": "Request generation of a report (step 1 of 3). Common reportType values: GET_FLAT_FILE_OPEN_LISTINGS_DATA (active listings), GET_MERCHANT_LISTINGS_ALL_DATA, GET_FBA_MYI_UNSUPPRESSED_INVENTORY_DATA, GET_SALES_AND_TRAFFIC_REPORT, GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE. Returns a reportId — poll it with amazon_get_report.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportType": {
+            "type": "string",
+            "description": "The report type identifier, e.g. GET_FLAT_FILE_OPEN_LISTINGS_DATA. Full list: https://developer-docs.amazon.com/sp-api/docs/report-type-values"
+          },
+          "dataStartTime": {
+            "type": "string",
+            "description": "Optional ISO 8601 start of the data window (for date-ranged reports)."
+          },
+          "dataEndTime": {
+            "type": "string",
+            "description": "Optional ISO 8601 end of the data window."
+          }
+        },
+        "required": ["reportType"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/reports/2021-06-30/reports",
+        "bodyMapping": {
+          "reportType": "$reportType",
+          "marketplaceIds": ["{{SPAPI_MARKETPLACE_ID}}"],
+          "dataStartTime": "$dataStartTime",
+          "dataEndTime": "$dataEndTime"
+        }
+      }
+    },
+    {
+      "name": "amazon_get_report",
+      "description": "Check a report's processing status (step 2 of 3). Poll until processingStatus is DONE, then read reportDocumentId and pass it to amazon_get_report_document. Other statuses: IN_QUEUE, IN_PROGRESS, CANCELLED, FATAL.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportId": {
+            "type": "string",
+            "description": "The reportId returned by amazon_create_report."
+          }
+        },
+        "required": ["reportId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/reports/2021-06-30/reports/{reportId}"
+      }
+    },
+    {
+      "name": "amazon_get_report_document",
+      "description": "Get the download descriptor of a finished report (step 3 of 3). Returns a pre-signed `url` (valid ~5 minutes; the file may be gzip-compressed — see compressionAlgorithm). Download that URL to read the report content.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "reportDocumentId": {
+            "type": "string",
+            "description": "The reportDocumentId from a DONE report."
+          }
+        },
+        "required": ["reportDocumentId"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/reports/2021-06-30/documents/{reportDocumentId}"
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/amazon-seller.live.spec.ts
+++ b/packages/backend/src/adapters/intl/amazon-seller.live.spec.ts
@@ -1,0 +1,237 @@
+import * as adapter from './amazon-seller.json';
+import { RestEngine } from '../../connectors/engines/rest.engine';
+import { OAuth2TokenService } from '../../connectors/engines/oauth2-token.service';
+import { LoginTokenService } from '../../connectors/engines/login-token.service';
+
+/**
+ * Two layers of verification for the amazon-seller (SP-API) adapter:
+ *
+ *   1. Static — always runs. Asserts the LWA OAuth2 wiring (token endpoint,
+ *      refresh_token grant, x-amz-access-token header), that every tool
+ *      targets a current SP-API version path, that the marketplace id is
+ *      env-injected (never a model-supplied parameter), and that the
+ *      three-step Reports flow is complete.
+ *
+ *   2. Live — skipped in CI. With real credentials (a private, self-authorized
+ *      Seller Central app) it performs the LWA refresh_token exchange and
+ *      calls getMarketplaceParticipations against the STATIC SANDBOX,
+ *      proving the whole chain: token exchange → x-amz-access-token header →
+ *      SP-API 200.
+ *
+ *   Run live with:
+ *     RUN_SPAPI_LIVE=1 SPAPI_CLIENT_ID=… SPAPI_CLIENT_SECRET=… \
+ *     SPAPI_REFRESH_TOKEN=… \
+ *     npx jest src/adapters/intl/amazon-seller.live.spec.ts
+ */
+
+interface Tool {
+  name: string;
+  parameters: {
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  endpointMapping: {
+    method: string;
+    path: string;
+    queryParams?: Record<string, unknown>;
+    bodyMapping?: Record<string, unknown>;
+    staticResponse?: string;
+  };
+}
+
+const a = adapter as unknown as {
+  slug: string;
+  requiredEnvVars: string[];
+  connector: {
+    baseUrl: string;
+    authType: string;
+    authConfig: Record<string, string>;
+  };
+  tools: Tool[];
+};
+
+const httpTools = () =>
+  a.tools.filter((t) => t.endpointMapping.method !== 'static');
+
+describe('amazon-seller adapter — static spec conformance', () => {
+  it('authenticates via LWA OAuth2 refresh_token into x-amz-access-token', () => {
+    expect(a.connector.authType).toBe('OAUTH2');
+    expect(a.connector.authConfig.grant).toBe('refresh_token');
+    expect(a.connector.authConfig.tokenUrl).toBe(
+      'https://api.amazon.com/auth/o2/token',
+    );
+    // SP-API does NOT read Authorization: Bearer — the access token must go
+    // into the x-amz-access-token header.
+    expect(a.connector.authConfig.headerName).toBe('x-amz-access-token');
+    expect(a.connector.authConfig.clientId).toBe('{{SPAPI_CLIENT_ID}}');
+    expect(a.connector.authConfig.clientSecret).toBe('{{SPAPI_CLIENT_SECRET}}');
+    expect(a.connector.authConfig.refreshToken).toBe('{{SPAPI_REFRESH_TOKEN}}');
+  });
+
+  it('base URL is the env-selected regional endpoint', () => {
+    expect(a.connector.baseUrl).toBe('{{SPAPI_ENDPOINT}}');
+    expect(a.requiredEnvVars).toEqual(
+      expect.arrayContaining([
+        'SPAPI_CLIENT_ID',
+        'SPAPI_CLIENT_SECRET',
+        'SPAPI_REFRESH_TOKEN',
+        'SPAPI_ENDPOINT',
+        'SPAPI_MARKETPLACE_ID',
+      ]),
+    );
+  });
+
+  it('every HTTP tool targets a current SP-API versioned path', () => {
+    const versioned =
+      /^\/(sellers\/v1|orders\/v0|catalog\/2022-04-01|fba\/inventory\/v1|products\/(pricing|fees)\/v0|finances\/v0|listings\/2021-08-01|reports\/2021-06-30)\//;
+    for (const t of httpTools()) {
+      if (!versioned.test(t.endpointMapping.path)) {
+        throw new Error(
+          `${t.name} targets an unexpected path: ${t.endpointMapping.path}`,
+        );
+      }
+    }
+  });
+
+  it('marketplace id is env-injected, never a model-supplied parameter', () => {
+    for (const t of a.tools) {
+      const props = Object.keys(t.parameters.properties ?? {});
+      // No tool may ask the model for a marketplace id — it comes from
+      // SPAPI_MARKETPLACE_ID via {{…}} interpolation.
+      expect(props.join(',')).not.toMatch(/marketplace/i);
+      const mapping = JSON.stringify(t.endpointMapping);
+      if (/[Mm]arketplaceIds?"/.test(mapping)) {
+        expect(mapping).toContain('{{SPAPI_MARKETPLACE_ID}}');
+      }
+    }
+  });
+
+  it('seller id for listings is env-injected in the path', () => {
+    const listings = a.tools.find((t) => t.name === 'amazon_get_listings_item')!;
+    expect(listings.endpointMapping.path).toBe(
+      '/listings/2021-08-01/items/{{SPAPI_SELLER_ID}}/{sku}',
+    );
+    expect(Object.keys(listings.parameters.properties ?? {})).not.toContain(
+      'sellerId',
+    );
+  });
+
+  it('reports flow is complete: create → status → document', () => {
+    const names = a.tools.map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'amazon_create_report',
+        'amazon_get_report',
+        'amazon_get_report_document',
+      ]),
+    );
+    const create = a.tools.find((t) => t.name === 'amazon_create_report')!;
+    expect(create.endpointMapping.method).toBe('POST');
+    expect(JSON.stringify(create.endpointMapping.bodyMapping)).toContain(
+      '{{SPAPI_MARKETPLACE_ID}}',
+    );
+  });
+
+  it('ships a no-parameter smoke-test tool (marketplaceParticipations)', () => {
+    const smoke = a.tools.find(
+      (t) => t.name === 'amazon_marketplace_participations',
+    )!;
+    expect(smoke.endpointMapping.method).toBe('GET');
+    expect(smoke.endpointMapping.path).toBe('/sellers/v1/marketplaceParticipations');
+    expect(Object.keys(smoke.parameters.properties ?? {})).toHaveLength(0);
+  });
+
+  it('static marketplace-ids reference covers the three regions', () => {
+    const ref = a.tools.find((t) => t.name === 'amazon_marketplace_ids')!;
+    expect(ref.endpointMapping.method).toBe('static');
+    const text = ref.endpointMapping.staticResponse ?? '';
+    expect(text).toContain('sellingpartnerapi-eu.amazon.com');
+    expect(text).toContain('sellingpartnerapi-na.amazon.com');
+    expect(text).toContain('sellingpartnerapi-fe.amazon.com');
+    expect(text).toContain('ATVPDKIKX0DER'); // US
+    expect(text).toContain('A1PA6795UKMFR9'); // DE
+  });
+});
+
+const maybe = process.env.RUN_SPAPI_LIVE ? describe : describe.skip;
+
+maybe('amazon-seller adapter — live sandbox reachability', () => {
+  const SANDBOX = 'https://sandbox.sellingpartnerapi-eu.amazon.com';
+
+  async function lwaExchange(): Promise<string> {
+    const res = await fetch('https://api.amazon.com/auth/o2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: process.env.SPAPI_REFRESH_TOKEN!,
+        client_id: process.env.SPAPI_CLIENT_ID!,
+        client_secret: process.env.SPAPI_CLIENT_SECRET!,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { access_token: string };
+    expect(data.access_token).toBeTruthy();
+    return data.access_token;
+  }
+
+  it('LWA exchange succeeds and the sandbox accepts x-amz-access-token', async () => {
+    const accessToken = await lwaExchange();
+
+    // Stub the token service so the engine injects OUR token — this exercises
+    // the real header-injection path (headerName: x-amz-access-token).
+    const oauth = {
+      getAccessToken: async () => accessToken,
+      refreshToken: async () => accessToken,
+    } as unknown as OAuth2TokenService;
+    const login = {} as unknown as LoginTokenService;
+    const engine = new RestEngine(oauth, login);
+
+    const smoke = a.tools.find(
+      (t) => t.name === 'amazon_marketplace_participations',
+    )!;
+    const result = (await engine.execute(
+      {
+        baseUrl: SANDBOX,
+        authType: 'OAUTH2',
+        authConfig: { ...a.connector.authConfig },
+      },
+      smoke.endpointMapping,
+      {},
+    )) as { payload: unknown[] };
+
+    expect(Array.isArray(result.payload)).toBe(true);
+    expect(result.payload.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('rejects a bogus token with 403 (endpoint recognised, auth enforced)', async () => {
+    const oauth = {
+      getAccessToken: async () => 'bogus-token-for-endpoint-validation',
+    } as unknown as OAuth2TokenService;
+    const login = {} as unknown as LoginTokenService;
+    const engine = new RestEngine(oauth, login);
+
+    let err: any;
+    try {
+      await engine.execute(
+        {
+          baseUrl: SANDBOX,
+          authType: 'OAUTH2',
+          // No refreshToken here: a 401/403 must surface, not trigger refresh.
+          authConfig: { headerName: 'x-amz-access-token' },
+        },
+        { method: 'GET', path: '/sellers/v1/marketplaceParticipations' },
+        {},
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect([401, 403]).toContain(err.response?.status);
+    // Prove the token went into the SP-API header, not Authorization.
+    expect(err.config?.headers['x-amz-access-token']).toBe(
+      'bogus-token-for-endpoint-validation',
+    );
+    expect(err.config?.headers.Authorization).toBeUndefined();
+  }, 30000);
+});

--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -611,4 +611,71 @@ describe('RestEngine', () => {
       );
     });
   });
+
+  describe('OAuth2 token header injection', () => {
+    const oauthConfig = (extra: Record<string, unknown> = {}) => ({
+      baseUrl: 'https://api.example.com',
+      authType: 'OAUTH2',
+      authConfig: {
+        clientId: 'cid',
+        clientSecret: 'sec',
+        refreshToken: 'rt',
+        tokenUrl: 'https://auth.example.com/token',
+        ...extra,
+      },
+    });
+
+    it('defaults to Authorization: Bearer <token>', async () => {
+      mockedAxios.mockResolvedValue({ data: {} });
+
+      await engine.execute(oauthConfig(), { method: 'GET', path: '/x' }, {});
+
+      const sent = mockedAxios.mock.calls[0][0] as any;
+      expect(sent.headers.Authorization).toBe('Bearer oauth2-access-token');
+    });
+
+    it('honours tokenPrefix on the Authorization header', async () => {
+      mockedAxios.mockResolvedValue({ data: {} });
+
+      await engine.execute(
+        oauthConfig({ tokenPrefix: 'Zoho-oauthtoken' }),
+        { method: 'GET', path: '/x' },
+        {},
+      );
+
+      const sent = mockedAxios.mock.calls[0][0] as any;
+      expect(sent.headers.Authorization).toBe('Zoho-oauthtoken oauth2-access-token');
+    });
+
+    it('sends the raw token in a custom headerName (Amazon SP-API style)', async () => {
+      mockedAxios.mockResolvedValue({ data: {} });
+
+      await engine.execute(
+        oauthConfig({ headerName: 'x-amz-access-token' }),
+        { method: 'GET', path: '/orders/v0/orders' },
+        {},
+      );
+
+      const sent = mockedAxios.mock.calls[0][0] as any;
+      expect(sent.headers['x-amz-access-token']).toBe('oauth2-access-token');
+      expect(sent.headers.Authorization).toBeUndefined();
+    });
+
+    it('re-injects the refreshed token into the custom header on 401 retry', async () => {
+      const err = new AxiosError('Unauthorized');
+      (err as any).response = { status: 401, data: {} };
+      mockedAxios.mockRejectedValueOnce(err).mockResolvedValueOnce({ data: { ok: true } });
+
+      const result = await engine.execute(
+        oauthConfig({ headerName: 'x-amz-access-token' }),
+        { method: 'GET', path: '/orders/v0/orders' },
+        {},
+      );
+
+      expect(result).toEqual({ ok: true });
+      const retried = mockedAxios.mock.calls[1][0] as any;
+      expect(retried.headers['x-amz-access-token']).toBe('new-access-token');
+      expect(retried.headers.Authorization).toBeUndefined();
+    });
+  });
 });

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -217,7 +217,7 @@ export class RestEngine {
         if (newToken) {
           axiosConfig.headers = {
             ...axiosConfig.headers,
-            Authorization: `Bearer ${newToken}`,
+            ...buildOauth2TokenHeader(config.authConfig, newToken),
           };
           const retryResponse = await axios(axiosConfig);
           return retryResponse.data;
@@ -326,11 +326,9 @@ export class RestEngine {
           config.authConfig,
           config.connectorId,
         );
-        // Some vendors use a non-standard prefix (e.g. Zoho: "Zoho-oauthtoken").
-        const prefix = String(config.authConfig?.tokenPrefix ?? 'Bearer');
         axiosConfig.headers = {
           ...axiosConfig.headers,
-          Authorization: `${prefix} ${accessToken}`,
+          ...buildOauth2TokenHeader(config.authConfig, accessToken),
         };
         // Some vendors require additional static headers alongside the
         // Bearer token (e.g. Etsy v3 requires both `Authorization: Bearer
@@ -614,6 +612,31 @@ function renderBodyTemplate(
       return JSON.stringify(value);
     },
   );
+}
+
+/**
+ * Build the header that carries an OAuth2 access token.
+ *
+ * Default: `Authorization: <tokenPrefix|Bearer> <token>`. Vendors that expect
+ * the token in a custom header (e.g. Amazon SP-API's `x-amz-access-token`)
+ * set authConfig.headerName — the raw token is sent there without a prefix,
+ * unless tokenPrefix is explicitly configured too.
+ */
+export function buildOauth2TokenHeader(
+  authConfig: Record<string, unknown> | undefined,
+  accessToken: string,
+): Record<string, string> {
+  const headerName = String(authConfig?.headerName ?? 'Authorization');
+  // Some vendors use a non-standard prefix (e.g. Zoho: "Zoho-oauthtoken").
+  const explicitPrefix = authConfig?.tokenPrefix;
+  if (headerName === 'Authorization') {
+    return { Authorization: `${String(explicitPrefix ?? 'Bearer')} ${accessToken}` };
+  }
+  return {
+    [headerName]: explicitPrefix
+      ? `${String(explicitPrefix)} ${accessToken}`
+      : accessToken,
+  };
 }
 
 /**


### PR DESCRIPTION
Implements the top community request from discussion #148 (**Amazon Sellercentral API**, requested by @blacky1991).

## Engine — OAuth2 custom token header (small, backward-compatible)
Amazon SP-API sends the LWA access token in **`x-amz-access-token`**, not `Authorization: Bearer`. The OAUTH2 case in `rest.engine.ts` hardcoded `Authorization`; a new optional `authConfig.headerName` selects the carrier header (raw token, no prefix, unless `tokenPrefix` is also set). The 401 auto-refresh retry injects into the same header. Defaults unchanged — zero impact on the 15 existing OAUTH2 adapters. New unit tests: default Bearer, `tokenPrefix`, custom header, refresh-retry re-injection.

## New catalog adapter `intl/amazon-seller` (15 tools, read-focused v1)
- **Auth**: LWA OAuth2 `refresh_token` grant against `https://api.amazon.com/auth/o2/token` — exactly what `oauth2-token.service` already implements. Regional endpoint (`SPAPI_ENDPOINT`), marketplace (`SPAPI_MARKETPLACE_ID`) and seller id (`SPAPI_SELLER_ID`) are env-injected, never model-supplied. No AWS SigV4 (Amazon dropped it).
- **Tools**: static marketplace-ids reference, `marketplaceParticipations` no-param smoke test, Orders v0 (list/get/items), Catalog Items 2022-04-01 (search/get), FBA Inventory v1, Product Pricing v0 (item offers / buy box), Product Fees v0 (estimate), Finances v0 (financial events), Listings Items 2021-08-01 (get), Reports 2021-06-30 (create → poll → document URL).
- **Instructions** cover the full seller setup (developer registration → private app → self-authorize), region/marketplace tables, the static sandbox, pagination, per-endpoint rate limits (429 already retried by the engine), and the deliberate v1 exclusions (buyer PII needs a Restricted Data Token + approved role; writes come later).

## Verified against the real API
With a real self-authorized (sandbox) Seller Central app: LWA exchange → **200** (1h token), sandbox EU `getMarketplaceParticipations` with `x-amz-access-token` → **200**; production 403 as expected for a sandbox-only authorization. The live spec (`RUN_SPAPI_LIVE=1`) reproduces this chain through the actual `RestEngine`.

Website content (marketplace entry + multilingual guides) follows in a separate anythingmcp-website PR.