### PR TITLE
feat(adapters): Georgian Railway connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -491,6 +491,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -993,7 +994,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
       "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.3",
@@ -1224,6 +1226,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1237,6 +1240,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -1279,7 +1283,6 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -1465,9 +1468,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1483,9 +1483,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1503,9 +1500,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1521,9 +1515,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1541,9 +1532,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1559,9 +1547,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1579,9 +1564,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1598,9 +1580,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1616,9 +1595,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1642,9 +1618,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1666,9 +1639,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1692,9 +1662,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1716,9 +1683,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1742,9 +1706,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1767,9 +1728,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1791,9 +1749,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3004,7 +2959,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3045,7 +2999,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3061,8 +3014,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
@@ -3091,6 +3043,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
       "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3137,6 +3090,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
       "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3176,6 +3130,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz",
       "integrity": "sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/jsonwebtoken": "9.0.10",
         "jsonwebtoken": "9.0.3"
@@ -3209,6 +3164,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
       "integrity": "sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "passport": "^0.5.0 || ^0.6.0 || ^0.7.0"
@@ -3219,6 +3175,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
       "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3478,9 +3435,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3496,9 +3450,6 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3516,9 +3467,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3534,9 +3482,6 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3656,6 +3601,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4117,6 +4063,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
       "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -7240,6 +7187,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
       "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
         "@opentelemetry/resources": "2.10.0",
@@ -7338,6 +7286,7 @@
       "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.62.1"
       },
@@ -7365,6 +7314,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.1.tgz",
       "integrity": "sha512-+xgrh2EhJVF79wC0yX5G4PI1Rdcm7Qn/nekNQ+t/O153wtNggruHal+fXHSa0QE+Tp/Cw5wvxeCEhZZ59xGm8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/client-runtime-utils": "7.9.1"
       },
@@ -11666,9 +11616,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11684,9 +11631,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11704,9 +11648,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11722,9 +11663,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11762,25 +11700,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -12186,6 +12105,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -12353,6 +12273,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -12448,6 +12369,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -12458,6 +12380,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -12597,6 +12520,7 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -13493,6 +13417,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13559,6 +13484,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14352,6 +14278,7 @@
       "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -14495,6 +14422,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -14865,6 +14793,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -14916,13 +14845,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -16313,6 +16244,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -16498,6 +16430,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -16808,7 +16741,6 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -16821,7 +16753,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
       "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -16899,6 +16830,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -16942,7 +16874,6 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
       "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -17978,6 +17909,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -18503,7 +18435,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -19276,6 +19207,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -20029,7 +19961,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -20124,8 +20055,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -20433,9 +20363,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -20455,9 +20382,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -20479,9 +20403,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -20501,9 +20422,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -22182,6 +22100,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
       "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
@@ -22840,6 +22759,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -23078,6 +22998,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -23194,6 +23115,7 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -23225,6 +23147,7 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -23291,7 +23214,6 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -23413,6 +23335,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -23462,6 +23385,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -23574,6 +23498,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23620,6 +23545,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.9.1",
         "@prisma/dev": "0.24.17",
@@ -23904,6 +23830,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24102,7 +24029,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -24485,6 +24413,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
       "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -25973,6 +25902,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26357,6 +26287,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -26593,6 +26524,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27092,6 +27024,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27158,6 +27091,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -27653,6 +27587,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -27662,7 +27597,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
@@ -27692,7 +27626,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@jmespath-community/jmespath": "^1.3.0",
@@ -28009,6 +27943,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -28046,7 +27981,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/adapters/catalog.ts
+++ b/packages/backend/src/adapters/catalog.ts
@@ -83,6 +83,7 @@ import * as freshchat from './intl/freshchat.json';
 import * as freshdesk from './intl/freshdesk.json';
 import * as freshservice from './intl/freshservice.json';
 import * as front from './intl/front.json';
+import * as georgianRailway from './intl/georgian-railway.json';
 import * as ghost from './intl/ghost.json';
 import * as gitbook from './intl/gitbook.json';
 import * as gocardless from './intl/gocardless.json';
