### PR TITLE
fix: static-tool interpolation crash + weclapp/mailshake adapter corrections

### DIFF
--- a/packages/backend/src/adapters/de/weclapp.json
+++ b/packages/backend/src/adapters/de/weclapp.json
@@ -123,7 +123,7 @@
     },
     {
       "name": "weclapp_list_invoices",
-      "description": "List sales invoices from weclapp ERP. Returns invoice numbers, amounts, due dates, and payment status. NOTE: invoice has NO 'customerName' field — do not request it in `properties` (weclapp returns 400); the name is in `recordAddress`, the link is `customerId`. Use `filter` for queries like 'paid-eq=false'. Date fields are Unix epoch milliseconds (e.g. 'invoiceDate-gt=1767225600000' for 2026-01-01).",
+      "description": "List sales invoices from weclapp ERP. Returns invoice numbers, amounts, due dates, and payment status. NOTE: invoice has NO 'customerName' field — do not request it in `properties` (weclapp returns 400); the name is in `recordAddress`, the link is `customerId`. Other common 400 traps: line items are `salesInvoiceItems` (not `invoiceItems`); the invoice-type field/filter is `salesInvoiceType` (not `invoiceType`); there is no `currencyName` (currency is `recordCurrencyId`, amounts are `netAmount`/`grossAmount`/`netAmountInCompanyCurrency`); a cancelled invoice is `status-eq=CANCELLED`, not an invoiceType. Use `filter` for queries like 'paid-eq=false'. Date fields are Unix epoch milliseconds (e.g. 'invoiceDate-gt=1767225600000' for 2026-01-01).",
       "parameters": {
         "type": "object",
         "properties": {
@@ -141,7 +141,7 @@
           },
           "filter": {
             "type": "string",
-            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull (the -null/-notnull operators take an EMPTY value, e.g. 'articleNumber-notnull='). Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
+            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull (the -null/-notnull operators take an EMPTY value, e.g. 'articleNumber-notnull='). The -in/-notin operators need a BRACKETED comma list: 'id-in=[6501,84566]' — NOT 'id-in=6501,84566' (that returns 400 'invalid parameter value'). Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
           },
           "sort": {
             "type": "string",
@@ -163,7 +163,7 @@
     },
     {
       "name": "weclapp_list_articles",
-      "description": "List articles (products) from weclapp ERP. Returns article numbers, names, prices, and stock info. Use `filter` like 'articleNumber-eq=ABC123' for SKU lookups.",
+      "description": "List articles (products) from weclapp ERP. Returns article numbers, names, and stock info. Use `filter` like 'articleNumber-eq=ABC123' for SKU lookups. NOTE on prices: an article has NO direct `salesPrice`/`purchasePrice`/`lastPurchasePrice`/`averagePurchasePrice`/`valuationPrice` property (those return 400 'unknown property'). Sales prices live in the `articlePrices` sub-entity and purchase prices in `supplySources` (note: `supplySources`, not `articleSupplySources`) — request those names in `properties` to get the nested price objects.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -181,7 +181,7 @@
           },
           "filter": {
             "type": "string",
-            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull (the -null/-notnull operators take an EMPTY value, e.g. 'articleNumber-notnull='). Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
+            "description": "weclapp filter. The property+operator IS the param name, so pass it as `property-operator=value` (NOT a `filter=` wrapper). Operators: -eq -ne -gt -lt -ge -le -like -ilike -in -notin -null -notnull (the -null/-notnull operators take an EMPTY value, e.g. 'articleNumber-notnull='). The -in/-notin operators need a BRACKETED comma list: 'id-in=[6501,84566]' — NOT 'id-in=6501,84566' (that returns 400 'invalid parameter value'). Examples: 'articleNumber-eq=A5101', 'productionArticle-eq=true', 'name-ilike=%hammer%'. Combine with '&'."
           },
           "sort": {
             "type": "string",

--- a/packages/backend/src/adapters/intl/mailshake.json
+++ b/packages/backend/src/adapters/intl/mailshake.json
@@ -21,9 +21,9 @@
   "tools": [
     {
       "name": "mailshake_me",
-      "description": "Return the team the API key belongs to.",
+      "description": "Return the user/team the API key belongs to. Useful as a first call to verify the API key works.",
       "parameters": { "type": "object", "properties": {} },
-      "endpointMapping": { "method": "POST", "path": "/users/me" }
+      "endpointMapping": { "method": "GET", "path": "/me" }
     },
     {
       "name": "mailshake_list_campaigns",

--- a/packages/backend/src/common/env-interpolation.util.spec.ts
+++ b/packages/backend/src/common/env-interpolation.util.spec.ts
@@ -31,6 +31,12 @@ describe('EnvInterpolation', () => {
       expect(interpolateString('{{API_BASE}}', {}))
         .toBe('{{API_BASE}}');
     });
+
+    it('should return a non-string template unchanged (no throw)', () => {
+      // Static tools omit `path`; interpolating undefined must not crash.
+      expect(interpolateString(undefined as unknown as string, envVars))
+        .toBeUndefined();
+    });
   });
 
   describe('interpolateDeep', () => {
@@ -82,6 +88,20 @@ describe('EnvInterpolation', () => {
       const mapping = { method: 'GET', path: '/users' };
       const result = interpolateConnectorConfig(config, mapping, {});
       expect(result.config.baseUrl).toBe('{{API_BASE}}');
+    });
+
+    it('should not throw for a static tool with no path', () => {
+      // Regression: a `static` tool endpointMapping has no `path`; with a
+      // connector that HAS env vars, interpolation used to crash on
+      // interpolateString(undefined).
+      const config = { baseUrl: 'https://v3.football.api-sports.io' };
+      const mapping = {
+        method: 'static',
+        staticResponse: 'PLAYBOOK …',
+      } as unknown as { method: string; path: string };
+      const result = interpolateConnectorConfig(config, mapping, envVars);
+      expect(result.endpointMapping.path).toBeUndefined();
+      expect(result.config.baseUrl).toBe('https://v3.football.api-sports.io');
     });
   });
 });

--- a/packages/backend/src/common/env-interpolation.util.ts
+++ b/packages/backend/src/common/env-interpolation.util.ts
@@ -19,6 +19,10 @@ export function interpolateString(
   template: string,
   envVars: Record<string, string>,
 ): string {
+  // Callers pass optional fields (e.g. a static tool's endpointMapping has no
+  // `path`). Guard against a non-string template so interpolation never throws
+  // "Cannot read properties of undefined (reading 'replace')".
+  if (typeof template !== 'string') return template;
   return template.replace(VAR_PATTERN, (match, varName) => {
     const trimmed = varName.trim();
     return envVars[trimmed] !== undefined ? envVars[trimmed] : match;


### PR DESCRIPTION
Fixes found analysing 72h of production usage (152 calls, 18 errors).

## 1. Backend crash (P0) — static tools with no `path`
`interpolateConnectorConfig` calls `interpolateString(endpointMapping.path)`, but a `static` tool's mapping has no `path`. On a connector that has env vars this threw **`Cannot read properties of undefined (reading 'replace')`**, breaking every static tool — e.g. API-Football's `af_analysis_playbook` failed 1/1. `interpolateString` now returns a non-string template unchanged. Regression tests added.

## 2. weclapp adapter descriptions — kills ~10 of the window's 400s
Two business users (purora.at, brandgarage.de) kept hitting `400 unknown property` / `invalid parameter value` because the model guessed field names. Documented the real ones (verified live against weclapp v2):
- `-in`/`-notin` need a **bracketed** list: `id-in=[6501,84566]` (`id-in=6501,84566` → 400).
- Articles have **no** `salesPrice`/`purchasePrice`/`lastPurchasePrice`/`averagePurchasePrice`/`valuationPrice`; prices live in the `articlePrices` and `supplySources` sub-entities.
- Invoices use `salesInvoiceItems` (not `invoiceItems`), `salesInvoiceType` (not `invoiceType`), and have no `currencyName` (`recordCurrencyId` + `*Amount`).

## 3. mailshake_me — 404
Hit `POST /users/me`; the documented endpoint is `GET /me`. Fixed path + method ([Mailshake API docs](https://github.com/colinmathews/mailshake-api-docs/blob/master/index.html)).

## Not in this PR
- **Reddit** (403, static token expires ~1h): the real fix is migrating the connector to OAuth2 (`client_credentials`, which the token service already supports). It's a **breaking change** to a live connector's env vars and needs a credentialed E2E test, so it's handled separately.
- weclapp `401` (a user's token lacks the articles permission) and `404` (nonexistent customer id) are user-side.