### PR TITLE
feat(connectors): expose OAuth2 token-endpoint auth method in the UI (v0.3.8)

### DIFF
--- a/docs/connectors/rest.md
+++ b/docs/connectors/rest.md
@@ -221,6 +221,42 @@ OAuth2 connectors use the **Authorization Code + PKCE** flow:
 4. After consent, the backend exchanges the authorization code for access and refresh tokens (stored encrypted).
 5. On 401 responses, the engine automatically refreshes the token using the stored refresh token and retries the request.
 
+#### Token endpoint authentication (`client_secret_basic`)
+
+By default the client credentials are sent **in the body** of the token request (`client_secret_post`).
+Some providers — **Datto RMM** and **DATEV** among them — only accept them as an **HTTP Basic header**
+(`Authorization: Basic base64(client_id:client_secret)`, RFC 6749 §2.3.1) and answer anything else with
+`401` at the code-exchange step.
+
+Pick the method in the connector form under **Token endpoint authentication**, or set it directly:
+
+```bash
+curl -s -X PATCH http://localhost:4000/api/connectors/$CONNECTOR_ID/oauth-config \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"tokenAuthMethod": "client_secret_basic"}'
+```
+
+Notes:
+
+- The setting applies to **both** the initial authorization-code exchange **and** later refreshes.
+- `PATCH .../oauth-config` merges — it will not drop the tokens already issued or the endpoints captured
+  during authorization. Send `""` to go back to the default.
+- `GET .../oauth-config` returns the current settings; the client secret and tokens are never returned,
+  only `hasClientSecret` / `hasAccessToken` / `hasRefreshToken` booleans.
+- After switching the method, re-run **Authorize with Provider** so a token is fetched the new way.
+
+Example — Datto RMM:
+
+| Field | Value |
+|---|---|
+| Authorization URL | `https://<zone>-api.centrastage.net/auth/oauth/authorize` |
+| Token URL | `https://<zone>-api.centrastage.net/auth/oauth/token` |
+| Client ID / Secret | `public-client` / `public` |
+| Token endpoint authentication | **HTTP Basic header** |
+
+The API key and secret key of the technical user are entered on the provider's own consent screen.
+
 ---
 
 ## Environment Variables

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/connectors/connectors.controller.spec.ts
+++ b/packages/backend/src/connectors/connectors.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { ConnectorsController } from './connectors.controller';
 
 const VALID_ENCRYPTION_KEY = 'a'.repeat(48);