@@ -364,6 +365,7 @@ const RAW_ADAPTERS: AdapterDefinition[] = [
   freshdesk as unknown as AdapterDefinition,
   freshservice as unknown as AdapterDefinition,
   front as unknown as AdapterDefinition,
+  georgianRailway as unknown as AdapterDefinition,
   ghost as unknown as AdapterDefinition,
   gitbook as unknown as AdapterDefinition,
   gocardless as unknown as AdapterDefinition,

--- a/packages/backend/src/adapters/intl/georgian-railway.json
+++ b/packages/backend/src/adapters/intl/georgian-railway.json
@@ -1,0 +1,149 @@
+{
+  "slug": "georgian-railway",
+  "name": "Georgian Railway",
+  "description": "Search Georgian Railway (საქართველოს რკინიგზა) passenger trains: find stations, look up services between any two stations on a given date, and read live seat availability and fares in GEL. Covers the Tbilisi–Batumi and Tbilisi–Zugdidi main lines and every regional stop. No account or API key needed.",
+  "region": "intl",
+  "category": "transport",
+  "icon": "train",
+  "docsUrl": "https://gr.com.ge",
+  "requiredEnvVars": [],
+  "instructions": "## Georgian Railway\n\nThis connector wraps the JSON API behind **gr.com.ge**, the official booking site of Georgian Railway (საქართველოს რკინიგზა). It is read-only, needs no account and no API key.\n\n**Always start with `gr_search_stations`.** Journey search takes numeric station codes, never names. Resolve the name the user gave you into a `station_code` first, then pass those codes to `gr_search_trains`. The station list holds 515 entries — most of them are freight platforms and halts, so prefer the result whose `name_en` matches the city exactly.\n\nThe main passenger stations are:\n\n| Station | Code |\n|---|---|\n| Tbilisi | `56014` |\n| Batumi | `57151` |\n| Kutaisi (airport) | `57450` |\n| Zugdidi | `57290` |\n| Poti | `57210` |\n\nBeware of near-duplicates: `56014` (Tbilisi, the passenger terminal) is the one travellers want, not `56000` / `56010` / `56020`, which are technical stations on the same node. The same applies to Batumi, where `57151` is the passenger station and `57150` is not.\n\nKutaisi is the trap worth remembering: the station that actually has bookable services is **Kutaisi International Airport (`57450`)**. `Kutaisi I` (`57530`) exists in the station list but returns no trains, so a search against it looks like \"no service\" when the real answer is \"wrong station\".\n\n**Reading a journey result.** Each train carries `train` (the service number, e.g. 803), `departure` / `arrival` as local times (`HH:MM:SS`), and `classes` — one entry per travel class actually on sale, each with `seatsLeft` and `price` in **GEL** (Georgian lari). An **empty `classes` array means the train runs but is sold out** for the requested passenger mix — say so rather than reporting that no train exists. `onSale: false` means booking is not open yet.\n\n**Dates and times.** `date` is the departure date in ISO 8601 with a `Z` suffix, but `departure` and `arrival` are **local Georgian time** (UTC+4) and are the fields to quote to a traveller. Ask for a concrete date if the user only says \"tomorrow\"; the API has no relative-date support.\n\n**Passenger mix.** `standard_passengers`, `child_passengers` and `disabled_passengers` change which fares and seat counts come back, so pass the real party composition. `routeType: 0` means all route types and is the sensible default.\n\n**Round trips.** Supplying `returnDateFrom` makes the API return two groups, outbound first and return second. The tool flattens them into a single list — read the `from` / `to` fields to tell the directions apart.\n\n**Language.** `interface-language` is set to `en` on the connector, so station and class names come back in English where a translation exists. Some names remain transliterated Georgian.\n\n**Booking is not exposed.** This connector only reads timetables, availability and fares. Actually buying a ticket has to happen on gr.com.ge — send the user there with the train number and date.\n\n**Stability.** This is the site's own internal API, not a published product with a compatibility guarantee. Endpoints can change without notice; if a tool starts failing, check gr.com.ge for changes.",
+  "connector": {
+    "name": "Georgian Railway",
+    "type": "REST",
+    "baseUrl": "https://gr.com.ge",
+    "authType": "NONE",
+    "headers": {
+      "Accept": "application/json",
+      "interface-language": "en",
+      "x-device": "web",
+      "User-Agent": "anythingmcp/1.0 (+https://anythingmcp.com)"
+    }
+  },
+  "tools": [
+    {
+      "name": "gr_search_stations",
+      "description": "Find Georgian Railway stations by name and return their station_code, which every other tool needs. Searches Georgian, English and Russian names at once, so 'Tbilisi', 'თბილისი' and 'Тбилиси' all work. Call this first to turn a place name into a code.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "search": {
+            "type": "string",
+            "description": "Station name or fragment, in Georgian, English or Russian (e.g. 'Batumi', 'თბილისი')."
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of stations to return. Defaults to 20; the full list is 515 entries.",
+            "default": 20
+          },
+          "page": {
+            "type": "number",
+            "description": "1-based page number, for paging through a large result set.",
+            "default": 1
+          }
+        },
+        "required": ["search"]
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/stations",
+        "queryParams": {
+          "search": "$search",
+          "limit": "$limit",
+          "page": "$page"
+        }
+      },
+      "responseMapping": {
+        "cacheTtl": 86400,
+        "transform": {
+          "mode": "jmespath",
+          "expression": "{ total: data.meta.totalItems, page: data.meta.currentPage, totalPages: data.meta.totalPages, stations: data.data[].{ code: station_code, name: name_en, nameKa: name_ka, nameRu: name_ru } }"
+        }
+      }
+    },
+    {
+      "name": "gr_search_trains",
+      "description": "Search Georgian Railway services between two stations on a date, returning departure and arrival times, the train number, and per-class seat availability with fares in GEL. Pass station codes from gr_search_stations, not names. Add returnDateFrom for a round trip.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "startStationCode": {
+            "type": "string",
+            "description": "Departure station code, e.g. '57151' for Batumi. Get it from gr_search_stations."
+          },
+          "endStationCode": {
+            "type": "string",
+            "description": "Arrival station code, e.g. '56014' for Tbilisi. Get it from gr_search_stations."
+          },
+          "departureDateFrom": {
+            "type": "string",
+            "description": "Outbound date as YYYY-MM-DD (e.g. '2026-08-25'). Relative dates are not supported."
+          },
+          "returnDateFrom": {
+            "type": "string",
+            "description": "Optional return date as YYYY-MM-DD. When set, return services are appended to the result."
+          },
+          "standard_passengers": {
+            "type": "number",
+            "description": "Number of adult passengers. Affects which fares and seat counts are returned.",
+            "default": 1
+          },
+          "child_passengers": {
+            "type": "number",
+            "description": "Number of child passengers.",
+            "default": 0
+          },
+          "disabled_passengers": {
+            "type": "number",
+            "description": "Number of passengers travelling with a disability concession.",
+            "default": 0
+          },
+          "routeType": {
+            "type": "number",
+            "description": "Route type filter. 0 means all route types and is the right default.",
+            "default": 0
+          }
+        },
+        "required": ["startStationCode", "endStationCode", "departureDateFrom"]
+      },
+      "endpointMapping": {
+        "method": "POST",
+        "path": "/api/ticket-search",
+        "bodyMapping": {
+          "startStationCode": "$startStationCode",
+          "endStationCode": "$endStationCode",
+          "departureDateFrom": "$departureDateFrom",
+          "returnDateFrom": "$returnDateFrom",
+          "standard_passengers": "$standard_passengers",
+          "child_passengers": "$child_passengers",
+          "disabled_passengers": "$disabled_passengers",
+          "routeType": "$routeType"
+        }
+      },
+      "responseMapping": {
+        "transform": {
+          "mode": "jmespath",
+          "expression": "[].{ train: rideNumber, from: rideStartStation.station.name, to: rideEndStation.station.name, departure: rideStartStation.departureTime, arrival: rideEndStation.arrivalTime, date: rideStartDate, onSale: saleFlag, classes: availableSeatsClasses[].{ class: seatClass.name, seatsLeft: availableNumberOfSeats, price: priceOfSeats.amount, currency: priceOfSeats.currencyCode } }"
+        }
+      }
+    },
+    {
+      "name": "gr_get_notifications",
+      "description": "Read the current service notices Georgian Railway publishes on its site: timetable changes, engineering works, cancellations and seasonal services. Worth checking alongside a journey search when a trip is close or a train looks unexpectedly unavailable.",
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      },
+      "endpointMapping": {
+        "method": "GET",
+        "path": "/api/info-content",
+        "queryParams": {
+          "type": "notifications"
+        }
+      },
+      "responseMapping": {
+        "cacheTtl": 3600
+      }
+    }
+  ]
+}

