### PR TITLE
feat(mcp): tool annotations + caller-context variables (v0.3.7)

### DIFF
--- a/docs/tool-definition.md
+++ b/docs/tool-definition.md
@@ -178,6 +178,116 @@ This filters the response to only include the specified fields, reducing token u
 
 ---
 
+## 4. Tool Annotations (Optional)
+
+Annotations are the [MCP spec's](https://modelcontextprotocol.io/specification) advisory hints that let an
+agent reason about a tool *before* calling it — above all whether it can change anything. An agent that
+knows a tool is read-only will probe it freely instead of asking for confirmation.
+
+| Hint | Spec default | Meaning |
+|---|---|---|
+| `title` | — | Human-readable title for display |
+| `readOnlyHint` | `false` | The tool does not modify its environment |
+| `destructiveHint` | `true` | The write removes/overwrites rather than only adding. Meaningful only when `readOnlyHint` is false |
+| `idempotentHint` | `false` | Repeating the call with the same arguments changes nothing further. Meaningful only when `readOnlyHint` is false |
+| `openWorldHint` | `true` | Interacts with an external system of unbounded scope |
+
+> Annotations are hints, not access control. The spec states clients must never make trust decisions based
+> on them. Real enforcement stays in roles and per-tool access.
+
+### Derived automatically
+
+You normally do not set these. AnythingMCP derives them from what the connector already declares:
+
+| Connector | Signal | Result |
+|---|---|---|
+| REST | `GET` / `HEAD` / `OPTIONS` | `readOnlyHint: true` |
+| REST | `POST` | write, additive, non-idempotent |
+| REST | `PUT` / `DELETE` | write, destructive, idempotent |
+| REST | `PATCH` | write, destructive, non-idempotent |
+| GraphQL | `query` / `mutation` | read-only / write |
+| Database | connector `readOnly` flag, or `SELECT` vs `INSERT`/`UPDATE`/`DELETE` in the statement | read-only / write; always `openWorldHint: false` |
+| Database | `static` method | read-only |
+| SOAP | operation name only | never asserts read-only; flags a clearly-named destructive op |
+| MCP bridge | the upstream server's own annotations | passed through verbatim |
+
+An unambiguous tool name (`delete_…`, `create_…`) refines `destructiveHint`, but **name heuristics never
+assert `readOnlyHint`**: wrongly claiming read-only would invite an agent to call a mutating tool freely,
+whereas omitting the hint only makes it more careful.
+
+### Overriding
+
+The one case the derivation cannot solve is a **read-only endpoint exposed over `POST`** — very common for
+search APIs, and indistinguishable from a write at the protocol level. Fix it per tool, in the UI via the
+tool's **Hints** button, or over the API:
+
+```bash
+# Mark a POST-based search as read-only
+curl -X PATCH .../api/connectors/<connectorId>/tools/<toolId>/annotations \
+  -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' \
+  -d '{"annotations": {"readOnlyHint": true}}'
+
+# Inspect derived vs override vs effective
+curl .../api/connectors/<connectorId>/tools/<toolId>/annotations -H 'Authorization: Bearer <token>'
+
+# Drop the override, go back to derived
+curl -X PATCH .../api/connectors/<connectorId>/tools/<toolId>/annotations \
+  -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' \
+  -d '{"annotations": null}'
+```
+
+An override survives a re-import. Annotations coming from an *upstream MCP server* are refreshed on
+re-import, since that server is authoritative about its own tools.
+
+---
+
+## 5. Caller-Context Variables (`{{amcp.*}}`)
+
+Connectors often front a **service**-based API while users authenticate to AnythingMCP individually (OAuth,
+per-user MCP API keys). The target system then only ever sees the service identity and cannot record who
+actually asked. These reserved variables forward the calling identity so it can — in headers, query
+parameters, the body, or the path:
+
+```json
+{
+  "method": "POST",
+  "path": "/tickets",
+  "headers": {
+    "X-Requested-By": "{{amcp.user_email}}"
+  },
+  "bodyMapping": {
+    "subject": "$subject",
+    "requestedBy": "{{amcp.user_email}}"
+  }
+}
+```
+
+| Variable | Value |
+|---|---|
+| `{{amcp.user_email}}` | E-mail of the calling user |
+| `{{amcp.user_id}}` | Internal user id |
+| `{{amcp.org_id}}` | Workspace (organization) id |
+| `{{amcp.server_id}}` | Id of the MCP server that exposed the tool |
+| `{{amcp.server_name}}` | Name of that MCP server |
+| `{{amcp.auth_method}}` | `jwt`, `mcp_api_key`, `static_api_key`, `static_bearer` or `none` |
+| `{{amcp.api_key_name}}` | Name of the MCP API key used, when applicable |
+
+Behaviour worth knowing:
+
+- **Opt-in.** Nothing is forwarded unless you write the variable somewhere. Identity is personal data, so it
+  is never attached automatically.
+- **Not always available.** Identity exists for OAuth and per-user MCP API keys. With an instance-wide static
+  API key or bearer token, and in anonymous mode, there is no user — the variable resolves to an **empty
+  string** rather than leaking a literal `{{amcp.…}}` to the target.
+- **Non-spoofable.** The values are resolved server-side from the authenticated request and merged *after*
+  connector env vars, so neither a workspace variable nor a tool argument can shadow them.
+- **Typos are rejected** when you save the tool, since at runtime an unknown reserved variable would silently
+  resolve to empty.
+- These variables apply to `baseUrl`, connector headers and the endpoint mapping. They are **not** substituted
+  inside `authConfig`.
+
+---
+
 ## Full Tool Example
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/prisma/migrations/20260725120000_add_tool_annotations/migration.sql
+++ b/packages/backend/prisma/migrations/20260725120000_add_tool_annotations/migration.sql
@@ -1,0 +1,6 @@
+-- Explicit MCP tool annotations (spec: ToolAnnotations). NULL = derive the
+-- hints from the connector (HTTP verb, query/mutation, readOnly flag, SQL text).
+-- Populated by an admin override — required for read-only endpoints exposed
+-- over POST, which no heuristic can detect — or captured from an upstream MCP
+-- server, whose own annotations are authoritative.
+ALTER TABLE "mcp_tools" ADD COLUMN "annotations" JSONB;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -414,6 +414,14 @@ model McpTool {
   //   fields: [...]
   // }
 
+  // Explicit MCP tool annotations (spec: ToolAnnotations). Null = derive them
+  // from the connector (HTTP verb, query/mutation, readOnly flag, SQL text).
+  // Set either by an admin override — needed for read-only endpoints that are
+  // exposed over POST, which no heuristic can detect — or captured from an
+  // upstream MCP server, whose own annotations are authoritative.
+  // { title?, readOnlyHint?, destructiveHint?, idempotentHint?, openWorldHint? }
+  annotations Json?
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/packages/backend/src/common/caller-context.util.spec.ts
+++ b/packages/backend/src/common/caller-context.util.spec.ts
@@ -179,4 +179,26 @@ describe('findUnknownCallerContextVars', () => {
       findUnknownCallerContextVars(['{{amcp.x}}', '{{amcp.x}}']),
     ).toEqual(['amcp.x']);
   });
+
+  it('stays linear on adversarial brace runs', () => {
+    // A looser pattern backtracks polynomially here (ReDoS). This scans
+    // operator-supplied tool config, so it must not be exploitable.
+    const evil = '{{{{'.repeat(20000);
+    const started = Date.now();
+    expect(findUnknownCallerContextVars(evil)).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('tolerates unterminated placeholders', () => {
+    expect(findUnknownCallerContextVars('{{amcp.user_email')).toEqual([]);
+  });
+});
+
+describe('usesCallerContext repeated calls', () => {
+  it('is stateless across calls', () => {
+    // A /g regex reused with .test() would alternate true/false.
+    const v = '{{amcp.user_email}}';
+    expect(usesCallerContext(v)).toBe(true);
+    expect(usesCallerContext(v)).toBe(true);
+  });
 });

--- a/packages/backend/src/common/caller-context.util.spec.ts
+++ b/packages/backend/src/common/caller-context.util.spec.ts
@@ -1,0 +1,182 @@
+import {
+  CALLER_CONTEXT_PREFIX,
+  CALLER_CONTEXT_VARIABLES,
+  buildCallerContextVars,
+  findUnknownCallerContextVars,
+  usesCallerContext,
+} from './caller-context.util';
+import {
+  interpolateConnectorConfig,
+  interpolateDeep,
+  interpolateString,
+} from './env-interpolation.util';
+
+const opts = { reservedPrefix: CALLER_CONTEXT_PREFIX };
+
+const context = {
+  userId: 'usr_1',
+  userEmail: 'dominik@example.com',
+  organizationId: 'org_1',
+  mcpServerId: 'srv_1',
+  mcpServerName: 'Prod',
+  authMethod: 'jwt',
+  apiKeyName: undefined,
+};
+
+describe('buildCallerContextVars', () => {
+  it('exposes the caller identity', () => {
+    const vars = buildCallerContextVars(context);
+    expect(vars['amcp.user_email']).toBe('dominik@example.com');
+    expect(vars['amcp.user_id']).toBe('usr_1');
+    expect(vars['amcp.org_id']).toBe('org_1');
+    expect(vars['amcp.server_id']).toBe('srv_1');
+    expect(vars['amcp.auth_method']).toBe('jwt');
+  });
+
+  it('defines every documented variable even with no context at all', () => {
+    // Instance-wide static credentials and anonymous mode carry no identity;
+    // the variables must still resolve so no placeholder reaches the target.
+    const vars = buildCallerContextVars(undefined);
+    for (const key of Object.keys(CALLER_CONTEXT_VARIABLES)) {
+      expect(vars[key]).toBe('');
+    }
+  });
+
+  it('resolves a missing single field to an empty string', () => {
+    expect(buildCallerContextVars(context)['amcp.api_key_name']).toBe('');
+  });
+});
+
+describe('interpolation of reserved variables', () => {
+  it('substitutes the caller e-mail into a header value', () => {
+    expect(
+      interpolateString(
+        'user={{amcp.user_email}}',
+        buildCallerContextVars(context),
+        opts,
+      ),
+    ).toBe('user=dominik@example.com');
+  });
+
+  it('tolerates surrounding whitespace in the placeholder', () => {
+    expect(
+      interpolateString('{{ amcp.user_id }}', buildCallerContextVars(context), opts),
+    ).toBe('usr_1');
+  });
+
+  it('resolves an unavailable value to empty rather than leaking the placeholder', () => {
+    expect(
+      interpolateString('u={{amcp.user_email}}', buildCallerContextVars(undefined), opts),
+    ).toBe('u=');
+  });
+
+  it('blanks an unknown reserved variable instead of sending braces downstream', () => {
+    expect(
+      interpolateString('x={{amcp.typo}}', buildCallerContextVars(context), opts),
+    ).toBe('x=');
+  });
+
+  it('still leaves a non-reserved unknown variable untouched', () => {
+    expect(interpolateString('{{NOT_SET}}', {}, opts)).toBe('{{NOT_SET}}');
+  });
+
+  it('substitutes inside nested structures', () => {
+    expect(
+      interpolateDeep(
+        { audit: { by: '{{amcp.user_email}}' }, tags: ['{{amcp.org_id}}'] },
+        buildCallerContextVars(context),
+        opts,
+      ),
+    ).toEqual({ audit: { by: 'dominik@example.com' }, tags: ['org_1'] });
+  });
+
+  it('cannot be shadowed by a workspace env var', () => {
+    // Reserved values are merged last precisely so a connector variable (which
+    // a workspace admin controls) cannot spoof the caller identity.
+    const vars = {
+      'amcp.user_email': 'attacker@evil.test',
+      ...buildCallerContextVars(context),
+    };
+    expect(interpolateString('{{amcp.user_email}}', vars, opts)).toBe(
+      'dominik@example.com',
+    );
+  });
+
+  it('reaches headers, query params, body and path via the connector config', () => {
+    const result = interpolateConnectorConfig(
+      { baseUrl: 'https://api.test', headers: { 'X-By': '{{amcp.user_email}}' } },
+      {
+        method: 'POST',
+        path: '/orgs/{{amcp.org_id}}/items',
+        queryParams: { actor: '{{amcp.user_id}}' },
+        bodyMapping: { requestedBy: '{{amcp.user_email}}' },
+        headers: { 'X-Server': '{{amcp.server_name}}' },
+      },
+      { ...buildCallerContextVars(context) },
+      opts,
+    );
+    expect(result.config.headers).toEqual({ 'X-By': 'dominik@example.com' });
+    expect(result.endpointMapping.path).toBe('/orgs/org_1/items');
+    expect(result.endpointMapping.queryParams).toEqual({ actor: 'usr_1' });
+    expect(result.endpointMapping.bodyMapping).toEqual({
+      requestedBy: 'dominik@example.com',
+    });
+    expect(result.endpointMapping.headers).toEqual({ 'X-Server': 'Prod' });
+  });
+
+  it('applies reserved vars even when the connector has no env vars', () => {
+    const result = interpolateConnectorConfig(
+      { baseUrl: 'https://api.test', headers: { 'X-By': '{{amcp.user_id}}' } },
+      { method: 'GET', path: '/x' },
+      buildCallerContextVars(context),
+      opts,
+    );
+    expect(result.config.headers).toEqual({ 'X-By': 'usr_1' });
+  });
+
+  it('leaves values alone when the feature is not used', () => {
+    const result = interpolateConnectorConfig(
+      { baseUrl: 'https://api.test', headers: { 'X-Static': 'plain' } },
+      { method: 'GET', path: '/x' },
+      buildCallerContextVars(context),
+      opts,
+    );
+    expect(result.config.headers).toEqual({ 'X-Static': 'plain' });
+    expect(result.endpointMapping.path).toBe('/x');
+  });
+});
+
+describe('usesCallerContext', () => {
+  it('detects a reference', () => {
+    expect(usesCallerContext('{{amcp.user_email}}')).toBe(true);
+    expect(usesCallerContext('{{ amcp.user_id }}')).toBe(true);
+  });
+
+  it('ignores ordinary variables and non-strings', () => {
+    expect(usesCallerContext('{{API_KEY}}')).toBe(false);
+    expect(usesCallerContext(42)).toBe(false);
+  });
+});
+
+describe('findUnknownCallerContextVars', () => {
+  it('finds typos so a bad config can be rejected at save time', () => {
+    expect(
+      findUnknownCallerContextVars({ h: { a: '{{amcp.user_mail}}' } }),
+    ).toEqual(['amcp.user_mail']);
+  });
+
+  it('accepts every documented variable', () => {
+    const template = Object.keys(CALLER_CONTEXT_VARIABLES).map((k) => `{{${k}}}`);
+    expect(findUnknownCallerContextVars(template)).toEqual([]);
+  });
+
+  it('ignores non-reserved variables', () => {
+    expect(findUnknownCallerContextVars('{{ANYTHING}}')).toEqual([]);
+  });
+
+  it('deduplicates repeated typos', () => {
+    expect(
+      findUnknownCallerContextVars(['{{amcp.x}}', '{{amcp.x}}']),
+    ).toEqual(['amcp.x']);
+  });
+});

--- a/packages/backend/src/common/caller-context.util.ts
+++ b/packages/backend/src/common/caller-context.util.ts
@@ -23,6 +23,16 @@
 /** Prefix marking the reserved, server-resolved namespace. */
 export const CALLER_CONTEXT_PREFIX = 'amcp.';
 
+/**
+ * Matches a reference to a reserved variable, e.g. `{{ amcp.user_email }}`.
+ *
+ * Every quantifier here spans a character class disjoint from what follows it
+ * (`\s`, then non-space/non-brace, then `\s`, then `}}`), so matching is linear.
+ * A looser `\{\{([^}]+)\}\}` would backtrack polynomially on input like
+ * `{{{{{{…` — a ReDoS, and this runs on operator-supplied tool config.
+ */
+const RESERVED_VAR_PATTERN = /\{\{\s*(amcp\.[^{}\s]*)\s*\}\}/g;
+
 /** Identity/context of the MCP caller, as resolved by the auth guard. */
 export interface CallerContext {
   userId?: string;
@@ -67,10 +77,9 @@ export function buildCallerContextVars(
 
 /** True when the string references at least one reserved variable. */
 export function usesCallerContext(value: unknown): boolean {
-  return (
-    typeof value === 'string' &&
-    new RegExp(`\\{\\{\\s*${CALLER_CONTEXT_PREFIX.replace('.', '\\.')}`).test(value)
-  );
+  // Deliberately not RESERVED_VAR_PATTERN: that one is /g, so .test() would
+  // advance lastIndex and make repeated calls return alternating results.
+  return typeof value === 'string' && /\{\{\s*amcp\./.test(value);
 }
 
 /**
@@ -82,14 +91,9 @@ export function findUnknownCallerContextVars(value: unknown): string[] {
   const found = new Set<string>();
   const walk = (node: unknown) => {
     if (typeof node === 'string') {
-      for (const match of node.matchAll(/\{\{([^}]+)\}\}/g)) {
-        const key = match[1].trim();
-        if (
-          key.startsWith(CALLER_CONTEXT_PREFIX) &&
-          !(key in CALLER_CONTEXT_VARIABLES)
-        ) {
-          found.add(key);
-        }
+      for (const match of node.matchAll(RESERVED_VAR_PATTERN)) {
+        const key = match[1];
+        if (!(key in CALLER_CONTEXT_VARIABLES)) found.add(key);
       }
       return;
     }

--- a/packages/backend/src/common/caller-context.util.ts
+++ b/packages/backend/src/common/caller-context.util.ts
@@ -1,0 +1,106 @@
+/**
+ * Caller-context variables — `{{amcp.*}}`.
+ *
+ * Connectors often sit in front of *service*-based APIs while users authenticate
+ * to AnythingMCP individually (OAuth, per-user MCP API keys). Without this, the
+ * target system only ever sees the service identity and cannot record who
+ * actually asked. These variables let an operator forward the calling identity
+ * explicitly, e.g. a header `X-Requested-By: {{amcp.user_email}}`.
+ *
+ * Design constraints:
+ *  - RESERVED and non-overridable: the values are resolved server-side from the
+ *    authenticated request, and are merged *after* connector env vars so a
+ *    workspace variable (or a tool argument) can never spoof an identity.
+ *  - OPT-IN: nothing is forwarded unless the operator writes the variable into a
+ *    header/query/body. Identity is personal data, so silently attaching it to
+ *    every outbound request would be wrong (and a GDPR problem).
+ *  - ALWAYS DEFINED: an unavailable value resolves to an empty string rather
+ *    than leaking a literal `{{amcp.…}}` to the target. Identity is absent for
+ *    instance-wide static credentials and in anonymous mode; it is present for
+ *    OAuth and per-user API keys.
+ */
+
+/** Prefix marking the reserved, server-resolved namespace. */
+export const CALLER_CONTEXT_PREFIX = 'amcp.';
+
+/** Identity/context of the MCP caller, as resolved by the auth guard. */
+export interface CallerContext {
+  userId?: string;
+  userEmail?: string;
+  organizationId?: string;
+  mcpServerId?: string;
+  mcpServerName?: string;
+  authMethod?: string;
+  apiKeyName?: string;
+}
+
+/** Every supported variable, with the doc string surfaced in the UI/API. */
+export const CALLER_CONTEXT_VARIABLES: Record<string, string> = {
+  'amcp.user_email':
+    'E-mail of the calling user. Empty for instance-wide static credentials and anonymous access.',
+  'amcp.user_id': 'Internal id of the calling user.',
+  'amcp.org_id': 'Id of the workspace (organization) the call belongs to.',
+  'amcp.server_id': 'Id of the MCP server that exposed the tool.',
+  'amcp.server_name': 'Name of the MCP server that exposed the tool.',
+  'amcp.auth_method':
+    'How the caller authenticated: jwt, mcp_api_key, static_api_key, static_bearer or none.',
+  'amcp.api_key_name': 'Name of the MCP API key used, when the caller used one.',
+};
+
+/**
+ * Build the reserved variable map. Every known key is always present so a
+ * missing identity yields an empty value instead of an unresolved placeholder.
+ */
+export function buildCallerContextVars(
+  context?: CallerContext,
+): Record<string, string> {
+  return {
+    'amcp.user_email': context?.userEmail ?? '',
+    'amcp.user_id': context?.userId ?? '',
+    'amcp.org_id': context?.organizationId ?? '',
+    'amcp.server_id': context?.mcpServerId ?? '',
+    'amcp.server_name': context?.mcpServerName ?? '',
+    'amcp.auth_method': context?.authMethod ?? '',
+    'amcp.api_key_name': context?.apiKeyName ?? '',
+  };
+}
+
+/** True when the string references at least one reserved variable. */
+export function usesCallerContext(value: unknown): boolean {
+  return (
+    typeof value === 'string' &&
+    new RegExp(`\\{\\{\\s*${CALLER_CONTEXT_PREFIX.replace('.', '\\.')}`).test(value)
+  );
+}
+
+/**
+ * Reserved variables referenced by a value (recursively) that are not
+ * recognised — i.e. typos. Callers use this to reject a bad configuration at
+ * save time, since at runtime they resolve to empty.
+ */
+export function findUnknownCallerContextVars(value: unknown): string[] {
+  const found = new Set<string>();
+  const walk = (node: unknown) => {
+    if (typeof node === 'string') {
+      for (const match of node.matchAll(/\{\{([^}]+)\}\}/g)) {
+        const key = match[1].trim();
+        if (
+          key.startsWith(CALLER_CONTEXT_PREFIX) &&
+          !(key in CALLER_CONTEXT_VARIABLES)
+        ) {
+          found.add(key);
+        }
+      }
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      Object.values(node).forEach(walk);
+    }
+  };
+  walk(value);
+  return [...found];
+}

--- a/packages/backend/src/common/env-interpolation.util.ts
+++ b/packages/backend/src/common/env-interpolation.util.ts
@@ -12,20 +12,37 @@
 
 const VAR_PATTERN = /\{\{([^}]+)\}\}/g;
 
+export interface InterpolateOptions {
+  /**
+   * Namespace prefix (e.g. `amcp.`) whose variables are resolved by the server
+   * rather than by the workspace. A variable under this prefix that has no
+   * value resolves to an empty string instead of being left verbatim, so an
+   * unresolved placeholder is never sent to the target system.
+   */
+  reservedPrefix?: string;
+}
+
 /**
  * Interpolate {{VAR}} patterns in a string.
+ *
+ * An unknown variable is left as-is (so a stray `{{` in a template survives) —
+ * except under `reservedPrefix`, which always resolves.
  */
 export function interpolateString(
   template: string,
   envVars: Record<string, string>,
+  options?: InterpolateOptions,
 ): string {
   // Callers pass optional fields (e.g. a static tool's endpointMapping has no
   // `path`). Guard against a non-string template so interpolation never throws
   // "Cannot read properties of undefined (reading 'replace')".
   if (typeof template !== 'string') return template;
+  const reservedPrefix = options?.reservedPrefix;
   return template.replace(VAR_PATTERN, (match, varName) => {
     const trimmed = varName.trim();
-    return envVars[trimmed] !== undefined ? envVars[trimmed] : match;
+    if (envVars[trimmed] !== undefined) return envVars[trimmed];
+    if (reservedPrefix && trimmed.startsWith(reservedPrefix)) return '';
+    return match;
   });
 }
 
@@ -36,21 +53,29 @@ export function interpolateString(
 export function interpolateDeep<T>(
   value: T,
   envVars: Record<string, string>,
+  options?: InterpolateOptions,
 ): T {
-  if (!envVars || Object.keys(envVars).length === 0) return value;
+  if (
+    (!envVars || Object.keys(envVars).length === 0) &&
+    !options?.reservedPrefix
+  ) {
+    return value;
+  }
 
   if (typeof value === 'string') {
-    return interpolateString(value, envVars) as unknown as T;
+    return interpolateString(value, envVars, options) as unknown as T;
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => interpolateDeep(item, envVars)) as unknown as T;
+    return value.map((item) =>
+      interpolateDeep(item, envVars, options),
+    ) as unknown as T;
   }
 
   if (value !== null && typeof value === 'object') {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = interpolateDeep(val, envVars);
+      result[key] = interpolateDeep(val, envVars, options);
     }
     return result as T;
   }
@@ -61,6 +86,10 @@ export function interpolateDeep<T>(
 /**
  * Interpolate connector config fields with env vars.
  * Applies to: baseUrl, headers, endpointMapping (path, queryParams, bodyMapping, headers).
+ *
+ * `options.reservedPrefix` enables the server-resolved namespace (see
+ * caller-context.util.ts). Reserved values must already be merged into
+ * `envVars` *after* the workspace's own vars so they cannot be shadowed.
  */
 export function interpolateConnectorConfig(
   config: {
@@ -75,33 +104,37 @@ export function interpolateConnectorConfig(
     headers?: Record<string, string>;
   },
   envVars: Record<string, string>,
+  options?: InterpolateOptions,
 ): {
   config: { baseUrl: string; headers?: Record<string, string> };
   endpointMapping: typeof endpointMapping;
 } {
-  if (!envVars || Object.keys(envVars).length === 0) {
+  if (
+    (!envVars || Object.keys(envVars).length === 0) &&
+    !options?.reservedPrefix
+  ) {
     return { config, endpointMapping };
   }
 
   return {
     config: {
       ...config,
-      baseUrl: interpolateString(config.baseUrl, envVars),
+      baseUrl: interpolateString(config.baseUrl, envVars, options),
       headers: config.headers
-        ? interpolateDeep(config.headers, envVars)
+        ? interpolateDeep(config.headers, envVars, options)
         : undefined,
     },
     endpointMapping: {
       ...endpointMapping,
-      path: interpolateString(endpointMapping.path, envVars),
+      path: interpolateString(endpointMapping.path, envVars, options),
       queryParams: endpointMapping.queryParams
-        ? interpolateDeep(endpointMapping.queryParams, envVars)
+        ? interpolateDeep(endpointMapping.queryParams, envVars, options)
         : undefined,
       bodyMapping: endpointMapping.bodyMapping
-        ? interpolateDeep(endpointMapping.bodyMapping, envVars)
+        ? interpolateDeep(endpointMapping.bodyMapping, envVars, options)
         : undefined,
       headers: endpointMapping.headers
-        ? interpolateDeep(endpointMapping.headers, envVars)
+        ? interpolateDeep(endpointMapping.headers, envVars, options)
         : undefined,
     },
   };

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -781,6 +781,7 @@ export class ConnectorsController {
           path: '/mcp',
         },
         outputSchema: rt.outputSchema ?? null,
+        annotations: rt.annotations ?? null,
       }));
 
       return this.createToolsFromParsed(connector.id, parsedTools);
@@ -1026,6 +1027,7 @@ export class ConnectorsController {
                 path: dto.url || '/mcp',
               },
               outputSchema: rt.outputSchema ?? null,
+              annotations: rt.annotations ?? null,
             });
           }
           break;
@@ -1216,6 +1218,13 @@ export class ConnectorsController {
               tool.outputSchema != null
                 ? (tool.outputSchema as any)
                 : (match.outputSchema as any),
+            // Annotations only arrive from an upstream MCP server, which is
+            // authoritative about its own tools. Every other import path leaves
+            // them untouched so an admin override survives a re-import.
+            annotations:
+              tool.annotations != null
+                ? (tool.annotations as any)
+                : (match.annotations as any),
             operationId: tool.operationId ?? match.operationId,
             deprecatedAt: null,
             // Re-enable if it was disabled only because we'd previously
@@ -1240,6 +1249,7 @@ export class ConnectorsController {
             endpointMapping: tool.endpointMapping as any,
             responseMapping: tool.responseMapping as any,
             outputSchema: (tool.outputSchema ?? null) as any,
+            annotations: (tool.annotations ?? null) as any,
           },
         });
         tools.push(created);

