### PR TITLE
feat(connectors): per-tool response mapping

### DIFF
--- a/docs/connectors/rest.md
+++ b/docs/connectors/rest.md
@@ -186,16 +186,86 @@ The `endpointMapping` defines how MCP tool parameters map to the HTTP request:
 
 ### Response Mapping
 
-Optionally filter and transform API responses:
+Optionally shape the API response before it reaches the AI client. Without it,
+the raw upstream response is returned unchanged.
+
+APIs routinely return far more than a tool needs — a Datto RMM device carries up
+to 300 UDF fields, IPs and remote-control URLs when the tool only wants hostname,
+site, OS and status. Every extra byte is billed to the agent's context window and
+exposed to a third-party model. A response mapping declares what a tool actually
+publishes.
 
 ```json
 {
   "responseMapping": {
-    "type": "json",
-    "fields": ["id", "name", "email", "status"]
+    "transform": {
+      "select": {
+        "page": {
+          "count": "$.pageDetails.count",
+          "totalCount": "$.pageDetails.totalCount",
+          "nextPageUrl": "$.pageDetails.nextPageUrl"
+        },
+        "devices": {
+          "$from": "$.devices[*]",
+          "$select": {
+            "id": "id",
+            "hostname": "hostname",
+            "siteName": "siteName",
+            "category": "deviceType.category",
+            "operatingSystem": "operatingSystem",
+            "online": "online",
+            "antivirusStatus": "antivirus.antivirusStatus"
+          }
+        }
+      },
+      "exclude": ["devices[*].udf"]
+    }
   }
 }
 ```