--- a/packages/backend/src/adapters/intl/georgian-railway.live.spec.ts
+++ b/packages/backend/src/adapters/intl/georgian-railway.live.spec.ts
@@ -1,0 +1,234 @@
+import {
+  applyResponseTransform,
+  validateTransform,
+} from '../../connectors/response-transform.util';
+import * as adapter from './georgian-railway.json';
+
+/**
+ * Static conformance for the Georgian Railway adapter.
+ *
+ * gr.com.ge exposes no documented API — this connector is built on the JSON
+ * endpoints its own site calls. Two things are therefore worth pinning: the
+ * request shape (so a careless edit doesn't silently point at the wrong host or
+ * verb) and the response mappings, which do the real work here. The upstream
+ * payload repeats each station in five near-identical objects, so the mapping
+ * is what makes the tool usable rather than a nicety.
+ *
+ * No network calls: the fixtures below are trimmed captures of real responses.
+ */
+
+const a = adapter as unknown as {
+  slug: string;
+  connector: { baseUrl: string; authType: string; headers: Record<string, string> };
+  tools: Array<{
+    name: string;
+    endpointMapping: { method: string; path: string };
+    responseMapping?: Record<string, unknown>;
+  }>;
+};
+
+const tool = (name: string) => a.tools.find((t) => t.name === name)!;
+
+describe('georgian-railway adapter — connector', () => {
+  it('targets gr.com.ge without credentials', () => {
+    expect(a.connector.baseUrl).toBe('https://gr.com.ge');
+    expect(a.connector.authType).toBe('NONE');
+  });
+
+  it('sends the headers the API requires', () => {
+    // The API answers with the site's HTML shell instead of JSON unless it is
+    // asked for JSON, and localises station names off interface-language.
+    expect(a.connector.headers.Accept).toBe('application/json');
+    expect(a.connector.headers['interface-language']).toBe('en');
+    expect(a.connector.headers['x-device']).toBe('web');
+  });
+
+  it('exposes exactly the three read tools', () => {
+    expect(a.tools.map((t) => t.name).sort()).toEqual([
+      'gr_get_notifications',
+      'gr_search_stations',
+      'gr_search_trains',
+    ]);
+  });
+
+  it('routes each tool at the endpoint the site uses', () => {
+    expect(tool('gr_search_stations').endpointMapping).toMatchObject({
+      method: 'GET',
+      path: '/api/stations',
+    });
+    // Search is a POST that answers 201 — it creates a search resource
+    // server-side. Switching it to GET returns the site's HTML, not results.
+    expect(tool('gr_search_trains').endpointMapping).toMatchObject({
+      method: 'POST',
+      path: '/api/ticket-search',
+    });
+    expect(tool('gr_get_notifications').endpointMapping).toMatchObject({
+      method: 'GET',
+      path: '/api/info-content',
+    });
+  });
+
+  it('has a valid transform on every tool that declares one', () => {
+    for (const t of a.tools) {
+      const transform = (t.responseMapping as { transform?: unknown } | undefined)?.transform;
+      if (transform === undefined) continue;
+      expect(validateTransform(transform)).toBeNull();
+    }
+  });
+});
+
+describe('georgian-railway adapter — response mappings', () => {
+  it('flattens a journey search into trains with fares and seat counts', () => {
+    // Real shape: [[outbound…],[return…]], each train repeating its stations.
+    const raw = [
+      [
+        {
+          id: 22461,
+          guid: '86481baf',
+          rideNumber: 803,
+          saleFlag: true,
+          rideStartDate: '2026-08-25T04:00:00Z',
+          rideStartStation: {
+            station: { id: 309, code: '57151', name: 'BATUMI(pass)' },
+            departureTime: '08:00:00',
+            arrivalTime: '08:08:00',
+          },
+          rideEndStation: {
+            station: { id: 98, code: '56014', name: 'TBILISI(pass)' },
+            departureTime: '12:00:00',
+            arrivalTime: '12:12:00',
+          },
+          availableSeatsClasses: [
+            {
+              seatClass: { id: 2, name: 'II Class' },
+              availableNumberOfSeats: 17,
+              priceOfSeats: { amount: 35, currencyCode: 'GEL' },
+            },
+          ],
+        },
+      ],
+      [
+        {
+          rideNumber: 804,
+          saleFlag: true,
+          rideStartDate: '2026-08-27T13:10:00Z',
+          rideStartStation: {
+            station: { code: '56014', name: 'TBILISI(pass)' },
+            departureTime: '17:10:00',
+          },
+          rideEndStation: {
+            station: { code: '57151', name: 'BATUMI(pass)' },
+            arrivalTime: '21:21:00',
+          },
+          availableSeatsClasses: [],
+        },
+      ],
+    ];
+
+    const out = applyResponseTransform(raw, tool('gr_search_trains').responseMapping as any);
+    expect(out.applied).toBe(true);
+    expect(out.error).toBeUndefined();
+    expect(out.value).toEqual([
+      {
+        train: 803,
+        from: 'BATUMI(pass)',
+        to: 'TBILISI(pass)',
+        departure: '08:00:00',
+        arrival: '12:12:00',
+        date: '2026-08-25T04:00:00Z',
+        onSale: true,
+        classes: [{ class: 'II Class', seatsLeft: 17, price: 35, currency: 'GEL' }],
+      },
+      {
+        train: 804,
+        from: 'TBILISI(pass)',
+        to: 'BATUMI(pass)',
+        departure: '17:10:00',
+        arrival: '21:21:00',
+        date: '2026-08-27T13:10:00Z',
+        onSale: true,
+        // Sold out for the requested party — the train still runs. The
+        // instructions tell the agent to report this as sold out, not as
+        // "no such train".
+        classes: [],
+      },
+    ]);
+  });
+
+  it('cuts a real journey payload by roughly an order of magnitude', () => {
+    const train = {
+      rideNumber: 803,
+      saleFlag: true,
+      rideStartDate: '2026-08-25T04:00:00Z',
+      routeType: { id: 2, code: 'local', name: 'მაგისტრალური', cultureName: [] },
+      // The upstream payload carries the same station five times over.
+      rideStartStation: { station: { code: '57151', name: 'BATUMI(pass)' }, departureTime: '08:00:00' },
+      startStation: { station: { code: '57151', name: 'BATUMI(pass)' }, departureTime: '08:00:00' },
+      actualStation: { station: { code: '57151', name: 'BATUMI(pass)' }, departureTime: '08:00:00' },
+      previousStation: null,
+      rideEndStation: { station: { code: '56014', name: 'TBILISI(pass)' }, arrivalTime: '12:12:00' },
+      endStation: { station: { code: '56014', name: 'TBILISI(pass)' }, arrivalTime: '12:12:00' },
+      availableSeatsClasses: [
+        {
+          carriageModel: null,
+          carriageRang: null,
+          carriageType: null,
+          seatGroupProperty: null,
+          seatClass: { id: 2, guid: 'Guid', index: 2, code: 'II Class', name: 'II Class', color: '#AED6F1' },
+          availableNumberOfSeats: 17,
+          priceOfSeats: { amount: 35, currencyCode: 'GEL' },
+          priceOfSeatsCash: null,
+        },
+      ],
+      availableSeatsGroups: [],
+    };
+    const raw = [[train, train, train, train]];
+
+    const out = applyResponseTransform(raw, tool('gr_search_trains').responseMapping as any);
+    const before = Buffer.byteLength(JSON.stringify(raw));
+    const after = Buffer.byteLength(JSON.stringify(out.value));
+    expect(out.applied).toBe(true);
+    expect(after).toBeLessThan(before / 4);
+  });
+
+  it('reduces the station list to codes and names', () => {
+    const raw = {
+      status: 'success',
+      data: {
+        data: [
+          {
+            id: 309,
+            station_id: '112',
+            name: 'ბათუმი',
+            name_en: 'Batumi',
+            name_ka: 'ბათუმი',
+            name_ru: 'БАТУМИ',
+            station_code: '57151',
+            priority: 0,
+            hide: false,
+            created_at: '2025-01-01T00:00:00Z',
+            updated_at: '2025-01-01T00:00:00Z',
+            deleted_at: null,
+            station_country_id: 1,
+            station_country: null,
+          },
+        ],
+        meta: { itemsPerPage: 20, totalItems: 2, currentPage: 1, totalPages: 1 },
+        links: {},
+      },
+    };
+
+    const out = applyResponseTransform(raw, tool('gr_search_stations').responseMapping as any);
+    expect(out.applied).toBe(true);
+    expect(out.value).toEqual({
+      total: 2,
+      page: 1,
+      totalPages: 1,
+      stations: [{ code: '57151', name: 'Batumi', nameKa: 'ბათუმი', nameRu: 'БАТУМИ' }],
+    });
+  });
+
+  it('caches the station list, which changes rarely', () => {
+    expect((tool('gr_search_stations').responseMapping as any).cacheTtl).toBe(86400);
+  });
+});

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Adds a read-only Georgian Railway (საქართველოს რკინიგზა) connector: station lookup, journey search with live seat availability and fares in GEL, and the operator's service notices. No account, no API key — so it fits the zero-credential onboarding path alongside Deutsche Bahn.

