### PR TITLE
fix(mcp-bridge): preserve the base URL path when calling a remote MCP server

### DIFF
--- a/docs/connectors/mcp-bridge.md
+++ b/docs/connectors/mcp-bridge.md
@@ -29,7 +29,7 @@ The MCP Bridge connector lets you connect to **other MCP servers** and re-expose
 
 1. Go to **Connectors** > **New Connector**
 2. Select **MCP** as the type
-3. Enter the **Remote MCP Server URL** (e.g., `http://other-mcp-server:3000/mcp`)
+3. Enter the **Remote MCP Server URL** — the *complete* endpoint URL, including its path (e.g., `http://other-mcp-server:3000/mcp`)
 4. Configure authentication for the remote server
 5. Click **Create**
 
@@ -49,6 +49,26 @@ curl -s http://localhost:4000/api/connectors \
     }
   }'
 ```
+
+### The base URL is the endpoint
+
+Whatever path you put in the base URL is the path AnythingMCP calls. This matters for
+providers that do not serve MCP at the root of their host:
+
+| Remote server | Base URL to enter |
+|---------------|-------------------|
+| Most hosted servers | `https://mcp.example.com/mcp` |
+| Snowflake managed MCP server | `https://<account>.snowflakecomputing.com/api/v2/databases/<db>/schemas/<schema>/mcp-servers/<name>` |
+| Another AnythingMCP instance | `https://your-anythingmcp.example.com/mcp/<serverId>` |
+| Zoho MCP | `https://<workspace>.zohomcp.com/mcp/<token>/message` |
+
+A base URL with **no** path (`https://mcp.example.com`) falls back to `/mcp`, which is where
+most servers listen.
+
+> **Changed behaviour.** Releases up to v0.4.2 always POSTed to `<origin>/mcp` and silently
+> discarded the base URL's path, so servers hosted under a path could never be reached
+> ([#501](https://github.com/HelpCode-ai/anythingmcp/issues/501)). If you had worked around
+> this by leaving an unrelated path in the base URL, set it back to the bare host.
 
 ---
 
@@ -80,6 +100,7 @@ MCP bridge tools use a simple mapping:
 |-------|-------------|
 | `method` | The tool name on the remote MCP server |
 | `bodyMapping` | Maps local parameters to remote tool parameters |
+| `path` | Optional. Overrides the endpoint for this tool only. A leading `/` is resolved against the host, a relative value is appended to the base URL's path, and a full `https://…` URL is used verbatim. The default `/mcp` means "use the connector's base URL". |
 
 ---
 

--- a/docs/tool-definition.md
+++ b/docs/tool-definition.md
@@ -161,6 +161,10 @@ Adapter authors don't need to declare them.
 }
 ```
 
+`path` is optional here: omit it and the call goes to the connector's base URL
+(or `<host>/mcp` if the base URL has no path). Set it only to send this one tool
+somewhere else — see [MCP Bridge](connectors/mcp-bridge.md).
+
 ---
 
 ## 3. Response Mapping (Optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -24391,7 +24391,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@jmespath-community/jmespath": "^1.3.0",
@@ -24662,7 +24662,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/src/common/ssrf.util.spec.ts
+++ b/packages/backend/src/common/ssrf.util.spec.ts
@@ -1,0 +1,30 @@
+import { extractSsrfBlockedHostname } from './ssrf.util';
+
+describe('extractSsrfBlockedHostname', () => {
+  // The allowlist is checked before the IP / loopback / DNS checks, so every
+  // one of these is genuinely fixable by allowlisting the host.
+  it.each([
+    ["SSRF guard: address '192.168.1.50' is not a public IP", '192.168.1.50'],
+    ["SSRF guard: hostname 'localhost' is loopback / local", 'localhost'],
+    [
+      "SSRF guard: hostname 'internal.example' resolves to non-public address '10.0.0.5'",
+      'internal.example',
+    ],
+    [
+      "SSRF guard: cannot resolve 'other-mcp-server': getaddrinfo ENOTFOUND other-mcp-server",
+      'other-mcp-server',
+    ],
+  ])('extracts the host from %s', (message, expected) => {
+    expect(extractSsrfBlockedHostname(message)).toBe(expected);
+  });
+
+  it.each([
+    "SSRF guard: invalid URL 'not a url'",
+    "SSRF guard: protocol 'file:' is not allowed",
+    'SSRF guard: empty hostname',
+    'ECONNREFUSED 127.0.0.1:3000',
+    '',
+  ])('returns undefined for %s (allowlisting would not help)', (message) => {
+    expect(extractSsrfBlockedHostname(message)).toBeUndefined();
+  });
+});

--- a/packages/backend/src/common/ssrf.util.ts
+++ b/packages/backend/src/common/ssrf.util.ts
@@ -240,5 +240,25 @@ export async function assertSafeOutboundHost(
   }
 }
 
+/**
+ * Pull the blocked host out of an SSRF guard message, when adding that host to
+ * the allowlist would actually unblock the request.
+ *
+ * The allowlist is consulted before the literal-IP, loopback and DNS checks
+ * (see assertSafeOutboundHost), so every "this address/hostname is not public"
+ * variant is fixable that way — including a Docker service name that does not
+ * resolve from outside its network. `invalid URL` and `protocol not allowed`
+ * are not: those are malformed input, so they return undefined and the caller
+ * shows the plain error.
+ */
+export function extractSsrfBlockedHostname(
+  message: string,
+): string | undefined {
+  const match = /SSRF guard:\s*(?:address|hostname|cannot resolve)\s*'([^']+)'/.exec(
+    message || '',
+  );
+  return match?.[1];
+}
+
 // Exposed for unit tests.
 export const __test = { isPublicIp, hostMatchesAllowlist, readPolicy };

--- a/packages/backend/src/common/url.util.spec.ts
+++ b/packages/backend/src/common/url.util.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import { normalizeConnectorBaseUrl } from './url.util';
+import { normalizeConnectorBaseUrl, resolveMcpEndpointUrl } from './url.util';
 
 describe('normalizeConnectorBaseUrl', () => {
   it('keeps a well-formed https URL untouched', () => {
@@ -47,6 +47,81 @@ describe('normalizeConnectorBaseUrl', () => {
   it('defaults to HTTP normalization when type is omitted', () => {
     expect(normalizeConnectorBaseUrl('api.example.com')).toBe(
       'https://api.example.com',
+    );
+  });
+});
+
+describe('resolveMcpEndpointUrl', () => {
+  const resolve = (base: string, path?: string) =>
+    resolveMcpEndpointUrl(base, path).toString();
+
+  it('defaults a bare origin to /mcp', () => {
+    expect(resolve('https://mcp.example.com', '/mcp')).toBe(
+      'https://mcp.example.com/mcp',
+    );
+    expect(resolve('https://mcp.example.com')).toBe(
+      'https://mcp.example.com/mcp',
+    );
+  });
+
+  it('treats a root path as a bare origin', () => {
+    expect(resolve('https://chat.z.ai/', '/mcp')).toBe('https://chat.z.ai/mcp');
+  });
+
+  it('leaves the common "<origin>/mcp" base URL untouched', () => {
+    expect(resolve('http://other-mcp-server:3000/mcp', '/mcp')).toBe(
+      'http://other-mcp-server:3000/mcp',
+    );
+  });
+
+  it('preserves a deep path — Snowflake managed MCP servers (#501)', () => {
+    const base =
+      'https://acct.snowflakecomputing.com/api/v2/databases/mydb/schemas/public/mcp-servers/my-server';
+    expect(resolve(base, '/mcp')).toBe(base);
+  });
+
+  it('preserves an AnythingMCP Cloud per-tenant endpoint', () => {
+    expect(resolve('https://cloud.anythingmcp.com/mcp/srv_123', '/mcp')).toBe(
+      'https://cloud.anythingmcp.com/mcp/srv_123',
+    );
+  });
+
+  it('drops a trailing slash instead of emitting a double slash', () => {
+    expect(resolve('https://mcp.example.com/api/mcp/', '/mcp')).toBe(
+      'https://mcp.example.com/api/mcp',
+    );
+  });
+
+  it('keeps a query string carried by the base URL', () => {
+    expect(resolve('https://gw.example.com/mcp?key=abc', '/mcp')).toBe(
+      'https://gw.example.com/mcp?key=abc',
+    );
+  });
+
+  it('resolves an explicit root-absolute override against the origin', () => {
+    expect(resolve('https://mcp.example.com', '/sse')).toBe(
+      'https://mcp.example.com/sse',
+    );
+    expect(resolve('https://mcp.example.com/ignored', '/sse')).toBe(
+      'https://mcp.example.com/sse',
+    );
+  });
+
+  it('joins a relative override onto the base path', () => {
+    expect(resolve('https://mcp.example.com/base', 'sub/mcp')).toBe(
+      'https://mcp.example.com/base/sub/mcp',
+    );
+  });
+
+  it('honours an absolute http(s) override verbatim', () => {
+    expect(
+      resolve('https://mcp.example.com', 'https://other.example.com/mcp'),
+    ).toBe('https://other.example.com/mcp');
+  });
+
+  it('rejects an unparseable base URL', () => {
+    expect(() => resolveMcpEndpointUrl('not a url', '/mcp')).toThrow(
+      BadRequestException,
     );
   });
 });

--- a/packages/backend/src/common/url.util.spec.ts
+++ b/packages/backend/src/common/url.util.spec.ts
@@ -125,3 +125,25 @@ describe('resolveMcpEndpointUrl', () => {
     );
   });
 });
+
+describe('resolveMcpEndpointUrl credential handling', () => {
+  it('keeps credentials embedded in the base URL', () => {
+    expect(
+      resolveMcpEndpointUrl('https://user:pass@mcp.example.com', '/mcp').toString(),
+    ).toBe('https://user:pass@mcp.example.com/mcp');
+
+    expect(
+      resolveMcpEndpointUrl('https://user:pass@mcp.example.com/deep/mcp', '/mcp').toString(),
+    ).toBe('https://user:pass@mcp.example.com/deep/mcp');
+
+    expect(
+      resolveMcpEndpointUrl('https://user:pass@mcp.example.com/deep', '/sse').toString(),
+    ).toBe('https://user:pass@mcp.example.com/sse');
+  });
+
+  it('keeps a non-default port', () => {
+    expect(
+      resolveMcpEndpointUrl('http://mcp.example.com:8931/tenant/a', '/mcp').toString(),
+    ).toBe('http://mcp.example.com:8931/tenant/a');
+  });
+});

--- a/packages/backend/src/common/url.util.ts
+++ b/packages/backend/src/common/url.util.ts
@@ -108,14 +108,30 @@ export function resolveMcpEndpointUrl(
 
   if (override && override !== DEFAULT_MCP_PATH) {
     if (/^https?:\/\//i.test(override)) return new URL(override);
-    if (override.startsWith('/')) return new URL(override, base.origin);
-    return new URL(`${basePath}/${override.replace(/^\/+/, '')}`, base.origin);
+    return withPath(
+      base,
+      override.startsWith('/')
+        ? override
+        : `${basePath}/${override.replace(/^\/+/, '')}`,
+      '',
+    );
   }
 
-  if (basePath) {
-    // Preserve the query string: some hosted gateways carry a key there.
-    return new URL(`${basePath}${base.search}`, base.origin);
-  }
+  // Preserve the query string: some hosted gateways carry a key there.
+  if (basePath) return withPath(base, basePath, base.search);
 
-  return new URL(DEFAULT_MCP_PATH, base.origin);
+  return withPath(base, DEFAULT_MCP_PATH, '');
+}
+
+/**
+ * Rebuild a URL with a different path, keeping everything else the base URL
+ * carried — port, and in particular any `user:pass@` credentials, which
+ * `new URL(path, origin)` would silently drop.
+ */
+function withPath(base: URL, pathname: string, search: string): URL {
+  const url = new URL(base.toString());
+  url.pathname = pathname;
+  url.search = search;
+  url.hash = '';
+  return url;
 }

--- a/packages/backend/src/common/url.util.ts
+++ b/packages/backend/src/common/url.util.ts
@@ -57,3 +57,65 @@ export function normalizeConnectorBaseUrl(
 
   return withScheme;
 }
+
+/**
+ * The path every discovered MCP tool has been stamped with since the MCP
+ * bridge shipped. It is a *default*, not a user choice: nothing in the UI ever
+ * asked for it, so it must not be allowed to override a real path.
+ */
+export const DEFAULT_MCP_PATH = '/mcp';
+
+/**
+ * Resolve the outbound URL of a remote MCP endpoint.
+ *
+ * The bridge used to build this with `new URL('/mcp', baseUrl)`, whose
+ * root-absolute path silently resolves against the *origin* and throws away
+ * any path the base URL carried. That made every MCP server not hosted at
+ * `<origin>/mcp` unreachable — Snowflake's managed servers
+ * (`/api/v2/databases/…/mcp-servers/<name>`), Zoho's
+ * (`/mcp/<token>/message`), and even AnythingMCP's own per-tenant
+ * `/mcp/<serverId>` endpoints (issue #501).
+ *
+ * Resolution order:
+ *  1. An override that is a full `http(s)://` URL wins verbatim — the same
+ *     per-tool escape hatch RestEngine offers for vendors spread over several
+ *     hosts.
+ *  2. A root-absolute override (`/sse`) resolves against the origin, exactly
+ *     as before, so explicitly-configured paths keep their meaning.
+ *  3. A relative override (`sub/mcp`) is joined onto the base URL's path.
+ *  4. No override — or the historical `/mcp` default, which is
+ *     indistinguishable from "unset" — means the base URL *is* the endpoint
+ *     when it carries a path, and `<origin>/mcp` when it does not.
+ */
+export function resolveMcpEndpointUrl(
+  baseUrl: string,
+  pathOverride?: string,
+): URL {
+  let base: URL;
+  try {
+    base = new URL((baseUrl ?? '').trim());
+  } catch {
+    throw new BadRequestException(
+      `"${baseUrl}" is not a valid MCP server URL. Use a full address like ` +
+        `https://mcp.example.com/mcp.`,
+    );
+  }
+
+  const override = (pathOverride ?? '').trim();
+  // Trailing slashes carry no meaning here and would otherwise produce a
+  // double slash at the seam ("…/base//sub").
+  const basePath = base.pathname.replace(/\/+$/, '');
+
+  if (override && override !== DEFAULT_MCP_PATH) {
+    if (/^https?:\/\//i.test(override)) return new URL(override);
+    if (override.startsWith('/')) return new URL(override, base.origin);
+    return new URL(`${basePath}/${override.replace(/^\/+/, '')}`, base.origin);
+  }
+
+  if (basePath) {
+    // Preserve the query string: some hosted gateways carry a key there.
+    return new URL(`${basePath}${base.search}`, base.origin);
+  }
+
+  return new URL(DEFAULT_MCP_PATH, base.origin);
+}

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -905,6 +905,9 @@ export class ConnectorsController {
         name: rt.name,
         description: rt.description || `MCP tool: ${rt.name}`,
         parameters: rt.inputSchema || { type: 'object', properties: {} },
+        // '/mcp' here is the historical *default*, not a user choice: when the
+        // connector's base URL carries a path of its own, resolveMcpEndpointUrl()
+        // treats this value as unset and calls the base URL directly (#501).
         endpointMapping: {
           method: rt.name,
           path: '/mcp',
@@ -1151,6 +1154,10 @@ export class ConnectorsController {
               name: rt.name,
               description: rt.description || `MCP tool: ${rt.name}`,
               parameters: rt.inputSchema || { type: 'object', properties: {} },
+              // dto.url is the optional path the user typed in the import
+              // dialog; '/mcp' is the fallback default, which
+              // resolveMcpEndpointUrl() treats as unset so a path in the
+              // connector's base URL wins (#501).
               endpointMapping: {
                 method: rt.name,
                 path: dto.url || '/mcp',

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -10,6 +10,7 @@ import { McpClientEngine } from './engines/mcp-client.engine';
 import { encrypt, decrypt } from '../common/crypto/encryption.util';
 import { getRequiredSecret } from '../common/secrets.util';
 import { resolveInternalDbRestUrl } from '../common/db-rest.util';
+import { extractSsrfBlockedHostname } from '../common/ssrf.util';
 import { normalizeConnectorBaseUrl } from '../common/url.util';
 import { resolveAdapterIcon } from './connector-icon.util';
 
@@ -331,19 +332,20 @@ export class ConnectorsService {
     // Network-layer errors (DNS, ECONNREFUSED, SSRF guard, timeout)
     const msg = String(error?.message || '');
 
-    // Specifically: SSRF guard blocked an internal hostname. Attach a fix
-    // hint so the UI can deep-link to the admin allowlist page.
-    const ssrfMatch = msg.match(
-      /SSRF guard:\s*hostname '([^']+)' resolves to non-public address/,
-    );
-    if (ssrfMatch) {
+    // Specifically: SSRF guard blocked an internal host. Attach a fix hint so
+    // the UI can deep-link to the admin allowlist page. This covers every
+    // blocked-host variant, not just the DNS one — a private IP, 'localhost'
+    // and an unresolvable Docker service name are all fixed by allowlisting,
+    // and MCP bridges to a server on the local network hit exactly those.
+    const ssrfHostname = extractSsrfBlockedHostname(msg);
+    if (ssrfHostname) {
       return {
         ok: false,
         kind: 'unreachable',
         message: msg,
         suggestedFix: {
           action: 'add-to-ssrf-allowlist',
-          hostname: ssrfMatch[1],
+          hostname: ssrfHostname,
           url: '/admin/settings#ssrf',
         },
       };

--- a/packages/backend/src/connectors/engines/mcp-client.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.spec.ts
@@ -102,6 +102,43 @@ describe('McpClientEngine endpoint resolution', () => {
     });
   });
 
+  describe('headers', () => {
+    it('forwards connector headers alongside the injected auth header', async () => {
+      // Snowflake needs both: the PAT in Authorization AND a token-type header.
+      await engine.execute(
+        {
+          baseUrl:
+            'https://acct.snowflakecomputing.com/api/v2/databases/db/schemas/public/mcp-servers/srv',
+          authType: 'BEARER_TOKEN',
+          authConfig: { token: 'snowflake-pat' },
+          headers: {
+            'X-Snowflake-Authorization-Token-Type': 'PROGRAMMATIC_ACCESS_TOKEN',
+          },
+        },
+        { method: 'query', path: '/mcp' },
+        {},
+      );
+
+      const { requestInit } = MockedTransport.mock.calls[0][1];
+      expect(requestInit.headers).toEqual({
+        'X-Snowflake-Authorization-Token-Type': 'PROGRAMMATIC_ACCESS_TOKEN',
+        Authorization: 'Bearer snowflake-pat',
+      });
+    });
+
+    it('sends the API key header on a path-hosted server', async () => {
+      await engine.listTools({
+        baseUrl: 'https://gw.example.com/tenant/a/mcp',
+        authType: 'API_KEY',
+        authConfig: { headerName: 'X-API-Key', apiKey: 'k-123' },
+        headers: {},
+      });
+
+      const { requestInit } = MockedTransport.mock.calls[0][1];
+      expect(requestInit.headers['X-API-Key']).toBe('k-123');
+    });
+  });
+
   describe('listTools', () => {
     it('discovers against the base URL path instead of <origin>/mcp', async () => {
       const baseUrl = 'https://app.linkmcp.io/api/mcp';

--- a/packages/backend/src/connectors/engines/mcp-client.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.spec.ts
@@ -1,0 +1,137 @@
+import { McpClientEngine } from './mcp-client.engine';
+import { OAuth2TokenService } from './oauth2-token.service';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { assertSafeOutboundUrl } from '../../common/ssrf.util';
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn(),
+}));
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: jest.fn(),
+}));
+jest.mock('../../common/ssrf.util', () => ({
+  assertSafeOutboundUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
+const MockedClient = Client as unknown as jest.Mock;
+const MockedTransport = StreamableHTTPClientTransport as unknown as jest.Mock;
+const mockedAssertSafeOutboundUrl = assertSafeOutboundUrl as jest.Mock;
+
+/** The URL the SDK transport was constructed with, as a string. */
+const transportUrl = (call = 0): string =>
+  String(MockedTransport.mock.calls[call][0]);
+
+describe('McpClientEngine endpoint resolution', () => {
+  let engine: McpClientEngine;
+  let client: {
+    connect: jest.Mock;
+    callTool: jest.Mock;
+    listTools: jest.Mock;
+    close: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      callTool: jest.fn().mockResolvedValue({ content: [] }),
+      listTools: jest.fn().mockResolvedValue({ tools: [] }),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    MockedClient.mockImplementation(() => client);
+    engine = new McpClientEngine({} as unknown as OAuth2TokenService);
+  });
+
+  const config = (baseUrl: string) => ({
+    baseUrl,
+    authType: 'NONE',
+    headers: {} as Record<string, string>,
+  });
+
+  describe('execute', () => {
+    it('POSTs to <origin>/mcp for a bare-origin base URL (unchanged behaviour)', async () => {
+      await engine.execute(
+        config('https://mcp.example.com'),
+        { method: 'ping', path: '/mcp' },
+        {},
+      );
+
+      expect(transportUrl()).toBe('https://mcp.example.com/mcp');
+      expect(client.callTool).toHaveBeenCalledWith({
+        name: 'ping',
+        arguments: {},
+      });
+    });
+
+    it('keeps the base URL path for a Snowflake managed MCP server (#501)', async () => {
+      const baseUrl =
+        'https://acct.snowflakecomputing.com/api/v2/databases/mydb/schemas/public/mcp-servers/my-server';
+
+      await engine.execute(
+        config(baseUrl),
+        { method: 'query', path: '/mcp' },
+        {},
+      );
+
+      expect(transportUrl()).toBe(baseUrl);
+    });
+
+    it('keeps the base URL path when bridging to an AnythingMCP Cloud tenant server', async () => {
+      const baseUrl = 'https://cloud.anythingmcp.com/mcp/srv_123';
+
+      await engine.execute(
+        config(baseUrl),
+        { method: 'ping', path: '/mcp' },
+        {},
+      );
+
+      expect(transportUrl()).toBe(baseUrl);
+    });
+
+    it('SSRF-checks the resolved URL, not the base origin', async () => {
+      const baseUrl = 'https://gw.example.com/tenant/a/mcp';
+
+      await engine.execute(
+        config(baseUrl),
+        { method: 'ping', path: '/mcp' },
+        {},
+      );
+
+      expect(mockedAssertSafeOutboundUrl).toHaveBeenCalledWith(baseUrl);
+    });
+  });
+
+  describe('listTools', () => {
+    it('discovers against the base URL path instead of <origin>/mcp', async () => {
+      const baseUrl = 'https://app.linkmcp.io/api/mcp';
+
+      await engine.listTools(config(baseUrl));
+
+      expect(transportUrl()).toBe(baseUrl);
+    });
+
+    it('still defaults to <origin>/mcp for a bare origin', async () => {
+      await engine.listTools(config('https://mcp.example.com'));
+
+      expect(transportUrl()).toBe('https://mcp.example.com/mcp');
+    });
+
+    it('honours an explicit mcpPath override', async () => {
+      await engine.listTools({
+        ...config('https://mcp.example.com'),
+        mcpPath: '/sse',
+      });
+
+      expect(transportUrl()).toBe('https://mcp.example.com/sse');
+    });
+
+    it('applies the SSRF guard on the discovery path too', async () => {
+      await engine.listTools(config('https://mcp.example.com/deep/path/mcp'));
+
+      expect(mockedAssertSafeOutboundUrl).toHaveBeenCalledWith(
+        'https://mcp.example.com/deep/path/mcp',
+      );
+    });
+  });
+});

--- a/packages/backend/src/connectors/engines/mcp-client.engine.ts
+++ b/packages/backend/src/connectors/engines/mcp-client.engine.ts
@@ -3,10 +3,17 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { OAuth2TokenService } from './oauth2-token.service';
 import { assertSafeOutboundUrl } from '../../common/ssrf.util';
+import { DEFAULT_MCP_PATH, resolveMcpEndpointUrl } from '../../common/url.util';
 
 @Injectable()
 export class McpClientEngine {
   private readonly logger = new Logger(McpClientEngine.name);
+
+  /**
+   * Base URLs already reported by {@link warnLegacyUrlChange}, so an upgrade
+   * notice is logged once per connector instead of on every tool call.
+   */
+  private readonly legacyUrlWarned = new Set<string>();
 
   constructor(private readonly oauth2TokenService: OAuth2TokenService) {}
 
@@ -28,10 +35,8 @@ export class McpClientEngine {
       `MCP bridge call: ${endpointMapping.method} → ${config.baseUrl}`,
     );
 
-    const mcpUrl = new URL(
-      endpointMapping.path || '/mcp',
-      config.baseUrl,
-    );
+    const mcpUrl = resolveMcpEndpointUrl(config.baseUrl, endpointMapping.path);
+    this.warnLegacyUrlChange(config.baseUrl, endpointMapping.path, mcpUrl);
     await assertSafeOutboundUrl(mcpUrl.toString());
 
     const headers: Record<string, string> = { ...config.headers };
@@ -119,9 +124,14 @@ export class McpClientEngine {
       annotations?: Record<string, unknown>;
     }>
   > {
-    const mcpUrl = new URL(config.mcpPath || '/mcp', config.baseUrl);
+    const mcpUrl = resolveMcpEndpointUrl(config.baseUrl, config.mcpPath);
+    this.warnLegacyUrlChange(config.baseUrl, config.mcpPath, mcpUrl);
 
     this.logger.debug(`MCP listTools: ${mcpUrl.toString()}`);
+
+    // Discovery reaches a user-supplied URL just like execute() does, so it
+    // needs the same SSRF guard — it was missing here.
+    await assertSafeOutboundUrl(mcpUrl.toString());
 
     const headers: Record<string, string> = { ...config.headers };
     await this.injectAuth(headers, config.authType, config.authConfig, config.connectorId);
@@ -162,6 +172,36 @@ export class McpClientEngine {
         // Ignore close errors
       }
     }
+  }
+
+  /**
+   * Until issue #501 was fixed, every bridge request went to `<origin>/mcp`
+   * because the path was resolved root-absolutely against the base URL. Any
+   * connector whose base URL carried a path is therefore called at a different
+   * address after the upgrade — log that once per connector so a self-hosted
+   * operator can see exactly what moved instead of guessing.
+   */
+  private warnLegacyUrlChange(
+    baseUrl: string,
+    pathOverride: string | undefined,
+    resolved: URL,
+  ): void {
+    if (this.legacyUrlWarned.has(baseUrl)) return;
+
+    let legacy: string;
+    try {
+      legacy = new URL(pathOverride || DEFAULT_MCP_PATH, baseUrl).toString();
+    } catch {
+      return;
+    }
+    if (legacy === resolved.toString()) return;
+
+    this.legacyUrlWarned.add(baseUrl);
+    this.logger.warn(
+      `MCP endpoint for "${baseUrl}" now resolves to ${resolved.toString()} ` +
+        `(previous releases called it at ${legacy}) — the base URL's path is ` +
+        `no longer discarded.`,
+    );
   }
 
   private async injectAuth(

--- a/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
+++ b/packages/backend/src/connectors/mcp-oauth-callback.controller.ts
@@ -125,6 +125,8 @@ export class McpOAuthCallbackController {
                 name: rt.name,
                 description: rt.description || `MCP tool: ${rt.name}`,
                 parameters: rt.inputSchema as any,
+                // Default path, not a user choice — resolveMcpEndpointUrl()
+                // treats it as unset when the base URL has a path (#501).
                 endpointMapping: {
                   method: rt.name,
                   path: '/mcp',

--- a/packages/backend/src/connectors/mcp-oauth.service.spec.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.spec.ts
@@ -63,3 +63,110 @@ describe('McpOAuthService.exchangeCodeForTokens client authentication', () => {
     expect((config as any).headers.Authorization).toMatch(/^Basic /);
   });
 });
+
+describe('McpOAuthService.discoverMetadata', () => {
+  let service: McpOAuthService;
+
+  const AS_METADATA = {
+    issuer: 'https://auth.example.com',
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/token',
+  };
+
+  /** Serve only the listed URLs; anything else 404s like a real server. */
+  const serve = (documents: Record<string, unknown>) => {
+    mockedAxios.get.mockImplementation(((url: string) =>
+      url in documents
+        ? Promise.resolve({ data: documents[url] } as any)
+        : Promise.reject(new Error('Request failed with status code 404'))) as any);
+  };
+
+  beforeEach(() => {
+    service = new McpOAuthService();
+    mockedAxios.get.mockReset();
+  });
+
+  it('follows the RFC 9728 protected-resource document of a path-hosted server', async () => {
+    serve({
+      'https://cloud.anythingmcp.com/.well-known/oauth-protected-resource/mcp/srv_1':
+        {
+          resource: 'https://cloud.anythingmcp.com/mcp/srv_1',
+          authorization_servers: ['https://auth.example.com'],
+        },
+      'https://auth.example.com/.well-known/oauth-authorization-server':
+        AS_METADATA,
+    });
+
+    const metadata = await service.discoverMetadata(
+      'https://cloud.anythingmcp.com/mcp/srv_1',
+    );
+
+    // An authorization server named by the resource is external on purpose,
+    // so it must NOT be rebased onto the MCP server's origin.
+    expect(metadata.authorization_endpoint).toBe(
+      'https://auth.example.com/authorize',
+    );
+    expect(metadata.token_endpoint).toBe('https://auth.example.com/token');
+  });
+
+  it('falls back to the path-inserted authorization-server metadata (RFC 8414 §3.1)', async () => {
+    serve({
+      'https://acct.snowflakecomputing.com/.well-known/oauth-authorization-server/api/v2/databases/db/schemas/public/mcp-servers/srv':
+        {
+          issuer: 'https://acct.snowflakecomputing.com',
+          authorization_endpoint:
+            'https://acct.snowflakecomputing.com/oauth/authorize',
+          token_endpoint: 'https://acct.snowflakecomputing.com/oauth/token-request',
+        },
+    });
+
+    const metadata = await service.discoverMetadata(
+      'https://acct.snowflakecomputing.com/api/v2/databases/db/schemas/public/mcp-servers/srv',
+    );
+
+    expect(metadata.token_endpoint).toBe(
+      'https://acct.snowflakecomputing.com/oauth/token-request',
+    );
+  });
+
+  it('still finds the origin-level document, and keeps rebasing it (legacy behaviour)', async () => {
+    serve({
+      'https://mcp.example.com/.well-known/oauth-authorization-server': {
+        issuer: 'http://localhost:4000',
+        authorization_endpoint: 'http://localhost:4000/oauth/authorize',
+        token_endpoint: 'http://localhost:4000/oauth/token',
+      },
+    });
+
+    const metadata = await service.discoverMetadata('https://mcp.example.com/mcp');
+
+    // A self-hosted server with a misconfigured OAUTH_SERVER_URL gets its
+    // endpoints pulled back onto the origin we actually reached.
+    expect(metadata.authorization_endpoint).toBe(
+      'https://mcp.example.com/oauth/authorize',
+    );
+    expect(metadata.token_endpoint).toBe('https://mcp.example.com/oauth/token');
+  });
+
+  it('only probes the origin-level document for a bare-origin base URL', async () => {
+    serve({
+      'https://mcp.example.com/.well-known/oauth-authorization-server': {
+        issuer: 'https://mcp.example.com',
+        authorization_endpoint: 'https://mcp.example.com/authorize',
+        token_endpoint: 'https://mcp.example.com/token',
+      },
+    });
+
+    await service.discoverMetadata('https://mcp.example.com');
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports every URL it tried when nothing is discoverable', async () => {
+    serve({});
+
+    await expect(
+      service.discoverMetadata('https://mcp.example.com/deep/mcp'),
+    ).rejects.toThrow(/oauth-protected-resource\/deep\/mcp/);
+  });
+});

--- a/packages/backend/src/connectors/mcp-oauth.service.ts
+++ b/packages/backend/src/connectors/mcp-oauth.service.ts
@@ -41,29 +41,146 @@ export class McpOAuthService {
   private pendingFlows = new Map<string, PendingOAuthFlow>();
 
   /**
-   * Fetch OAuth Authorization Server Metadata (RFC 8414)
-   * from a remote MCP server's .well-known endpoint.
+   * Discover the OAuth metadata of a remote MCP server.
    *
-   * If the metadata contains endpoint URLs with a different origin than the
-   * actual server (common misconfiguration), they are rebased automatically.
+   * An MCP server hosted under a path (Snowflake's managed servers,
+   * AnythingMCP's own `/mcp/<serverId>` endpoints, …) publishes its metadata
+   * at a *path-inserted* well-known URL: RFC 8414 §3.1 and RFC 9728 §3 put the
+   * resource path after the well-known suffix, not before it. Looking only at
+   * `<origin>/.well-known/oauth-authorization-server` — which is all this used
+   * to do — therefore misses every such server (#501).
+   *
+   * Candidates are tried in order, first usable document wins, and the
+   * origin-level URL stays last so nothing that works today regresses.
    */
   async discoverMetadata(baseUrl: string): Promise<OAuthMetadata> {
-    const actualOrigin = new URL(baseUrl).origin;
+    const base = new URL(baseUrl);
+    const actualOrigin = base.origin;
+    const resourcePath = base.pathname.replace(/\/+$/, '');
 
-    // Try the standard well-known path
-    const metadataUrl = new URL(
-      '/.well-known/oauth-authorization-server',
-      baseUrl,
-    ).toString();
+    const candidates: Array<{ url: string; protectedResource: boolean }> = [];
+    if (resourcePath) {
+      candidates.push(
+        // RFC 9728 — what current MCP clients look for first.
+        {
+          url: `${actualOrigin}/.well-known/oauth-protected-resource${resourcePath}`,
+          protectedResource: true,
+        },
+        {
+          url: `${actualOrigin}/.well-known/oauth-authorization-server${resourcePath}`,
+          protectedResource: false,
+        },
+        {
+          url: `${actualOrigin}/.well-known/openid-configuration${resourcePath}`,
+          protectedResource: false,
+        },
+      );
+    }
+    candidates.push({
+      url: `${actualOrigin}/.well-known/oauth-authorization-server`,
+      protectedResource: false,
+    });
 
-    this.logger.debug(`Discovering OAuth metadata from ${metadataUrl}`);
+    const failures: string[] = [];
 
-    await assertSafeOutboundUrl(metadataUrl);
-    const response = await axios.get(metadataUrl, { timeout: 10000 });
-    const metadata: OAuthMetadata = response.data;
+    for (const candidate of candidates) {
+      let document: any;
+      try {
+        document = await this.fetchJson(candidate.url);
+      } catch (err: any) {
+        failures.push(`${candidate.url}: ${err.message}`);
+        continue;
+      }
 
-    // Rebase endpoint URLs if the remote server reports a different origin
-    // (e.g. the server's OAUTH_SERVER_URL env var is misconfigured).
+      // A protected-resource document does not carry the endpoints itself; it
+      // points at one or more authorization servers, which may legitimately
+      // live on another origin.
+      if (candidate.protectedResource) {
+        const issuer = document?.authorization_servers?.[0];
+        if (!issuer) {
+          failures.push(`${candidate.url}: no authorization_servers entry`);
+          continue;
+        }
+        try {
+          const metadata = await this.fetchAuthorizationServerMetadata(issuer);
+          this.logger.debug(
+            `OAuth metadata for ${baseUrl} discovered via protected-resource document at ${candidate.url} (issuer ${issuer})`,
+          );
+          // No rebasing here: the resource explicitly named an external
+          // authorization server, so its origin is intentional.
+          return metadata;
+        } catch (err: any) {
+          failures.push(`${issuer}: ${err.message}`);
+          continue;
+        }
+      }
+
+      if (!document?.authorization_endpoint || !document?.token_endpoint) {
+        failures.push(`${candidate.url}: missing authorization/token endpoint`);
+        continue;
+      }
+
+      this.logger.debug(
+        `OAuth metadata for ${baseUrl} discovered at ${candidate.url}`,
+      );
+      return this.rebaseToOrigin(document as OAuthMetadata, actualOrigin);
+    }
+
+    throw new Error(
+      `Could not discover OAuth metadata for ${baseUrl}. Tried: ${failures.join('; ')}`,
+    );
+  }
+
+  /**
+   * Fetch RFC 8414 metadata for an issuer, honouring path-insertion for
+   * issuers that carry a path, then falling back to the OpenID Connect
+   * discovery document.
+   */
+  private async fetchAuthorizationServerMetadata(
+    issuer: string,
+  ): Promise<OAuthMetadata> {
+    const parsed = new URL(issuer);
+    const issuerPath = parsed.pathname.replace(/\/+$/, '');
+
+    const urls = [
+      `${parsed.origin}/.well-known/oauth-authorization-server${issuerPath}`,
+      `${parsed.origin}/.well-known/openid-configuration${issuerPath}`,
+      `${parsed.origin}${issuerPath}/.well-known/openid-configuration`,
+    ];
+
+    const failures: string[] = [];
+    for (const url of urls) {
+      try {
+        const document = await this.fetchJson(url);
+        if (document?.authorization_endpoint && document?.token_endpoint) {
+          return document as OAuthMetadata;
+        }
+        failures.push(`${url}: missing authorization/token endpoint`);
+      } catch (err: any) {
+        failures.push(`${url}: ${err.message}`);
+      }
+    }
+
+    throw new Error(`no usable metadata (${failures.join('; ')})`);
+  }
+
+  private async fetchJson(url: string): Promise<any> {
+    await assertSafeOutboundUrl(url);
+    const response = await axios.get(url, { timeout: 10000 });
+    return response.data;
+  }
+
+  /**
+   * Rebase endpoint URLs onto the MCP server's own origin when the metadata
+   * reports a different one (e.g. a self-hosted server whose OAUTH_SERVER_URL
+   * env var is misconfigured). Only applied to same-origin AS metadata — a
+   * protected-resource document naming an external authorization server is
+   * taken at face value.
+   */
+  private rebaseToOrigin(
+    metadata: OAuthMetadata,
+    actualOrigin: string,
+  ): OAuthMetadata {
     const rebase = (endpoint: string): string => {
       try {
         const parsed = new URL(endpoint);

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -23,7 +23,7 @@ const IMPORT_SOURCES = [
   { id: 'graphql', label: 'GraphQL Introspection', placeholder: 'Enter GraphQL endpoint URL...' },
   { id: 'wsdl', label: 'WSDL', placeholder: 'Enter WSDL URL...' },
   { id: 'json', label: 'JSON Definition', placeholder: '[\n  {\n    "name": "get_users",\n    "description": "Fetch users",\n    "parameters": { "type": "object", "properties": { "limit": { "type": "number" } } },\n    "endpointMapping": { "method": "GET", "path": "/users", "queryParams": { "limit": "$limit" } }\n  }\n]' },
-  { id: 'mcp', label: 'MCP Discovery', placeholder: 'Enter MCP endpoint path (default: /mcp)' },
+  { id: 'mcp', label: 'MCP Discovery', placeholder: "Optional — leave empty to use the connector's Base URL" },
 ];
 
 const EDIT_DEFAULT_LOGIN_BODY = '{\n  "username": "${username}",\n  "password": "${password}"\n}';

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -296,10 +296,27 @@ export default function NewConnectorPage() {
                   type="text"
                   value={baseUrl}
                   onChange={(e) => setBaseUrl(e.target.value)}
-                  placeholder={selectedType === 'DATABASE' ? 'postgresql://user:pass@host:5432/db  or  mysql://user:pass@host:3306/db' : 'https://api.example.com/v1'}
+                  placeholder={
+                    selectedType === 'DATABASE'
+                      ? 'postgresql://user:pass@host:5432/db  or  mysql://user:pass@host:3306/db'
+                      : selectedType === 'MCP'
+                        ? 'https://mcp.example.com/mcp'
+                        : 'https://api.example.com/v1'
+                  }
                   className={cn(inputClass, 'font-mono text-[13px]')}
                   required
                 />
+                {selectedType === 'MCP' && (
+                  <p className="mt-1 text-xs text-[var(--text-3)]">
+                    Paste the complete MCP endpoint URL including its path — e.g. a
+                    Snowflake managed server at{' '}
+                    <span className="font-mono">
+                      /api/v2/databases/db/schemas/public/mcp-servers/srv
+                    </span>
+                    . A bare host with no path defaults to{' '}
+                    <span className="font-mono">/mcp</span>.
+                  </p>
+                )}
               </div>
 
               {selectedType === 'DATABASE' && (


### PR DESCRIPTION
Fixes #501.

## The bug

MCP bridge requests were built with `new URL('/mcp', baseUrl)`. A root-absolute path resolves against the **origin**, so any path in the connector's base URL was silently discarded and every request went to `<origin>/mcp`.

Not only the Snowflake case from the issue: it also breaks bridging to **our own Cloud**, since AnythingMCP serves each tenant at `/mcp/<serverId>` — rewritten to `<origin>/mcp`, a route that does not exist.

```
POST https://app.linkmcp.io/mcp      → 404   ← what we sent
POST https://app.linkmcp.io/api/mcp  → 401   ← what the user configured; exists
```

The REST engine has always preserved the base path (`joinBaseAndPath`); the MCP engine was the outlier.

## The fix

`resolveMcpEndpointUrl()` in `common/url.util.ts` resolves the endpoint once, for tool calls and discovery alike. `/mcp` is the historical *default* stamped on every discovered tool — never a user choice — so it is treated as "unset" and loses to a real path in the base URL. An explicit root-absolute override still resolves against the origin, a relative one is appended to the base path, and a full `https://…` override is honoured verbatim. Credentials embedded in the base URL (`user:pass@`) are preserved, which `new URL(path, origin)` would have dropped.

## Compatibility — measured, not argued

Every `(base_url, endpointMapping.path)` pair on cloud.anythingmcp.com run through both the old and new resolution: **17 of 20 identical**. The 3 that change:

| base URL | old | new | tools / calls today |
|---|---|---|---|
| `app.linkmcp.io/api/mcp` | `/mcp` (404) | `/api/mcp` (401, exists) | 0 / 0 |
| `…zohomcp.com/mcp/<token>/message` | `/mcp` | full path | 0 / 0 |
| `core.telegram.org/bots/api` | `/mcp` | `/bots/api` | 0 / 0 (not an MCP server) |

All three are the bug's victims. Everything with real usage — 8 connectors at `<origin>/mcp`, 38 tools, all 22 recorded tool calls — resolves to a byte-identical URL. Stored tool paths in production are `/mcp`, `/feed`, `/v1/search` and one absolute URL; all four shapes are covered by tests and unchanged.

## OAuth discovery

`discoverMetadata` only ever probed `<origin>/.well-known/oauth-authorization-server`, missing the path-inserted metadata RFC 8414 §3.1 and RFC 9728 require — including the protected-resource documents this repo serves itself. It now walks a candidate chain with the origin-level URL **last**, so the legacy shape resolves exactly as before (rebase hack included).

Replaying old vs new against the real servers of every OAuth2 MCP connector in production:

- **Helium 10** — was `404`, now discovers `members.helium10.com/authhub/…`.
- **LinkedIn, Notion** — identical.
- **DineDash** — changes, and the change is a **fix**: the old code rebased Supabase's endpoints onto `www.dinedash.io`, and `https://www.dinedash.io/auth/v1/oauth/authorize` is a 404 page, while the Supabase endpoint the protected-resource document names answers `400 client_id is required`. So endpoints are no longer rebased when a resource deliberately names an external authorization server — rebasing stays for the same-origin case it was written for.

No OAuth2 MCP connector in production has ever completed a flow (`auth_config` empty on all four, DineDash never updated after creation), so there is no working flow to regress.

Our own well-known controller derives its base from the incoming request, never from a stale `SERVER_URL`, so AnythingMCP→AnythingMCP bridging is correct without rebasing.

## SSRF

`listTools()` reached a user-supplied URL with no `assertSafeOutboundUrl()` call, unlike `execute()` — reachable from tool discovery, connector import, test-connection and the OAuth callback. Now guarded.

Since that makes the guard newly reachable on discovery, Test Connection now offers the allowlist deep-link for **every** blocked-host message, not just the DNS one: a private IP, `localhost` and an unresolvable Docker service name were dead ends before, and an MCP bridge to a server on the local network hits exactly those. The allowlist is consulted before the IP, loopback and DNS checks, so it genuinely fixes all four.

## Verification

- Backend suite: **3615 passed, 0 failed** (11 resolver cases, 10 engine, 5 OAuth discovery, 9 SSRF-message).
- `npm run build` green (backend + frontend).
- 22-check behaviour matrix over real sockets against a server mounted at several paths: Snowflake shape, Cloud `/mcp/<serverId>`, bare origin, `/sse` override, absolute per-tool URL, trailing slash, query string, unknown path, plus `Authorization: Bearer <PAT>` and `X-Snowflake-Authorization-Token-Type` present on **all 4** requests of a call (POST initialize, notification, GET stream, tools/call).
- 12-check OAuth discovery matrix over real sockets: legacy misconfigured server still rebased, AnythingMCP→AnythingMCP via protected-resource, path-inserted AS metadata, external AS not rebased, bare origin still exactly one request, and a clear error naming every candidate tried.
- Zero shipped adapters are of type MCP, and the cloud db-rest host swap does not touch MCP base URLs.