--- a/packages/backend/src/connectors/engines/mcp-client.engine.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.ts
@@ -116,6 +116,7 @@ export class McpClientEngine {
       description: string;
       inputSchema: Record<string, unknown>;
       outputSchema?: Record<string, unknown>;
+      annotations?: Record<string, unknown>;
     }>
   > {
     const mcpUrl = new URL(config.mcpPath || '/mcp', config.baseUrl);
@@ -147,6 +148,11 @@ export class McpClientEngine {
         },
         ...(tool.outputSchema
           ? { outputSchema: tool.outputSchema as Record<string, unknown> }
+          : {}),
+        // The upstream server knows its own tools' semantics better than any
+        // heuristic of ours, so carry its annotations through verbatim.
+        ...(tool.annotations
+          ? { annotations: tool.annotations as Record<string, unknown> }
           : {}),
       }));
     } finally {

--- a/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
+++ b/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
@@ -129,6 +129,8 @@ export class McpOAuthCallbackController {
                   method: rt.name,
                   path: '/mcp',
                 } as any,
+                // The upstream server is authoritative about its own tools.
+                annotations: (rt.annotations ?? null) as any,
               },
             });
             toolsImported++;

--- a/packages/backend/src/connectors/tools.controller.ts
+++ b/packages/backend/src/connectors/tools.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   UseGuards,
   ForbiddenException,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -27,6 +28,15 @@ import { McpServerService } from '../mcp-server/mcp-server.service';
 import { ConnectorsService } from './connectors.service';
 import { inferJsonSchema } from './output-schema.util';
 import { classifyToolExecutionError } from './connector-error.util';