## Where the API came from

gr.com.ge publishes no API. This is built on the JSON endpoints the booking site itself calls, captured from its network traffic and then re-verified from a plain HTTP client — no cookie, no browser context, no auth. The `TS…` cookie the site sets is a WAF artefact and is not required.

| Endpoint | Tool |
|---|---|
| `GET /api/stations?search=&limit=&page=` | `gr_search_stations` — 515 stations, server-side search across Georgian, English and Russian names |
| `POST /api/ticket-search` | `gr_search_trains` — times, train number, per-class seats and fares |
| `GET /api/info-content?type=notifications` | `gr_get_notifications` |

Three headers are load-bearing: without `Accept: application/json` the API returns the site's HTML shell rather than JSON, `interface-language` selects the language of station and class names, and `x-device: web` mirrors what the site sends. They are pinned in a spec so an edit can't quietly drop them.

## Response mapping

This connector is a good argument for the v0.4.0 feature. The upstream journey payload repeats each station in five near-identical objects (`rideStartStation`, `startStation`, `actualStation`, …) and wraps outbound and return in a nested array. A JMESPath transform flattens it to one row per train:

```json
{ "train": 803, "from": "BATUMI(pass)", "to": "TBILISI(pass)",
  "departure": "08:00:00", "arrival": "12:12:00", "onSale": true,
  "classes": [ { "class": "II Class", "seatsLeft": 17, "price": 35, "currency": "GEL" } ] }
```

