### PR TITLE
ci: add mirkopoloni to the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,4 +25,4 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/HelpCode-ai/anythingmcp/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'keysersoft,dependabot[bot],Claude'
+          allowlist: 'keysersoft,mirkopoloni,dependabot[bot],Claude'


### PR DESCRIPTION
Unblocks #481, whose `cla` check is the only red one left.

`cla.yml` runs on `pull_request_target`, which resolves the workflow from the base branch, so an allowlist entry added inside a contributor's own PR has no effect on that PR. It has to land on `main` first; a `recheck` comment on #481 then turns the check green.