+import {
+  ToolAnnotations,
+  deriveToolAnnotations,
+  parseAnnotationsOverride,
+} from '../mcp-server/tool-annotations';
+import {
+  CALLER_CONTEXT_VARIABLES,
+  findUnknownCallerContextVars,
+} from '../common/caller-context.util';
 
 class CreateToolDto {
   @ApiProperty({
@@ -133,6 +143,24 @@ class BulkCreateToolsDto {
   tools: CreateToolDto[];
 }
 
+class SetToolAnnotationsDto {
+  @ApiPropertyOptional({
+    description:
+      'MCP tool annotations to advertise for this tool, overriding the values ' +
+      'derived from the connector. Allowed keys: title, readOnlyHint, ' +
+      'destructiveHint, idempotentHint, openWorldHint. Send null to drop the ' +
+      'override and go back to the derived values. Typical use: marking a ' +
+      'search endpoint that is exposed over POST as readOnlyHint=true.',
+    type: 'object',
+    additionalProperties: true,
+    nullable: true,
+    example: { readOnlyHint: true },
+  })
+  @IsOptional()
+  @IsObject()
+  annotations?: Record<string, unknown> | null;
+}
+
 class SetToolProxyDto {
   @ApiProperty({
     description:
@@ -193,6 +221,22 @@ export class ToolsController {
     if (connector.userId !== req.user.sub && req.user.role !== 'ADMIN') {
       throw new ForbiddenException('Only the connector owner or an admin can modify this resource');
     }
+    return connector;
+  }
+
+  /**
+   * Reject a typo'd reserved variable (e.g. `{{amcp.user_mail}}`) at save time.
+   * At runtime these resolve to an empty string on purpose — so without this
+   * check a misspelling would silently forward nothing.
+   */
+  private assertKnownCallerContextVars(endpointMapping: unknown) {
+    const unknown = findUnknownCallerContextVars(endpointMapping);
+    if (unknown.length > 0) {
+      throw new BadRequestException(
+        `Unknown caller-context variable(s): ${unknown.join(', ')}. ` +
+          `Available: ${Object.keys(CALLER_CONTEXT_VARIABLES).join(', ')}.`,
+      );
+    }
   }
 
   @Get()
@@ -213,6 +257,7 @@ export class ToolsController {
     @Body() dto: CreateToolDto,
   ) {
     await this.assertCanWriteConnector(connectorId, req);
+    this.assertKnownCallerContextVars(dto.endpointMapping);
     const tool = await this.prisma.mcpTool.create({
       data: {
         connectorId,
@@ -290,6 +335,9 @@ export class ToolsController {
     @Body() dto: UpdateToolDto,
   ) {
     await this.assertCanWriteConnector(connectorId, req);
+    if (dto.endpointMapping !== undefined) {
+      this.assertKnownCallerContextVars(dto.endpointMapping);
+    }
     // Bind the toolId to the connectorId in the WHERE clause so that
     // a request like /connectors/<my>/tools/<other-org's-tool> cannot
     // update a tool that doesn't belong to the requested connector.
@@ -303,6 +351,97 @@ export class ToolsController {
 
     await this.mcpServer.reloadConnectorTools(connectorId);
     return this.prisma.mcpTool.findUnique({ where: { id: toolId } });
+  }
+
+  @Get(':toolId/annotations')
+  @ApiOperation({
+    summary: 'Get the MCP annotations advertised for a tool',
+    description:
+      'Returns `derived` (inferred from the connector: HTTP verb, ' +
+      'query/mutation, readOnly flag, SQL text), `override` (the stored ' +
+      'explicit value, if any) and `effective` (what MCP clients actually ' +
+      'see). Also lists the supported keys.',
+  })
+  async getAnnotations(
+    @Req() req: any,
+    @Param('toolId') toolId: string,
+    @Param('connectorId') connectorId: string,
+  ) {
+    const connector = await this.assertCanWriteConnector(connectorId, req);
+    const tool = await this.prisma.mcpTool.findFirst({
+      where: { id: toolId, connectorId },
+    });
+    if (!tool) throw new ForbiddenException('Tool not found');
+
+    const source = {
+      name: tool.name,
+      connectorType: (connector as { type: string }).type,
+      endpointMapping: tool.endpointMapping as { method?: string; path?: string },
+      connectorConfig: {
+        config: (connector as { config?: Record<string, unknown> | null }).config,
+      },
+    };
+    return {
+      derived: deriveToolAnnotations(source),
+      override: (tool.annotations as Record<string, unknown> | null) ?? null,
+      effective: deriveToolAnnotations({ ...source, annotations: tool.annotations }),
+      supportedKeys: [
+        'title',
+        'readOnlyHint',
+        'destructiveHint',
+        'idempotentHint',
+        'openWorldHint',
+      ],
+    };
+  }
+
+  @Patch(':toolId/annotations')
+  @ApiOperation({
+    summary: 'Override the MCP annotations advertised for a tool',
+    description:
+      'Annotations are advisory hints (per the MCP spec, clients must not base ' +
+      'trust decisions on them) that let an agent tell a read-only tool from a ' +
+      'mutating one. They are normally derived from the connector; use this to ' +
+      'correct a case the derivation cannot know — most commonly a read-only ' +
+      'search exposed over POST. Send `annotations: null` to reset to derived.',
+  })
+  async setAnnotations(
+    @Req() req: any,
+    @Param('toolId') toolId: string,
+    @Param('connectorId') connectorId: string,
+    @Body() dto: SetToolAnnotationsDto,
+  ) {
+    const connector = await this.assertCanWriteConnector(connectorId, req);
+
+    let override: ToolAnnotations | null;
+    try {
+      override = parseAnnotationsOverride(dto.annotations ?? null);
+    } catch (err: any) {
+      throw new BadRequestException(err.message);
+    }
+
+    const result = await this.prisma.mcpTool.updateMany({
+      where: { id: toolId, connectorId },
+      data: { annotations: (override ?? null) as any },
+    });
+    if (result.count === 0) {
+      throw new ForbiddenException('Tool not found');
+    }
+
+    await this.mcpServer.reloadConnectorTools(connectorId);
+    const tool = await this.prisma.mcpTool.findUnique({ where: { id: toolId } });
+    return {
+      override,
+      effective: deriveToolAnnotations({
+        name: tool!.name,
+        connectorType: (connector as { type: string }).type,
+        endpointMapping: tool!.endpointMapping as { method?: string; path?: string },
+        connectorConfig: {
+          config: (connector as { config?: Record<string, unknown> | null }).config,
+        },
+        annotations: tool!.annotations,
+      }),
+    };
   }
 
   @Patch(':toolId/proxy')

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -13,6 +13,10 @@ import { LicenseGuardService } from '../license/license-guard.service';
 import { DeploymentService } from '../common/deployment.service';
 import { PrismaService } from '../common/prisma.service';
 import { interpolateConnectorConfig } from '../common/env-interpolation.util';
+import {
+  CALLER_CONTEXT_PREFIX,
+  buildCallerContextVars,
+} from '../common/caller-context.util';
 import { resolveInternalDbRestUrl } from '../common/db-rest.util';
 import { KgService } from '../knowledge-graph/kg.service';
 import type { RegisteredTool } from './tool-registry';
@@ -194,6 +198,14 @@ export class DynamicMcpTools {
     try {
       const envVars = tool.connectorConfig.envVars || {};
 
+      // Reserved {{amcp.*}} caller-context vars are merged AFTER the
+      // workspace's own env vars, so a connector variable can never shadow
+      // (i.e. spoof) the authenticated identity.
+      const interpolationVars = {
+        ...envVars,
+        ...buildCallerContextVars(context),
+      };
+
       // Interpolate {{VAR}} patterns in config and endpoint mapping
       const {
         config: interpolatedConfig,
@@ -204,7 +216,8 @@ export class DynamicMcpTools {
           headers: tool.connectorConfig.headers,
         },
         tool.endpointMapping,
-        envVars,
+        interpolationVars,
+        { reservedPrefix: CALLER_CONTEXT_PREFIX },
       );
 
       // Decide proxy routing (env present + tool opted in + cloud rate-limit).

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -25,6 +25,10 @@ import { RolesService } from '../roles/roles.service';
 import { registerDemoTools } from './mcp-demo.tools';
 import { KgService } from '../knowledge-graph/kg.service';
 import { outputSchemaToZodShape } from '../connectors/output-schema.util';
+import {
+  annotationsSignature,
+  deriveToolAnnotations,
+} from './tool-annotations';
 
 /** Minimal handle returned by McpServer.tool()/registerTool() that we keep so a
  * live (stateful) session can drop a tool when its surface changes. */
@@ -658,11 +662,16 @@ export class McpEndpointController {
         ? outputSchemaToZodShape(tool.outputSchema)
         : null;
 
+      // Advisory hints (readOnlyHint & co) so an agent can tell a probe-safe
+      // tool from a mutating one before calling it.
+      const annotations = deriveToolAnnotations(tool);
+
       const sig = [
         tool.name,
         tool.description,
         Object.keys(zodShape).sort().join(','),
         outShape ? Object.keys(outShape).sort().join(',') : '',
+        annotationsSignature(annotations),
       ].join('');
 
       entries.push({
@@ -700,21 +709,16 @@ export class McpEndpointController {
             return result;
           };
 
-          if (outShape) {
-            return mcpServer.registerTool(
-              tool.name,
-              {
-                description: tool.description,
-                inputSchema: zodShape,
-                outputSchema: outShape,
-              },
-              handler,
-            ) as unknown as ToolHandle;
-          }
-          return mcpServer.tool(
+          // registerTool for both branches: the legacy tool() overload has no
+          // slot for annotations.
+          return mcpServer.registerTool(
             tool.name,
-            tool.description,
-            zodShape,
+            {
+              description: tool.description,
+              inputSchema: zodShape,
+              ...(outShape ? { outputSchema: outShape } : {}),
+              annotations,
+            },
             handler,
           ) as unknown as ToolHandle;
         },
@@ -735,18 +739,27 @@ export class McpEndpointController {
         name: 'kg_how_to_obtain',
         sig: 'kg_how_to_obtain',
         register: (mcpServer: McpServer) =>
-          mcpServer.tool(
+          mcpServer.registerTool(
             'kg_how_to_obtain',
-            'Knowledge graph for THIS MCP server: given an entity or a parameter you need ' +
-              '(e.g. "customer_id", "order", "person"), returns which entities/tools produce ' +
-              'or relate to it across the connectors assigned to this server, plus any ' +
-              'human-written descriptions and the workspace skills (pre-built workflows) you ' +
-              'can use. Relationships are learned from these connectors, real usage, and ' +
-              'curated edits, so you can chain tool calls.',
             {
-              query: z
-                .string()
-                .describe('An entity or parameter name, e.g. "customer_id" or "deal".'),
+              description:
+                'Knowledge graph for THIS MCP server: given an entity or a parameter you need ' +
+                '(e.g. "customer_id", "order", "person"), returns which entities/tools produce ' +
+                'or relate to it across the connectors assigned to this server, plus any ' +
+                'human-written descriptions and the workspace skills (pre-built workflows) you ' +
+                'can use. Relationships are learned from these connectors, real usage, and ' +
+                'curated edits, so you can chain tool calls.',
+              inputSchema: {
+                query: z
+                  .string()
+                  .describe('An entity or parameter name, e.g. "customer_id" or "deal".'),
+              },
+              // Pure lookup over this workspace's own graph.
+              annotations: {
+                title: 'How to obtain',
+                readOnlyHint: true,
+                openWorldHint: false,
+              },
             },
             async (args: { query: string }) => {
               const result = await this.kgService.lookup(orgId, args.query, {

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -12,6 +12,10 @@ import { RolesService } from '../roles/roles.service';
 import { McpServersService } from '../mcp-servers/mcp-servers.service';
 import { McpSessionManager } from '../mcp-servers/mcp-session.manager';
 import { KgStaticService } from '../knowledge-graph/kg-static.service';
+import {
+  ToolAnnotations,
+  deriveToolAnnotations,
+} from './tool-annotations';
 
 @Injectable()
 export class McpServerService implements OnModuleInit {
@@ -81,6 +85,7 @@ export class McpServerService implements OnModuleInit {
             | Record<string, unknown>
             | undefined,
           outputSchema: tool.outputSchema as unknown,
+          annotations: tool.annotations as unknown,
         };
 
         // Register in our internal registry (for execution lookup)
@@ -100,7 +105,12 @@ export class McpServerService implements OnModuleInit {
         // time via getToolForOrg/getTool, so the second+ registration with
         // the same name would just overwrite and emit a warning.
         if (this.toolRegistry.countByName(tool.name) === 1) {
-          this.registerMcpTool(tool.name, tool.description, effectiveSchema);
+          this.registerMcpTool(
+            tool.name,
+            tool.description,
+            effectiveSchema,
+            deriveToolAnnotations(toolDef),
+          );
         }
       }
     }
@@ -152,6 +162,7 @@ export class McpServerService implements OnModuleInit {
             | Record<string, unknown>
             | undefined,
           outputSchema: tool.outputSchema as unknown,
+          annotations: tool.annotations as unknown,
         };
 
         this.toolRegistry.registerTool(toolDef);
@@ -165,7 +176,12 @@ export class McpServerService implements OnModuleInit {
         // single-tenant MCP registry only when this is the first tool
         // with this name across all orgs/connectors.
         if (this.toolRegistry.countByName(tool.name) === 1) {
-          this.registerMcpTool(tool.name, tool.description, effectiveSchema);
+          this.registerMcpTool(
+            tool.name,
+            tool.description,
+            effectiveSchema,
+            deriveToolAnnotations(toolDef),
+          );
         }
       }
     }
@@ -205,6 +221,7 @@ export class McpServerService implements OnModuleInit {
     name: string,
     description: string,
     jsonSchema: Record<string, unknown>,
+    annotations?: ToolAnnotations,
   ): void {
     const zodParams = this.jsonSchemaToZod(jsonSchema);
 
@@ -212,6 +229,7 @@ export class McpServerService implements OnModuleInit {
       name,
       description,
       parameters: zodParams,
+      ...(annotations ? { annotations } : {}),
       handler: async (args: Record<string, unknown>, _context: any, request: any) => {
         // Check role-based tool access if user is identified
         const user = request?.user;

--- a/packages/backend/src/mcp-server/tool-annotations.spec.ts
+++ b/packages/backend/src/mcp-server/tool-annotations.spec.ts
@@ -1,0 +1,304 @@
+import {
+  annotationsSignature,
+  deriveToolAnnotations,
+  parseAnnotationsOverride,
+} from './tool-annotations';
+
+const rest = (method: string, name = 'do_thing') => ({
+  name,
+  connectorType: 'REST',
+  endpointMapping: { method, path: '/x' },
+});
+
+describe('deriveToolAnnotations', () => {
+  describe('REST', () => {
+    it.each(['GET', 'HEAD', 'OPTIONS'])('marks %s read-only', (method) => {
+      expect(deriveToolAnnotations(rest(method)).readOnlyHint).toBe(true);
+    });
+
+    it('does not emit write-only hints for a read-only tool', () => {
+      // destructiveHint/idempotentHint are meaningful only when
+      // readOnlyHint is false; emitting them would be noise.
+      const a = deriveToolAnnotations(rest('GET'));
+      expect(a.destructiveHint).toBeUndefined();
+      expect(a.idempotentHint).toBeUndefined();
+    });
+
+    it('treats POST as an additive, non-idempotent write', () => {
+      expect(deriveToolAnnotations(rest('POST', 'create_invoice'))).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      });
+    });
+
+    it('treats PUT as destructive and idempotent', () => {
+      expect(deriveToolAnnotations(rest('PUT', 'replace_doc'))).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      });
+    });
+
+    it('treats PATCH as destructive but not idempotent', () => {
+      expect(deriveToolAnnotations(rest('PATCH', 'edit_doc'))).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+      });
+    });
+
+    it('treats DELETE as destructive and idempotent', () => {
+      expect(deriveToolAnnotations(rest('DELETE', 'delete_doc'))).toMatchObject({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      });
+    });
+
+    it('lets an unambiguous name correct the verb baseline', () => {
+      // A delete exposed over POST is destructive, not additive.
+      expect(deriveToolAnnotations(rest('POST', 'delete_customer')).destructiveHint).toBe(
+        true,
+      );
+    });
+
+    it('never claims read-only for POST, even when the name reads like a search', () => {
+      // POST /search is extremely common but indistinguishable from a write at
+      // the protocol level. Wrongly asserting read-only would invite an agent
+      // to call a mutating tool freely, so this needs the explicit override.
+      const a = deriveToolAnnotations(rest('POST', 'search_products'));
+      expect(a.readOnlyHint).toBe(false);
+    });
+
+    it('is case-insensitive about the verb', () => {
+      expect(deriveToolAnnotations(rest('get')).readOnlyHint).toBe(true);
+    });
+
+    it('omits read/write hints when the verb is unknown', () => {
+      const a = deriveToolAnnotations(rest('WEIRD', 'neutral_name'));
+      expect(a.readOnlyHint).toBeUndefined();
+    });
+  });
+
+  describe('GraphQL', () => {
+    it('marks a query read-only', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'get_user',
+          connectorType: 'GRAPHQL',
+          endpointMapping: { method: 'query', path: 'query { user }' },
+        }).readOnlyHint,
+      ).toBe(true);
+    });
+
+    it('marks a mutation as a write', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'create_user',
+          connectorType: 'GRAPHQL',
+          endpointMapping: { method: 'mutation', path: 'mutation { x }' },
+        }),
+      ).toMatchObject({ readOnlyHint: false, destructiveHint: false });
+    });
+  });
+
+  describe('DATABASE', () => {
+    it('is a closed world', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'q',
+          connectorType: 'DATABASE',
+          endpointMapping: { method: 'query', path: 'SELECT 1' },
+        }).openWorldHint,
+      ).toBe(false);
+    });
+
+    it('honours the connector-level readOnly flag', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'run_sql',
+          connectorType: 'DATABASE',
+          endpointMapping: { method: 'query', path: 'DELETE FROM t' },
+          connectorConfig: { config: { readOnly: true } },
+        }).readOnlyHint,
+      ).toBe(true);
+    });
+
+    it('detects a SELECT as read-only', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'list_orders',
+          connectorType: 'DATABASE',
+          endpointMapping: { method: 'query', path: '  SELECT * FROM orders' },
+          connectorConfig: { config: { readOnly: false } },
+        }).readOnlyHint,
+      ).toBe(true);
+    });
+
+    it('detects a write statement even inside a CTE', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'archive_orders',
+          connectorType: 'DATABASE',
+          endpointMapping: {
+            method: 'query',
+            path: 'WITH x AS (SELECT 1) INSERT INTO archive SELECT * FROM x',
+          },
+          connectorConfig: { config: { readOnly: false } },
+        }).readOnlyHint,
+      ).toBe(false);
+    });
+
+    it('ignores SQL keywords that only appear in comments', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'list_orders',
+          connectorType: 'DATABASE',
+          endpointMapping: {
+            method: 'query',
+            path: '-- do not delete anything\nSELECT * FROM orders',
+          },
+          connectorConfig: { config: { readOnly: false } },
+        }).readOnlyHint,
+      ).toBe(true);
+    });
+
+    it('marks a static response read-only', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'get_guide',
+          connectorType: 'DATABASE',
+          endpointMapping: { method: 'static', path: '' },
+          connectorConfig: { config: { readOnly: false } },
+        }).readOnlyHint,
+      ).toBe(true);
+    });
+  });
+
+  describe('SOAP and MCP proxy', () => {
+    it('never asserts read-only without verb semantics', () => {
+      const a = deriveToolAnnotations({
+        name: 'GetCustomerDetails',
+        connectorType: 'SOAP',
+        endpointMapping: { method: 'GetCustomerDetails', path: 'Port' },
+      });
+      expect(a.readOnlyHint).toBeUndefined();
+    });
+
+    it('still flags a confidently-named destructive operation', () => {
+      expect(
+        deriveToolAnnotations({
+          name: 'DeleteCustomer',
+          connectorType: 'SOAP',
+          endpointMapping: { method: 'DeleteCustomer', path: 'Port' },
+        }),
+      ).toMatchObject({ readOnlyHint: false, destructiveHint: true });
+    });
+  });
+
+  describe('title', () => {
+    it('humanizes snake_case and camelCase names', () => {
+      expect(deriveToolAnnotations(rest('GET', 'get_customer_orders')).title).toBe(
+        'Get customer orders',
+      );
+      expect(deriveToolAnnotations(rest('GET', 'getCustomerOrders')).title).toBe(
+        'Get customer orders',
+      );
+    });
+  });
+
+  describe('explicit annotations', () => {
+    it('override the derived values', () => {
+      // The POST-search case, fixed by an admin.
+      const a = deriveToolAnnotations({
+        ...rest('POST', 'search_products'),
+        annotations: { readOnlyHint: true },
+      });
+      expect(a.readOnlyHint).toBe(true);
+    });
+
+    it('drop stale write hints when flipping a tool to read-only', () => {
+      const a = deriveToolAnnotations({
+        ...rest('DELETE', 'delete_thing'),
+        annotations: { readOnlyHint: true },
+      });
+      expect(a.destructiveHint).toBeUndefined();
+      expect(a.idempotentHint).toBeUndefined();
+    });
+
+    it('keep derived values for keys the override does not set', () => {
+      const a = deriveToolAnnotations({
+        ...rest('GET', 'get_thing'),
+        annotations: { title: 'Custom title' },
+      });
+      expect(a.title).toBe('Custom title');
+      expect(a.readOnlyHint).toBe(true);
+    });
+
+    it('ignore unknown keys and wrongly-typed values', () => {
+      const a = deriveToolAnnotations({
+        ...rest('GET'),
+        annotations: { bogus: true, readOnlyHint: 'yes' },
+      });
+      expect(a).not.toHaveProperty('bogus');
+      expect(a.readOnlyHint).toBe(true); // derived value survives
+    });
+
+    it('tolerate a non-object stored value', () => {
+      expect(() =>
+        deriveToolAnnotations({ ...rest('GET'), annotations: 'nonsense' }),
+      ).not.toThrow();
+    });
+  });
+});
+
+describe('annotationsSignature', () => {
+  it('changes when a hint changes, so live sessions re-emit tools/list_changed', () => {
+    const a = annotationsSignature(deriveToolAnnotations(rest('GET', 'x')));
+    const b = annotationsSignature(
+      deriveToolAnnotations({ ...rest('GET', 'x'), annotations: { readOnlyHint: false } }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('is stable for equal annotations', () => {
+    expect(annotationsSignature(deriveToolAnnotations(rest('GET', 'x')))).toBe(
+      annotationsSignature(deriveToolAnnotations(rest('GET', 'x'))),
+    );
+  });
+});
+
+describe('parseAnnotationsOverride', () => {
+  it('accepts a valid partial override', () => {
+    expect(parseAnnotationsOverride({ readOnlyHint: true })).toEqual({
+      readOnlyHint: true,
+    });
+  });
+
+  it('returns null for null (reset to derived)', () => {
+    expect(parseAnnotationsOverride(null)).toBeNull();
+  });
+
+  it('returns null when nothing usable was provided', () => {
+    expect(parseAnnotationsOverride({})).toBeNull();
+  });
+
+  it('rejects unknown keys', () => {
+    expect(() => parseAnnotationsOverride({ readOnly: true })).toThrow(
+      /Unknown annotation keys/,
+    );
+  });
+
+  it('rejects wrong types', () => {
+    expect(() => parseAnnotationsOverride({ readOnlyHint: 'true' })).toThrow(
+      /must be a boolean/,
+    );
+    expect(() => parseAnnotationsOverride({ title: 5 })).toThrow(/must be a string/);
+  });
+
+  it('rejects arrays and scalars', () => {
+    expect(() => parseAnnotationsOverride([1])).toThrow(/must be an object/);
+    expect(() => parseAnnotationsOverride('x')).toThrow(/must be an object/);
+  });
+});

--- a/packages/backend/src/mcp-server/tool-annotations.ts
+++ b/packages/backend/src/mcp-server/tool-annotations.ts
@@ -1,0 +1,315 @@
+/**
+ * MCP tool annotations (spec: ToolAnnotations).
+ *
+ * Annotations are *hints* that let an agent reason about a tool before calling
+ * it — most importantly `readOnlyHint`, which tells the agent "this one cannot
+ * change anything, probe it freely". They are advisory by design: the spec is
+ * explicit that clients must not make trust decisions based on them, so nothing
+ * here is a security control (real enforcement stays in roles/tool access).
+ *
+ * We derive them from signals we already hold per tool — the HTTP verb for
+ * REST, query/mutation for GraphQL, the connector's readOnly flag and the SQL
+ * text for databases — and let an explicit value override the derivation.
+ *
+ * Derivation is deliberately CONSERVATIVE about `readOnlyHint`: we only claim
+ * read-only when the protocol says so (GET, GraphQL query, SELECT, …). Wrongly
+ * claiming read-only would invite an agent to call a mutating tool freely,
+ * whereas wrongly omitting it only makes the agent more careful. Name-based
+ * guessing is therefore used to *soften* `destructiveHint`, never to assert
+ * read-only — the classic `POST /search` case is handled by the per-tool
+ * override instead of a guess.
+ */
+
+export interface ToolAnnotations {
+  /** Human-readable title for display. */
+  title?: string;
+  /** True = the tool does not modify its environment. Spec default: false. */
+  readOnlyHint?: boolean;
+  /**
+   * True = may perform destructive updates; false = additive only.
+   * Spec default: true. Meaningful only when readOnlyHint is false.
+   */
+  destructiveHint?: boolean;
+  /**
+   * True = repeated identical calls have no additional effect.
+   * Spec default: false. Meaningful only when readOnlyHint is false.
+   */
+  idempotentHint?: boolean;
+  /** True = interacts with an "open world" of external entities. Spec default: true. */
+  openWorldHint?: boolean;
+}
+
+/** Minimal tool shape needed to derive annotations (works for both MCP surfaces). */
+export interface AnnotationSource {
+  name: string;
+  connectorType: string;
+  endpointMapping?: { method?: string; path?: string } | null;
+  /** connector-level settings; `readOnly` is set for DATABASE connectors */
+  connectorConfig?: { config?: Record<string, unknown> | null } | null;
+  /**
+   * Explicit annotations that win over the derived ones: either a user override
+   * or, for MCP-proxy tools, the annotations reported by the upstream server.
+   */
+  annotations?: unknown;
+}
+
+const ANNOTATION_KEYS = [
+  'title',
+  'readOnlyHint',
+  'destructiveHint',
+  'idempotentHint',
+  'openWorldHint',
+] as const;
+
+// Verbs that only ever read. OPTIONS/HEAD included for completeness.
+const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+// Write verbs → [destructive, idempotent]. POST is additive by convention
+// (create/append); PUT/DELETE replace-or-remove and are idempotent; PATCH
+// mutates in place without that guarantee.
+const WRITE_METHODS: Record<string, { destructive: boolean; idempotent: boolean }> = {
+  POST: { destructive: false, idempotent: false },
+  PUT: { destructive: true, idempotent: true },
+  PATCH: { destructive: true, idempotent: false },
+  DELETE: { destructive: true, idempotent: true },
+};
+
+// Name fragments that mark a write as merely additive rather than destructive.
+const ADDITIVE_NAME_HINTS = [
+  'create',
+  'add',
+  'insert',
+  'new',
+  'append',
+  'upload',
+  'submit',
+  'send',
+  'register',
+  'invite',
+  'start',
+  'open',
+];
+
+// Name fragments that mark a write as destructive (removes or overwrites data).
+const DESTRUCTIVE_NAME_HINTS = [
+  'delete',
+  'remove',
+  'drop',
+  'purge',
+  'destroy',
+  'truncate',
+  'revoke',
+  'cancel',
+  'archive',
+  'deactivate',
+  'disable',
+  'reset',
+  'clear',
+  'overwrite',
+  'replace',
+];
+
+// SQL keywords that mean the statement writes. Checked as whole words anywhere
+// in the statement so a CTE ending in an INSERT is not mistaken for a read.
+const SQL_WRITE_RE =
+  /\b(insert|update|delete|drop|truncate|alter|create|replace|merge|upsert|grant|revoke|call|do)\b/i;
+const SQL_READ_START_RE = /^\s*(with|select|show|explain|describe|desc|pragma|table|values)\b/i;
+
+/** `get_customer_orders` / `getCustomerOrders` → `Get customer orders`. */
+function humanizeName(name: string): string {
+  const words = name
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!words) return name;
+  return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase();
+}
+
+function nameSuggestsDestructive(name: string): boolean | undefined {
+  const lower = name.toLowerCase();
+  if (DESTRUCTIVE_NAME_HINTS.some((h) => lower.includes(h))) return true;
+  if (ADDITIVE_NAME_HINTS.some((h) => lower.includes(h))) return false;
+  return undefined;
+}
+
+/** Read-only verdict for a SQL/Mongo statement, or undefined when unclear. */
+function sqlIsReadOnly(statement: string | undefined): boolean | undefined {
+  if (!statement || typeof statement !== 'string') return undefined;
+  // Strip line and block comments so `-- delete stuff` can't flip the verdict.
+  const sql = statement
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ');
+  if (SQL_WRITE_RE.test(sql)) return false;
+  if (SQL_READ_START_RE.test(sql)) return true;
+  return undefined;
+}
+
+/** Keep only known annotation keys with well-typed values. */
+function sanitize(raw: unknown): ToolAnnotations | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const src = raw as Record<string, unknown>;
+  const out: ToolAnnotations = {};
+  for (const key of ANNOTATION_KEYS) {
+    const value = src[key];
+    if (key === 'title') {
+      if (typeof value === 'string' && value.trim()) out.title = value.trim();
+    } else if (typeof value === 'boolean') {
+      out[key] = value;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Derive annotations from what the connector already tells us. Returns only the
+ * hints we can actually justify — an omitted hint means "spec default", which
+ * is the safe reading in every case.
+ */
+function derive(tool: AnnotationSource): ToolAnnotations {
+  const type = (tool.connectorType || '').toUpperCase();
+  const rawMethod = tool.endpointMapping?.method;
+  const method = typeof rawMethod === 'string' ? rawMethod.trim() : '';
+  const annotations: ToolAnnotations = { title: humanizeName(tool.name) };
+
+  // A database or a static payload is a closed domain; everything else talks
+  // to an external system we cannot bound.
+  const closedWorld = type === 'DATABASE';
+  annotations.openWorldHint = !closedWorld;
+
+  let readOnly: boolean | undefined;
+  let destructive: boolean | undefined;
+  let idempotent: boolean | undefined;
+
+  switch (type) {
+    case 'REST':
+    case 'WEBHOOK': {
+      const verb = method.toUpperCase();
+      if (READ_METHODS.has(verb)) {
+        readOnly = true;
+      } else if (WRITE_METHODS[verb]) {
+        readOnly = false;
+        const byVerb = WRITE_METHODS[verb];
+        // The verb sets the baseline; an unambiguous name can correct it
+        // (e.g. `delete_user` exposed as POST is destructive, not additive).
+        destructive = nameSuggestsDestructive(tool.name) ?? byVerb.destructive;
+        idempotent = byVerb.idempotent;
+      }
+      break;
+    }
+
+    case 'GRAPHQL': {
+      const op = method.toLowerCase();
+      if (op === 'query') {
+        readOnly = true;
+      } else if (op === 'mutation' || op === 'subscription') {
+        readOnly = false;
+        destructive = nameSuggestsDestructive(tool.name);
+        idempotent = false;
+      }
+      break;
+    }
+
+    case 'DATABASE': {
+      // `static` returns a canned payload — it cannot touch anything.
+      if (method === 'static') {
+        readOnly = true;
+        break;
+      }
+      if (method === 'mongo_schema') {
+        readOnly = true;
+        break;
+      }
+      // A read-only connector cannot write regardless of the statement.
+      const connectorReadOnly = tool.connectorConfig?.config?.readOnly;
+      if (connectorReadOnly === true) {
+        readOnly = true;
+        break;
+      }
+      const byStatement = sqlIsReadOnly(tool.endpointMapping?.path);
+      if (byStatement !== undefined) {
+        readOnly = byStatement;
+        if (!byStatement) {
+          destructive = nameSuggestsDestructive(tool.name);
+          idempotent = false;
+        }
+      }
+      break;
+    }
+
+    case 'SOAP':
+    case 'MCP':
+    default: {
+      // SOAP operation names and remote MCP tool names carry no verb
+      // semantics. Never assert read-only here; at most flag a write we can
+      // name with confidence, so agents still get the destructive signal.
+      const byName = nameSuggestsDestructive(tool.name);
+      if (byName === true) {
+        readOnly = false;
+        destructive = true;
+      }
+      break;
+    }
+  }
+
+  if (readOnly !== undefined) annotations.readOnlyHint = readOnly;
+  // destructive/idempotent are meaningful only for writes — emitting them
+  // alongside readOnlyHint:true would be noise the spec tells clients to ignore.
+  if (readOnly === false) {
+    if (destructive !== undefined) annotations.destructiveHint = destructive;
+    if (idempotent !== undefined) annotations.idempotentHint = idempotent;
+  }
+
+  return annotations;
+}
+
+/**
+ * Annotations to advertise for a tool: derived from the connector, with any
+ * explicit annotations (user override, or upstream MCP server) layered on top.
+ */
+export function deriveToolAnnotations(tool: AnnotationSource): ToolAnnotations {
+  const explicit = sanitize(tool.annotations);
+  const derived = derive(tool);
+  if (!explicit) return derived;
+  const merged = { ...derived, ...explicit };
+  // An override that flips the tool to read-only must not leave stale
+  // write-only hints behind.
+  if (merged.readOnlyHint === true) {
+    delete merged.destructiveHint;
+    delete merged.idempotentHint;
+  }
+  return merged;
+}
+
+/** Stable string form, so a change in annotations invalidates a session's tool set. */
+export function annotationsSignature(annotations: ToolAnnotations): string {
+  return ANNOTATION_KEYS.filter((k) => annotations[k] !== undefined)
+    .map((k) => `${k}=${String(annotations[k])}`)
+    .join('|');
+}
+
+/** Validate a user-supplied override, rejecting unknown keys and bad types. */
+export function parseAnnotationsOverride(raw: unknown): ToolAnnotations | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('annotations must be an object');
+  }
+  const src = raw as Record<string, unknown>;
+  const unknownKeys = Object.keys(src).filter(
+    (k) => !(ANNOTATION_KEYS as readonly string[]).includes(k),
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Unknown annotation keys: ${unknownKeys.join(', ')}. Allowed: ${ANNOTATION_KEYS.join(', ')}`,
+    );
+  }
+  for (const key of ANNOTATION_KEYS) {
+    if (src[key] === undefined || src[key] === null) continue;
+    if (key === 'title') {
+      if (typeof src[key] !== 'string') throw new Error('title must be a string');
+    } else if (typeof src[key] !== 'boolean') {
+      throw new Error(`${key} must be a boolean`);
+    }
+  }
+  return sanitize(src) ?? null;
+}

--- a/packages/backend/src/mcp-server/tool-registry.ts
+++ b/packages/backend/src/mcp-server/tool-registry.ts
@@ -42,6 +42,9 @@ export interface RegisteredTool {
   responseMapping?: Record<string, unknown>;
   // JSON Schema of the response, served to clients as the tool's outputSchema.
   outputSchema?: unknown;
+  // Explicit MCP tool annotations: an admin override, or the annotations
+  // reported by an upstream MCP server. Layered over the derived ones.
+  annotations?: unknown;
 }
 
 @Injectable()

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge, StatusPill } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { ToolAnnotationsEditor } from '@/components/tool-annotations-editor';
 
 const IMPORT_SOURCES = [
   { id: 'openapi', label: 'OpenAPI / Swagger', placeholder: 'Paste OpenAPI JSON/YAML or enter URL...' },
@@ -40,6 +41,8 @@ export default function ConnectorDetailPage() {
   // Whether CONNECTOR_PROXY_URL is configured on this instance — drives
   // visibility of the per-tool "Use proxy" checkbox.
   const [proxyAvailable, setProxyAvailable] = useState(false);
+  // Tool whose MCP hints (annotations) panel is expanded, if any.
+  const [hintsToolId, setHintsToolId] = useState<string | null>(null);
 
   // OAuth + MCP discovery
   const [authorizing, setAuthorizing] = useState(false);
@@ -1203,6 +1206,15 @@ export default function ConnectorDetailPage() {
                             Edit
                           </button>
                           <button
+                            onClick={() =>
+                              setHintsToolId(hintsToolId === tool.id ? null : tool.id)
+                            }
+                            title="MCP annotations — tells agents whether this tool is read-only, destructive, idempotent."
+                            className="inline-flex items-center justify-center rounded-[7px] border border-[var(--border)] bg-[var(--surface)] text-[var(--text-2)] px-2.5 py-1 text-xs font-medium transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"
+                          >
+                            {hintsToolId === tool.id ? 'Close hints' : 'Hints'}
+                          </button>
+                          <button
                             onClick={() => handleToggleTool(tool.id, tool.isEnabled)}
                             className="inline-flex items-center justify-center rounded-[7px] border border-[var(--border)] bg-[var(--surface)] text-[var(--text-2)] px-2.5 py-1 text-xs font-medium transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"
                           >
@@ -1230,6 +1242,16 @@ export default function ConnectorDetailPage() {
                           </button>
                         </div>
                       </div>
+
+                      {/* MCP annotations (hints) */}
+                      {hintsToolId === tool.id && (
+                        <div className="mt-3 pt-3 border-t border-[var(--border)]">
+                          <ToolAnnotationsEditor
+                            connectorId={id}
+                            toolId={tool.id}
+                          />
+                        </div>
+                      )}
 
                       {/* Tool Playground */}
                       {testingToolId === tool.id && (() => {

--- a/packages/frontend/src/components/tool-annotations-editor.tsx
+++ b/packages/frontend/src/components/tool-annotations-editor.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { tools, type ToolAnnotations } from '@/lib/api';
+import { useAuth } from '@/lib/auth-context';
+
+/** The three boolean hints an operator may want to correct, in spec order. */
+const BOOLEAN_HINTS: {
+  key: 'readOnlyHint' | 'destructiveHint' | 'idempotentHint' | 'openWorldHint';
+  label: string;
+  help: string;
+}[] = [
+  {
+    key: 'readOnlyHint',
+    label: 'Read-only',
+    help: 'The tool cannot change anything. Agents probe read-only tools much more freely — set this for searches exposed over POST.',
+  },
+  {
+    key: 'destructiveHint',
+    label: 'Destructive',
+    help: 'The write removes or overwrites data, rather than only adding to it. Only meaningful when the tool is not read-only.',
+  },
+  {
+    key: 'idempotentHint',
+    label: 'Idempotent',
+    help: 'Calling it again with the same arguments changes nothing further. Only meaningful when the tool is not read-only.',
+  },
+  {
+    key: 'openWorldHint',
+    label: 'Open world',
+    help: 'Talks to an external system whose contents we cannot bound. False for a database or a static payload.',
+  },
+];
+
+type TriState = 'auto' | 'true' | 'false';
+
+function toTri(value: boolean | undefined): TriState {
+  if (value === undefined) return 'auto';
+  return value ? 'true' : 'false';
+}
+
+/**
+ * Per-tool editor for MCP annotations.
+ *
+ * The values are normally derived from the connector; this exists for the cases
+ * the derivation cannot know — above all a read-only search endpoint exposed
+ * over POST, which we deliberately do not guess at.
+ */
+export function ToolAnnotationsEditor({
+  connectorId,
+  toolId,
+  onSaved,
+}: {
+  connectorId: string;
+  toolId: string;
+  onSaved?: (effective: ToolAnnotations) => void;
+}) {
+  const { token } = useAuth();
+  const [derived, setDerived] = useState<ToolAnnotations>({});
+  const [effective, setEffective] = useState<ToolAnnotations>({});
+  const [hasOverride, setHasOverride] = useState(false);
+  const [title, setTitle] = useState('');
+  const [tri, setTri] = useState<Record<string, TriState>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    setLoading(true);
+    tools
+      .getAnnotations(connectorId, toolId, token)
+      .then((r) => {
+        if (cancelled) return;
+        setDerived(r.derived || {});
+        setEffective(r.effective || {});
+        setHasOverride(!!r.override);
+        setTitle(r.override?.title ?? '');
+        setTri({
+          readOnlyHint: toTri(r.override?.readOnlyHint),
+          destructiveHint: toTri(r.override?.destructiveHint),
+          idempotentHint: toTri(r.override?.idempotentHint),
+          openWorldHint: toTri(r.override?.openWorldHint),
+        });
+      })
+      .catch((err) => !cancelled && setMsg(`Error: ${err.message}`))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [connectorId, toolId, token]);
+
+  const save = async (reset = false) => {
+    if (!token) return;
+    setSaving(true);
+    setMsg('');
+    try {
+      let override: ToolAnnotations | null = null;
+      if (!reset) {
+        const next: ToolAnnotations = {};
+        if (title.trim()) next.title = title.trim();
+        for (const { key } of BOOLEAN_HINTS) {
+          const state = tri[key];
+          if (state === 'true') next[key] = true;
+          else if (state === 'false') next[key] = false;
+        }
+        override = Object.keys(next).length > 0 ? next : null;
+      }
+      const r = await tools.setAnnotations(connectorId, toolId, override, token);
+      setEffective(r.effective || {});
+      setHasOverride(!!r.override);
+      if (reset) {
+        setTitle('');
+        setTri({});
+      }
+      setMsg(reset ? 'Reset to derived values' : 'Saved');
+      onSaved?.(r.effective || {});
+      setTimeout(() => setMsg(''), 3000);
+    } catch (err: any) {
+      setMsg(`Error: ${err.message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-xs text-[var(--text-3)]">Loading hints…</div>;
+  }
+
+  const readOnly = effective.readOnlyHint === true;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-[var(--text-3)]">
+        Hints MCP clients read before calling this tool — most importantly whether it
+        is read-only. They are inferred from the connector; override them only when
+        the inference is wrong (typically a read-only search exposed over POST).
+      </p>
+
+      <div>
+        <label className="block text-[12.5px] font-medium text-[var(--text-2)] mb-1">
+          Title
+        </label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={derived.title || 'Derived from the tool name'}
+          className="w-full h-9 rounded-[9px] border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--text)] outline-none focus:border-[var(--brand)]"
+        />
+      </div>
+
+      <div className="space-y-2">
+        {BOOLEAN_HINTS.map(({ key, label, help }) => {
+          // Per the spec these two only carry meaning for a write.
+          const dimmed =
+            readOnly && (key === 'destructiveHint' || key === 'idempotentHint');
+          return (
+            <div
+              key={key}
+              className={`flex items-center justify-between gap-3 ${dimmed ? 'opacity-50' : ''}`}
+            >
+              <div className="min-w-0">
+                <div className="text-[12.5px] font-medium text-[var(--text-2)]">
+                  {label}
+                  {dimmed && (
+                    <span className="ml-1 font-normal text-[var(--text-3)]">
+                      (ignored for read-only tools)
+                    </span>
+                  )}
+                </div>
+                <div className="text-[11px] text-[var(--text-3)]">{help}</div>
+              </div>
+              <select
+                value={tri[key] ?? 'auto'}
+                onChange={(e) =>
+                  setTri((prev) => ({ ...prev, [key]: e.target.value as TriState }))
+                }
+                className="h-8 flex-shrink-0 rounded-[7px] border border-[var(--border)] bg-[var(--surface)] px-2 text-xs text-[var(--text)] outline-none focus:border-[var(--brand)]"
+              >
+                <option value="auto">
+                  Auto{derived[key] !== undefined ? ` (${derived[key] ? 'yes' : 'no'})` : ''}
+                </option>
+                <option value="true">Yes</option>
+                <option value="false">No</option>
+              </select>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="rounded-[9px] border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2">
+        <div className="text-[11px] uppercase tracking-wide text-[var(--text-3)] mb-1">
+          Advertised to clients
+        </div>
+        <code className="text-[11px] font-mono text-[var(--text-2)] break-all">
+          {Object.keys(effective).length > 0
+            ? JSON.stringify(effective)
+            : '— none —'}
+        </code>
+      </div>
+
+      {msg && (
+        <p
+          className={`text-xs ${msg.startsWith('Error') ? 'text-[var(--danger)]' : 'text-[var(--ok)]'}`}
+        >
+          {msg}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          onClick={() => save(false)}
+          disabled={saving}
+          className="inline-flex items-center justify-center rounded-[7px] border border-[var(--brand)] bg-[var(--brand)] text-white px-2.5 py-1 text-xs font-semibold disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save hints'}
+        </button>
+        {hasOverride && (
+          <button
+            onClick={() => save(true)}
+            disabled={saving}
+            className="inline-flex items-center justify-center rounded-[7px] border border-[var(--border)] bg-[var(--surface)] text-[var(--text-2)] px-2.5 py-1 text-xs font-medium transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)] disabled:opacity-50"
+          >
+            Reset to derived
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -241,6 +241,19 @@ export const adapters = {
 };
 
 // Tools
+/**
+ * MCP tool annotations — advisory hints an agent reads before calling a tool.
+ * Normally derived from the connector; an override corrects cases the
+ * derivation cannot know (classically a read-only search exposed over POST).
+ */
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
 export const tools = {
   list: (connectorId: string, token: string) =>
     request<any[]>(`/api/connectors/${connectorId}/tools`, { token }),
@@ -259,6 +272,23 @@ export const tools = {
       body: { useProxy },
       token,
     }),
+  getAnnotations: (connectorId: string, toolId: string, token: string) =>
+    request<{
+      derived: ToolAnnotations;
+      override: ToolAnnotations | null;
+      effective: ToolAnnotations;
+      supportedKeys: string[];
+    }>(`/api/connectors/${connectorId}/tools/${toolId}/annotations`, { token }),
+  setAnnotations: (
+    connectorId: string,
+    toolId: string,
+    annotations: ToolAnnotations | null,
+    token: string,
+  ) =>
+    request<{ override: ToolAnnotations | null; effective: ToolAnnotations }>(
+      `/api/connectors/${connectorId}/tools/${toolId}/annotations`,
+      { method: 'PATCH', body: { annotations }, token },
+    ),
   delete: (connectorId: string, toolId: string, token: string) =>
     request(`/api/connectors/${connectorId}/tools/${toolId}`, { method: 'DELETE', token }),
   test: (connectorId: string, toolId: string, params: Record<string, unknown>, token: string) =>


### PR DESCRIPTION
Implements both requests from a customer (pikoworks) building agents on top of AnythingMCP.

## 1. MCP tool annotations

Agents can now tell a probe-safe tool from a mutating one *before* calling it. The hints (`title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are derived from signals we already hold:

| Connector | Signal | Result |
|---|---|---|
| REST | `GET`/`HEAD`/`OPTIONS` | read-only |
| REST | `POST` / `PUT`,`DELETE` / `PATCH` | additive · destructive+idempotent · destructive |
| GraphQL | `query` / `mutation` | read-only / write |
| Database | connector `readOnly` flag, or `SELECT` vs write keywords in the statement | read-only / write, always closed-world |
| SOAP | operation name only | never asserts read-only |
| MCP bridge | upstream server's annotations | **passed through** (previously discarded) |

**Derivation is conservative about `readOnlyHint`** — only the protocol may assert it. Wrongly claiming read-only invites an agent to call a mutating tool freely; omitting it only makes the agent more careful. Tool names therefore only refine `destructiveHint`.

The one case no heuristic can settle — **a read-only search exposed over `POST`** — is handled by a per-tool override:

- `GET /api/connectors/:cid/tools/:tid/annotations` → `{ derived, override, effective, supportedKeys }`
- `PATCH` same path with `{"annotations": {"readOnlyHint": true}}`, or `null` to reset
- **Hints** panel per tool in the connector UI

An override survives a re-import; upstream MCP annotations refresh on re-import (that server is authoritative about its own tools).

Both MCP surfaces are covered. Legacy `tool()` registrations became `registerTool()` since only the latter carries annotations, and annotations are part of a session's tool signature so a change re-emits `tools/list_changed` to live stateful sessions.

> Per the spec, annotations are advisory — clients must not base trust decisions on them. Enforcement stays in roles/tool access.

## 2. Caller-context variables `{{amcp.*}}`

Connectors often front **service**-based APIs while users authenticate individually (OAuth, per-user MCP API keys), so the target system cannot record who actually asked. A reserved namespace now forwards the caller in headers, query params, body and path:

```json
{ "headers": { "X-Requested-By": "{{amcp.user_email}}" } }
```

Available: `user_email`, `user_id`, `org_id`, `server_id`, `server_name`, `auth_method`, `api_key_name`.

The identity was already resolved per request but never reached the engines. Design points:

- **Non-spoofable** — resolved server-side and merged *after* workspace env vars, so neither a connector variable nor a tool argument can shadow it.
- **Opt-in** — nothing is forwarded unless the operator writes the variable somewhere (identity is personal data / GDPR).
- **Always defined** — with instance-wide static credentials or anonymous mode there is no user, so the variable resolves to an empty string instead of leaking a literal `{{amcp.…}}` downstream. A typo'd reserved variable is rejected when the tool is saved.
- Applies to `baseUrl`, connector headers and the endpoint mapping; **not** to `authConfig`.

## Migration

One additive column: `mcp_tools.annotations JSONB` (nullable → derive).

## Verification

- Backend **3457 tests green** (+102 new across annotation derivation and context interpolation, including the non-spoofable and no-identity cases)
- Backend `tsc` clean · Frontend `tsc` + `build` clean
- Docs: `docs/tool-definition.md` sections 4 and 5