Measured against a real four-train response: **12172 B → 1072 B (−91%)**. Station search is mapped the same way (−78%) and cached for a day, since the station list is effectively static.

## Instructions cover the traps found while testing

- An **empty `classes` array means sold out**, not "no such train" — the train still runs. Without this an agent reports no service on a busy route.
- **Kutaisi** is the sharp edge: the bookable station is **Kutaisi International Airport (`57450`)**. `Kutaisi I` (`57530`) is in the station list but returns zero trains on every date tested, which looks identical to "no service".
- Tbilisi and Batumi each have technical stations on adjacent codes (`56000`/`56010`/`56020`, `57150`) that a name search surfaces next to the passenger terminal.

Station codes in the instructions were each verified against the live API rather than written from the search page — two of my first drafts were wrong and the searches caught them.

## Caveats

`POST /api/ticket-search` answers **201**: it creates a search resource server-side. It is read-only in effect, but the derived MCP annotation will treat POST as non-read-only, which is the conservative and correct default.

This is an undocumented internal API and can change without notice — the same exposure that just cost us the Playtomic adapter. The spec pins host, verbs and mapping shape so a break surfaces as a failing test rather than a silent wrong answer.

## Verification

Adapter validator 188/188. Full suite green: 208 suites / 3578 tests, lint clean. Both transforms were run through the production `applyResponseTransform` against real captured responses, and every station code and route in the instructions was confirmed against the live API.