### PR TITLE
fix(connectors): retry transient TLS (EPROTO) and 421 proxy failures

### DIFF
--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -436,6 +436,39 @@ describe('RestEngine', () => {
       expect(mockedAxios).toHaveBeenCalledTimes(2);
     });
 
+    // A web-unblocker proxy answers 421 when its own upstream TLS handshake to
+    // the origin fails, so the origin never processed the request.
+    it('retries on 421 (misdirected request, e.g. proxy upstream TLS failure)', async () => {
+      mockedAxios
+        .mockRejectedValueOnce(err(421))
+        .mockResolvedValueOnce({ data: { ok: true } });
+
+      const result = await engine.execute(
+        { baseUrl: 'https://api.example.com', authType: 'NONE' },
+        { method: 'GET', path: '/' },
+        {},
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(mockedAxios).toHaveBeenCalledTimes(2);
+    });
+
+    // TLS alert while writing — the request never reached the application.
+    it('retries on a TLS-level error (EPROTO)', async () => {
+      mockedAxios
+        .mockRejectedValueOnce(err(undefined, 'EPROTO'))
+        .mockResolvedValueOnce({ data: { ok: true } });
+
+      const result = await engine.execute(
+        { baseUrl: 'https://api.example.com', authType: 'NONE' },
+        { method: 'GET', path: '/' },
+        {},
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(mockedAxios).toHaveBeenCalledTimes(2);
+    });
+
     it('does NOT retry on a 400 client error', async () => {
       mockedAxios.mockRejectedValue(err(400));
 

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -247,16 +247,30 @@ export class RestEngine {
   /**
    * Whether an error is a transient failure worth retrying. We only retry on
    * signals that strongly imply the origin did NOT process the request:
-   * 429/502/503/504 responses, or connection-level failures with no response.
-   * This keeps non-idempotent writes safe (a 500 is never retried).
+   * 421/429/502/503/504 responses, or connection-level failures with no
+   * response. This keeps non-idempotent writes safe (a 500 is never retried).
+   *
+   * 421 (Misdirected Request) means the request reached a server that could not
+   * produce a response for the target — RFC 9110 explicitly allows retrying it
+   * on a different connection. Our web-unblocker proxy returns it when its own
+   * upstream TLS handshake to the origin fails, so the origin never saw the
+   * request.
+   *
+   * EPROTO is a TLS-level failure while writing (e.g. the origin or an
+   * intermediary aborts the handshake with an alert). Like the other codes
+   * here, the request never reached the application, so a retry is safe.
    */
   private isTransientError(error: unknown): boolean {
     if (!(error instanceof AxiosError)) return false;
     const status = error.response?.status;
-    if (status) return [429, 502, 503, 504].includes(status);
-    return ['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'ECONNABORTED'].includes(
-      error.code ?? '',
-    );
+    if (status) return [421, 429, 502, 503, 504].includes(status);
+    return [
+      'ECONNRESET',
+      'ETIMEDOUT',
+      'EAI_AGAIN',
+      'ECONNABORTED',
+      'EPROTO',
+    ].includes(error.code ?? '');
   }
 
   /** Execute the request with a small bounded backoff on transient errors. */


### PR DESCRIPTION
## What
Add `421` and `EPROTO` to the REST engine's transient-error retry policy.

## Why
A paying customer's ERP connector failed **27 consecutive calls** with `write EPROTO … tlsv1 alert internal error`, then later with `421 Misdirected Request` from the web-unblocker proxy. Neither was retried, so every transient hiccup surfaced as a hard tool failure — the customer stopped using the product two days after paying.

Both signals satisfy the policy's existing safety criterion (*"the origin did NOT process the request"*, which keeps non-idempotent writes safe):

- **421** — RFC 9110 explicitly permits retrying on a different connection. Our unblocker proxy returns it when its **own** upstream TLS handshake to the origin fails, so the origin never saw the request.
- **EPROTO** — TLS alert while writing; the request never reached the application.

## Verification
Tested against the live origin from the cloud droplet — **both direct and proxied requests succeed** (`401`, i.e. TLS fine, auth intentionally omitted), confirming the failures were transient rather than a broken configuration. So the retry would have recovered them.

Added two regression tests; `rest.engine.spec.ts` passes 29/29.