@@ -110,6 +110,154 @@ describe('ConnectorsController role enforcement', () => {
       });
 
       expect(prisma.connector.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('OAuth2 config endpoints', () => {
+  const oauthConnector = (over: Record<string, unknown> = {}) => ({
+    id: 'c1',
+    type: 'REST',
+    authType: 'OAUTH2',
+    userId: 'u1',
+    organizationId: 'org1',
+    ...over,
+  });
+
+  const build = (connector: any) =>
+    buildController({
+      connectorsService: {
+        findById: jest.fn().mockResolvedValue(connector),
+        updateAuthConfigMerge: jest.fn().mockResolvedValue(connector),
+      },
+    });
+
+  describe('PATCH :id/oauth-config', () => {
+    it('merges only the fields that were sent', async () => {
+      // A partial edit must not blank the rest of the config — the stored
+      // tokens and endpoints live in the same object.
+      const { controller, connectorsService } = build(oauthConnector());
+
+      await controller.updateOAuthConfig(req('ADMIN'), 'c1', {
+        tokenAuthMethod: 'client_secret_basic',
+      });
+
+      expect(connectorsService.updateAuthConfigMerge).toHaveBeenCalledWith('c1', {
+        tokenAuthMethod: 'client_secret_basic',
+      });
+    });
+
+    it('passes client credentials through when supplied', async () => {
+      const { controller, connectorsService } = build(oauthConnector());
+
+      await controller.updateOAuthConfig(req('ADMIN'), 'c1', {
+        clientId: 'public-client',
+        clientSecret: 'public',
+        tokenAuthMethod: 'client_secret_basic',
+      });
+
+      expect(connectorsService.updateAuthConfigMerge).toHaveBeenCalledWith('c1', {
+        clientId: 'public-client',
+        clientSecret: 'public',
+        tokenAuthMethod: 'client_secret_basic',
+      });
+    });
+
+    it('resets to the default when the auth method is cleared', async () => {
+      const { controller, connectorsService } = build(oauthConnector());
+
+      await controller.updateOAuthConfig(req('ADMIN'), 'c1', {
+        tokenAuthMethod: '',
+      });
+
+      expect(connectorsService.updateAuthConfigMerge).toHaveBeenCalledWith('c1', {
+        tokenAuthMethod: undefined,
+      });
+    });
+
+    it('does not write anything when the body is empty', async () => {
+      const { controller, connectorsService } = build(oauthConnector());
+
+      await controller.updateOAuthConfig(req('ADMIN'), 'c1', {});
+
+      expect(connectorsService.updateAuthConfigMerge).not.toHaveBeenCalled();
+    });
+
+    it('rejects connectors that do not use OAuth2', async () => {
+      const { controller, connectorsService } = build(
+        oauthConnector({ authType: 'BEARER_TOKEN' }),
+      );
+
+      await expect(
+        controller.updateOAuthConfig(req('ADMIN'), 'c1', {
+          tokenAuthMethod: 'client_secret_basic',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(connectorsService.updateAuthConfigMerge).not.toHaveBeenCalled();
+    });
+
+    it('rejects VIEWER', async () => {
+      const { controller, connectorsService } = build(oauthConnector());
+
+      await expect(
+        controller.updateOAuthConfig(req('VIEWER'), 'c1', {
+          tokenAuthMethod: 'client_secret_basic',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(connectorsService.updateAuthConfigMerge).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET :id/oauth-config', () => {
+    it('never returns the client secret or the issued tokens', async () => {
+      const { encrypt } = require('../common/crypto/encryption.util');
+      const authConfig = encrypt(
+        JSON.stringify({
+          clientId: 'public-client',
+          clientSecret: 'public',
+          tokenUrl: 'https://example.invalid/token',
+          tokenAuthMethod: 'client_secret_basic',
+          accessToken: 'at',
+          refreshToken: 'rt',
+        }),
+        VALID_ENCRYPTION_KEY,
+      );
+      const { controller } = build(oauthConnector({ authConfig }));
+
+      const result = await controller.getOAuthConfig(req('ADMIN'), 'c1');
+
+      expect(result).toMatchObject({
+        clientId: 'public-client',
+        tokenUrl: 'https://example.invalid/token',
+        tokenAuthMethod: 'client_secret_basic',
+        hasClientSecret: true,
+        hasAccessToken: true,
+        hasRefreshToken: true,
+      });
+      expect(JSON.stringify(result)).not.toContain('public"');
+      expect(JSON.stringify(result)).not.toContain('"at"');
+      expect(JSON.stringify(result)).not.toContain('"rt"');
+    });
+
+    it('reports the default auth method when none is stored', async () => {
+      const { controller } = build(oauthConnector({ authConfig: null }));
+
+      const result = await controller.getOAuthConfig(req('ADMIN'), 'c1');
+
+      expect(result.tokenAuthMethod).toBe('client_secret_post');
+      expect(result.hasClientSecret).toBe(false);
+    });
+
+    it('degrades gracefully when the stored config cannot be decrypted', async () => {
+      // e.g. after an encryption-key rotation — the page must still load.
+      const { controller } = build(oauthConnector({ authConfig: 'not-decryptable' }));
+
+      const result = await controller.getOAuthConfig(req('ADMIN'), 'c1');
+
+      expect(result.clientId).toBe('');
+      expect(result.tokenAuthMethod).toBe('client_secret_post');
     });
   });
 });

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Put,
+  Patch,
   Delete,
   Body,
   Param,
@@ -11,6 +12,7 @@ import {
   UseGuards,
   Logger,
   ForbiddenException,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -23,6 +25,7 @@ import {
   IsObject,
   IsBoolean,
   IsArray,
+  IsIn,
   ValidateNested,
   ArrayMinSize,
 } from 'class-validator';
@@ -219,6 +222,49 @@ class UpdateConnectorDto {
   @IsOptional()
   @IsString()
   instructions?: string;
+}
+
+class UpdateOAuthConfigDto {
+  @ApiPropertyOptional({ description: 'OAuth2 client id.' })
+  @IsOptional()
+  @IsString()
+  clientId?: string;
+
+  @ApiPropertyOptional({ description: 'OAuth2 client secret.' })
+  @IsOptional()
+  @IsString()
+  clientSecret?: string;
+
+  @ApiPropertyOptional({ description: 'Authorization endpoint.' })
+  @IsOptional()
+  @IsString()
+  authorizationUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Token endpoint.' })
+  @IsOptional()
+  @IsString()
+  tokenUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Space-separated scopes.' })
+  @IsOptional()
+  @IsString()
+  scopes?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'How client credentials are presented to the token endpoint. ' +
+      '`client_secret_post` (default) sends them in the request body; ' +
+      '`client_secret_basic` sends them as an HTTP Basic header (RFC 6749 ' +
+      '§2.3.1). Providers such as Datto RMM and DATEV reject body-supplied ' +
+      'credentials with 401 and require basic. Applies to both the initial ' +
+      'authorization-code exchange and later token refreshes. Empty string ' +
+      'resets to the default.',
+    enum: ['', 'client_secret_post', 'client_secret_basic', 'basic', 'post'],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['', 'client_secret_post', 'client_secret_basic', 'basic', 'post'])
+  tokenAuthMethod?: string;
 }
 
 class ImportToolsDto {
@@ -623,6 +669,89 @@ export class ConnectorsController {
     const connector = await this.connectorsService.findById(id);
     this.assertCanWrite(connector, req);
     return this.connectorsService.update(id, dto);
+  }
+
+  @Get(':id/oauth-config')
+  @ApiOperation({
+    summary: 'Read the non-secret OAuth2 settings of a connector',
+    description:
+      'Returns the endpoints, client id and token-endpoint auth method so the ' +
+      'UI can show the current configuration. The client secret and the issued ' +
+      'tokens are never returned — only booleans saying whether they are set.',
+  })
+  async getOAuthConfig(@Req() req: any, @Param('id') id: string) {
+    const connector = await this.connectorsService.findById(id);
+    this.assertOrgMatch(connector, req);
+
+    let cfg: Record<string, unknown> = {};
+    if (connector.authConfig) {
+      try {
+        cfg = JSON.parse(decrypt(connector.authConfig, this.encryptionKey));
+      } catch {
+        // Unreadable config (e.g. rotated key) — report it as empty rather
+        // than failing the page load.
+      }
+    }
+    const str = (v: unknown) => (typeof v === 'string' ? v : '');
+    return {
+      clientId: str(cfg.clientId),
+      authorizationUrl: str(cfg.authorizationUrl),
+      tokenUrl: str(cfg.tokenUrl),
+      scopes: str(cfg.scopes),
+      tokenAuthMethod: str(cfg.tokenAuthMethod) || 'client_secret_post',
+      hasClientSecret: !!cfg.clientSecret,
+      hasAccessToken: !!cfg.accessToken,
+      hasRefreshToken: !!cfg.refreshToken,
+    };
+  }
+
+  @Patch(':id/oauth-config')
+  @ApiOperation({
+    summary: 'Update the OAuth2 settings of a connector (partial)',
+    description:
+      'Merges the supplied fields into the connector\'s existing authConfig ' +
+      'instead of replacing it, so the stored access/refresh tokens and the ' +
+      'endpoints established during authorization are preserved. Omitted ' +
+      'fields keep their current value; send an empty string to clear one. ' +
+      'Use `tokenAuthMethod` when a provider rejects credentials sent in the ' +
+      'request body (RFC 6749 §2.3.1 client_secret_basic) — Datto RMM and ' +
+      'DATEV both require it.',
+  })
+  async updateOAuthConfig(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: UpdateOAuthConfigDto,
+  ) {
+    const connector = await this.connectorsService.findById(id);
+    this.assertCanWrite(connector, req);
+
+    if (connector.authType !== 'OAUTH2') {
+      throw new BadRequestException('Connector auth type must be OAUTH2');
+    }
+
+    // Only forward what the caller actually sent, so a partial edit (e.g.
+    // just the auth method) never blanks the other settings.
+    const patch: Record<string, unknown> = {};
+    for (const key of [
+      'clientId',
+      'clientSecret',
+      'authorizationUrl',
+      'tokenUrl',
+      'scopes',
+    ] as const) {
+      if (dto[key] !== undefined) patch[key] = dto[key];
+    }
+    if (dto.tokenAuthMethod !== undefined) {
+      // Empty = back to the default (credentials in the body).
+      patch.tokenAuthMethod = dto.tokenAuthMethod || undefined;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return { message: 'Nothing to update' };
+    }
+
+    await this.connectorsService.updateAuthConfigMerge(id, patch);
+    return { message: 'OAuth configuration updated' };
   }
 
   @Delete(':id')

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -55,6 +55,8 @@ export default function ConnectorDetailPage() {
   const [editAuthType, setEditAuthType] = useState('NONE');
   const [editAuthKey, setEditAuthKey] = useState('');
   const [editAuthValue, setEditAuthValue] = useState('');
+  // OAuth2 only: how client credentials reach the token endpoint.
+  const [editTokenAuthMethod, setEditTokenAuthMethod] = useState('client_secret_post');
   // LOGIN_TOKEN (credentials → short-lived token, auto-refreshed) fields
   const [editLtLoginUrl, setEditLtLoginUrl] = useState('');
   const [editLtMethod, setEditLtMethod] = useState('POST');
@@ -121,6 +123,15 @@ export default function ConnectorDetailPage() {
       // Don't pre-fill credentials — they are encrypted on the server
       setEditAuthKey('');
       setEditAuthValue('');
+      // The auth method is not secret, so it can be shown. Without this the
+      // select would always read "body" and saving any other field would
+      // silently reset a connector configured for HTTP Basic.
+      if (c.authType === 'OAUTH2' && c.type !== 'MCP') {
+        connectors
+          .getOAuthConfig(id, token)
+          .then((r) => setEditTokenAuthMethod(r.tokenAuthMethod || 'client_secret_post'))
+          .catch(() => setEditTokenAuthMethod('client_secret_post'));
+      }
       // authConfig is encrypted server-side, so LOGIN_TOKEN fields start empty;
       // headers are stored in the clear and can be pre-filled for editing.
       setEditLtPassword('');
@@ -224,6 +235,22 @@ export default function ConnectorDetailPage() {
         data.config = { readOnly: editDbReadOnly };
       }
       await connectors.update(id, data, token);
+
+      // OAuth2 credentials live in authConfig alongside the issued tokens, so
+      // they are patched separately (a full write would discard the tokens and
+      // the endpoints captured during authorization).
+      if (editAuthType === 'OAUTH2' && connector.type !== 'MCP') {
+        const oauthPatch: Record<string, string> = {
+          tokenAuthMethod:
+            editTokenAuthMethod === 'client_secret_basic'
+              ? 'client_secret_basic'
+              : '',
+        };
+        if (editAuthKey) oauthPatch.clientId = editAuthKey;
+        if (editAuthValue) oauthPatch.clientSecret = editAuthValue;
+        await connectors.updateOAuthConfig(id, oauthPatch, token);
+      }
+
       setMsg('Connector updated');
       setEditing(false);
       fetchConnector();
@@ -761,6 +788,21 @@ export default function ConnectorDetailPage() {
                       <label className="block text-sm font-medium mb-1">Client Secret</label>
                       <input type="password" value={editAuthValue} onChange={(e) => setEditAuthValue(e.target.value)} placeholder="Leave empty to keep current" className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]" />
                     </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Token endpoint authentication</label>
+                    <select
+                      value={editTokenAuthMethod}
+                      onChange={(e) => setEditTokenAuthMethod(e.target.value)}
+                      className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-sm bg-[var(--surface)] focus:outline-none focus:border-[var(--border-strong)]"
+                    >
+                      <option value="client_secret_post">Client secret in body (default)</option>
+                      <option value="client_secret_basic">HTTP Basic header (client_secret_basic)</option>
+                    </select>
+                    <p className="mt-1 text-xs text-[var(--text-3)]">
+                      Switch to HTTP Basic if the token exchange fails with 401 — Datto RMM
+                      and DATEV require it. Applies to refreshes too. Re-authorize after changing it.
+                    </p>
                   </div>
                   <p className="text-xs text-[var(--text-3)]">
                     Leave credential fields empty to keep the current values. Authorization URL, Token URL, and Scopes are preserved from initial setup.

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -48,6 +48,9 @@ export default function NewConnectorPage() {
   const [oauthAuthUrl, setOauthAuthUrl] = useState('');
   const [oauthTokenUrl, setOauthTokenUrl] = useState('');
   const [oauthScopes, setOauthScopes] = useState('');
+  // How client credentials reach the token endpoint. Some providers (Datto RMM,
+  // DATEV) reject body-supplied credentials and require an HTTP Basic header.
+  const [oauthTokenAuthMethod, setOauthTokenAuthMethod] = useState('client_secret_post');
   // LOGIN_TOKEN (credentials → short-lived token, auto-refreshed) fields
   const [ltLoginUrl, setLtLoginUrl] = useState('');
   const [ltMethod, setLtMethod] = useState('POST');
@@ -107,6 +110,10 @@ export default function NewConnectorPage() {
             authorizationUrl: oauthAuthUrl,
             tokenUrl: oauthTokenUrl,
             scopes: oauthScopes || undefined,
+            tokenAuthMethod:
+              oauthTokenAuthMethod === 'client_secret_basic'
+                ? 'client_secret_basic'
+                : undefined,
           };
         }
         return undefined;
@@ -406,6 +413,21 @@ export default function NewConnectorPage() {
                   <div>
                     <label className={labelClass}>Scopes</label>
                     <input type="text" value={oauthScopes} onChange={(e) => setOauthScopes(e.target.value)} placeholder="read write (space-separated, optional)" className={cn(inputClass, 'font-mono text-[13px]')} />
+                  </div>
+                  <div>
+                    <label className={labelClass}>Token endpoint authentication</label>
+                    <select
+                      value={oauthTokenAuthMethod}
+                      onChange={(e) => setOauthTokenAuthMethod(e.target.value)}
+                      className={inputClass}
+                    >
+                      <option value="client_secret_post">Client secret in body (default)</option>
+                      <option value="client_secret_basic">HTTP Basic header (client_secret_basic)</option>
+                    </select>
+                    <p className="mt-1 text-xs text-[var(--text-3)]">
+                      Switch to HTTP Basic if the provider returns 401 when exchanging the
+                      code — Datto RMM and DATEV both require it. Applies to token refreshes too.
+                    </p>
                   </div>
                   <div className="rounded-[9px] border border-[var(--t-info-fg)]/20 bg-[var(--t-info-bg)] p-3 text-sm text-[var(--t-info-fg)]">
                     <p>After creating the connector, you will be redirected to authorize via OAuth2. Tokens will be stored securely.</p>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -187,6 +187,39 @@ export const connectors = {
     request<any>(`/api/connectors/${id}`, { token }),
   update: (id: string, data: unknown, token: string) =>
     request(`/api/connectors/${id}`, { method: 'PUT', body: data, token }),
+  /** Non-secret OAuth2 settings, for pre-filling the edit form. */
+  getOAuthConfig: (id: string, token: string) =>
+    request<{
+      clientId: string;
+      authorizationUrl: string;
+      tokenUrl: string;
+      scopes: string;
+      tokenAuthMethod: string;
+      hasClientSecret: boolean;
+      hasAccessToken: boolean;
+      hasRefreshToken: boolean;
+    }>(`/api/connectors/${id}/oauth-config`, { token }),
+  /**
+   * Partial update of the OAuth2 settings. Merges server-side, so editing one
+   * field keeps the stored tokens and the rest of the configuration intact.
+   */
+  updateOAuthConfig: (
+    id: string,
+    data: {
+      clientId?: string;
+      clientSecret?: string;
+      authorizationUrl?: string;
+      tokenUrl?: string;
+      scopes?: string;
+      tokenAuthMethod?: string;
+    },
+    token: string,
+  ) =>
+    request<{ message: string }>(`/api/connectors/${id}/oauth-config`, {
+      method: 'PATCH',
+      body: data,
+      token,
+    }),
   delete: (id: string, token: string) =>
     request(`/api/connectors/${id}`, { method: 'DELETE', token }),
   test: (id: string, token: string) =>


### PR DESCRIPTION
Reported by a customer (pikoworks) building a **Datto RMM** connector: the authorization dialog works, but the code exchange fails with `OAuth2 error: Request failed with status code 401`.

## Root cause

Datto's token endpoint only accepts client credentials as an **HTTP Basic header** (`client_secret_basic`, RFC 6749 §2.3.1) and rejects the body-supplied form. The same flow succeeds in Postman with *"Send as Basic Auth header"*.

The engine has actually supported this since **v0.3.5** (added for DATEV, which behaves identically) — `authConfig.tokenAuthMethod` is honoured both in `mcp-oauth.service.ts` (code exchange) and `oauth2-token.service.ts` (refresh). **But there was no UI for it**, so unless you knew to craft `authConfig` by hand, it was effectively unreachable. That's the gap this closes.

## Changes

**Token endpoint authentication selector** — in the connector form, on create *and* edit:
- *Client secret in body* (default, `client_secret_post`)
- *HTTP Basic header* (`client_secret_basic`)

**New endpoints**

| | |
|---|---|
| `GET /api/connectors/:id/oauth-config` | Current non-secret settings. The client secret and issued tokens are **never** returned — only `hasClientSecret` / `hasAccessToken` / `hasRefreshToken`. |
| `PATCH /api/connectors/:id/oauth-config` | Partial update, **merged** into the existing `authConfig`. |

The PATCH merges rather than replaces on purpose: `authConfig` also holds the issued access/refresh tokens and the endpoints captured during authorization, so a full write would silently destroy a working authorization. Omitted fields keep their value; `tokenAuthMethod: ""` resets to the default.

## Bug found while doing this

On the connector edit page the OAuth2 **Client ID** and **Client Secret** inputs were rendered but **never saved** — `buildAuthConfig()` had no `OAUTH2` case, so it fell through to `default: return undefined` and the values were silently dropped. The placeholder even said *"Leave empty to keep current"*, which made the no-op look intentional. They now persist through the merge endpoint.

The selector is also pre-filled from the stored config — without that, saving any unrelated field (e.g. the connector name) would have silently reset a connector already configured for HTTP Basic.

## Verification

- Backend: **3469 tests green** (+12 covering merge semantics, the empty-body no-op, the non-OAuth2 rejection, VIEWER rejection, and that the GET leaks neither secret nor tokens — including the key-rotation fallback)
- Backend `tsc` clean · Frontend `tsc` + `build` clean
- Docs: `docs/connectors/rest.md` gains a *Token endpoint authentication* section with a Datto RMM example

## Note for the reporter

Their instance is running pre-v0.3.5 code (the snippet they quoted predates the fix), so they need to update to pick this up.
