### PR TITLE
fix(connectors): migrate Playtomic to api.app.playtomic.io + require account (v0.4.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -27868,7 +27868,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@jmespath-community/jmespath": "^1.3.0",
@@ -28286,7 +28286,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/adapters/intl/playtomic-public.json
+++ b/packages/backend/src/adapters/intl/playtomic-public.json
@@ -1,21 +1,43 @@
 {
   "slug": "playtomic-public",
-  "name": "Playtomic (Public)",
-  "description": "Find padel, tennis, and futsal courts worldwide — read-only, no account needed. Search clubs near you, check court availability and pricing, browse Playtomic's tenant catalog. 4 tools, zero setup.",
-  "instructions": "This connector wraps Playtomic's **public** read endpoints — no login, no API key, no setup. It's the fastest way to give an AI agent the ability to find padel/tennis courts and check availability.\n\n**What you can do without an account**:\n- Search clubs (tenants) by geo coordinate + radius, optionally filtered by sport.\n- Fetch a single club's full details (resources/courts, opening info, address, timezone, images).\n- Read free time slots for a given day across one or more clubs, with prices.\n- Read Playtomic's sport configuration (allowed durations, resource types, sport list).\n\n**What requires the full Playtomic connector instead**:\n- Your own profile, level, match history, social graph.\n- Open matches you can join.\n- Member/club-specific discounted pricing (this connector returns generic pricing).\n- Booking a court (write operations are not exposed — Playtomic has no official public booking API).\n\n**Pricing notes**:\n- `price` is a string like `\"48 EUR\"` — parse amount + currency separately.\n- Same `start_time` may appear multiple times with different `duration` values (60/90/120 min). These are alternative bookings of the same slot, not separate free slots.\n- `duration` is in **minutes**.\n\n**Time handling**:\n- `local_start_min` / `local_start_max` are naive ISO-8601 in the tenant's local timezone — find the timezone in `tenant.address.timezone` (e.g. `Europe/Berlin`).\n- For a full-day window use `2026-05-23T00:00:00` → `2026-05-23T23:59:59`.\n\n**Joining availability back to courts**: every availability row has a `resource_id`; map it back to `tenant.resources[].name` from `get_tenant` to know which court (indoor/outdoor, single/double, etc.).\n\n**Rate limits**: Playtomic has no published public-API SLA. Be gentle — under 1 req/s is safe. The connector identifies itself honestly as AnythingMCP (no UA spoofing).\n\n**Stability**: this is an undocumented/internal API reverse-engineered from the iOS app. Endpoints can change without notice. If a tool breaks, check the docs URL for updates.\n\n**Suggested starter prompts**:\n- \"Find padel clubs within 30 km of Milan that are open today.\"\n- \"What time slots are free on Saturday afternoon at FREIBURG PADEL?\"\n- \"Compare prices across all padel clubs in Madrid for Sunday morning, 90-minute sessions.\"\n- \"Which courts in Barcelona offer indoor crystal padel?\"",
+  "name": "Playtomic (Lite)",
+  "description": "Find padel, tennis, and futsal courts worldwide — read-only. Search clubs near you, check court availability and pricing, browse Playtomic's tenant catalog. 4 read tools; needs a free Playtomic account (email + password), no API key.",
+  "instructions": "This is the **lite, read-only** Playtomic connector — the fastest way to give an AI agent the ability to find padel/tennis courts and check availability, without the 13-tool full connector's personal-data scope.\n\n**Authentication (handled automatically)**: Playtomic closed anonymous access to its API in mid-2025, so even read-only club search now needs an authenticated session. Provide a **free** Playtomic account (`PLAYTOMIC_EMAIL` + `PLAYTOMIC_PASSWORD`); the AnythingMCP `LOGIN_TOKEN` engine logs in, attaches `Authorization: Bearer <jwt>` to every call, caches the token encrypted, and re-logs in automatically ~60 s before expiry and on any `401`. Your password is stored encrypted and only sent over TLS to Playtomic's login endpoint. No club membership is required — any registered Playtomic user works.\n\n**What you can do**:\n- Search clubs (tenants) by geo coordinate + radius, optionally filtered by sport.\n- Fetch a single club's full details (resources/courts, opening info, address, timezone, images).\n- Read free time slots for a given day across one or more clubs, with prices.\n- Read Playtomic's sport configuration (allowed durations, resource types, sport list).\n\n**What requires the full Playtomic connector instead**:\n- Your own profile, level, match history, social graph.\n- Open matches you can join.\n- Member/club-specific discounted pricing (this connector returns generic pricing).\n- Booking a court (write operations are not exposed — Playtomic has no official public booking API).\n\n**Pricing notes**:\n- `price` is a string like `\"48 EUR\"` — parse amount + currency separately.\n- Same `start_time` may appear multiple times with different `duration` values (60/90/120 min). These are alternative bookings of the same slot, not separate free slots.\n- `duration` is in **minutes**.\n\n**Time handling**:\n- `local_start_min` / `local_start_max` are naive ISO-8601 in the tenant's local timezone — find the timezone in `tenant.address.timezone` (e.g. `Europe/Berlin`).\n- For a full-day window use `2026-05-23T00:00:00` → `2026-05-23T23:59:59`.\n\n**Joining availability back to courts**: every availability row has a `resource_id`; map it back to `tenant.resources[].name` from `get_tenant` to know which court (indoor/outdoor, single/double, etc.).\n\n**Rate limits**: Playtomic has no published public-API SLA. Be gentle — under 1 req/s is safe. The connector identifies itself honestly as AnythingMCP (no UA spoofing).\n\n**Stability**: this is an undocumented/internal API reverse-engineered from the iOS app. Endpoints can change without notice. If a tool breaks, check the docs URL for updates.\n\n**Suggested starter prompts**:\n- \"Find padel clubs within 30 km of Milan that are open today.\"\n- \"What time slots are free on Saturday afternoon at FREIBURG PADEL?\"\n- \"Compare prices across all padel clubs in Madrid for Sunday morning, 90-minute sessions.\"\n- \"Which courts in Barcelona offer indoor crystal padel?\"",
   "region": "intl",
   "category": "sports",
   "icon": "playtomic",
   "docsUrl": "https://playtomic.io",
   "featured": true,
   "priority": 80,
-  "requiredEnvVars": [],
+  "requiredEnvVars": [
+    "PLAYTOMIC_EMAIL",
+    "PLAYTOMIC_PASSWORD"
+  ],
   "connector": {
-    "name": "Playtomic Public API",
+    "name": "Playtomic Lite",
     "type": "REST",
-    "baseUrl": "https://app.playtomic.io",
-    "authType": "NONE",
-    "authConfig": {}
+    "baseUrl": "https://api.app.playtomic.io",
+    "authType": "LOGIN_TOKEN",
+    "authConfig": {
+      "loginUrl": "https://api.app.playtomic.io/v3/auth/login",
+      "loginMethod": "POST",
+      "loginBody": {
+        "requested_user_roles": [
+          "ROLE_CUSTOMER"
+        ],
+        "email": "${username}",
+        "password": "${password}"
+      },
+      "username": "{{PLAYTOMIC_EMAIL}}",
+      "password": "{{PLAYTOMIC_PASSWORD}}",
+      "tokenJsonPath": "access_token",
+      "expiryJsonPath": "access_token_expiration",
+      "expiryFormat": "iso8601",
+      "refreshOn401": true,
+      "proactiveRefreshSeconds": 60,
+      "headerName": "Authorization",
+      "headerTemplate": "Bearer ${token}"
+    }
   },
   "tools": [
     {
@@ -62,7 +84,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/tenants",
+        "path": "/v1/tenants",
         "queryParams": {
           "coordinate": "$coordinate",
           "radius": "$radius",
@@ -91,7 +113,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/tenants/{tenant_id}"
+        "path": "/v1/tenants/{tenant_id}"
       }
     },
     {
@@ -132,7 +154,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/availability",
+        "path": "/v1/availability",
         "queryParams": {
           "sport_id": "$sport_id",
           "tenant_id": "$tenant_id",
@@ -151,7 +173,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v2/configuration"
+        "path": "/v2/configuration"
       }
     }
   ]

--- a/packages/backend/src/adapters/intl/playtomic-public.live.spec.ts
+++ b/packages/backend/src/adapters/intl/playtomic-public.live.spec.ts
@@ -12,12 +12,21 @@ const a = adapter as unknown as {
 };
 
 describe('playtomic-public adapter — static spec conformance', () => {
-  it('is the read-only NONE-auth variant in the sports category', () => {
+  it('is the read-only LOGIN_TOKEN lite variant in the sports category', () => {
     expect(a.slug).toBe('playtomic-public');
     expect(a.category).toBe('sports');
-    expect(a.connector.baseUrl).toBe('https://app.playtomic.io');
-    expect(a.connector.authType).toBe('NONE');
-    expect(a.requiredEnvVars).toEqual([]);
+    expect(a.connector.baseUrl).toBe('https://api.app.playtomic.io');
+    expect(a.connector.authType).toBe('LOGIN_TOKEN');
+    expect(a.requiredEnvVars).toEqual(['PLAYTOMIC_EMAIL', 'PLAYTOMIC_PASSWORD']);
+  });
+
+  it('logs in via /v3/auth/login and reads access_token like the full connector', () => {
+    const auth = a.connector.authConfig as Record<string, unknown>;
+    expect(auth.loginUrl).toBe('https://api.app.playtomic.io/v3/auth/login');
+    expect(auth.tokenJsonPath).toBe('access_token');
+    expect(auth.expiryJsonPath).toBe('access_token_expiration');
+    const body = auth.loginBody as Record<string, unknown>;
+    expect(body.requested_user_roles).toEqual(['ROLE_CUSTOMER']);
   });
 
   it('exposes exactly the 4 public read tools', () => {
@@ -32,14 +41,14 @@ describe('playtomic-public adapter — static spec conformance', () => {
   it('search_tenants forces playtomic_status=ACTIVE and accepts geo coordinate', () => {
     const t = a.tools.find((x) => x.name === 'playtomic_search_tenants')!;
     expect(t.endpointMapping.method).toBe('GET');
-    expect(t.endpointMapping.path).toBe('/api/v1/tenants');
+    expect(t.endpointMapping.path).toBe('/v1/tenants');
     expect(t.endpointMapping.queryParams?.coordinate).toBe('$coordinate');
     expect(t.endpointMapping.queryParams?.playtomic_status).toBe('ACTIVE');
   });
 
-  it('availability uses the documented /api/v1/availability path and naive ISO bounds', () => {
+  it('availability uses the documented /v1/availability path and naive ISO bounds', () => {
     const t = a.tools.find((x) => x.name === 'playtomic_get_availability')!;
-    expect(t.endpointMapping.path).toBe('/api/v1/availability');
+    expect(t.endpointMapping.path).toBe('/v1/availability');
     expect(t.endpointMapping.queryParams?.local_start_min).toBe('$local_start_min');
     expect(t.endpointMapping.queryParams?.local_start_max).toBe('$local_start_max');
   });

--- a/packages/backend/src/adapters/intl/playtomic.json
+++ b/packages/backend/src/adapters/intl/playtomic.json
@@ -2,7 +2,7 @@
   "slug": "playtomic",
   "name": "Playtomic",
   "description": "Full Playtomic access for padel, tennis, and futsal players. Search clubs and availability, find open matches to join, read your own profile, level, stats, history, and recommendations. 13 tools, email + password auth with automatic JWT refresh.",
-  "instructions": "## Authentication (handled automatically)\n\nPlaytomic uses email + password to mint a ~1-hour JWT. The AnythingMCP `LOGIN_TOKEN` engine handles login, caching, and refresh:\n\n1. `POST https://app.playtomic.io/api/v3/auth/login` with `{ email, password, requested_user_roles: [\"ROLE_CUSTOMER\"] }`.\n2. The response contains `access_token` (JWT, ~1h TTL) and `refresh_token` (~60d).\n3. Every tool call attaches `Authorization: Bearer <access_token>`.\n4. The engine proactively re-logs in 60 s before expiry and on any `401`. Tokens are cached encrypted in the `connector_auth_cache` DB table.\n\n## Credentials\n\n- `PLAYTOMIC_EMAIL` — your Playtomic account email.\n- `PLAYTOMIC_PASSWORD` — your plain account password. Stored encrypted; only sent over TLS to Playtomic's login endpoint.\n\n## When dedicated tools are not enough\n\nThe 13 tools below cover the common Playtomic workflows. Anything not exposed (e.g. accepting a join request, creating a match, paying for a booking) requires Playtomic's mobile app — there is no documented public booking write API and we deliberately don't expose write endpoints.\n\n## Public vs full connector\n\nIf you only want to **search clubs and check availability** (no account, no personal data), use the `playtomic-public` connector instead — same 4 read tools but no credentials needed.\n\n## Pricing notes\n\n- `price` is a string like `\"48 EUR\"` — parse amount + currency.\n- The same `start_time` may appear with several `duration` values (60/90/120 min). These are alternative bookings of the same slot, not separate free slots.\n- `duration` is in **minutes**.\n- If your account has linked club memberships, pricing returned by `playtomic_get_availability` reflects your member discount.\n\n## Time handling\n\n- `local_start_min` / `local_start_max` are naive ISO-8601 in the **tenant's** local timezone (see `tenant.address.timezone`, e.g. `Europe/Berlin`). For a full day use `T00:00:00` → `T23:59:59` on the same date.\n- Match/course/tournament date filters use the same naive ISO format unless otherwise noted.\n\n## Joining availability to courts\n\nEvery availability row has a `resource_id`. Map it back to `tenant.resources[]` (from `playtomic_get_tenant`) to know court name, indoor/outdoor, single/double, surface.\n\n## Levels & match recommendations\n\n- `level_value` is your Playtomic skill rating (typically 0–7). `level_confidence` reflects how many matches the rating is based on.\n- `playtomic_match_recommendations` returns open matches at your level near a coordinate. Empty array = no recommendations right now (it's normal).\n\n## Rate limits\n\nPlaytomic has no published SLA. Keep request volume reasonable (≤1 req/s steady state). The engine auto-handles `401` with a retry-after-relogin and gives up after one retry — if you see `401` twice, check that your credentials are correct.\n\n## Stability\n\nThis is an undocumented/internal API reverse-engineered from the Playtomic iOS app. Endpoints can change without notice. If a tool starts failing, check the AnythingMCP docs for a connector update.\n\n## Useful starter prompts\n\n- \"Find open padel matches at my level near Milan this weekend.\" → `playtomic_match_recommendations`\n- \"What's my current padel level on Playtomic?\" → `playtomic_get_my_level`\n- \"How many padel matches have I won this year?\" → `playtomic_get_my_stats`\n- \"At which clubs do I play the most?\" → `playtomic_get_top_clubs`\n- \"Show me free crystal-court slots tomorrow afternoon within 20 km of my home.\" → `playtomic_search_tenants` + `playtomic_get_availability`\n- \"Are there any padel tournaments coming up near Barcelona?\" → `playtomic_list_tournaments`",
+  "instructions": "## Authentication (handled automatically)\n\nPlaytomic uses email + password to mint a ~1-hour JWT. The AnythingMCP `LOGIN_TOKEN` engine handles login, caching, and refresh:\n\n1. `POST https://api.app.playtomic.io/v3/auth/login` with `{ email, password, requested_user_roles: [\"ROLE_CUSTOMER\"] }`.\n2. The response contains `access_token` (JWT, ~1h TTL) and `refresh_token` (~60d).\n3. Every tool call attaches `Authorization: Bearer <access_token>`.\n4. The engine proactively re-logs in 60 s before expiry and on any `401`. Tokens are cached encrypted in the `connector_auth_cache` DB table.\n\n## Credentials\n\n- `PLAYTOMIC_EMAIL` — your Playtomic account email.\n- `PLAYTOMIC_PASSWORD` — your plain account password. Stored encrypted; only sent over TLS to Playtomic's login endpoint.\n\n## When dedicated tools are not enough\n\nThe 13 tools below cover the common Playtomic workflows. Anything not exposed (e.g. accepting a join request, creating a match, paying for a booking) requires Playtomic's mobile app — there is no documented public booking write API and we deliberately don't expose write endpoints.\n\n## Public vs full connector\n\nIf you only want to **search clubs and check availability** (no personal data), use the `playtomic-public` (Playtomic Lite) connector instead — the same 4 read tools with a lighter scope. It still needs a free Playtomic account, since Playtomic closed anonymous API access.\n\n## Pricing notes\n\n- `price` is a string like `\"48 EUR\"` — parse amount + currency.\n- The same `start_time` may appear with several `duration` values (60/90/120 min). These are alternative bookings of the same slot, not separate free slots.\n- `duration` is in **minutes**.\n- If your account has linked club memberships, pricing returned by `playtomic_get_availability` reflects your member discount.\n\n## Time handling\n\n- `local_start_min` / `local_start_max` are naive ISO-8601 in the **tenant's** local timezone (see `tenant.address.timezone`, e.g. `Europe/Berlin`). For a full day use `T00:00:00` → `T23:59:59` on the same date.\n- Match/course/tournament date filters use the same naive ISO format unless otherwise noted.\n\n## Joining availability to courts\n\nEvery availability row has a `resource_id`. Map it back to `tenant.resources[]` (from `playtomic_get_tenant`) to know court name, indoor/outdoor, single/double, surface.\n\n## Levels & match recommendations\n\n- `level_value` is your Playtomic skill rating (typically 0–7). `level_confidence` reflects how many matches the rating is based on.\n- `playtomic_match_recommendations` returns open matches at your level near a coordinate. Empty array = no recommendations right now (it's normal).\n\n## Rate limits\n\nPlaytomic has no published SLA. Keep request volume reasonable (≤1 req/s steady state). The engine auto-handles `401` with a retry-after-relogin and gives up after one retry — if you see `401` twice, check that your credentials are correct.\n\n## Stability\n\nThis is an undocumented/internal API reverse-engineered from the Playtomic iOS app. Endpoints can change without notice. If a tool starts failing, check the AnythingMCP docs for a connector update.\n\n## Useful starter prompts\n\n- \"Find open padel matches at my level near Milan this weekend.\" → `playtomic_match_recommendations`\n- \"What's my current padel level on Playtomic?\" → `playtomic_get_my_level`\n- \"How many padel matches have I won this year?\" → `playtomic_get_my_stats`\n- \"At which clubs do I play the most?\" → `playtomic_get_top_clubs`\n- \"Show me free crystal-court slots tomorrow afternoon within 20 km of my home.\" → `playtomic_search_tenants` + `playtomic_get_availability`\n- \"Are there any padel tournaments coming up near Barcelona?\" → `playtomic_list_tournaments`",
   "region": "intl",
   "category": "sports",
   "icon": "playtomic",
@@ -16,10 +16,10 @@
   "connector": {
     "name": "Playtomic",
     "type": "REST",
-    "baseUrl": "https://app.playtomic.io",
+    "baseUrl": "https://api.app.playtomic.io",
     "authType": "LOGIN_TOKEN",
     "authConfig": {
-      "loginUrl": "https://app.playtomic.io/api/v3/auth/login",
+      "loginUrl": "https://api.app.playtomic.io/v3/auth/login",
       "loginMethod": "POST",
       "loginBody": {
         "requested_user_roles": [
@@ -84,7 +84,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/tenants",
+        "path": "/v1/tenants",
         "queryParams": {
           "coordinate": "$coordinate",
           "radius": "$radius",
@@ -113,7 +113,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/tenants/{tenant_id}"
+        "path": "/v1/tenants/{tenant_id}"
       }
     },
     {
@@ -153,7 +153,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/availability",
+        "path": "/v1/availability",
         "queryParams": {
           "sport_id": "$sport_id",
           "tenant_id": "$tenant_id",
@@ -173,7 +173,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v2/configuration"
+        "path": "/v2/configuration"
       }
     },
     {
@@ -186,7 +186,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v2/users/me"
+        "path": "/v2/users/me"
       }
     },
     {
@@ -205,7 +205,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/levels",
+        "path": "/v1/levels",
         "queryParams": {
           "user_id": "me",
           "with_history": "$with_history"
@@ -232,7 +232,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/matches_summary/results",
+        "path": "/v1/matches_summary/results",
         "queryParams": {
           "player_user_id": "me",
           "sport_id": "$sport_id"
@@ -269,7 +269,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/matches_summary/top_tenants_by_player",
+        "path": "/v1/matches_summary/top_tenants_by_player",
         "queryParams": {
           "player_user_id": "me",
           "sport_id": "$sport_id",
@@ -312,7 +312,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/matches",
+        "path": "/v1/matches",
         "queryParams": {
           "after_end_date": "$after_end_date",
           "before_end_date": "$before_end_date",
@@ -341,7 +341,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/matches/{match_id}"
+        "path": "/v1/matches/{match_id}"
       }
     },
     {
@@ -373,7 +373,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/match_recommendations",
+        "path": "/v1/match_recommendations",
         "queryParams": {
           "coordinate": "$coordinate",
           "size": "$size",
@@ -410,7 +410,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v2/tournaments",
+        "path": "/v2/tournaments",
         "queryParams": {
           "to_start_date": "$to_start_date",
           "status": "$status",
@@ -459,7 +459,7 @@
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/api/v1/leagues",
+        "path": "/v1/leagues",
         "queryParams": {
           "coordinate": "$coordinate",
           "radius": "$radius",

--- a/packages/backend/src/adapters/intl/playtomic.live.spec.ts
+++ b/packages/backend/src/adapters/intl/playtomic.live.spec.ts
@@ -19,14 +19,14 @@ describe('playtomic adapter — static spec conformance', () => {
   it('is the full LOGIN_TOKEN variant in the sports category', () => {
     expect(a.slug).toBe('playtomic');
     expect(a.category).toBe('sports');
-    expect(a.connector.baseUrl).toBe('https://app.playtomic.io');
+    expect(a.connector.baseUrl).toBe('https://api.app.playtomic.io');
     expect(a.connector.authType).toBe('LOGIN_TOKEN');
     expect(a.requiredEnvVars).toEqual(['PLAYTOMIC_EMAIL', 'PLAYTOMIC_PASSWORD']);
   });
 
-  it('login posts to /api/v3/auth/login with ROLE_CUSTOMER and reads access_token + expiration', () => {
+  it('login posts to /v3/auth/login with ROLE_CUSTOMER and reads access_token + expiration', () => {
     const auth = a.connector.authConfig as Record<string, unknown>;
-    expect(auth.loginUrl).toBe('https://app.playtomic.io/api/v3/auth/login');
+    expect(auth.loginUrl).toBe('https://api.app.playtomic.io/v3/auth/login');
     expect(auth.loginMethod).toBe('POST');
     expect(auth.tokenJsonPath).toBe('access_token');
     expect(auth.expiryJsonPath).toBe('access_token_expiration');

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/src/lib/demo-connectors.ts
+++ b/packages/frontend/src/lib/demo-connectors.ts
@@ -1,7 +1,7 @@
 // Curated, zero-credential connectors used for the onboarding "aha moment":
 // install in one click (no auth), then auto-run a sample tool so a brand-new
 // user sees a real, successful result before being asked to connect anything.
-// All three are authType NONE in the adapter catalog.
+// All of them are authType NONE in the adapter catalog.
 export interface DemoConnector {
   slug: string;
   name: string;
@@ -29,14 +29,6 @@ export const DEMO_CONNECTORS: DemoConnector[] = [
     blurb: 'Official EUR exchange rates — no key.',
     tool: 'bundesbank_get_exchange_rates',
     params: { currency: 'USD' },
-  },
-  {
-    slug: 'playtomic-public',
-    name: 'Playtomic',
-    emoji: '🎾',
-    blurb: 'Padel sport catalog — no login.',
-    tool: 'playtomic_get_sport_configuration',
-    params: {},
   },
 ];
 


### PR DESCRIPTION
## Why

Playtomic **closed anonymous access** to its API and moved it to `api.app.playtomic.io` (dropping the `/api` prefix) around 2026-07-31. Both shipped Playtomic adapters broke: old paths return `404`, and the previously-public `tenants`/`availability` endpoints now return `401 {"status":"UNAUTHORIZED"}` without a Bearer token. This is what customers hit as "Playtomic MCP 404 even for the public one".

## What

- **`playtomic` (full, 13 tools)** — repoint `baseUrl` + `loginUrl` to `api.app.playtomic.io`, drop `/api` from all tool paths. Auth flow (`LOGIN_TOKEN`, email+password → JWT) was already correct.
- **`playtomic-public` → "Playtomic (Lite)"** — convert `authType: NONE` → **`LOGIN_TOKEN`**. The 4 read-only tools (search clubs, club details, availability, sport configuration) now require a **free Playtomic account** (`PLAYTOMIC_EMAIL` + `PLAYTOMIC_PASSWORD`) — no API key, no club membership. Generic pricing preserved.
- **Onboarding demo** — removed `playtomic-public` from the zero-credential `DEMO_CONNECTORS` autorun (it now needs login, so the one-click "aha moment" would fail). It stays in the marketplace starter list.
- **Specs** — both conformance specs updated (10/10 green).

## Auth: no spoofing

Verified end-to-end against a real account: `POST /v3/auth/login` → `200` + `access_token`; every data + personal endpoint returns `200` with the **Bearer token alone** — no `X-Requested-With` / iOS User-Agent spoofing. The existing `LOGIN_TOKEN` engine handles login, encrypted token caching, and refresh (proactive + on 401).

## Follow-up

Website content (separate PR) updates the Playtomic guides/marketplace copy that still claim "no account needed".