### PR TITLE
chore(release): v0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anythingmcp",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/backend",
@@ -24391,7 +24391,7 @@
     },
     "packages/backend": {
       "name": "@anythingmcp/backend",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@jmespath-community/jmespath": "^1.3.0",
@@ -24662,7 +24662,7 @@
     },
     "packages/frontend": {
       "name": "@anythingmcp/frontend",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Version bump for the Destatis GENESIS fix (#481) and the platform changes it carried: form-body Content-Type is no longer overwritten, adapters can declare a healthcheck path and optional env vars.