+
+#### `transform` keys
+
+| Key | Meaning |
+|-----|---------|
+| `select` | Output template. Keys are the output names; leaf syntax below. |
+| `include` | Keep only these paths, preserving the original document shape. |
+| `exclude` | Drop these paths. Applied **before** `include` / `select`. |
+| `expression` | A [JMESPath](https://jmespath.org) expression, with `"mode": "jmespath"`. Use it for computed values (`length(devices)`) and filters (``devices[?online == `false`]``). |
+| `mode` | `select` (default), `jmespath`, or `off` to keep the config without applying it. |
+| `fallbackToRaw` | Default `true`: a mapping that fails returns the raw response and logs a warning rather than failing the call. Set `false` to surface the error instead. |
+| `maxBytes` | Hard cap on the serialized output. `0` / absent = no cap. On overflow the result is replaced by `{ "_truncated": true, … }`. |
+
+#### Leaf syntax in `select`
+
+| Leaf | Result |
+|------|--------|
+| `"$.a.b"` / `"a.b"` | Value at that path. A leading `$.` is optional. |
+| `"items[*].id"` | Array of `id` over `items` — elements without the field are skipped. |
+| `"items[0].id"`, `"items[-1].id"` | Index access; negative counts from the end. |
+| `"a['weird.key']"` | Quoted segment, for keys containing dots. |
+| `"= my-source"` | Static string literal (`= ` prefix), for constants. |
+| `42`, `true`, `null` | Passed through as-is. |
+| `{ "$from": "path[*]", "$select": { … } }` | Reshape every element of an array. Optional `$limit` caps how many. |
+
+A path that does not resolve leaves its key **out** of the output rather than
+emitting `null` — that is what keeps mapped responses small.
+
+Response mapping applies to every connector type, not just REST.
+
+#### Legacy shape
+
+`{"type": "json", "fields": [...]}` is still honoured and behaves as
+`transform.include`.
+
+#### Editing and previewing
+
+- UI: **Connector → tool → Edit → Response Mapping**. "Preview with last real
+  response" maps the most recent recorded response for that tool without calling
+  the API again, and shows the size delta.
+- API: `PATCH /api/connectors/:id/tools/:toolId/response-mapping` sets or clears
+  it, `POST .../preview-mapping` dry-runs one. The tool test endpoint returns
+  both `result` (raw) and `mapped`.
 
 ---
 

--- a/docs/tool-definition.md
+++ b/docs/tool-definition.md
@@ -318,11 +318,30 @@ Behaviour worth knowing:
     }
   },
   "responseMapping": {
-    "type": "json",
-    "fields": ["id", "name", "price", "category"]
+    "transform": {
+      "select": {
+        "total": "$.meta.totalCount",
+        "products": {
+          "$from": "$.data[*]",
+          "$select": {
+            "id": "id",
+            "name": "attributes.name",
+            "price": "attributes.price.amount",
+            "category": "relationships.category.name"
+          }
+        }
+      }
+    }
   }
 }
 ```
+
+`responseMapping.transform` shapes the response before it reaches the AI client —
+fewer tokens, and only the fields this tool needs leave the workspace. It is
+optional: without it the raw upstream response is returned unchanged. See
+[REST connector → Response Mapping](connectors/rest.md#response-mapping) for the
+full syntax (`select`, `include`, `exclude`, JMESPath, `maxBytes`) — it applies
+to every connector type, not just REST.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -491,6 +491,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -993,7 +994,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
       "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.3",
@@ -1016,37 +1018,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.3"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1245,6 +1216,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1258,6 +1230,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -1300,7 +1273,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -2833,6 +2805,18 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jmespath-community/jmespath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jmespath-community/jmespath/-/jmespath-1.3.0.tgz",
+      "integrity": "sha512-nzOrEdWKNpognj6CT+1Atr7gw0bqUC1KTBRyasBXS9NjFpz+og7LeFZrIQqV81GRcCzKa5H+DNipvv7NQK3GzA==",
+      "license": "MPL-2.0",
+      "bin": {
+        "jp": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2930,7 +2914,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2971,7 +2954,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2987,8 +2969,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
@@ -3017,6 +2998,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
       "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3063,6 +3045,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
       "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3102,6 +3085,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz",
       "integrity": "sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/jsonwebtoken": "9.0.10",
         "jsonwebtoken": "9.0.3"
@@ -3135,6 +3119,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
       "integrity": "sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "passport": "^0.5.0 || ^0.6.0 || ^0.7.0"
@@ -3145,6 +3130,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
       "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3403,9 +3389,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3421,9 +3404,6 @@
       "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3441,9 +3421,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3459,9 +3436,6 @@
       "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3581,6 +3555,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4059,6 +4034,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
       "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -7182,6 +7158,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
       "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.9.0",
         "@opentelemetry/resources": "2.9.0",
@@ -7280,6 +7257,7 @@
       "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.62.0"
       },
@@ -7307,6 +7285,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.0.tgz",
       "integrity": "sha512-BTG/mB+WL/1sD2gWwdNc2uuVJjNNBgCDlPFdjco6jJArgbg4IAChtzVeW4debFa/NKBbsGedCjET316sjllWTQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/client-runtime-utils": "7.9.0"
       },
@@ -11272,6 +11251,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
       "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.220.0",
         "import-in-the-middle": "^3.0.0",
@@ -12363,6 +12343,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -12530,6 +12511,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -12625,6 +12607,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -12635,6 +12618,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -12774,6 +12758,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -13670,6 +13655,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13736,6 +13722,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14529,6 +14516,7 @@
       "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -14672,6 +14660,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -15042,6 +15031,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -15093,13 +15083,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -16490,6 +16482,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -16675,6 +16668,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -16985,7 +16979,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -16998,7 +16991,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
       "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -17076,6 +17068,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -17119,7 +17112,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
       "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -18155,6 +18147,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -18680,7 +18673,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -19453,6 +19445,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -20206,7 +20199,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -20301,8 +20293,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -22347,6 +22338,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
       "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
@@ -23005,6 +22997,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -23243,6 +23236,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -23359,6 +23353,7 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -23390,6 +23385,7 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -23456,7 +23452,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -23578,6 +23573,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -23627,6 +23623,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -23739,6 +23736,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23785,6 +23783,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.9.0",
         "@prisma/dev": "0.24.14",
@@ -24069,6 +24068,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24267,7 +24267,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -24650,6 +24651,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
       "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -26133,6 +26135,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26517,6 +26520,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -26753,6 +26757,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27252,6 +27257,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27318,6 +27324,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -27813,6 +27820,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -27822,7 +27830,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
@@ -27852,9 +27859,10 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@jmespath-community/jmespath": "^1.3.0",
         "@nestjs/common": "^11.1.28",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.28",
@@ -28170,6 +28178,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -28207,7 +28216,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",
@@ -23,6 +23,7 @@
     "db:studio": "npx prisma studio"
   },
   "dependencies": {
+    "@jmespath-community/jmespath": "^1.3.0",
     "@nestjs/common": "^11.1.28",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.28",

--- a/packages/backend/src/connectors/engines/engine-types.ts
+++ b/packages/backend/src/connectors/engines/engine-types.ts
@@ -63,16 +63,22 @@ export type AnyEndpointMapping =
   | McpEndpointMapping;
 
 /**
- * Common metadata that may appear on responseMapping. We only use cacheTtl
- * for the moment (used by dynamic-mcp-tools to short-circuit re-execution).
+ * Metadata that may appear on a tool's responseMapping.
+ *
+ * `cacheTtl`  — Redis response cache TTL in seconds (DynamicMcpTools).
+ * `followUp`  — workflow hint appended to the tool result: tells the calling
+ *               agent what to do next, to drive multi-step tool chains.
+ * `transform` — optional response shaping applied before the result reaches the
+ *               MCP client (see response-transform.util).
+ * `fields`    — legacy include list, kept working as a shorthand for
+ *               `transform.include`.
  */
 export interface ResponseMapping {
   cacheTtl?: number;
   type?: string;
   fields?: string[];
-  // Optional workflow hint appended to the tool result (see DynamicMcpTools):
-  // tells the calling agent what to do next, to drive multi-step tool chains.
   followUp?: string;
+  transform?: Record<string, unknown>;
   [k: string]: unknown;
 }
 

--- a/packages/backend/src/connectors/response-transform.util.spec.ts
+++ b/packages/backend/src/connectors/response-transform.util.spec.ts
@@ -345,6 +345,27 @@ describe('applyResponseTransform — include / exclude', () => {
     expect(out.value).toEqual({ a: { keep: 1 } });
   });
 
+  it('keeps element positions when including a single array index', () => {
+    const out = applyResponseTransform(
+      { items: [{ a: 1, b: 9 }, { a: 2, b: 9 }, { a: 3, b: 9 }] },
+      { transform: { include: ['items[1].a'] } },
+    );
+    // Positions preserved, and the result must be a dense array — a sparse one
+    // would serialize with stray nulls and confuse the calling agent.
+    const items = (out.value as { items: unknown[] }).items;
+    expect(items).toHaveLength(3);
+    expect(items[1]).toEqual({ a: 2 });
+    expect(JSON.parse(JSON.stringify(items))).toEqual([null, { a: 2 }, null]);
+  });
+
+  it('excludes a field under a single array index without dropping siblings', () => {
+    const out = applyResponseTransform(
+      { items: [{ a: 1, b: 2 }, { a: 3, b: 4 }] },
+      { transform: { exclude: ['items[0].b'] } },
+    );
+    expect(out.value).toEqual({ items: [{ a: 1 }, { a: 3, b: 4 }] });
+  });
+
   it('runs the legacy `fields` list as an include', () => {
     const out = applyResponseTransform(DATTO, { type: 'json', fields: ['pageDetails.count'] });
     expect(out.applied).toBe(true);

--- a/packages/backend/src/connectors/response-transform.util.spec.ts
+++ b/packages/backend/src/connectors/response-transform.util.spec.ts
@@ -1,0 +1,531 @@
+import {
+  applyResponseTransform,
+  hasTransform,
+  parsePath,
+  readTransform,
+  validateTransform,
+} from './response-transform.util';
+
+/** Datto RMM-shaped payload — the case that motivated the feature. */
+const DATTO = {
+  pageDetails: { count: 2, totalCount: 812, nextPageUrl: 'https://api/v2/account/devices?page=2' },
+  devices: [
+    {
+      id: 1,
+      uid: 'u-1',
+      siteName: 'HQ',
+      hostname: 'PC-01',
+      deviceType: { category: 'Desktop', type: 'Workstation' },
+      operatingSystem: 'Windows 11',
+      online: true,
+      suspended: false,
+      antivirus: { antivirusStatus: 'RunningAndUpToDate', antivirusProduct: 'Defender' },
+      patchManagement: { patchStatus: 'FullyPatched' },
+      udf: { udf1: 'x', udf2: 'y' },
+      internalToken: 'secret',
+    },
+    {
+      id: 2,
+      uid: 'u-2',
+      siteName: 'Branch',
+      hostname: 'PC-02',
+      deviceType: { category: 'Laptop', type: 'Workstation' },
+      operatingSystem: 'Windows 10',
+      online: false,
+      suspended: false,
+      antivirus: { antivirusStatus: 'NotInstalled' },
+      patchManagement: { patchStatus: 'NoPolicy' },
+      udf: { udf1: 'z' },
+      internalToken: 'secret2',
+    },
+  ],
+};
+
+describe('parsePath', () => {
+  it('parses dotted paths with an optional $ root', () => {
+    expect(parsePath('$.a.b')).toEqual([
+      { kind: 'key', name: 'a' },
+      { kind: 'key', name: 'b' },
+    ]);
+    expect(parsePath('a.b')).toEqual(parsePath('$.a.b'));
+    expect(parsePath('$a')).toEqual([{ kind: 'key', name: 'a' }]);
+  });
+
+  it('parses wildcards, indexes and quoted keys', () => {
+    expect(parsePath('devices[*].id')).toEqual([
+      { kind: 'key', name: 'devices' },
+      { kind: 'wildcard' },
+      { kind: 'key', name: 'id' },
+    ]);
+    expect(parsePath('a[0]')).toEqual([{ kind: 'key', name: 'a' }, { kind: 'index', index: 0 }]);
+    expect(parsePath('a[-1]')).toEqual([{ kind: 'key', name: 'a' }, { kind: 'index', index: -1 }]);
+    expect(parsePath("a['weird.key']")).toEqual([
+      { kind: 'key', name: 'a' },
+      { kind: 'key', name: 'weird.key' },
+    ]);
+  });
+
+  it('rejects malformed and unsafe paths', () => {
+    expect(() => parsePath('a[')).toThrow(/Unclosed/);
+    expect(() => parsePath('a[x]')).toThrow(/Invalid array index/);
+    expect(() => parsePath('')).toThrow(/Empty path/);
+    expect(() => parsePath('__proto__.x')).toThrow(/Unsafe/);
+    expect(() => parsePath('a.constructor')).toThrow(/Unsafe/);
+    expect(() => parsePath('a.b.c.d.e.f.g.h'.repeat(10))).toThrow(/too deep/);
+  });
+});
+
+describe('readTransform / hasTransform', () => {
+  it('returns null when there is nothing to do', () => {
+    expect(readTransform(undefined)).toBeNull();
+    expect(readTransform(null)).toBeNull();
+    expect(readTransform({})).toBeNull();
+    expect(readTransform({ cacheTtl: 300, followUp: 'next' })).toBeNull();
+    expect(readTransform({ transform: {} })).toBeNull();
+    expect(readTransform({ transform: { mode: 'off', select: { a: 'a' } } })).toBeNull();
+    expect(hasTransform({ cacheTtl: 60 })).toBe(false);
+  });
+
+  it('honours the legacy documented `fields` shape as an include list', () => {
+    expect(readTransform({ type: 'json', fields: ['a', 'b.c'] })).toEqual({
+      include: ['a', 'b.c'],
+    });
+    expect(hasTransform({ type: 'json', fields: ['a'] })).toBe(true);
+  });
+});
+
+describe('applyResponseTransform — no-op path', () => {
+  it('returns the very same reference when no transform is configured', () => {
+    const raw = { a: 1 };
+    for (const rm of [undefined, null, {}, { cacheTtl: 300 }, { followUp: 'x' }] as any[]) {
+      const out = applyResponseTransform(raw, rm);
+      expect(out.applied).toBe(false);
+      expect(out.value).toBe(raw); // identity, not just deep equality
+      expect(out.error).toBeUndefined();
+    }
+  });
+
+  it('is a no-op for mode "off"', () => {
+    const raw = { a: 1 };
+    const out = applyResponseTransform(raw, { transform: { mode: 'off', select: { x: 'a' } } });
+    expect(out.applied).toBe(false);
+    expect(out.value).toBe(raw);
+  });
+});
+
+describe('applyResponseTransform — select mode', () => {
+  it('reshapes the motivating Datto RMM response', () => {
+    const out = applyResponseTransform(DATTO, {
+      transform: {
+        select: {
+          page: {
+            count: '$.pageDetails.count',
+            totalCount: '$.pageDetails.totalCount',
+            nextPageUrl: '$.pageDetails.nextPageUrl',
+          },
+          devices: {
+            $from: '$.devices[*]',
+            $select: {
+              id: 'id',
+              hostname: 'hostname',
+              siteName: 'siteName',
+              category: 'deviceType.category',
+              operatingSystem: 'operatingSystem',
+              online: 'online',
+              antivirusStatus: 'antivirus.antivirusStatus',
+              patchStatus: 'patchManagement.patchStatus',
+            },
+          },
+        },
+      },
+    });
+
+    expect(out.applied).toBe(true);
+    expect(out.error).toBeUndefined();
+    expect(out.value).toEqual({
+      page: { count: 2, totalCount: 812, nextPageUrl: 'https://api/v2/account/devices?page=2' },
+      devices: [
+        {
+          id: 1,
+          hostname: 'PC-01',
+          siteName: 'HQ',
+          category: 'Desktop',
+          operatingSystem: 'Windows 11',
+          online: true,
+          antivirusStatus: 'RunningAndUpToDate',
+          patchStatus: 'FullyPatched',
+        },
+        {
+          id: 2,
+          hostname: 'PC-02',
+          siteName: 'Branch',
+          category: 'Laptop',
+          operatingSystem: 'Windows 10',
+          online: false,
+          antivirusStatus: 'NotInstalled',
+          patchStatus: 'NoPolicy',
+        },
+      ],
+    });
+  });
+
+  it('shrinks the payload substantially', () => {
+    const before = JSON.stringify(DATTO).length;
+    const after = JSON.stringify(
+      applyResponseTransform(DATTO, {
+        transform: {
+          select: { devices: { $from: 'devices[*]', $select: { hostname: 'hostname' } } },
+        },
+      }).value,
+    ).length;
+    expect(after).toBeLessThan(before / 4);
+  });
+
+  it('omits keys whose path does not resolve, rather than emitting null', () => {
+    const out = applyResponseTransform({ a: 1 }, { transform: { select: { a: 'a', b: 'missing.path' } } });
+    expect(out.value).toEqual({ a: 1 });
+    expect(Object.keys(out.value as object)).not.toContain('b');
+  });
+
+  it('keeps falsy values that do exist', () => {
+    const out = applyResponseTransform(
+      { zero: 0, empty: '', no: false, nil: null },
+      { transform: { select: { zero: 'zero', empty: 'empty', no: 'no', nil: 'nil' } } },
+    );
+    expect(out.value).toEqual({ zero: 0, empty: '', no: false, nil: null });
+  });
+
+  it('supports wildcards, indexes and negative indexes', () => {
+    const doc = { items: [{ n: 1 }, { n: 2 }, { n: 3 }] };
+    expect(
+      applyResponseTransform(doc, {
+        transform: { select: { all: 'items[*].n', first: 'items[0].n', last: 'items[-1].n' } },
+      }).value,
+    ).toEqual({ all: [1, 2, 3], first: 1, last: 3 });
+  });
+
+  it('skips array elements missing the projected field', () => {
+    const doc = { items: [{ n: 1 }, { other: 2 }, { n: 3 }] };
+    expect(applyResponseTransform(doc, { transform: { select: { ns: 'items[*].n' } } }).value).toEqual({
+      ns: [1, 3],
+    });
+  });
+
+  it('walks object values with a wildcard', () => {
+    const doc = { byId: { a: { n: 1 }, b: { n: 2 } } };
+    expect(applyResponseTransform(doc, { transform: { select: { ns: 'byId[*].n' } } }).value).toEqual({
+      ns: [1, 2],
+    });
+  });
+
+  it('supports static literals and passthrough scalars', () => {
+    const out = applyResponseTransform(
+      { a: 1 },
+      {
+        transform: {
+          select: {
+            source: '= datto-rmm',
+            tight: '=x',
+            version: 2,
+            enabled: true,
+            nothing: null,
+          },
+        },
+      },
+    );
+    expect(out.value).toEqual({
+      source: 'datto-rmm',
+      tight: 'x',
+      version: 2,
+      enabled: true,
+      nothing: null,
+    });
+  });
+
+  it('supports nested templates and arrays of specs', () => {
+    const out = applyResponseTransform(
+      { a: { b: 1 }, c: 2 },
+      { transform: { select: { deep: { inner: { value: 'a.b' } }, list: ['a.b', 'c', 'missing'] } } },
+    );
+    expect(out.value).toEqual({ deep: { inner: { value: 1 } }, list: [1, 2] });
+  });
+
+  it('$from without $select returns the raw elements', () => {
+    const out = applyResponseTransform(
+      { items: [{ a: 1 }, { a: 2 }] },
+      { transform: { select: { items: { $from: 'items[*]' } } } },
+    );
+    expect(out.value).toEqual({ items: [{ a: 1 }, { a: 2 }] });
+  });
+
+  it('$from on a non-array wraps a single object, and on a missing path omits the key', () => {
+    expect(
+      applyResponseTransform(
+        { one: { a: 1 } },
+        { transform: { select: { list: { $from: 'one', $select: { a: 'a' } } } } },
+      ).value,
+    ).toEqual({ list: [{ a: 1 }] });
+
+    expect(
+      applyResponseTransform(
+        {},
+        { transform: { select: { list: { $from: 'nope', $select: { a: 'a' } } } } },
+      ).value,
+    ).toEqual({});
+  });
+
+  it('$limit caps the number of mapped elements', () => {
+    const out = applyResponseTransform(
+      { items: [{ a: 1 }, { a: 2 }, { a: 3 }] },
+      { transform: { select: { items: { $from: 'items[*]', $limit: 2, $select: { a: 'a' } } } } },
+    );
+    expect(out.value).toEqual({ items: [{ a: 1 }, { a: 2 }] });
+  });
+
+  it('handles an empty array and a root-level array', () => {
+    expect(
+      applyResponseTransform({ items: [] }, { transform: { select: { items: { $from: 'items[*]', $select: { a: 'a' } } } } })
+        .value,
+    ).toEqual({ items: [] });
+
+    expect(
+      applyResponseTransform([{ a: 1 }, { a: 2 }], {
+        transform: { select: { rows: { $from: '$[*]', $select: { a: 'a' } } } },
+      }).value,
+    ).toEqual({ rows: [{ a: 1 }, { a: 2 }] });
+  });
+
+  it('handles a scalar or null root without throwing', () => {
+    expect(applyResponseTransform('plain text', { transform: { select: { a: 'a' } } }).value).toEqual({});
+    expect(applyResponseTransform(null, { transform: { select: { a: 'a' } } }).value).toEqual({});
+  });
+});
+
+describe('applyResponseTransform — include / exclude', () => {
+  it('excludes nested paths across an array with a wildcard', () => {
+    const out = applyResponseTransform(DATTO, {
+      transform: { exclude: ['devices[*].udf', 'devices[*].internalToken', 'pageDetails.nextPageUrl'] },
+    });
+    const value = out.value as typeof DATTO;
+    expect(out.applied).toBe(true);
+    expect(value.devices[0]).not.toHaveProperty('udf');
+    expect(value.devices[0]).not.toHaveProperty('internalToken');
+    expect(value.devices[0].hostname).toBe('PC-01');
+    expect(value.pageDetails).toEqual({ count: 2, totalCount: 812 });
+  });
+
+  it('does not mutate the raw response', () => {
+    const before = JSON.stringify(DATTO);
+    applyResponseTransform(DATTO, { transform: { exclude: ['devices[*].udf'] } });
+    expect(JSON.stringify(DATTO)).toBe(before);
+  });
+
+  it('excluding a missing path is a no-op', () => {
+    expect(applyResponseTransform({ a: 1 }, { transform: { exclude: ['b.c'] } }).value).toEqual({ a: 1 });
+  });
+
+  it('includes only the listed paths, preserving shape', () => {
+    const out = applyResponseTransform(DATTO, {
+      transform: { include: ['pageDetails.totalCount', 'devices[*].hostname', 'devices[*].online'] },
+    });
+    expect(out.value).toEqual({
+      pageDetails: { totalCount: 812 },
+      devices: [
+        { hostname: 'PC-01', online: true },
+        { hostname: 'PC-02', online: false },
+      ],
+    });
+  });
+
+  it('applies exclude before select', () => {
+    const out = applyResponseTransform(
+      { a: { keep: 1, drop: 2 } },
+      { transform: { exclude: ['a.drop'], select: { a: 'a' } } },
+    );
+    expect(out.value).toEqual({ a: { keep: 1 } });
+  });
+
+  it('runs the legacy `fields` list as an include', () => {
+    const out = applyResponseTransform(DATTO, { type: 'json', fields: ['pageDetails.count'] });
+    expect(out.applied).toBe(true);
+    expect(out.value).toEqual({ pageDetails: { count: 2 } });
+  });
+});
+
+describe('applyResponseTransform — jmespath mode', () => {
+  it('evaluates an expression, including computed values', () => {
+    const out = applyResponseTransform(DATTO, {
+      transform: {
+        mode: 'jmespath',
+        expression: '{ total: length(devices), offline: devices[?online == `false`].hostname }',
+      },
+    });
+    expect(out.applied).toBe(true);
+    expect(out.value).toEqual({ total: 2, offline: ['PC-02'] });
+  });
+
+  it('infers jmespath mode from the presence of an expression', () => {
+    const out = applyResponseTransform(DATTO, { transform: { expression: 'devices[*].hostname' } });
+    expect(out.value).toEqual(['PC-01', 'PC-02']);
+  });
+
+  it('falls back to raw on an invalid expression', () => {
+    const out = applyResponseTransform(DATTO, { transform: { mode: 'jmespath', expression: '((((' } });
+    expect(out.applied).toBe(false);
+    expect(out.value).toBe(DATTO);
+    expect(out.error).toBeTruthy();
+    expect(out.fatal).toBe(false);
+  });
+
+  it('rejects an over-long expression', () => {
+    const out = applyResponseTransform(DATTO, {
+      transform: { mode: 'jmespath', expression: 'a'.repeat(5000) },
+    });
+    expect(out.applied).toBe(false);
+    expect(out.error).toMatch(/too long/);
+  });
+});
+
+describe('applyResponseTransform — failure handling', () => {
+  it('falls back to the raw response by default', () => {
+    const out = applyResponseTransform(DATTO, { transform: { select: { a: 'a[' } } });
+    expect(out.applied).toBe(false);
+    expect(out.value).toBe(DATTO);
+    expect(out.error).toMatch(/Unclosed/);
+    expect(out.fatal).toBe(false);
+  });
+
+  it('marks the outcome fatal when fallbackToRaw is false', () => {
+    const out = applyResponseTransform(DATTO, {
+      transform: { fallbackToRaw: false, select: { a: 'a[' } },
+    });
+    expect(out.applied).toBe(false);
+    expect(out.fatal).toBe(true);
+    expect(out.error).toBeTruthy();
+  });
+
+  it('rejects a non-array include/exclude', () => {
+    const out = applyResponseTransform(DATTO, { transform: { include: 'a' as any } });
+    expect(out.applied).toBe(false);
+    expect(out.error).toMatch(/must be an array/);
+  });
+});
+
+describe('applyResponseTransform — security and limits', () => {
+  it('never pollutes Object.prototype from template keys', () => {
+    // Built via JSON.parse so "__proto__" is a real own property — an object
+    // literal would instead invoke the prototype setter and test nothing.
+    const select = JSON.parse('{"__proto__": {"polluted": "= yes"}, "ok": "a"}');
+    expect(Object.prototype.hasOwnProperty.call(select, '__proto__')).toBe(true);
+    const out = applyResponseTransform({ a: 1 }, { transform: { select } });
+    expect(({} as any).polluted).toBeUndefined();
+    expect(out.value).toEqual({ ok: 1 });
+    expect(Object.getPrototypeOf(out.value)).toBe(Object.prototype);
+  });
+
+  it('never pollutes Object.prototype from upstream keys during exclude', () => {
+    const hostile = JSON.parse('{"a": 1, "__proto__": {"polluted": "yes"}}');
+    applyResponseTransform(hostile, { transform: { exclude: ['a'] } });
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('refuses to traverse prototype paths', () => {
+    const out = applyResponseTransform({ a: 1 }, { transform: { select: { x: 'constructor.name' } } });
+    expect(out.applied).toBe(false);
+    expect(out.error).toMatch(/Unsafe/);
+  });
+
+  it('rejects a template nested past the depth limit', () => {
+    let deep: Record<string, unknown> = { leaf: 'a' };
+    for (let i = 0; i < 15; i++) deep = { nest: deep };
+    const out = applyResponseTransform({ a: 1 }, { transform: { select: deep } });
+    expect(out.applied).toBe(false);
+    expect(out.error).toMatch(/too deeply/);
+  });
+
+  it('rejects an over-long include list', () => {
+    const out = applyResponseTransform({ a: 1 }, {
+      transform: { include: Array.from({ length: 501 }, (_, i) => `f${i}`) },
+    });
+    expect(out.applied).toBe(false);
+    expect(out.error).toMatch(/too many entries/);
+  });
+
+  it('caps the output at maxBytes for arrays', () => {
+    const doc = { rows: Array.from({ length: 200 }, (_, i) => ({ i, pad: 'x'.repeat(50) })) };
+    const out = applyResponseTransform(doc, {
+      transform: { expression: 'rows', maxBytes: 500 },
+    });
+    expect(out.truncated).toBe(true);
+    const value = out.value as { _truncated: boolean; items: unknown[] };
+    expect(value._truncated).toBe(true);
+    expect(value.items.length).toBeGreaterThan(0);
+    expect(value.items.length).toBeLessThan(200);
+    expect(JSON.stringify(out.value).length).toBeLessThan(1200);
+  });
+
+  it('caps the output at maxBytes for objects', () => {
+    const doc = { blob: 'x'.repeat(5000) };
+    const out = applyResponseTransform(doc, { transform: { select: { blob: 'blob' }, maxBytes: 200 } });
+    expect(out.truncated).toBe(true);
+    expect((out.value as any)._truncated).toBe(true);
+    expect((out.value as any).preview).toHaveLength(200);
+  });
+
+  it('leaves output under maxBytes untouched', () => {
+    const out = applyResponseTransform({ a: 1 }, { transform: { select: { a: 'a' }, maxBytes: 10_000 } });
+    expect(out.truncated).toBe(false);
+    expect(out.value).toEqual({ a: 1 });
+  });
+});
+
+describe('validateTransform', () => {
+  it('accepts an empty / absent config', () => {
+    expect(validateTransform(undefined)).toBeNull();
+    expect(validateTransform(null)).toBeNull();
+    expect(validateTransform({})).toBeNull();
+  });
+
+  it('accepts a well-formed select template', () => {
+    expect(
+      validateTransform({
+        select: { page: { count: '$.pageDetails.count' }, devices: { $from: 'devices[*]', $select: { id: 'id' } } },
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts a valid jmespath expression', () => {
+    expect(validateTransform({ mode: 'jmespath', expression: 'devices[*].hostname' })).toBeNull();
+  });
+
+  it('accepts function calls that would type-error against an empty document', () => {
+    // Regression: validation used to *evaluate* the expression against `{}`,
+    // so `length(products)` — valid, and the main reason to reach for JMESPath
+    // — was rejected with a 400 because `products` resolved to null.
+    expect(validateTransform({ mode: 'jmespath', expression: 'length(products)' })).toBeNull();
+    expect(
+      validateTransform({
+        mode: 'jmespath',
+        expression: '{count: length(products), titles: products[*].title}',
+      }),
+    ).toBeNull();
+    expect(validateTransform({ expression: 'sort_by(devices, &hostname)' })).toBeNull();
+    expect(validateTransform({ expression: 'max(prices) - min(prices)' })).toBeNull();
+  });
+
+  it('rejects malformed configs with an actionable message', () => {
+    expect(validateTransform('nope')).toMatch(/must be an object/);
+    expect(validateTransform({ mode: 'magic' })).toMatch(/Unknown mode/);
+    expect(validateTransform({ mode: 'jmespath' })).toMatch(/requires an expression/);
+    expect(validateTransform({ mode: 'jmespath', expression: '((((' })).toBeTruthy();
+    expect(validateTransform({ select: 'x' })).toMatch(/must be an object/);
+    expect(validateTransform({ select: { a: 'b[' } })).toMatch(/Unclosed/);
+    expect(validateTransform({ select: { a: { $from: 42 } } })).toMatch(/\$from/);
+    expect(validateTransform({ select: { a: { $from: 'x', $select: 'y' } } })).toMatch(/\$select/);
+    expect(validateTransform({ include: 'a' })).toMatch(/must be an array/);
+    expect(validateTransform({ exclude: [''] })).toMatch(/non-empty strings/);
+    expect(validateTransform({ maxBytes: -1 })).toMatch(/non-negative/);
+    expect(validateTransform({ fallbackToRaw: 'yes' })).toMatch(/boolean/);
+    expect(validateTransform({ expression: 'a'.repeat(5000) })).toMatch(/too long/);
+  });
+});

--- a/packages/backend/src/connectors/response-transform.util.ts
+++ b/packages/backend/src/connectors/response-transform.util.ts
@@ -1,0 +1,680 @@
+/**
+ * Response transformation — optional, per-tool shaping of an API response
+ * before it is handed to the MCP client.
+ *
+ * Why: upstream endpoints routinely return far more than a tool needs (a Datto
+ * RMM device carries up to 300 UDF fields, IPs and remote-control URLs when the
+ * tool only wants hostname/site/OS/status). Every one of those bytes is billed
+ * to the agent's context window and widens what a third-party model gets to see.
+ * This lets the operator declare the exposed data model per tool, separately
+ * from the full API response.
+ *
+ * Design constraints, in priority order:
+ *   1. A tool without a transform must behave EXACTLY as before — same object,
+ *      same reference. This ships to live customers; the no-op path is the one
+ *      that must never regress.
+ *   2. A broken mapping must never break a working tool. Errors fall back to the
+ *      raw response unless the operator explicitly opted out.
+ *   3. No code execution. Templates are data; the JMESPath escape hatch is a
+ *      data-only expression language. Untrusted upstream keys and operator
+ *      template keys are both filtered for prototype-pollution vectors.
+ *   4. Bounded work. Depth, wildcard fan-out and emitted-node caps, so a
+ *      pathological response or template cannot pin a worker.
+ */
+import {
+  compile as jmespathCompile,
+  search as jmespathSearch,
+} from '@jmespath-community/jmespath';
+import type { ResponseMapping } from './engines/engine-types';
+
+/* ------------------------------------------------------------------ */
+/*  Public contract                                                    */
+/* ------------------------------------------------------------------ */
+
+export interface ResponseTransform {
+  /**
+   * 'select'   — declarative template (default when `select` is present)
+   * 'jmespath' — evaluate `expression`
+   * 'off'      — explicitly disabled; keeps the config around without applying it
+   */
+  mode?: 'select' | 'jmespath' | 'off' | string;
+  /** Keep only these paths, preserving the original document shape. */
+  include?: string[];
+  /** Drop these paths from the document. Applied before include/select. */
+  exclude?: string[];
+  /** Output template: keys are output names, leaves are paths or literals. */
+  select?: Record<string, unknown>;
+  /** JMESPath expression (mode: 'jmespath'). */
+  expression?: string;
+  /** On error, return the raw response instead of failing. Default true. */
+  fallbackToRaw?: boolean;
+  /** Hard cap on the serialized output. 0 / absent = no cap. */
+  maxBytes?: number;
+}
+
+export interface TransformOutcome {
+  /** The value to return to the client. Raw response when `applied` is false. */
+  value: unknown;
+  /** Whether a transform actually ran and changed the value. */
+  applied: boolean;
+  /** Human-readable reason the transform did not run. */
+  error?: string;
+  /** True when the operator asked for errors to surface instead of falling back. */
+  fatal?: boolean;
+  /** True when `maxBytes` kicked in. */
+  truncated?: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Limits                                                             */
+/* ------------------------------------------------------------------ */
+
+const MAX_EXPRESSION_LENGTH = 4000;
+const MAX_TEMPLATE_DEPTH = 10;
+const MAX_PATH_TOKENS = 32;
+const MAX_OUTPUT_NODES = 50_000;
+const MAX_PATHS = 500;
+
+// Same guard as output-schema.util: upstream responses and operator templates
+// both feed object keys, so neither may reach Object.prototype.
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isSafeKey(k: string): boolean {
+  return !DANGEROUS_KEYS.has(k);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+class TransformError extends Error {}
+
+/* ------------------------------------------------------------------ */
+/*  Path parsing — hand-written scanner, no backtracking regex          */
+/* ------------------------------------------------------------------ */
+
+type PathToken =
+  | { kind: 'key'; name: string }
+  | { kind: 'index'; index: number }
+  | { kind: 'wildcard' };
+
+/**
+ * Parse `$.devices[*].deviceType.category`, `devices[0].id`, `a['weird.key']`.
+ * A leading `$.` / `$` is optional so paths read the same absolute or relative.
+ */
+export function parsePath(raw: string): PathToken[] {
+  const tokens: PathToken[] = [];
+  let i = 0;
+  const s = raw.trim();
+
+  if (s.startsWith('$')) {
+    i = 1;
+    if (s[i] === '.') i++;
+  }
+
+  let buffer = '';
+  const flushKey = () => {
+    if (buffer.length === 0) return;
+    if (!isSafeKey(buffer)) {
+      throw new TransformError(`Unsafe path segment "${buffer}"`);
+    }
+    tokens.push({ kind: 'key', name: buffer });
+    buffer = '';
+  };
+
+  while (i < s.length) {
+    const c = s[i];
+    if (c === '.') {
+      flushKey();
+      i++;
+    } else if (c === '[') {
+      flushKey();
+      const close = s.indexOf(']', i);
+      if (close === -1) throw new TransformError(`Unclosed "[" in path "${raw}"`);
+      const inner = s.slice(i + 1, close).trim();
+      if (inner === '*') {
+        tokens.push({ kind: 'wildcard' });
+      } else if (
+        (inner.startsWith("'") && inner.endsWith("'")) ||
+        (inner.startsWith('"') && inner.endsWith('"'))
+      ) {
+        const name = inner.slice(1, -1);
+        if (!isSafeKey(name)) {
+          throw new TransformError(`Unsafe path segment "${name}"`);
+        }
+        tokens.push({ kind: 'key', name });
+      } else {
+        const n = Number(inner);
+        if (!Number.isInteger(n)) {
+          throw new TransformError(`Invalid array index "${inner}" in path "${raw}"`);
+        }
+        tokens.push({ kind: 'index', index: n });
+      }
+      i = close + 1;
+    } else {
+      buffer += c;
+      i++;
+    }
+    if (tokens.length > MAX_PATH_TOKENS) {
+      throw new TransformError(`Path "${raw}" is too deep (max ${MAX_PATH_TOKENS} segments)`);
+    }
+  }
+  flushKey();
+
+  if (tokens.length === 0) {
+    throw new TransformError(`Empty path "${raw}"`);
+  }
+  return tokens;
+}
+
+/**
+ * Resolve a token path against a value.
+ *
+ * A wildcard turns the rest of the path into a projection: elements that don't
+ * have the remaining path are skipped rather than yielding null, which is what
+ * keeps mapped responses small. A missing path resolves to "not found", and the
+ * caller omits the key entirely.
+ */
+function resolveTokens(
+  value: unknown,
+  tokens: PathToken[],
+  i: number,
+): { found: boolean; value?: unknown } {
+  if (i >= tokens.length) return { found: true, value };
+  const token = tokens[i];
+
+  if (token.kind === 'wildcard') {
+    const items = Array.isArray(value)
+      ? value
+      : isPlainObject(value)
+        ? Object.values(value)
+        : null;
+    if (items === null) return { found: false };
+    const out: unknown[] = [];
+    for (const item of items) {
+      const r = resolveTokens(item, tokens, i + 1);
+      if (r.found) out.push(r.value);
+    }
+    return { found: true, value: out };
+  }
+
+  if (token.kind === 'index') {
+    if (!Array.isArray(value)) return { found: false };
+    const idx = token.index < 0 ? value.length + token.index : token.index;
+    if (idx < 0 || idx >= value.length) return { found: false };
+    return resolveTokens(value[idx], tokens, i + 1);
+  }
+
+  if (!isPlainObject(value) || !hasOwn(value, token.name)) return { found: false };
+  return resolveTokens(value[token.name], tokens, i + 1);
+}
+
+function resolvePath(root: unknown, path: string): { found: boolean; value?: unknown } {
+  return resolveTokens(root, parsePath(path), 0);
+}
+
+/* ------------------------------------------------------------------ */
+/*  include / exclude — shape-preserving pruning                       */
+/* ------------------------------------------------------------------ */
+
+function assertPathList(paths: unknown, field: string): string[] {
+  if (!Array.isArray(paths)) {
+    throw new TransformError(`"${field}" must be an array of paths`);
+  }
+  if (paths.length > MAX_PATHS) {
+    throw new TransformError(`"${field}" has too many entries (max ${MAX_PATHS})`);
+  }
+  return paths.map((p) => {
+    if (typeof p !== 'string' || !p.trim()) {
+      throw new TransformError(`"${field}" entries must be non-empty strings`);
+    }
+    return p;
+  });
+}
+
+/** Deep-copy `root` keeping only the listed paths, preserving the original shape. */
+function pickPaths(root: unknown, paths: string[]): unknown {
+  const parsed = paths.map(parsePath);
+  const budget = { nodes: 0 };
+  let out: unknown = undefined;
+  for (const tokens of parsed) {
+    out = mergePick(out, root, tokens, 0, budget);
+  }
+  return out === undefined ? (Array.isArray(root) ? [] : {}) : out;
+}
+
+function mergePick(
+  acc: unknown,
+  value: unknown,
+  tokens: PathToken[],
+  i: number,
+  budget: { nodes: number },
+): unknown {
+  if (++budget.nodes > MAX_OUTPUT_NODES) {
+    throw new TransformError(`Output too large (over ${MAX_OUTPUT_NODES} nodes)`);
+  }
+  if (i >= tokens.length) return value;
+
+  const token = tokens[i];
+
+  if (token.kind === 'wildcard' || token.kind === 'index') {
+    if (!Array.isArray(value)) return acc;
+    const base: unknown[] = Array.isArray(acc) ? [...acc] : [];
+    if (token.kind === 'index') {
+      const idx = token.index < 0 ? value.length + token.index : token.index;
+      if (idx < 0 || idx >= value.length) return acc;
+      base[idx] = mergePick(base[idx], value[idx], tokens, i + 1, budget);
+      return base;
+    }
+    for (let k = 0; k < value.length; k++) {
+      base[k] = mergePick(base[k], value[k], tokens, i + 1, budget);
+    }
+    return base;
+  }
+
+  if (!isPlainObject(value) || !hasOwn(value, token.name)) return acc;
+  // parsePath already rejected the prototype-pollution key names, and
+  // Object.fromEntries never walks the prototype chain.
+  const base: Record<string, unknown> = isPlainObject(acc) ? acc : {};
+  return Object.fromEntries([
+    ...Object.entries(base).filter(([k]) => k !== token.name),
+    [token.name, mergePick(base[token.name], value[token.name], tokens, i + 1, budget)],
+  ]);
+}
+
+/** Deep-copy `root` with the listed paths removed. */
+function omitPaths(root: unknown, paths: string[]): unknown {
+  let out = root;
+  for (const path of paths) {
+    out = omitPath(out, parsePath(path), 0, { nodes: 0 });
+  }
+  return out;
+}
+
+function omitPath(
+  value: unknown,
+  tokens: PathToken[],
+  i: number,
+  budget: { nodes: number },
+): unknown {
+  if (++budget.nodes > MAX_OUTPUT_NODES) {
+    throw new TransformError(`Response too large to prune (over ${MAX_OUTPUT_NODES} nodes)`);
+  }
+  const token = tokens[i];
+  const isLast = i === tokens.length - 1;
+
+  if (token.kind === 'wildcard') {
+    if (Array.isArray(value)) {
+      return value.map((el) => omitPath(el, tokens, i + 1, budget));
+    }
+    if (isPlainObject(value)) {
+      return Object.fromEntries(
+        Object.entries(value)
+          .filter(([k]) => isSafeKey(k))
+          .map(([k, v]) => [k, omitPath(v, tokens, i + 1, budget)]),
+      );
+    }
+    return value;
+  }
+
+  if (token.kind === 'index') {
+    if (!Array.isArray(value)) return value;
+    const idx = token.index < 0 ? value.length + token.index : token.index;
+    if (idx < 0 || idx >= value.length) return value;
+    if (isLast) return value.filter((_, k) => k !== idx);
+    const copy = [...value];
+    copy[idx] = omitPath(copy[idx], tokens, i + 1, budget);
+    return copy;
+  }
+
+  if (!isPlainObject(value)) return value;
+  if (isLast) {
+    return Object.fromEntries(
+      Object.entries(value).filter(([k]) => isSafeKey(k) && k !== token.name),
+    );
+  }
+  if (!hasOwn(value, token.name)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([k]) => isSafeKey(k))
+      .map(([k, v]) => [k, k === token.name ? omitPath(v, tokens, i + 1, budget) : v]),
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  select — declarative output template                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Build the output described by `template`, resolved against `root`.
+ *
+ * Leaf semantics:
+ *   "$.a.b" / "a.b"      → path lookup; the key is omitted when not found
+ *   "= literal"          → the static string "literal"
+ *   42 / true / null     → passed through as-is
+ *   { $from, $select }   → iterate an array, reshaping each element
+ *   { ... }              → nested template
+ *   [ ... ]              → array of the above
+ */
+function buildFromTemplate(
+  root: unknown,
+  template: Record<string, unknown>,
+  depth: number,
+  budget: { nodes: number },
+): Record<string, unknown> {
+  if (depth > MAX_TEMPLATE_DEPTH) {
+    throw new TransformError(`Template nested too deeply (max ${MAX_TEMPLATE_DEPTH})`);
+  }
+  const entries: [string, unknown][] = [];
+  for (const [key, spec] of Object.entries(template)) {
+    if (!isSafeKey(key)) continue;
+    const resolved = resolveTemplateValue(root, spec, depth, budget);
+    if (resolved.found) entries.push([key, resolved.value]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function resolveTemplateValue(
+  root: unknown,
+  spec: unknown,
+  depth: number,
+  budget: { nodes: number },
+): { found: boolean; value?: unknown } {
+  if (++budget.nodes > MAX_OUTPUT_NODES) {
+    throw new TransformError(`Output too large (over ${MAX_OUTPUT_NODES} nodes)`);
+  }
+
+  if (typeof spec === 'string') {
+    if (spec.startsWith('=')) {
+      // "= value" / "=value" — static literal, escape hatch for constants that
+      // would otherwise be read as a path.
+      const literal = spec.slice(1);
+      return { found: true, value: literal.startsWith(' ') ? literal.slice(1) : literal };
+    }
+    return resolvePath(root, spec);
+  }
+
+  if (Array.isArray(spec)) {
+    const out: unknown[] = [];
+    for (const item of spec) {
+      const r = resolveTemplateValue(root, item, depth + 1, budget);
+      if (r.found) out.push(r.value);
+    }
+    return { found: true, value: out };
+  }
+
+  if (isPlainObject(spec)) {
+    if (hasOwn(spec, '$from')) {
+      return resolveIteration(root, spec, depth, budget);
+    }
+    return { found: true, value: buildFromTemplate(root, spec, depth + 1, budget) };
+  }
+
+  // number / boolean / null / undefined → literal
+  return { found: spec !== undefined, value: spec };
+}
+
+/** `{ $from: "$.devices[*]", $select: { … } }` — reshape every array element. */
+function resolveIteration(
+  root: unknown,
+  spec: Record<string, unknown>,
+  depth: number,
+  budget: { nodes: number },
+): { found: boolean; value?: unknown } {
+  const from = spec.$from;
+  if (typeof from !== 'string') {
+    throw new TransformError('"$from" must be a path string');
+  }
+  const source = resolvePath(root, from);
+  if (!source.found) return { found: false };
+
+  const items = Array.isArray(source.value)
+    ? source.value
+    : source.value === undefined || source.value === null
+      ? []
+      : [source.value];
+
+  const limit = typeof spec.$limit === 'number' && spec.$limit > 0 ? spec.$limit : undefined;
+  const slice = limit ? items.slice(0, limit) : items;
+
+  const select = spec.$select;
+  if (select === undefined) {
+    return { found: true, value: slice };
+  }
+  if (!isPlainObject(select)) {
+    throw new TransformError('"$select" must be an object');
+  }
+
+  const out = slice.map((item) => buildFromTemplate(item, select, depth + 1, budget));
+  return { found: true, value: out };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Size cap                                                           */
+/* ------------------------------------------------------------------ */
+
+function capSize(value: unknown, maxBytes: number): { value: unknown; truncated: boolean } {
+  const json = safeStringify(value);
+  if (json === undefined || Buffer.byteLength(json, 'utf8') <= maxBytes) {
+    return { value, truncated: false };
+  }
+
+  if (Array.isArray(value)) {
+    const kept: unknown[] = [];
+    let size = 2; // []
+    for (const item of value) {
+      const itemJson = safeStringify(item) ?? 'null';
+      const itemSize = Buffer.byteLength(itemJson, 'utf8') + 1;
+      if (size + itemSize > maxBytes) break;
+      size += itemSize;
+      kept.push(item);
+    }
+    return {
+      value: {
+        _truncated: true,
+        _note: `Response exceeded maxBytes (${maxBytes}); kept ${kept.length} of ${value.length} items.`,
+        items: kept,
+      },
+      truncated: true,
+    };
+  }
+
+  return {
+    value: {
+      _truncated: true,
+      _note: `Response exceeded maxBytes (${maxBytes}). Narrow the response mapping or raise maxBytes.`,
+      _originalBytes: Buffer.byteLength(json, 'utf8'),
+      preview: json.slice(0, maxBytes),
+    },
+    truncated: true,
+  };
+}
+
+function safeStringify(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Entry points                                                       */
+/* ------------------------------------------------------------------ */
+
+/** Read the transform config out of a responseMapping, honouring legacy `fields`. */
+export function readTransform(
+  responseMapping: ResponseMapping | Record<string, unknown> | null | undefined,
+): ResponseTransform | null {
+  if (!isPlainObject(responseMapping)) return null;
+
+  const raw = responseMapping.transform;
+  if (isPlainObject(raw)) {
+    const t = raw as ResponseTransform;
+    if (t.mode === 'off') return null;
+    const hasWork =
+      t.select !== undefined ||
+      t.expression !== undefined ||
+      t.include !== undefined ||
+      t.exclude !== undefined;
+    return hasWork ? t : null;
+  }
+
+  // Legacy shape documented since the first release but never implemented:
+  //   responseMapping: { type: "json", fields: ["a", "b.c"] }
+  // Treat `fields` as an include list so the documented behaviour finally works.
+  if (Array.isArray(responseMapping.fields) && responseMapping.fields.length > 0) {
+    return { include: responseMapping.fields as string[] };
+  }
+
+  return null;
+}
+
+/** True when this tool has a response mapping that would change the output. */
+export function hasTransform(
+  responseMapping: ResponseMapping | Record<string, unknown> | null | undefined,
+): boolean {
+  return readTransform(responseMapping) !== null;
+}
+
+/**
+ * Validate a transform config without running it. Returns an error message, or
+ * null when the config is usable. Used at save time so a broken mapping is
+ * rejected with a 400 instead of silently degrading at runtime.
+ */
+export function validateTransform(transform: unknown): string | null {
+  if (transform === null || transform === undefined) return null;
+  if (!isPlainObject(transform)) return 'transform must be an object';
+
+  const t = transform as ResponseTransform;
+  if (t.mode !== undefined && !['select', 'jmespath', 'off'].includes(String(t.mode))) {
+    return `Unknown mode "${t.mode}" — expected "select", "jmespath" or "off"`;
+  }
+  if (t.maxBytes !== undefined && (typeof t.maxBytes !== 'number' || t.maxBytes < 0)) {
+    return 'maxBytes must be a non-negative number';
+  }
+  if (t.fallbackToRaw !== undefined && typeof t.fallbackToRaw !== 'boolean') {
+    return 'fallbackToRaw must be a boolean';
+  }
+
+  try {
+    if (t.include !== undefined) assertPathList(t.include, 'include').forEach(parsePath);
+    if (t.exclude !== undefined) assertPathList(t.exclude, 'exclude').forEach(parsePath);
+    if (t.select !== undefined) {
+      if (!isPlainObject(t.select)) return 'select must be an object';
+      validateTemplate(t.select, 0);
+    }
+    if (t.expression !== undefined) {
+      if (typeof t.expression !== 'string' || !t.expression.trim()) {
+        return 'expression must be a non-empty string';
+      }
+      if (t.expression.length > MAX_EXPRESSION_LENGTH) {
+        return `expression is too long (max ${MAX_EXPRESSION_LENGTH} characters)`;
+      }
+      // Parse only. Evaluating against a stand-in document would reject
+      // perfectly valid expressions on a type error — `length(products)` is
+      // correct but throws against `{}` because `products` resolves to null.
+      jmespathCompile(t.expression);
+    }
+  } catch (err: any) {
+    return err?.message ? String(err.message) : 'Invalid transform';
+  }
+
+  if (String(t.mode) === 'jmespath' && !t.expression) {
+    return 'mode "jmespath" requires an expression';
+  }
+  return null;
+}
+
+function validateTemplate(template: Record<string, unknown>, depth: number): void {
+  if (depth > MAX_TEMPLATE_DEPTH) {
+    throw new TransformError(`Template nested too deeply (max ${MAX_TEMPLATE_DEPTH})`);
+  }
+  for (const spec of Object.values(template)) {
+    if (typeof spec === 'string') {
+      if (!spec.startsWith('=')) parsePath(spec);
+    } else if (Array.isArray(spec)) {
+      validateTemplate({ ...spec } as Record<string, unknown>, depth + 1);
+    } else if (isPlainObject(spec)) {
+      if (hasOwn(spec, '$from')) {
+        if (typeof spec.$from !== 'string') throw new TransformError('"$from" must be a path string');
+        parsePath(spec.$from);
+        if (spec.$select !== undefined) {
+          if (!isPlainObject(spec.$select)) throw new TransformError('"$select" must be an object');
+          validateTemplate(spec.$select, depth + 1);
+        }
+      } else {
+        validateTemplate(spec, depth + 1);
+      }
+    }
+  }
+}
+
+/**
+ * Apply a tool's response mapping to a raw engine result.
+ *
+ * Returns the raw value untouched (same reference) when no transform is
+ * configured — this is the hot path for every existing tool and must stay a
+ * single check.
+ */
+export function applyResponseTransform(
+  raw: unknown,
+  responseMapping: ResponseMapping | Record<string, unknown> | null | undefined,
+): TransformOutcome {
+  const transform = readTransform(responseMapping);
+  if (!transform) return { value: raw, applied: false };
+
+  const fallbackToRaw = transform.fallbackToRaw !== false;
+
+  try {
+    let work: unknown = raw;
+
+    if (transform.exclude !== undefined) {
+      work = omitPaths(work, assertPathList(transform.exclude, 'exclude'));
+    }
+    if (transform.include !== undefined) {
+      work = pickPaths(work, assertPathList(transform.include, 'include'));
+    }
+
+    const mode =
+      transform.mode ??
+      (transform.expression ? 'jmespath' : transform.select ? 'select' : 'passthrough');
+
+    if (mode === 'jmespath') {
+      const expression = transform.expression;
+      if (typeof expression !== 'string' || !expression.trim()) {
+        throw new TransformError('mode "jmespath" requires an expression');
+      }
+      if (expression.length > MAX_EXPRESSION_LENGTH) {
+        throw new TransformError(`expression is too long (max ${MAX_EXPRESSION_LENGTH} characters)`);
+      }
+      work = jmespathSearch(work as any, expression);
+    } else if (transform.select !== undefined) {
+      if (!isPlainObject(transform.select)) {
+        throw new TransformError('select must be an object');
+      }
+      work = buildFromTemplate(work, transform.select, 0, { nodes: 0 });
+    }
+
+    let truncated = false;
+    if (typeof transform.maxBytes === 'number' && transform.maxBytes > 0) {
+      const capped = capSize(work, transform.maxBytes);
+      work = capped.value;
+      truncated = capped.truncated;
+    }
+
+    return { value: work, applied: true, truncated };
+  } catch (err: any) {
+    const message = err?.message ? String(err.message) : 'Response mapping failed';
+    return {
+      value: raw,
+      applied: false,
+      error: message,
+      fatal: !fallbackToRaw,
+    };
+  }
+}

--- a/packages/backend/src/connectors/response-transform.util.ts
+++ b/packages/backend/src/connectors/response-transform.util.ts
@@ -261,19 +261,21 @@ function mergePick(
 
   const token = tokens[i];
 
+  // Array branches rebuild with map rather than an indexed write: it keeps
+  // element positions aligned with the source, avoids producing a sparse array
+  // (which would serialize as stray nulls), and leaves no computed-property
+  // write for a reader — or a static analyzer — to have to reason about.
   if (token.kind === 'wildcard' || token.kind === 'index') {
     if (!Array.isArray(value)) return acc;
-    const base: unknown[] = Array.isArray(acc) ? [...acc] : [];
+    const prev: unknown[] = Array.isArray(acc) ? acc : [];
     if (token.kind === 'index') {
       const idx = token.index < 0 ? value.length + token.index : token.index;
       if (idx < 0 || idx >= value.length) return acc;
-      base[idx] = mergePick(base[idx], value[idx], tokens, i + 1, budget);
-      return base;
+      return value.map((el, k) =>
+        k === idx ? mergePick(prev[k], el, tokens, i + 1, budget) : prev[k],
+      );
     }
-    for (let k = 0; k < value.length; k++) {
-      base[k] = mergePick(base[k], value[k], tokens, i + 1, budget);
-    }
-    return base;
+    return value.map((el, k) => mergePick(prev[k], el, tokens, i + 1, budget));
   }
 
   if (!isPlainObject(value) || !hasOwn(value, token.name)) return acc;
@@ -326,9 +328,7 @@ function omitPath(
     const idx = token.index < 0 ? value.length + token.index : token.index;
     if (idx < 0 || idx >= value.length) return value;
     if (isLast) return value.filter((_, k) => k !== idx);
-    const copy = [...value];
-    copy[idx] = omitPath(copy[idx], tokens, i + 1, budget);
-    return copy;
+    return value.map((el, k) => (k === idx ? omitPath(el, tokens, i + 1, budget) : el));
   }
 
   if (!isPlainObject(value)) return value;

--- a/packages/backend/src/connectors/tools.controller.spec.ts
+++ b/packages/backend/src/connectors/tools.controller.spec.ts
@@ -1,0 +1,292 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { ToolsController } from './tools.controller';
+
+const RAW = {
+  pageDetails: { count: 1, totalCount: 812 },
+  devices: [{ id: 1, hostname: 'PC-01', deviceType: { category: 'Desktop' }, udf: { u1: 'x' } }],
+};
+
+const TRANSFORM = {
+  select: {
+    total: '$.pageDetails.totalCount',
+    devices: { $from: '$.devices[*]', $select: { hostname: 'hostname' } },
+  },
+};
+
+const MAPPED = { total: 812, devices: [{ hostname: 'PC-01' }] };
+
+function buildController(overrides: { prisma?: any; connectorsService?: any; mcpServer?: any } = {}) {
+  const prisma = overrides.prisma ?? {
+    mcpTool: {
+      create: jest.fn().mockResolvedValue({ id: 't1' }),
+      update: jest.fn().mockResolvedValue({ id: 't1' }),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      findFirst: jest.fn().mockResolvedValue({ id: 't1', responseMapping: null }),
+      findUnique: jest.fn().mockResolvedValue({ id: 't1' }),
+    },
+    toolInvocation: { findMany: jest.fn().mockResolvedValue([]) },
+  };
+  const connectorsService = overrides.connectorsService ?? {
+    findById: jest.fn().mockResolvedValue({ id: 'c1', organizationId: 'org1', userId: 'u1', type: 'REST' }),
+    executeConnectorCall: jest.fn().mockResolvedValue(RAW),
+  };
+  const mcpServer = overrides.mcpServer ?? {
+    reloadConnectorTools: jest.fn().mockResolvedValue(undefined),
+  };
+  const controller = new ToolsController(prisma as any, mcpServer as any, connectorsService as any);
+  return { controller, prisma, connectorsService, mcpServer };
+}
+
+const req = (role = 'ADMIN') => ({ user: { sub: 'u1', organizationId: 'org1', role } });
+
+describe('ToolsController — response mapping validation', () => {
+  it('rejects a malformed transform on create instead of degrading at call time', async () => {
+    const { controller, prisma } = buildController();
+    await expect(
+      controller.create(req(), 'c1', {
+        name: 't',
+        description: 'd',
+        parameters: {},
+        endpointMapping: { method: 'GET', path: '/x' },
+        responseMapping: { transform: { select: { a: 'bad[' } } },
+      } as any),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.mcpTool.create).not.toHaveBeenCalled();
+  });
+
+  it('accepts a well-formed transform', async () => {
+    const { controller, prisma } = buildController();
+    await controller.create(req(), 'c1', {
+      name: 't',
+      description: 'd',
+      parameters: {},
+      endpointMapping: { method: 'GET', path: '/x' },
+      responseMapping: { transform: TRANSFORM },
+    } as any);
+    expect(prisma.mcpTool.create).toHaveBeenCalled();
+  });
+
+  it('rejects a malformed transform on update', async () => {
+    const { controller, prisma } = buildController();
+    await expect(
+      controller.update(req(), 't1', 'c1', {
+        responseMapping: { transform: { mode: 'jmespath', expression: '((((' } },
+      } as any),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.mcpTool.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('drops a stale outputSchema when the transform changes', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue({ responseMapping: { transform: { select: { a: 'a' } } } });
+    await controller.update(req(), 't1', 'c1', { responseMapping: { transform: TRANSFORM } } as any);
+    expect(prisma.mcpTool.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ outputSchema: null }) }),
+    );
+  });
+
+  it('keeps the outputSchema when the transform is unchanged', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue({ responseMapping: { transform: TRANSFORM } });
+    await controller.update(req(), 't1', 'c1', {
+      responseMapping: { transform: TRANSFORM, cacheTtl: 60 },
+    } as any);
+    const data = prisma.mcpTool.updateMany.mock.calls[0][0].data;
+    expect(data.outputSchema).toBeUndefined();
+  });
+});
+
+describe('ToolsController — PATCH response-mapping', () => {
+  it('stores the transform while preserving cacheTtl and followUp', async () => {
+    const { controller, prisma, mcpServer } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue({
+      responseMapping: { cacheTtl: 300, followUp: 'then call X' },
+    });
+
+    const res = await controller.setResponseMapping(req(), 't1', 'c1', { transform: TRANSFORM });
+
+    expect(res).toEqual({ transform: TRANSFORM, active: true });
+    expect(prisma.mcpTool.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          responseMapping: { cacheTtl: 300, followUp: 'then call X', transform: TRANSFORM },
+        }),
+      }),
+    );
+    expect(mcpServer.reloadConnectorTools).toHaveBeenCalledWith('c1');
+  });
+
+  it('clears the transform on null and keeps the other keys', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue({
+      responseMapping: { cacheTtl: 300, transform: TRANSFORM },
+    });
+
+    const res = await controller.setResponseMapping(req(), 't1', 'c1', { transform: null });
+
+    expect(res).toEqual({ transform: null, active: false });
+    expect(prisma.mcpTool.updateMany.mock.calls[0][0].data.responseMapping).toEqual({ cacheTtl: 300 });
+  });
+
+  it('rejects a malformed transform', async () => {
+    const { controller } = buildController();
+    await expect(
+      controller.setResponseMapping(req(), 't1', 'c1', { transform: { select: { a: 'a[' } } }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('refuses a tool that does not belong to the connector', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue(null);
+    await expect(
+      controller.setResponseMapping(req(), 't1', 'c1', { transform: TRANSFORM }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('refuses a VIEWER', async () => {
+    const { controller } = buildController();
+    await expect(
+      controller.setResponseMapping(req('VIEWER'), 't1', 'c1', { transform: TRANSFORM }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});
+
+describe('ToolsController — preview-mapping', () => {
+  it('maps an explicit sample without calling the upstream API', async () => {
+    const { controller, connectorsService } = buildController();
+    const res: any = await controller.previewMapping(req(), 't1', 'c1', {
+      transform: TRANSFORM,
+      sample: RAW,
+    });
+
+    expect(connectorsService.executeConnectorCall).not.toHaveBeenCalled();
+    expect(res.ok).toBe(true);
+    expect(res.sampleSource).toBe('body');
+    expect(res.mapped).toEqual(MAPPED);
+    expect(res.mappingApplied).toBe(true);
+    expect(res.rawBytes).toBeGreaterThan(res.mappedBytes);
+    expect(res.bytesSavedPct).toBeGreaterThan(0);
+  });
+
+  it('falls back to the most recent recorded response', async () => {
+    const { controller, prisma } = buildController();
+    prisma.toolInvocation.findMany.mockResolvedValue([
+      { output: null, createdAt: new Date('2026-07-30') },
+      { output: RAW, createdAt: new Date('2026-07-29') },
+    ]);
+
+    const res: any = await controller.previewMapping(req(), 't1', 'c1', { transform: TRANSFORM });
+
+    expect(res.ok).toBe(true);
+    expect(res.sampleSource).toBe('last-invocation');
+    expect(res.raw).toEqual(RAW);
+    expect(res.mapped).toEqual(MAPPED);
+  });
+
+  it('explains what to do when there is no sample at all', async () => {
+    const { controller } = buildController();
+    const res: any = await controller.previewMapping(req(), 't1', 'c1', { transform: TRANSFORM });
+    expect(res.ok).toBe(false);
+    expect(res.sampleSource).toBe('none');
+    expect(res.error).toMatch(/Run the tool once/);
+  });
+
+  it('previews the stored mapping when no transform is supplied', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue({ responseMapping: { transform: TRANSFORM } });
+    const res: any = await controller.previewMapping(req(), 't1', 'c1', { sample: RAW });
+    expect(res.mapped).toEqual(MAPPED);
+  });
+
+  it('previews "no mapping" for an explicit null', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findFirst.mockResolvedValue({ responseMapping: { transform: TRANSFORM } });
+    const res: any = await controller.previewMapping(req(), 't1', 'c1', {
+      transform: null,
+      sample: RAW,
+    });
+    expect(res.mappingApplied).toBe(false);
+    expect(res.mapped).toEqual(RAW);
+  });
+
+  it('rejects a malformed transform', async () => {
+    const { controller } = buildController();
+    await expect(
+      controller.previewMapping(req(), 't1', 'c1', { transform: { select: { a: 'a[' } }, sample: RAW }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('stores nothing', async () => {
+    const { controller, prisma } = buildController();
+    await controller.previewMapping(req(), 't1', 'c1', { transform: TRANSFORM, sample: RAW });
+    expect(prisma.mcpTool.update).not.toHaveBeenCalled();
+    expect(prisma.mcpTool.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('ToolsController — test endpoint', () => {
+  const tool = (responseMapping?: unknown) => ({
+    id: 't1',
+    connectorId: 'c1',
+    outputSchema: { type: 'object', properties: { pageDetails: {} } },
+    endpointMapping: { method: 'GET', path: '/devices' },
+    responseMapping,
+    connector: { id: 'c1', authType: 'NONE', type: 'REST' },
+  });
+
+  it('keeps `result` raw and adds the mapped view', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findUnique.mockResolvedValue(tool({ transform: TRANSFORM }));
+
+    const res: any = await controller.testTool('c1', 't1', req(), {});
+
+    expect(res.ok).toBe(true);
+    expect(res.result).toEqual(RAW); // unchanged for existing API consumers
+    expect(res.mapped).toEqual(MAPPED);
+    expect(res.mappingApplied).toBe(true);
+    expect(res.bytesSavedPct).toBeGreaterThan(0);
+  });
+
+  it('reports mappingApplied=false and mapped=raw for a tool without a mapping', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findUnique.mockResolvedValue(tool(undefined));
+
+    const res: any = await controller.testTool('c1', 't1', req(), {});
+
+    expect(res.mappingApplied).toBe(false);
+    expect(res.mapped).toEqual(RAW);
+    expect(res.rawBytes).toBe(res.mappedBytes);
+    expect(res.bytesSavedPct).toBe(0);
+  });
+
+  it('previews an unsaved transform passed in the body without persisting it', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findUnique.mockResolvedValue(tool(undefined));
+
+    const res: any = await controller.testTool('c1', 't1', req(), { transform: TRANSFORM });
+
+    expect(res.mapped).toEqual(MAPPED);
+    expect(prisma.mcpTool.update).not.toHaveBeenCalled();
+  });
+
+  it('reports a broken mapping instead of hiding it', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findUnique.mockResolvedValue(tool({ transform: { select: { a: 'a[' } } }));
+
+    const res: any = await controller.testTool('c1', 't1', req(), {});
+
+    expect(res.ok).toBe(true);
+    expect(res.mappingApplied).toBe(false);
+    expect(res.mappingError).toMatch(/Unclosed/);
+  });
+
+  it('infers the output schema from the mapped shape when a mapping is active', async () => {
+    const { controller, prisma } = buildController();
+    prisma.mcpTool.findUnique.mockResolvedValue({ ...tool({ transform: TRANSFORM }), outputSchema: null });
+
+    await controller.testTool('c1', 't1', req(), {});
+
+    const inferred = prisma.mcpTool.update.mock.calls[0][0].data.outputSchema;
+    expect(Object.keys(inferred.properties).sort()).toEqual(['devices', 'total']);
+  });
+});

--- a/packages/backend/src/connectors/tools.controller.ts
+++ b/packages/backend/src/connectors/tools.controller.ts
@@ -29,6 +29,11 @@ import { ConnectorsService } from './connectors.service';
 import { inferJsonSchema } from './output-schema.util';
 import { classifyToolExecutionError } from './connector-error.util';
 import {
+  applyResponseTransform,
+  hasTransform,
+  validateTransform,
+} from './response-transform.util';
+import {
   ToolAnnotations,
   deriveToolAnnotations,
   parseAnnotationsOverride,
@@ -38,6 +43,34 @@ import {
   findUnknownCallerContextVars,
   usesCallerContextDeep,
 } from '../common/caller-context.util';
+
+const RESPONSE_MAPPING_DESC =
+  'Optional response handling for this tool. Keys: `cacheTtl` (seconds), ' +
+  '`followUp` (workflow hint appended to the result) and `transform` — the ' +
+  'response shaping applied before the result reaches the MCP client. ' +
+  '`transform` accepts `include` / `exclude` (path lists, shape preserved), ' +
+  '`select` (output template: leaves are paths like `$.a.b`, `= literal` for ' +
+  'static values, `{ $from, $select }` to reshape array elements), ' +
+  '`expression` with `mode: "jmespath"`, `fallbackToRaw` (default true) and ' +
+  '`maxBytes`. Omit `transform` and the raw upstream response is returned ' +
+  'unchanged.';
+
+const RESPONSE_MAPPING_EXAMPLE = {
+  transform: {
+    select: {
+      page: { count: '$.pageDetails.count', totalCount: '$.pageDetails.totalCount' },
+      devices: {
+        $from: '$.devices[*]',
+        $select: {
+          id: 'id',
+          hostname: 'hostname',
+          category: 'deviceType.category',
+          antivirusStatus: 'antivirus.antivirusStatus',
+        },
+      },
+    },
+  },
+};
 
 class CreateToolDto {
   @ApiProperty({
@@ -78,9 +111,10 @@ class CreateToolDto {
   endpointMapping: Record<string, unknown>;
 
   @ApiPropertyOptional({
-    description: 'Optional response shaping (field selection, rename).',
+    description: RESPONSE_MAPPING_DESC,
     type: 'object',
     additionalProperties: true,
+    example: RESPONSE_MAPPING_EXAMPLE,
   })
   @IsOptional()
   @IsObject()
@@ -117,9 +151,10 @@ class UpdateToolDto {
   endpointMapping?: Record<string, unknown>;
 
   @ApiPropertyOptional({
-    description: 'Response shaping.',
+    description: RESPONSE_MAPPING_DESC,
     type: 'object',
     additionalProperties: true,
+    example: RESPONSE_MAPPING_EXAMPLE,
   })
   @IsOptional()
   @IsObject()
@@ -193,6 +228,55 @@ class TestToolDto {
   @IsOptional()
   @IsObject()
   params?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description:
+      'Response transform to preview for this run, overriding the one stored on ' +
+      'the tool. Lets the editor try an unsaved mapping against a live response. ' +
+      'The stored mapping is not modified.',
+    type: 'object',
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsObject()
+  transform?: Record<string, unknown>;
+}
+
+class SetResponseMappingDto {
+  @ApiPropertyOptional({
+    description:
+      'The response transform to store. Send `null` to remove it and go back to ' +
+      'returning the raw upstream response. `cacheTtl` and `followUp` on the ' +
+      'tool are preserved.',
+    type: 'object',
+    additionalProperties: true,
+    nullable: true,
+    example: RESPONSE_MAPPING_EXAMPLE.transform,
+  })
+  @IsOptional()
+  @IsObject()
+  transform?: Record<string, unknown> | null;
+}
+
+class PreviewMappingDto {
+  @ApiPropertyOptional({
+    description:
+      'The transform to evaluate. Defaults to the one stored on the tool.',
+    type: 'object',
+    additionalProperties: true,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsObject()
+  transform?: Record<string, unknown> | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Sample response to map. When omitted, the most recent real response ' +
+      'recorded for this tool is used.',
+  })
+  @IsOptional()
+  sample?: unknown;
 }
 
 @ApiTags('Tools')
@@ -240,6 +324,72 @@ export class ToolsController {
     }
   }
 
+  /**
+   * Reject a malformed response transform at save time. Left to runtime it
+   * would silently fall back to the raw response, which reads as "the mapping
+   * does nothing" — the hardest kind of bug to diagnose from the UI.
+   */
+  private assertValidResponseMapping(responseMapping: unknown) {
+    if (!responseMapping || typeof responseMapping !== 'object') return;
+    const transform = (responseMapping as Record<string, unknown>).transform;
+    if (transform === undefined || transform === null) return;
+    const error = validateTransform(transform);
+    if (error) {
+      throw new BadRequestException(`Invalid response mapping: ${error}`);
+    }
+  }
+
+  /**
+   * Most recent real response recorded for a tool, used as the sample for the
+   * mapping preview. Scans the last few successful invocations rather than
+   * filtering on JSON null in SQL: `output` is only null for older rows, and a
+   * small scan keeps the query portable.
+   */
+  private async findLatestSample(
+    toolId: string,
+  ): Promise<{ output: unknown; createdAt: Date } | null> {
+    const recent = await this.prisma.toolInvocation.findMany({
+      where: { toolId, status: 'SUCCESS' },
+      orderBy: { createdAt: 'desc' },
+      take: 10,
+      select: { output: true, createdAt: true },
+    });
+    const hit = recent.find((r) => r.output !== null && r.output !== undefined);
+    return hit ? { output: hit.output, createdAt: hit.createdAt } : null;
+  }
+
+  private static byteLength(value: unknown): number {
+    try {
+      const json = JSON.stringify(value);
+      return json === undefined ? 0 : Buffer.byteLength(json, 'utf8');
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Summary of what a transform did to a response, shared by the test and
+   * preview endpoints so the UI can render the same "12.4 KB → 0.9 KB (−93%)"
+   * badge in both places.
+   */
+  private static mappingSummary(raw: unknown, mapping: unknown) {
+    const outcome = applyResponseTransform(raw, mapping as any);
+    const rawBytes = ToolsController.byteLength(raw);
+    const mappedBytes = outcome.applied
+      ? ToolsController.byteLength(outcome.value)
+      : rawBytes;
+    return {
+      mapped: outcome.value,
+      mappingApplied: outcome.applied,
+      ...(outcome.error ? { mappingError: outcome.error } : {}),
+      ...(outcome.truncated ? { mappingTruncated: true } : {}),
+      rawBytes,
+      mappedBytes,
+      bytesSavedPct:
+        rawBytes > 0 ? Math.round(((rawBytes - mappedBytes) / rawBytes) * 100) : 0,
+    };
+  }
+
   @Get()
   @ApiOperation({ summary: 'List tools for a connector' })
   async list(@Req() req: any, @Param('connectorId') connectorId: string) {
@@ -259,6 +409,7 @@ export class ToolsController {
   ) {
     await this.assertCanWriteConnector(connectorId, req);
     this.assertKnownCallerContextVars(dto.endpointMapping);
+    this.assertValidResponseMapping(dto.responseMapping);
     const tool = await this.prisma.mcpTool.create({
       data: {
         connectorId,
@@ -297,6 +448,7 @@ export class ToolsController {
     const skipped: string[] = [];
 
     for (const dto of toolDefs) {
+      this.assertValidResponseMapping(dto.responseMapping);
       try {
         const tool = await this.prisma.mcpTool.create({
           data: {
@@ -339,12 +491,32 @@ export class ToolsController {
     if (dto.endpointMapping !== undefined) {
       this.assertKnownCallerContextVars(dto.endpointMapping);
     }
+    if (dto.responseMapping !== undefined) {
+      this.assertValidResponseMapping(dto.responseMapping);
+    }
+
+    // A changed transform changes the shape clients receive, so the stored
+    // outputSchema (inferred from the previous shape) no longer describes it.
+    // Drop it and let the next successful test re-infer it.
+    const data: Record<string, unknown> = { ...(dto as Record<string, unknown>) };
+    if (dto.responseMapping !== undefined) {
+      const current = await this.prisma.mcpTool.findFirst({
+        where: { id: toolId, connectorId },
+        select: { responseMapping: true },
+      });
+      const before = JSON.stringify(
+        (current?.responseMapping as Record<string, unknown> | null)?.transform ?? null,
+      );
+      const after = JSON.stringify(dto.responseMapping?.transform ?? null);
+      if (before !== after) data.outputSchema = null;
+    }
+
     // Bind the toolId to the connectorId in the WHERE clause so that
     // a request like /connectors/<my>/tools/<other-org's-tool> cannot
     // update a tool that doesn't belong to the requested connector.
     const result = await this.prisma.mcpTool.updateMany({
       where: { id: toolId, connectorId },
-      data: dto as any,
+      data: data as any,
     });
     if (result.count === 0) {
       throw new ForbiddenException('Tool not found');
@@ -445,6 +617,158 @@ export class ToolsController {
     };
   }
 
+  @Get(':toolId/response-mapping')
+  @ApiOperation({
+    summary: 'Get the response mapping configured for a tool',
+    description:
+      'Returns the stored `transform` (or null), whether it is active, and ' +
+      'whether a recent real response is available to preview it against.',
+  })
+  async getResponseMapping(
+    @Req() req: any,
+    @Param('toolId') toolId: string,
+    @Param('connectorId') connectorId: string,
+  ) {
+    await this.assertCanWriteConnector(connectorId, req);
+    const tool = await this.prisma.mcpTool.findFirst({
+      where: { id: toolId, connectorId },
+      select: { responseMapping: true },
+    });
+    if (!tool) throw new ForbiddenException('Tool not found');
+
+    const responseMapping = tool.responseMapping as Record<string, unknown> | null;
+    const lastSample = await this.findLatestSample(toolId);
+
+    return {
+      transform: (responseMapping?.transform as Record<string, unknown>) ?? null,
+      active: hasTransform(responseMapping),
+      sampleAvailable: !!lastSample,
+      sampleCapturedAt: lastSample?.createdAt ?? null,
+    };
+  }
+
+  @Patch(':toolId/response-mapping')
+  @ApiOperation({
+    summary: 'Set or clear the response mapping for a tool',
+    description:
+      'Stores `responseMapping.transform` without touching `cacheTtl` or ' +
+      '`followUp`. Response mapping shrinks what an MCP client receives — ' +
+      'fewer tokens, and only the fields the tool actually needs leave the ' +
+      'workspace. Send `transform: null` to go back to the raw response. ' +
+      'A malformed transform is rejected here rather than silently ignored at ' +
+      'call time.',
+  })
+  async setResponseMapping(
+    @Req() req: any,
+    @Param('toolId') toolId: string,
+    @Param('connectorId') connectorId: string,
+    @Body() dto: SetResponseMappingDto,
+  ) {
+    await this.assertCanWriteConnector(connectorId, req);
+
+    const tool = await this.prisma.mcpTool.findFirst({
+      where: { id: toolId, connectorId },
+      select: { responseMapping: true },
+    });
+    if (!tool) throw new ForbiddenException('Tool not found');
+
+    if (dto.transform) {
+      const error = validateTransform(dto.transform);
+      if (error) throw new BadRequestException(`Invalid response mapping: ${error}`);
+    }
+
+    // Merge, so cacheTtl / followUp survive a mapping edit.
+    const current = (tool.responseMapping as Record<string, unknown> | null) ?? {};
+    const next: Record<string, unknown> = { ...current };
+    if (dto.transform) {
+      next.transform = dto.transform;
+    } else {
+      delete next.transform;
+    }
+
+    await this.prisma.mcpTool.updateMany({
+      where: { id: toolId, connectorId },
+      data: {
+        responseMapping: (Object.keys(next).length > 0 ? next : null) as any,
+        // The advertised outputSchema described the previous shape.
+        outputSchema: null as any,
+      },
+    });
+
+    await this.mcpServer.reloadConnectorTools(connectorId);
+    return {
+      transform: dto.transform ?? null,
+      active: hasTransform(next),
+    };
+  }
+
+  @Post(':toolId/preview-mapping')
+  @ApiOperation({
+    summary: 'Preview a response mapping without calling the upstream API',
+    description:
+      'Runs a transform against a sample response and returns the mapped ' +
+      'result plus the size delta. With no `sample`, the most recent real ' +
+      'response recorded for this tool is used — so a mapping can be built and ' +
+      'checked against production-shaped data without hitting the API again. ' +
+      'Purely read-only: nothing is stored.',
+  })
+  async previewMapping(
+    @Req() req: any,
+    @Param('toolId') toolId: string,
+    @Param('connectorId') connectorId: string,
+    @Body() dto: PreviewMappingDto,
+  ) {
+    await this.assertCanWriteConnector(connectorId, req);
+
+    const tool = await this.prisma.mcpTool.findFirst({
+      where: { id: toolId, connectorId },
+      select: { responseMapping: true },
+    });
+    if (!tool) throw new ForbiddenException('Tool not found');
+
+    if (dto.transform) {
+      const error = validateTransform(dto.transform);
+      if (error) throw new BadRequestException(`Invalid response mapping: ${error}`);
+    }
+
+    let sample = dto.sample;
+    let sampleSource: 'body' | 'last-invocation' | 'none' = 'body';
+    let sampleCapturedAt: Date | null = null;
+
+    if (sample === undefined) {
+      const last = await this.findLatestSample(toolId);
+      if (!last) {
+        return {
+          ok: false,
+          sampleSource: 'none' as const,
+          error:
+            'No sample available. Run the tool once (Test, or from a connected ' +
+            'client), or pass a `sample` in the request body.',
+        };
+      }
+      sample = last.output;
+      sampleSource = 'last-invocation';
+      sampleCapturedAt = last.createdAt;
+    }
+
+    // An explicit `transform: null` previews "no mapping"; omitting the key
+    // previews whatever is stored on the tool.
+    const mapping =
+      dto.transform !== undefined
+        ? dto.transform === null
+          ? null
+          : { transform: dto.transform }
+        : (tool.responseMapping as Record<string, unknown> | null);
+
+    return {
+      ok: true,
+      sampleSource,
+      sampleCapturedAt,
+      raw: sample,
+      ...ToolsController.mappingSummary(sample, mapping),
+    };
+  }
+
   @Patch(':toolId/proxy')
   @ApiOperation({
     summary: 'Toggle proxy / web-unblocker routing for a single tool',
@@ -518,11 +842,25 @@ export class ToolsController {
       );
       const durationMs = Date.now() - startTime;
       const withNote = callerContextNote ? { note: callerContextNote } : {};
+
+      // Shape the response the same way a real MCP call would. `result` stays
+      // the raw upstream payload so existing API consumers are unaffected; the
+      // mapped view is additive. An unsaved `transform` in the body wins, so
+      // the editor can try a mapping before committing to it.
+      const mapping = body.transform
+        ? { transform: body.transform }
+        : (tool.responseMapping as Record<string, unknown> | null);
+      const summary = ToolsController.mappingSummary(result, mapping);
+
       // Auto-fill the tool's output schema from this real response (first time
-      // only). Best-effort — never let it affect the test result.
+      // only). Infer from the mapped shape when a mapping is active, so the
+      // advertised schema describes what clients actually receive.
+      // Best-effort — never let it affect the test result.
       if (!tool.outputSchema) {
         try {
-          const inferred = inferJsonSchema(result);
+          const inferred = inferJsonSchema(
+            summary.mappingApplied ? summary.mapped : result,
+          );
           if (inferred) {
             await this.prisma.mcpTool.update({
               where: { id: tool.id },
@@ -538,6 +876,7 @@ export class ToolsController {
         ok: true,
         durationMs,
         result,
+        ...summary,
         ...withNote,
       };
     } catch (err: any) {

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.spec.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.spec.ts
@@ -1,0 +1,186 @@
+import { DynamicMcpTools } from './dynamic-mcp-tools';
+import type { RegisteredTool } from './tool-registry';
+
+/**
+ * Runtime behaviour of response shaping, the response cache and the workflow
+ * hint — the three things that share the result-rendering path.
+ */
+
+const RAW = {
+  pageDetails: { count: 1, totalCount: 812 },
+  devices: [
+    { id: 1, hostname: 'PC-01', deviceType: { category: 'Desktop' }, udf: { u1: 'x' } },
+  ],
+};
+
+const SELECT_TRANSFORM = {
+  transform: {
+    select: {
+      total: '$.pageDetails.totalCount',
+      devices: { $from: '$.devices[*]', $select: { hostname: 'hostname', category: 'deviceType.category' } },
+    },
+  },
+};
+
+const MAPPED = { total: 812, devices: [{ hostname: 'PC-01', category: 'Desktop' }] };
+
+function makeTool(responseMapping?: Record<string, unknown>): RegisteredTool {
+  return {
+    id: 'tool-1',
+    connectorId: 'conn-1',
+    organizationId: 'org-1',
+    name: 'list_devices',
+    description: 'List devices',
+    parameters: { type: 'object', properties: {} },
+    connectorType: 'REST',
+    connectorConfig: { baseUrl: 'https://api.example.com', authType: 'NONE' },
+    endpointMapping: { method: 'GET', path: '/devices' },
+    responseMapping,
+  };
+}
+
+function build(tool: RegisteredTool, opts: { engineResult?: unknown; cached?: string | null } = {}) {
+  const redis = {
+    get: jest.fn().mockResolvedValue(opts.cached ?? null),
+    set: jest.fn().mockResolvedValue(undefined),
+    incr: jest.fn(),
+    expire: jest.fn(),
+    ttl: jest.fn(),
+  };
+  const audit = { logInvocation: jest.fn().mockResolvedValue(undefined) };
+  const restEngine = {
+    execute: jest.fn().mockResolvedValue(opts.engineResult ?? RAW),
+  };
+  const executor = new DynamicMcpTools(
+    { getTool: () => tool, getToolForOrg: () => tool } as any,
+    audit as any,
+    redis as any,
+    { checkLicenseActive: jest.fn().mockResolvedValue(undefined) } as any,
+    { isCloud: () => false } as any,
+    {} as any,
+    restEngine as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    { scheduleObservationalIngest: jest.fn() } as any,
+  );
+  return { executor, redis, audit, restEngine };
+}
+
+describe('DynamicMcpTools — response shaping', () => {
+  it('leaves the output byte-identical when no transform is configured', async () => {
+    const { executor } = build(makeTool());
+    const res = await executor.executeTool('list_devices', {});
+    expect(res.content[0].text).toBe(JSON.stringify(RAW, null, 2));
+    expect(res.isError).toBeUndefined();
+  });
+
+  it('is a no-op when responseMapping only carries cacheTtl / followUp', async () => {
+    const { executor } = build(makeTool({ cacheTtl: 0, followUp: undefined }));
+    const res = await executor.executeTool('list_devices', {});
+    expect(res.content[0].text).toBe(JSON.stringify(RAW, null, 2));
+  });
+
+  it('applies a configured transform to the text and to structuredContent', async () => {
+    const { executor } = build(makeTool(SELECT_TRANSFORM));
+    const res = await executor.executeTool('list_devices', {});
+    expect(JSON.parse(res.content[0].text)).toEqual(MAPPED);
+    expect(res.structured).toEqual(MAPPED);
+  });
+
+  it('applies the transform for every connector type, not just REST', async () => {
+    const soapTool = { ...makeTool(SELECT_TRANSFORM), connectorType: 'SOAP' };
+    const soapEngine = { execute: jest.fn().mockResolvedValue(RAW) };
+    const executor = new DynamicMcpTools(
+      { getTool: () => soapTool, getToolForOrg: () => soapTool } as any,
+      { logInvocation: jest.fn() } as any,
+      { get: jest.fn(), set: jest.fn() } as any,
+      { checkLicenseActive: jest.fn() } as any,
+      { isCloud: () => false } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      soapEngine as any,
+      {} as any,
+      {} as any,
+      { scheduleObservationalIngest: jest.fn() } as any,
+    );
+    const res = await executor.executeTool('list_devices', {});
+    expect(soapEngine.execute).toHaveBeenCalled();
+    expect(JSON.parse(res.content[0].text)).toEqual(MAPPED);
+  });
+
+  it('appends the workflow hint after the mapped payload, and keeps structuredContent parseable', async () => {
+    const { executor } = build(makeTool({ ...SELECT_TRANSFORM, followUp: 'now call get_device' }));
+    const res = await executor.executeTool('list_devices', {});
+    expect(res.content[0].text).toContain('WORKFLOW HINT');
+    expect(res.content[0].text.startsWith(JSON.stringify(MAPPED, null, 2))).toBe(true);
+    // The whole text is no longer valid JSON — this is exactly why the
+    // executor hands back `structured` instead of making callers re-parse it.
+    expect(() => JSON.parse(res.content[0].text)).toThrow();
+    expect(res.structured).toEqual(MAPPED);
+  });
+
+  it('audits the RAW response, not the mapped one', async () => {
+    const { executor, audit } = build(makeTool(SELECT_TRANSFORM));
+    await executor.executeTool('list_devices', {});
+    expect(audit.logInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({ output: RAW, status: 'SUCCESS' }),
+    );
+  });
+
+  it('returns the raw response and does not fail the call when the mapping is broken', async () => {
+    const { executor } = build(makeTool({ transform: { select: { bad: 'a[' } } }));
+    const res = await executor.executeTool('list_devices', {});
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(res.content[0].text)).toEqual(RAW);
+  });
+
+  it('surfaces the error instead when fallbackToRaw is false', async () => {
+    const { executor } = build(
+      makeTool({ transform: { fallbackToRaw: false, select: { bad: 'a[' } } }),
+    );
+    const res = await executor.executeTool('list_devices', {});
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content[0].text).error).toMatch(/Response mapping failed/);
+  });
+});
+
+describe('DynamicMcpTools — response cache', () => {
+  it('caches the raw response, not the rendered text', async () => {
+    const { executor, redis } = build(makeTool({ ...SELECT_TRANSFORM, cacheTtl: 300 }));
+    await executor.executeTool('list_devices', {});
+    expect(redis.set).toHaveBeenCalledTimes(1);
+    const [key, value, ttl] = redis.set.mock.calls[0];
+    expect(key).toMatch(/^tool_cache:v2:list_devices:/);
+    expect(ttl).toBe(300);
+    expect(JSON.parse(value)).toEqual(RAW);
+  });
+
+  it('re-applies the mapping on a cache hit, so a mapping edit takes effect at once', async () => {
+    const { executor, restEngine } = build(makeTool({ ...SELECT_TRANSFORM, cacheTtl: 300 }), {
+      cached: JSON.stringify(RAW),
+    });
+    const res = await executor.executeTool('list_devices', {});
+    expect(restEngine.execute).not.toHaveBeenCalled(); // served from cache
+    expect(JSON.parse(res.content[0].text)).toEqual(MAPPED);
+    expect(res.structured).toEqual(MAPPED);
+  });
+
+  it('re-executes rather than serving an unparsable cache entry', async () => {
+    const { executor, restEngine } = build(makeTool({ cacheTtl: 300 }), {
+      cached: 'not json{',
+    });
+    const res = await executor.executeTool('list_devices', {});
+    expect(restEngine.execute).toHaveBeenCalled();
+    expect(JSON.parse(res.content[0].text)).toEqual(RAW);
+  });
+
+  it('does not touch the cache when cacheTtl is absent', async () => {
+    const { executor, redis } = build(makeTool(SELECT_TRANSFORM));
+    await executor.executeTool('list_devices', {});
+    expect(redis.get).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -18,7 +18,9 @@ import {
   buildCallerContextVars,
 } from '../common/caller-context.util';
 import { resolveInternalDbRestUrl } from '../common/db-rest.util';
+import { applyResponseTransform } from '../connectors/response-transform.util';
 import { KgService } from '../knowledge-graph/kg.service';
+import type { ResponseMapping } from '../connectors/engines/engine-types';
 import type { RegisteredTool } from './tool-registry';
 
 /**
@@ -136,7 +138,16 @@ export class DynamicMcpTools {
       connectorIds?: string[];
       intent?: string;
     },
-  ): Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }> {
+  ): Promise<{
+    content: { type: 'text'; text: string }[];
+    isError?: boolean;
+    /**
+     * The result as an object, before it was serialized into `content[0].text`.
+     * Lets the MCP endpoint build structuredContent without re-parsing the text
+     * — which silently produced `{}` for any tool with a followUp hint.
+     */
+    structured?: unknown;
+  }> {
     // Check license before executing tool (cloud mode only)
     try {
       await this.licenseGuard.checkLicenseActive(context?.organizationId);
@@ -176,19 +187,23 @@ export class DynamicMcpTools {
       };
     }
 
-    // Check response cache
-    const responseMapping = tool.responseMapping as
-      | import('../connectors/engines/engine-types').ResponseMapping
-      | undefined;
+    // Check response cache. The cache holds the *raw* upstream response, so
+    // editing a tool's response mapping takes effect immediately instead of
+    // after up to cacheTtl seconds.
+    const responseMapping = tool.responseMapping as ResponseMapping | undefined;
     const cacheTtl = responseMapping?.cacheTtl;
     if (cacheTtl && cacheTtl > 0) {
       const cacheKey = this.buildCacheKey(toolName, params);
       const cached = await this.redisService.get(cacheKey);
       if (cached) {
-        this.logger.debug(`Cache hit for tool ${toolName}`);
-        return {
-          content: [{ type: 'text' as const, text: cached }],
-        };
+        try {
+          const raw = JSON.parse(cached);
+          this.logger.debug(`Cache hit for tool ${toolName}`);
+          return this.renderResult(raw, responseMapping, toolName);
+        } catch {
+          // Unreadable entry — fall through and re-execute.
+          this.logger.warn(`Discarding unparsable cache entry for tool ${toolName}`);
+        }
       }
     }
 
@@ -277,31 +292,19 @@ export class DynamicMcpTools {
       // Grow the knowledge graph from this real call (debounced, fire-and-forget).
       void this.kgService.scheduleObservationalIngest(context?.organizationId);
 
-      let resultText = JSON.stringify(result, null, 2);
-
-      // Optional per-tool workflow hint. When a tool's responseMapping.followUp
-      // is set, append it to the result so the calling agent sees — mid-workflow,
-      // inside the tool output it just received — what it should do next (e.g.
-      // "a complete answer also needs tools X and Y; call them before replying").
-      // This drives multi-step tool chains far more reliably than a pre-call
-      // description, which agents often read but don't act on. Purely additive
-      // and opt-in: tools without followUp are unaffected.
-      if (responseMapping?.followUp) {
-        resultText += `\n\n---\nWORKFLOW HINT (guidance for the assistant, not part of the API response): ${responseMapping.followUp}`;
-      }
-
-      // Cache the response if cacheTtl is set
+      // Cache the raw response if cacheTtl is set (shaping happens on read).
       if (cacheTtl && cacheTtl > 0) {
         const cacheKey = this.buildCacheKey(toolName, params);
-        await this.redisService.set(cacheKey, resultText, cacheTtl);
-        this.logger.debug(
-          `Cached response for tool ${toolName} (TTL: ${cacheTtl}s)`,
-        );
+        const serialized = JSON.stringify(result);
+        if (serialized !== undefined) {
+          await this.redisService.set(cacheKey, serialized, cacheTtl);
+          this.logger.debug(
+            `Cached response for tool ${toolName} (TTL: ${cacheTtl}s)`,
+          );
+        }
       }
 
-      return {
-        content: [{ type: 'text' as const, text: resultText }],
-      };
+      return this.renderResult(result, responseMapping, toolName);
     } catch (error: any) {
       const durationMs = Date.now() - startTime;
       const errorDetail = this.extractErrorDetail(error);
@@ -339,6 +342,69 @@ export class DynamicMcpTools {
     }
   }
 
+  /**
+   * Turn a raw engine result into the MCP tool result.
+   *
+   * Two opt-in per-tool behaviours live here, in this order:
+   *
+   *  1. `responseMapping.transform` — response shaping. Upstream endpoints
+   *     routinely return far more than the tool needs (a Datto RMM device
+   *     carries up to 300 UDF fields when the tool wants five), and every extra
+   *     byte is billed to the agent's context and exposed to a third-party
+   *     model. A tool without a transform takes the identity path and its
+   *     output is byte-identical to before this existed.
+   *
+   *  2. `responseMapping.followUp` — a workflow hint appended to the result so
+   *     the calling agent sees, mid-workflow, what it should do next. Drives
+   *     multi-step tool chains far more reliably than a pre-call description.
+   *
+   * A broken mapping must never break a working tool, so a transform error
+   * falls back to the raw response and only warns — unless the operator set
+   * `fallbackToRaw: false`, which is an explicit "I'd rather see the error".
+   */
+  private renderResult(
+    raw: unknown,
+    responseMapping: ResponseMapping | undefined,
+    toolName: string,
+  ): {
+    content: { type: 'text'; text: string }[];
+    isError?: boolean;
+    structured?: unknown;
+  } {
+    const outcome = applyResponseTransform(raw, responseMapping);
+
+    if (outcome.error) {
+      if (outcome.fatal) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                { error: `Response mapping failed: ${outcome.error}` },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+      this.logger.warn(
+        `Response mapping for tool ${toolName} failed (${outcome.error}) — returning the raw response.`,
+      );
+    }
+
+    let resultText = JSON.stringify(outcome.value, null, 2) ?? 'null';
+    if (responseMapping?.followUp) {
+      resultText += `\n\n---\nWORKFLOW HINT (guidance for the assistant, not part of the API response): ${responseMapping.followUp}`;
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: resultText }],
+      structured: outcome.value,
+    };
+  }
+
   private buildCacheKey(
     toolName: string,
     params: Record<string, unknown>,
@@ -347,7 +413,10 @@ export class DynamicMcpTools {
       .update(JSON.stringify(params, Object.keys(params).sort()))
       .digest('hex')
       .slice(0, 12);
-    return `tool_cache:${toolName}:${paramsHash}`;
+    // v2: entries hold the raw upstream response instead of the rendered text.
+    // The prefix bump makes sure a v1 entry is never read back in the new
+    // format — old keys simply expire.
+    return `tool_cache:v2:${toolName}:${paramsHash}`;
   }
 
   /**

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
@@ -178,3 +178,98 @@ describe('McpEndpointController — tenant isolation', () => {
     expect(res.status).not.toHaveBeenCalledWith(403);
   });
 });
+
+/**
+ * structuredContent is what an MCP client parses when a tool advertises an
+ * outputSchema. It used to be rebuilt by re-parsing content[0].text, which
+ * silently produced {} for every tool carrying a followUp workflow hint (the
+ * appended text is not JSON). The executor now hands back the object directly.
+ */
+describe('McpEndpointController — structuredContent', () => {
+  const TOOL = {
+    id: 't1',
+    name: 'list_devices',
+    description: 'List devices',
+    parameters: { type: 'object', properties: {} },
+    connectorType: 'REST',
+    connectorConfig: { envVars: {} },
+    endpointMapping: { method: 'GET', path: '/devices' },
+    outputSchema: { type: 'object', properties: { total: {}, devices: {} } },
+  };
+
+  function planHandler(executeResult: any) {
+    const toolExecutor = { executeTool: jest.fn().mockResolvedValue(executeResult) };
+    const controller = new McpEndpointController(
+      { findById: jest.fn() } as any,
+      { getAllTools: jest.fn().mockReturnValue([]) } as any,
+      toolExecutor as any,
+      { getAllowedToolIds: jest.fn() } as any,
+      { lookup: jest.fn(), isEnabled: jest.fn(), captureIntentEnabled: jest.fn() } as any,
+      { get: jest.fn(), add: jest.fn(), remove: jest.fn() } as any,
+    );
+
+    const entries = (controller as any).planToolSet({
+      serverTools: [TOOL],
+      allowedToolIds: null,
+      captureIntent: false,
+      invocationContext: { organizationId: 'org-A', mcpServerId: 'srv-A' },
+    });
+
+    let handler: any;
+    const fakeMcpServer = {
+      registerTool: (_n: string, _c: unknown, h: any) => {
+        handler = h;
+        return {};
+      },
+    };
+    entries.find((e: any) => e.name === 'list_devices').register(fakeMcpServer);
+    return handler;
+  }
+
+  it('uses the executor object, so a followUp hint no longer empties it', async () => {
+    const mapped = { total: 812, devices: [{ hostname: 'PC-01' }] };
+    const handler = planHandler({
+      content: [
+        {
+          type: 'text',
+          text: `${JSON.stringify(mapped, null, 2)}\n\n---\nWORKFLOW HINT: call get_device next`,
+        },
+      ],
+      structured: mapped,
+    });
+
+    const result = await handler({});
+    expect(result.structuredContent).toEqual(mapped);
+    // Our transport field must not leak into the MCP result.
+    expect(result).not.toHaveProperty('structured');
+  });
+
+  it('still parses content[0].text when the executor provides no object', async () => {
+    const handler = planHandler({
+      content: [{ type: 'text', text: '{"total": 812}' }],
+    });
+    const result = await handler({});
+    expect(result.structuredContent).toEqual({ total: 812 });
+  });
+
+  it('falls back to {} for a non-object result', async () => {
+    const handler = planHandler({
+      content: [{ type: 'text', text: '[1,2,3]' }],
+      structured: [1, 2, 3],
+    });
+    const result = await handler({});
+    expect(result.structuredContent).toEqual({});
+  });
+
+  it('skips structuredContent on an error result', async () => {
+    const handler = planHandler({
+      content: [{ type: 'text', text: '{"error":"boom"}' }],
+      structured: { error: 'boom' },
+      isError: true,
+    });
+    const result = await handler({});
+    expect(result.structuredContent).toBeUndefined();
+    expect(result).not.toHaveProperty('structured');
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -693,20 +693,31 @@ export class McpEndpointController {
               ctx,
             );
             // When an outputSchema is advertised, the SDK requires
-            // structuredContent on success. Provide the parsed object
+            // structuredContent on success. Provide the result object
             // (permissive schema never fails); errors skip validation.
+            // `structured` is our own transport field, not part of the MCP
+            // result shape — strip it before returning either way.
+            const { structured: direct, ...rest } = result;
             if (outShape && !result.isError) {
+              // Prefer the executor's object. Re-parsing content[0].text used
+              // to be the only source, and it silently yielded {} for every
+              // tool with a followUp hint (the appended text broke JSON.parse).
+              // The text parse stays as a fallback for results without it.
               let structured: Record<string, unknown> = {};
-              try {
-                const parsed = JSON.parse(result.content?.[0]?.text ?? '{}');
-                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-                  structured = parsed;
-              } catch {
-                /* keep {} */
+              if (direct && typeof direct === 'object' && !Array.isArray(direct)) {
+                structured = direct as Record<string, unknown>;
+              } else if (direct === undefined) {
+                try {
+                  const parsed = JSON.parse(result.content?.[0]?.text ?? '{}');
+                  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+                    structured = parsed;
+                } catch {
+                  /* keep {} */
+                }
               }
-              return { ...result, structuredContent: structured };
+              return { ...rest, structuredContent: structured };
             }
-            return result;
+            return rest;
           };
 
           // registerTool for both branches: the legacy tool() overload has no

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
-import { connectors, tools } from '@/lib/api';
+import { connectors, tools, type ToolTestResult } from '@/lib/api';
 import { findDemoByTool } from '@/lib/demo-connectors';
 import { ToolEditor } from '@/components/tool-editor';
 import { McpAssignModal } from '@/components/mcp-assign-modal';
@@ -27,6 +27,12 @@ const IMPORT_SOURCES = [
 ];
 
 const EDIT_DEFAULT_LOGIN_BODY = '{\n  "username": "${username}",\n  "password": "${password}"\n}';
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 export default function ConnectorDetailPage() {
   const { token } = useAuth();
@@ -93,7 +99,10 @@ export default function ConnectorDetailPage() {
   const [testingToolId, setTestingToolId] = useState<string | null>(null);
   const [testParams, setTestParams] = useState('{}');
   const [testRunning, setTestRunning] = useState(false);
-  const [toolTestResult, setToolTestResult] = useState<{ ok: boolean; durationMs: number; result?: unknown; error?: string; [key: string]: unknown } | null>(null);
+  const [toolTestResult, setToolTestResult] = useState<ToolTestResult | null>(null);
+  // Which side of a mapped response the playground shows. Defaults to what an
+  // AI client would actually receive.
+  const [testResponseView, setTestResponseView] = useState<'mapped' | 'raw'>('mapped');
 
   // Import modal
   const [showImport, setShowImport] = useState(false);
@@ -394,6 +403,7 @@ export default function ConnectorDetailPage() {
     if (!token) return;
     setTestRunning(true);
     setToolTestResult(null);
+    setTestResponseView('mapped');
     try {
       const params =
         paramsOverride !== undefined ? paramsOverride : JSON.parse(testParams);
@@ -1176,11 +1186,16 @@ export default function ConnectorDetailPage() {
                     <ToolEditor
                       connectorType={connector.type}
                       envVarKeys={new Set(envVarEntries.map((e) => e.key.trim()).filter(Boolean))}
+                      connectorId={id}
+                      toolId={tool.id}
                       existingTool={{
                         name: tool.name,
                         description: tool.description,
                         parameters: tool.parameters || { type: 'object', properties: {} },
                         endpointMapping: tool.endpointMapping || { method: 'GET', path: '/' },
+                        // Without this the editor starts from an empty mapping
+                        // and wipes cacheTtl / followUp / transform on save.
+                        responseMapping: tool.responseMapping || undefined,
                       }}
                       onSave={(data) => handleUpdateTool(tool.id, data)}
                       onCancel={() => setEditingToolId(null)}
@@ -1207,6 +1222,15 @@ export default function ConnectorDetailPage() {
                                 title={`Removed from the source spec on ${new Date(tool.deprecatedAt).toLocaleString()}. Role assignments and history are preserved.`}
                               >
                                 deprecated
+                              </Badge>
+                            )}
+                            {tool.responseMapping?.transform && (
+                              <Badge
+                                tone="info"
+                                className="flex-shrink-0"
+                                title="A response mapping shapes this tool's output before it reaches the AI client. Edit it under Response Mapping."
+                              >
+                                mapped
                               </Badge>
                             )}
                           </div>
@@ -1367,6 +1391,39 @@ export default function ConnectorDetailPage() {
                                   </span>
                                 )}
                               </label>
+                              {/* Raw vs mapped, so the effect of a response
+                                  mapping (and its token saving) is visible
+                                  right where the tool is exercised. */}
+                              {toolTestResult?.ok && toolTestResult.mappingApplied === true && (
+                                <div className="flex items-center gap-2 mb-1 flex-wrap">
+                                  {(['mapped', 'raw'] as const).map((view) => (
+                                    <button
+                                      key={view}
+                                      onClick={() => setTestResponseView(view)}
+                                      className={cn(
+                                        'rounded-[7px] border px-2 py-0.5 text-[11px] font-medium transition-colors',
+                                        testResponseView === view
+                                          ? 'border-[var(--brand)] bg-[var(--brand-tint)] text-[var(--brand)]'
+                                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--text-2)]',
+                                      )}
+                                    >
+                                      {view === 'mapped' ? 'Mapped (what the AI sees)' : 'Raw API response'}
+                                    </button>
+                                  ))}
+                                  <span className="text-[11px] text-[var(--text-3)]">
+                                    {formatBytes(Number(toolTestResult.rawBytes) || 0)} →{' '}
+                                    {formatBytes(Number(toolTestResult.mappedBytes) || 0)} (
+                                    {Number(toolTestResult.bytesSavedPct) > 0 ? '−' : ''}
+                                    {Math.abs(Number(toolTestResult.bytesSavedPct) || 0)}%)
+                                  </span>
+                                </div>
+                              )}
+                              {toolTestResult?.ok && typeof toolTestResult.mappingError === 'string' && (
+                                <div className="mb-2 rounded-[9px] border border-[var(--t-warn-bg)] bg-[var(--t-warn-bg)] px-3 py-2 text-xs text-[var(--t-warn-fg)]">
+                                  Response mapping failed ({String(toolTestResult.mappingError)}) — the
+                                  raw response is being returned. Fix it under Edit → Response Mapping.
+                                </div>
+                              )}
                               {toolTestResult && typeof toolTestResult.note === 'string' && (
                                 <div className="mt-2 rounded-[9px] border border-[var(--t-info-fg)]/20 bg-[var(--t-info-bg)] px-3 py-2 text-xs text-[var(--t-info-fg)]">
                                   {toolTestResult.note}
@@ -1396,7 +1453,14 @@ export default function ConnectorDetailPage() {
                               <pre className="w-full border border-[var(--border)] rounded-[9px] px-3 py-2 text-xs bg-[var(--surface-2)] font-mono overflow-auto max-h-40 min-h-[8rem]">
                                 {toolTestResult
                                   ? toolTestResult.ok
-                                    ? JSON.stringify(toolTestResult.result, null, 2)
+                                    ? JSON.stringify(
+                                        toolTestResult.mappingApplied === true &&
+                                          testResponseView === 'mapped'
+                                          ? toolTestResult.mapped
+                                          : toolTestResult.result,
+                                        null,
+                                        2,
+                                      )
                                     : JSON.stringify(toolTestResult, null, 2)
                                   : 'Click "Run Test" to execute this tool...'}
                               </pre>

--- a/packages/frontend/src/components/tool-editor/index.tsx
+++ b/packages/frontend/src/components/tool-editor/index.tsx
@@ -2,6 +2,15 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { AppSelect } from '@/components/ui/select';
+import {
+  EMPTY_MAPPING_STATE,
+  ResponseMappingPanel,
+  mappingStateInvalid,
+  parseTransformToState,
+  stateToTransform,
+  type ResponseMappingState,
+} from './response-mapping-panel';
+import type { ResponseTransform } from '@/lib/api';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                             */
@@ -48,6 +57,14 @@ export interface ToolEditorData {
   bodyEncoding?: string;
   /** Static text response (returned directly without any API/DB call) */
   staticResponse?: string;
+  /** Optional shaping of the API response before it reaches the AI client */
+  responseMapping?: ResponseMappingState;
+  /**
+   * Everything else already stored under responseMapping (e.g. followUp).
+   * Round-tripped verbatim so saving from the GUI cannot silently drop keys
+   * this editor doesn't render.
+   */
+  responseMappingExtra?: Record<string, unknown>;
 }
 
 interface ToolEditorProps {
@@ -64,6 +81,9 @@ interface ToolEditorProps {
   };
   /** Environment variable keys — parameters matching these names are auto-filled at runtime */
   envVarKeys?: Set<string>;
+  /** Enables the response-mapping preview (needs a saved tool to sample from) */
+  connectorId?: string;
+  toolId?: string;
   onSave: (data: {
     name: string;
     description: string;
@@ -254,7 +274,10 @@ function parseExistingTool(
     });
   }
 
-  const rm = tool.responseMapping as any;
+  // Split responseMapping into the parts this editor renders (cacheTtl,
+  // transform) and everything else, which is round-tripped untouched.
+  const rm = (tool.responseMapping ?? {}) as Record<string, unknown>;
+  const { cacheTtl: _cacheTtl, transform, ...responseMappingExtra } = rm;
 
   return {
     name: tool.name,
@@ -266,7 +289,9 @@ function parseExistingTool(
     soapOperation: connectorType === 'SOAP' ? em.method : undefined,
     sqlTemplate: connectorType === 'DATABASE' && em.method !== 'static' ? em.path : undefined,
     staticResponse: em.staticResponse || undefined,
-    cacheTtl: rm?.cacheTtl || 0,
+    cacheTtl: (rm.cacheTtl as number) || 0,
+    responseMapping: parseTransformToState(transform as ResponseTransform | undefined),
+    responseMappingExtra,
     bodyTemplate: detectedBodyTemplate,
     useBodyTemplate: detectedUseBodyTemplate,
     bodyMappingJson: detectedBodyMappingJson,
@@ -400,9 +425,20 @@ function buildToolPayload(data: ToolEditorData, connectorType: string) {
     endpointMapping,
   };
 
+  // Rebuild responseMapping from its parts. Anything this editor doesn't
+  // render (followUp, …) is carried over verbatim — reconstructing the object
+  // from cacheTtl alone used to wipe it on every save from the GUI.
+  const responseMapping: Record<string, unknown> = { ...(data.responseMappingExtra ?? {}) };
   if (data.cacheTtl && data.cacheTtl > 0) {
-    result.responseMapping = { cacheTtl: data.cacheTtl };
+    responseMapping.cacheTtl = data.cacheTtl;
   }
+  const transform = data.responseMapping ? stateToTransform(data.responseMapping) : null;
+  if (transform) {
+    responseMapping.transform = transform;
+  }
+  // Always sent, even when empty: omitting the key leaves whatever is stored in
+  // place, so switching the mapping back to "Off" would never take effect.
+  result.responseMapping = responseMapping;
 
   return result;
 }
@@ -415,6 +451,8 @@ export function ToolEditor({
   connectorType,
   existingTool,
   envVarKeys,
+  connectorId,
+  toolId,
   onSave,
   onCancel,
   saving = false,
@@ -438,6 +476,9 @@ export function ToolEditor({
   const [useBodyMappingJson, setUseBodyMappingJson] = useState(false);
   const [bodyEncoding, setBodyEncoding] = useState('json');
   const [staticResponse, setStaticResponse] = useState('');
+  const [responseMapping, setResponseMapping] =
+    useState<ResponseMappingState>(EMPTY_MAPPING_STATE);
+  const [responseMappingExtra, setResponseMappingExtra] = useState<Record<string, unknown>>({});
 
   // Initialize from existing tool
   useEffect(() => {
@@ -459,6 +500,8 @@ export function ToolEditor({
       }
       if (parsed.bodyEncoding) setBodyEncoding(parsed.bodyEncoding);
       if (parsed.staticResponse) setStaticResponse(parsed.staticResponse);
+      setResponseMapping(parsed.responseMapping ?? EMPTY_MAPPING_STATE);
+      setResponseMappingExtra(parsed.responseMappingExtra ?? {});
     }
   }, [existingTool, type]);
 
@@ -558,6 +601,8 @@ export function ToolEditor({
       bodyMappingJson: useBodyMappingJson ? bodyMappingJson : undefined,
       useBodyMappingJson,
       bodyEncoding: !useBodyTemplate ? bodyEncoding : undefined,
+      responseMapping,
+      responseMappingExtra,
     };
     onSave(buildToolPayload(data, type));
   };
@@ -570,7 +615,8 @@ export function ToolEditor({
     name.trim() &&
     description.trim() &&
     params.every((p) => p.name.trim()) &&
-    !bodyMappingJsonInvalid;
+    !bodyMappingJsonInvalid &&
+    !mappingStateInvalid(responseMapping);
 
   return (
     <div className="border border-[var(--border)] rounded-lg p-5 space-y-5 bg-[var(--card)]">
@@ -1055,6 +1101,16 @@ export function ToolEditor({
         </p>
       </div>
 
+      {/* Response Mapping */}
+      {method !== 'static' && (
+        <ResponseMappingPanel
+          state={responseMapping}
+          onChange={setResponseMapping}
+          connectorId={connectorId}
+          toolId={toolId}
+        />
+      )}
+
       {/* Preview */}
       <div>
         <details className="text-xs">
@@ -1063,7 +1119,7 @@ export function ToolEditor({
           </summary>
           <pre className="mt-2 p-3 bg-[var(--muted)] rounded text-[10px] font-mono overflow-x-auto max-h-48 overflow-y-auto">
             {JSON.stringify(
-              buildToolPayload({ name, description, method, path, params, graphqlQuery, sqlTemplate, staticResponse: method === 'static' ? staticResponse : undefined, cacheTtl, bodyTemplate: useBodyTemplate ? bodyTemplate : undefined, useBodyTemplate, bodyMappingJson: useBodyMappingJson ? bodyMappingJson : undefined, useBodyMappingJson, bodyEncoding: !useBodyTemplate ? bodyEncoding : undefined }, type),
+              buildToolPayload({ name, description, method, path, params, graphqlQuery, sqlTemplate, staticResponse: method === 'static' ? staticResponse : undefined, cacheTtl, bodyTemplate: useBodyTemplate ? bodyTemplate : undefined, useBodyTemplate, bodyMappingJson: useBodyMappingJson ? bodyMappingJson : undefined, useBodyMappingJson, bodyEncoding: !useBodyTemplate ? bodyEncoding : undefined, responseMapping, responseMappingExtra }, type),
               null,
               2,
             )}

--- a/packages/frontend/src/components/tool-editor/response-mapping-panel.tsx
+++ b/packages/frontend/src/components/tool-editor/response-mapping-panel.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useAuth } from '@/lib/auth-context';
+import { tools, type MappingPreview, type ResponseTransform } from '@/lib/api';
+
+/* ------------------------------------------------------------------ */
+/*  Editor state <-> ResponseTransform                                 */
+/* ------------------------------------------------------------------ */
+
+export interface ResponseMappingState {
+  mode: 'off' | 'select' | 'jmespath';
+  /** JSON text of the `select` template (mode: select). */
+  selectJson: string;
+  /** One path per line (mode: select). */
+  excludeText: string;
+  /** JMESPath expression (mode: jmespath). */
+  expression: string;
+  fallbackToRaw: boolean;
+  maxBytes: number;
+}
+
+export const EMPTY_MAPPING_STATE: ResponseMappingState = {
+  mode: 'off',
+  selectJson: '',
+  excludeText: '',
+  expression: '',
+  fallbackToRaw: true,
+  maxBytes: 0,
+};
+
+const EXAMPLE_SELECT = `{
+  "page": {
+    "count": "$.pageDetails.count",
+    "totalCount": "$.pageDetails.totalCount",
+    "nextPageUrl": "$.pageDetails.nextPageUrl"
+  },
+  "devices": {
+    "$from": "$.devices[*]",
+    "$select": {
+      "id": "id",
+      "hostname": "hostname",
+      "siteName": "siteName",
+      "category": "deviceType.category",
+      "operatingSystem": "operatingSystem",
+      "online": "online",
+      "antivirusStatus": "antivirus.antivirusStatus"
+    }
+  }
+}`;
+
+const EXAMPLE_EXPRESSION = '{ total: length(devices), hostnames: devices[*].hostname }';
+
+export function parseTransformToState(
+  transform: ResponseTransform | null | undefined,
+): ResponseMappingState {
+  if (!transform) return EMPTY_MAPPING_STATE;
+  const mode: ResponseMappingState['mode'] =
+    transform.mode === 'off'
+      ? 'off'
+      : transform.mode === 'jmespath' || (!transform.mode && transform.expression)
+        ? 'jmespath'
+        : 'select';
+  return {
+    mode,
+    selectJson: transform.select ? JSON.stringify(transform.select, null, 2) : '',
+    excludeText: (transform.exclude ?? []).join('\n'),
+    expression: transform.expression ?? '',
+    fallbackToRaw: transform.fallbackToRaw !== false,
+    maxBytes: typeof transform.maxBytes === 'number' ? transform.maxBytes : 0,
+  };
+}
+
+/** Returns null when the mapping is off or empty (⇒ raw response is returned). */
+export function stateToTransform(state: ResponseMappingState): ResponseTransform | null {
+  if (state.mode === 'off') return null;
+
+  const exclude = state.excludeText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const transform: ResponseTransform = { mode: state.mode };
+
+  if (state.mode === 'jmespath') {
+    if (!state.expression.trim()) return null;
+    transform.expression = state.expression.trim();
+  } else {
+    const select = safeParseObject(state.selectJson);
+    if (select) transform.select = select;
+    if (exclude.length > 0) transform.exclude = exclude;
+    if (!transform.select && !transform.exclude) return null;
+  }
+
+  if (!state.fallbackToRaw) transform.fallbackToRaw = false;
+  if (state.maxBytes > 0) transform.maxBytes = state.maxBytes;
+  return transform;
+}
+
+function safeParseObject(raw: string): Record<string, unknown> | null {
+  if (!raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the operator typed something that doesn't parse yet. */
+export function mappingStateInvalid(state: ResponseMappingState): boolean {
+  return state.mode === 'select' && !!state.selectJson.trim() && !safeParseObject(state.selectJson);
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+interface Props {
+  state: ResponseMappingState;
+  onChange: (next: ResponseMappingState) => void;
+  /** Needed for the live preview — absent while creating a brand-new tool. */
+  connectorId?: string;
+  toolId?: string;
+}
+
+export function ResponseMappingPanel({ state, onChange, connectorId, toolId }: Props) {
+  const { token } = useAuth();
+  const [preview, setPreview] = useState<MappingPreview | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const set = (patch: Partial<ResponseMappingState>) => onChange({ ...state, ...patch });
+  const invalid = mappingStateInvalid(state);
+  const canPreview = !!(connectorId && toolId && token) && !invalid;
+
+  const transform = useMemo(() => stateToTransform(state), [state]);
+
+  const runPreview = async () => {
+    if (!connectorId || !toolId || !token) return;
+    setPreviewing(true);
+    setPreviewError(null);
+    try {
+      const res = await tools.previewMapping(connectorId, toolId, { transform }, token);
+      setPreview(res);
+      if (!res.ok) setPreviewError(res.error ?? 'Preview failed');
+    } catch (err: any) {
+      setPreviewError(err?.message || 'Preview failed');
+      setPreview(null);
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  return (
+    <div className="border border-[var(--border)] rounded-md p-3 space-y-3">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <label className="text-xs font-semibold">Response Mapping</label>
+          <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
+            Shape the API response before it reaches the AI client. Fewer tokens, and only
+            the fields this tool actually needs leave your workspace. Off = the raw response
+            is returned unchanged.
+          </p>
+        </div>
+        <div className="flex gap-3 text-xs">
+          {(
+            [
+              ['off', 'Off'],
+              ['select', 'Field selection'],
+              ['jmespath', 'JMESPath'],
+            ] as const
+          ).map(([value, label]) => (
+            <label key={value} className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="radio"
+                name="responseMappingMode"
+                checked={state.mode === value}
+                onChange={() => set({ mode: value })}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {state.mode === 'select' && (
+        <div className="space-y-2">
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-[11px] font-medium">Output template (JSON)</label>
+              <button
+                type="button"
+                onClick={() => set({ selectJson: EXAMPLE_SELECT })}
+                className="text-[11px] text-[var(--brand)] hover:underline"
+              >
+                Insert example
+              </button>
+            </div>
+            <textarea
+              value={state.selectJson}
+              onChange={(e) => set({ selectJson: e.target.value })}
+              rows={10}
+              spellCheck={false}
+              placeholder={'{\n  "id": "$.data.id",\n  "name": "$.data.attributes.name"\n}'}
+              className="w-full px-2 py-1.5 border border-[var(--border)] rounded-md bg-[var(--background)] text-xs font-mono"
+            />
+            {invalid && (
+              <p className="text-[11px] text-[var(--danger)]">
+                Not valid JSON — saving is disabled until this parses.
+              </p>
+            )}
+            <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
+              Keys are the output names. A leaf is a path (<code>$.a.b</code>,{' '}
+              <code>items[*].id</code>, <code>list[-1].x</code>), a static value (
+              <code>&quot;= my-source&quot;</code>), or{' '}
+              <code>{'{ "$from": "$.rows[*]", "$select": { … } }'}</code> to reshape every
+              element of an array. A path that does not resolve is left out.
+            </p>
+          </div>
+
+          <div>
+            <label className="text-[11px] font-medium block mb-1">
+              Exclude paths (one per line)
+            </label>
+            <textarea
+              value={state.excludeText}
+              onChange={(e) => set({ excludeText: e.target.value })}
+              rows={3}
+              spellCheck={false}
+              placeholder={'devices[*].udf\ninternalToken'}
+              className="w-full px-2 py-1.5 border border-[var(--border)] rounded-md bg-[var(--background)] text-xs font-mono"
+            />
+            <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
+              Removed before the template runs. Use this alone (no template) to drop a few
+              noisy fields while keeping everything else.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {state.mode === 'jmespath' && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="text-[11px] font-medium">JMESPath expression</label>
+            <button
+              type="button"
+              onClick={() => set({ expression: EXAMPLE_EXPRESSION })}
+              className="text-[11px] text-[var(--brand)] hover:underline"
+            >
+              Insert example
+            </button>
+          </div>
+          <textarea
+            value={state.expression}
+            onChange={(e) => set({ expression: e.target.value })}
+            rows={4}
+            spellCheck={false}
+            placeholder="devices[*].{id: id, host: hostname, category: deviceType.category}"
+            className="w-full px-2 py-1.5 border border-[var(--border)] rounded-md bg-[var(--background)] text-xs font-mono"
+          />
+          <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
+            Full JMESPath, including functions — use this for computed values such as{' '}
+            <code>length(devices)</code> or filters like{' '}
+            <code>devices[?online == `false`]</code>.
+          </p>
+        </div>
+      )}
+
+      {state.mode !== 'off' && (
+        <>
+          <div className="flex flex-wrap items-center gap-4">
+            <label className="flex items-center gap-1.5 text-[11px] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={state.fallbackToRaw}
+                onChange={(e) => set({ fallbackToRaw: e.target.checked })}
+              />
+              Fall back to the raw response if the mapping fails
+            </label>
+            <label className="flex items-center gap-1.5 text-[11px]">
+              Max response size
+              <input
+                type="number"
+                min={0}
+                value={state.maxBytes}
+                onChange={(e) => set({ maxBytes: Math.max(0, parseInt(e.target.value) || 0) })}
+                className="w-24 border border-[var(--input)] rounded px-2 py-1 text-xs bg-[var(--background)]"
+              />
+              bytes (0 = no limit)
+            </label>
+          </div>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              type="button"
+              onClick={runPreview}
+              disabled={!canPreview || previewing}
+              title={
+                canPreview
+                  ? 'Runs the mapping against the most recent real response for this tool. No API call is made.'
+                  : 'Save the tool and run it once to get a real response to preview against.'
+              }
+              className="border border-[var(--border)] px-3 py-1 rounded text-xs hover:bg-[var(--accent)] disabled:opacity-50"
+            >
+              {previewing ? 'Previewing…' : 'Preview with last real response'}
+            </button>
+            {preview?.ok && (
+              <span className="text-[11px] text-[var(--muted-foreground)]">
+                {formatBytes(preview.rawBytes ?? 0)} → {formatBytes(preview.mappedBytes ?? 0)}{' '}
+                <strong
+                  className={
+                    (preview.bytesSavedPct ?? 0) > 0 ? 'text-[var(--ok,#16a34a)]' : undefined
+                  }
+                >
+                  ({(preview.bytesSavedPct ?? 0) > 0 ? '−' : ''}
+                  {Math.abs(preview.bytesSavedPct ?? 0)}%)
+                </strong>
+                {preview.sampleCapturedAt && (
+                  <> · sample from {new Date(preview.sampleCapturedAt).toLocaleString()}</>
+                )}
+              </span>
+            )}
+          </div>
+
+          {previewError && (
+            <p className="text-[11px] text-[var(--danger)]">{previewError}</p>
+          )}
+          {preview?.ok && preview.mappingError && (
+            <p className="text-[11px] text-[var(--danger)]">
+              Mapping failed ({preview.mappingError}) — the raw response is shown.
+            </p>
+          )}
+
+          {preview?.ok && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              <div>
+                <p className="text-[10px] font-medium text-[var(--muted-foreground)] mb-1">
+                  Raw response
+                </p>
+                <pre className="p-2 bg-[var(--muted)] rounded text-[10px] font-mono overflow-auto max-h-56">
+                  {JSON.stringify(preview.raw, null, 2)}
+                </pre>
+              </div>
+              <div>
+                <p className="text-[10px] font-medium text-[var(--muted-foreground)] mb-1">
+                  What the AI client receives
+                </p>
+                <pre className="p-2 bg-[var(--muted)] rounded text-[10px] font-mono overflow-auto max-h-56">
+                  {JSON.stringify(preview.mapped, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -287,6 +287,55 @@ export interface ToolAnnotations {
   openWorldHint?: boolean;
 }
 
+/**
+ * Optional per-tool shaping of the API response before it reaches the MCP
+ * client. Absent means the raw upstream response is returned unchanged.
+ */
+export interface ResponseTransform {
+  mode?: 'select' | 'jmespath' | 'off';
+  /** Keep only these paths, preserving the document shape. */
+  include?: string[];
+  /** Drop these paths. Applied before include/select. */
+  exclude?: string[];
+  /** Output template — leaves are paths (`$.a.b`), `= literal`, or `{ $from, $select }`. */
+  select?: Record<string, unknown>;
+  /** JMESPath expression, for computed values. */
+  expression?: string;
+  /** On error, return the raw response instead of failing. Default true. */
+  fallbackToRaw?: boolean;
+  /** Hard cap on the serialized output. 0 = off. */
+  maxBytes?: number;
+}
+
+/** Size accounting returned by the test and preview endpoints. */
+export interface MappingSummary {
+  mapped?: unknown;
+  mappingApplied?: boolean;
+  mappingError?: string;
+  mappingTruncated?: boolean;
+  rawBytes?: number;
+  mappedBytes?: number;
+  bytesSavedPct?: number;
+}
+
+export interface MappingPreview extends MappingSummary {
+  ok: boolean;
+  sampleSource: 'body' | 'last-invocation' | 'none';
+  sampleCapturedAt?: string | null;
+  raw?: unknown;
+  error?: string;
+}
+
+export interface ToolTestResult extends MappingSummary {
+  ok: boolean;
+  durationMs: number;
+  result?: unknown;
+  error?: string;
+  note?: string;
+  hint?: string;
+  kind?: string;
+}
+
 export const tools = {
   list: (connectorId: string, token: string) =>
     request<any[]>(`/api/connectors/${connectorId}/tools`, { token }),
@@ -322,13 +371,49 @@ export const tools = {
       `/api/connectors/${connectorId}/tools/${toolId}/annotations`,
       { method: 'PATCH', body: { annotations }, token },
     ),
+  getResponseMapping: (connectorId: string, toolId: string, token: string) =>
+    request<{
+      transform: ResponseTransform | null;
+      active: boolean;
+      sampleAvailable: boolean;
+      sampleCapturedAt: string | null;
+    }>(`/api/connectors/${connectorId}/tools/${toolId}/response-mapping`, { token }),
+  setResponseMapping: (
+    connectorId: string,
+    toolId: string,
+    transform: ResponseTransform | null,
+    token: string,
+  ) =>
+    request<{ transform: ResponseTransform | null; active: boolean }>(
+      `/api/connectors/${connectorId}/tools/${toolId}/response-mapping`,
+      { method: 'PATCH', body: { transform }, token },
+    ),
+  /** Dry-run a mapping against a sample (or the last real response). No API call. */
+  previewMapping: (
+    connectorId: string,
+    toolId: string,
+    body: { transform?: ResponseTransform | null; sample?: unknown },
+    token: string,
+  ) =>
+    request<MappingPreview>(
+      `/api/connectors/${connectorId}/tools/${toolId}/preview-mapping`,
+      { method: 'POST', body, token },
+    ),
   delete: (connectorId: string, toolId: string, token: string) =>
     request(`/api/connectors/${connectorId}/tools/${toolId}`, { method: 'DELETE', token }),
-  test: (connectorId: string, toolId: string, params: Record<string, unknown>, token: string) =>
-    request<{ ok: boolean; durationMs: number; result?: unknown; error?: string }>(
-      `/api/connectors/${connectorId}/tools/${toolId}/test`,
-      { method: 'POST', body: { params }, token },
-    ),
+  test: (
+    connectorId: string,
+    toolId: string,
+    params: Record<string, unknown>,
+    token: string,
+    transform?: ResponseTransform | null,
+  ) =>
+    request<ToolTestResult>(`/api/connectors/${connectorId}/tools/${toolId}/test`, {
+      method: 'POST',
+      // MCP-standard field name; `params` is still sent for older backends.
+      body: { arguments: params, params, ...(transform ? { transform } : {}) },
+      token,
+    }),
 };
 
 // Audit


### PR DESCRIPTION
## Why

Requested by a customer running Datto RMM: the device endpoint returns up to 300 UDF fields, IPs and remote-control URLs per device when the tool only needs hostname, site, OS and status. Every extra byte is billed to the agent's context window and exposed to a third-party model.

This adds an optional, per-tool transformation of the API response before it reaches the MCP client — the tool's published data model, declared separately from the full API response.

## Contract

Lives under the **existing** `mcp_tools.response_mapping` JSON column in a new `transform` key, so there is **no migration** and adapter JSON, import/export, catalog re-sync and the version fingerprint keep working unchanged.

```jsonc
{
  "cacheTtl": 300,            // existing
  "followUp": "…",            // existing
  "transform": {              // new — all optional
    "select": {               // output template
      "page": { "count": "$.pageDetails.count" },
      "devices": {
        "$from": "$.devices[*]",
        "$select": { "id": "id", "category": "deviceType.category" }
      },
      "source": "= datto-rmm"  // "= …" = static literal
    },
    "include": [], "exclude": ["devices[*].udf"],
    "expression": "…",         // JMESPath, with mode: "jmespath"
    "fallbackToRaw": true, "maxBytes": 0
  }
}
```

Applied at the single shared render point in `DynamicMcpTools`, so it covers **REST, SOAP, GraphQL, DATABASE and MCP-bridge** alike.

## Compatibility

| Invariant | How |
|---|---|
| No transform ⇒ byte-identical output | single early return, asserted by spec |
| A broken mapping never fails a working tool | falls back to raw + warns; `fallbackToRaw: false` opts out |
| No migration | new key inside the existing Json column |
| `POST :toolId/test` keeps returning raw `result` | `mapped` is additive |
| Audit log keeps storing the raw response | analytics, KG and preview samples unaffected |

Production audit before merge: of **19,633** tools, **0** use `transform`, **0** use the legacy `fields`, **0** use `followUp`, and **7** use `cacheTtl` — the only ones whose runtime path changes (one cache miss after deploy).

## Pre-existing bugs fixed along the way

1. **`{"type":"json","fields":[…]}` was documented but never implemented** (`docs/tool-definition.md`, `docs/connectors/rest.md`). Now works, as a `transform.include` alias.
2. **The UI destroyed `responseMapping`**: `buildToolPayload` rebuilt it from `cacheTtl` alone and the connector page never passed the stored value into the editor — saving a tool from the UI wiped `cacheTtl` and `followUp`. Same bug class as the v0.3.9 `bodyMapping` fix.
3. **`structuredContent` was broken for every tool with a `followUp` hint**: it was rebuilt via `JSON.parse(content[0].text)`, and the appended hint text broke the parse, silently yielding `{}`. The executor now returns the object directly.
4. The response cache now stores the **raw** response (key prefix bumped to `tool_cache:v2:`), so a mapping edit takes effect on the next call instead of after up to `cacheTtl` seconds.
5. `outputSchema` is re-inferred from the mapped shape and dropped when the transform changes, so the advertised schema matches what clients receive.

## API

| Method | Route | |
|---|---|---|
| GET / PATCH | `…/tools/:toolId/response-mapping` | read / set / clear, preserving `cacheTtl` + `followUp` |
| POST | `…/tools/:toolId/preview-mapping` | dry-run against the last recorded real response — no upstream call, nothing stored |
| POST | `…/tools/:toolId/test` | now also returns `mapped`, `mappingApplied`, `rawBytes`, `mappedBytes`, `bytesSavedPct`; accepts an unsaved `transform` override |

A malformed transform is rejected with 400 at save time rather than silently degrading at call time.

## UI

Response Mapping panel in the tool editor (mode selector, output template, exclude paths, fallback + max size), with **"Preview with last real response"** showing raw ↔ mapped side by side and the size delta. Playground gains Mapped/Raw tabs and the saving badge; the tool list gains a `mapped` badge.

## Verification

- 81 new tests; full suite green: **207 suites / 3560 tests**. Build + lint clean.
- End-to-end against a live fat API: no mapping ⇒ identical output; with mapping **4543 → 384 bytes (−92%)**; verified through a **real MCP session** with correct `structuredContent`; broken mapping ⇒ raw response, call still succeeds; cache verified to hold raw with mapping edits taking effect immediately; UI round-trip preserves `cacheTtl` + `followUp` + `transform`.
- UI driven in a browser: preview showed **3.0 KB → 21 B (−99%)** against a real recorded response.

E2E caught a bug 47 unit tests missed: `validateTransform` *evaluated* the JMESPath expression against `{}`, so valid expressions like `length(products)` — the main reason to reach for JMESPath — were rejected with a 400. Now parses via `compile()`, with a regression test.

## Note

One line of the lockfile diff is npm's own re-resolution: two optional wasm fallbacks (`@emnapi/core`, `@emnapi/runtime`) were pruned. No platform binaries removed; `npm ci --dry-run` passes.