### PR TITLE
fix(auth): harden authentication before SSO

### DIFF
--- a/packages/backend/prisma/migrations/20260731120000_add_security_events/migration.sql
+++ b/packages/backend/prisma/migrations/20260731120000_add_security_events/migration.sql
@@ -1,0 +1,45 @@
+-- =============================================================================
+-- Migration: Add security_events (authentication / authorization audit trail)
+-- =============================================================================
+-- Append-only trail for auth events. `tool_invocations` cannot host these: its
+-- `tool_id` is NOT NULL with an FK to `mcp_tools`, so events like a rejected
+-- token or an SSO-driven role change have nowhere to go today and only reach
+-- the application logs.
+--
+-- `organization_id` is nullable BY DESIGN: the most security-relevant events
+-- (a forged token, a login for an unknown user) occur before an org can be
+-- resolved. Keeping them with a null org is better than dropping them.
+--
+-- All FKs are ON DELETE SET NULL, never CASCADE: removing a user or an
+-- organization must not erase the record of what happened.
+--
+-- Deliberately NOT added to prisma/rls/enable-rls.sql — see the note on the
+-- SecurityEvent model in schema.prisma.
+-- =============================================================================
+
+CREATE TABLE "security_events" (
+    "id"              TEXT NOT NULL,
+    "event"           TEXT NOT NULL,
+    "actor_type"      TEXT NOT NULL,
+    "organization_id" TEXT,
+    "actor_user_id"   TEXT,
+    "target_user_id"  TEXT,
+    "metadata"        JSONB,
+    "ip"              TEXT,
+    "user_agent"      TEXT,
+    "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "security_events_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "security_events_organization_id_created_at_idx" ON "security_events"("organization_id", "created_at");
+CREATE INDEX "security_events_event_created_at_idx"          ON "security_events"("event", "created_at");
+CREATE INDEX "security_events_actor_user_id_created_at_idx"  ON "security_events"("actor_user_id", "created_at");
+CREATE INDEX "security_events_target_user_id_created_at_idx" ON "security_events"("target_user_id", "created_at");
+
+ALTER TABLE "security_events" ADD CONSTRAINT "security_events_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "security_events" ADD CONSTRAINT "security_events_actor_user_id_fkey"
+    FOREIGN KEY ("actor_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "security_events" ADD CONSTRAINT "security_events_target_user_id_fkey"
+    FOREIGN KEY ("target_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/backend/prisma/migrations/20260731130000_add_session_revocation/migration.sql
+++ b/packages/backend/prisma/migrations/20260731130000_add_session_revocation/migration.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- Migration: Add session revocation + password-login gate to users
+-- =============================================================================
+-- Tokens are stateless JWTs and `/revoke` is advertised but unimplemented, so
+-- nothing could be revoked before its natural expiry (24h for a dashboard
+-- token, longer for an MCP refresh token).
+--
+-- `sessions_valid_from` is a cutover instant: any token whose `iat` predates it
+-- is refused. Deliberately a timestamp and NOT an epoch counter — a counter must
+-- be echoed back as a token claim, and MCP access tokens are minted by
+-- @rekog/mcp-nest, which cannot be asked to carry one. Every JWT already has
+-- `iat`, so one column revokes both token families.
+--
+-- `password_login_disabled` gates password login AND password reset. Gating only
+-- login would leave /api/auth/forgot-password as a way for an SSO-only user with
+-- mailbox access to set a password and bypass SSO, MFA and Conditional Access.
+--
+-- Both are additive with safe defaults, so a running old container is unaffected.
+-- =============================================================================
+
+ALTER TABLE "users" ADD COLUMN "sessions_valid_from" TIMESTAMP(3);
+ALTER TABLE "users" ADD COLUMN "password_login_disabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- `password_hash` becomes nullable: a user provisioned through an external IdP
+-- never has one. Widening a NOT NULL column is safe for a running old container
+-- (it only ever reads existing non-null values); nothing writes NULL until SSO
+-- provisioning lands.
+ALTER TABLE "users" ALTER COLUMN "password_hash" DROP NOT NULL;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Organization {
   kgConnectorState KgConnectorState[]
   kgValueSeen      KgValueSeen[]
   kgSkills         KgSkillSuggestion[]
+  securityEvents   SecurityEvent[]
 
   @@map("organizations")
 }
@@ -87,7 +88,8 @@ enum UserRole {
 model User {
   id             String   @id @default(cuid())
   email          String   @unique
-  passwordHash   String   @map("password_hash")
+  // Nullable: users provisioned through an external IdP never have one.
+  passwordHash   String?  @map("password_hash")
   name           String?
   role           UserRole @default(EDITOR)
   emailVerified  Boolean  @default(false) @map("email_verified")
@@ -113,9 +115,35 @@ model User {
   firstSuccessfulInvocationAt DateTime? @map("first_successful_invocation_at")
   activationReminderAt        DateTime? @map("activation_reminder_at")
 
+  // ── Revocation ────────────────────────────────────────────────────────────
+  // Tokens are stateless JWTs signed with a shared secret, and `/revoke` is
+  // advertised but unimplemented, so until now NOTHING could be revoked before
+  // its natural expiry — not a demoted user's session, not a deprovisioned
+  // account, not an MCP token.
+  //
+  // `sessionsValidFrom` is a cutover instant: any token whose `iat` predates it
+  // is refused. A timestamp rather than an epoch COUNTER on purpose — a counter
+  // has to be echoed back as a claim, and MCP access tokens are minted by
+  // @rekog/mcp-nest, which we cannot ask to carry one. Every JWT already has
+  // `iat`, so this single field revokes both token families at once.
+  //
+  // Comparison is at second granularity (`iat` is in seconds), leaving a
+  // sub-second window where a token minted in the very same second as the
+  // revocation survives. Accepted: closing it would instead reject a legitimate
+  // token issued moments after a password change.
+  sessionsValidFrom DateTime? @map("sessions_valid_from")
+
+  // Set when the user must authenticate through an external IdP. Gates BOTH
+  // password login and password RESET — otherwise anyone with mailbox access
+  // could set a password and walk straight past SSO, MFA and Conditional Access.
+  passwordLoginDisabled Boolean @default(false) @map("password_login_disabled")
+
   // MCP tool governance — optional custom role for tool access control
   mcpRoleId String? @map("mcp_role_id")
   mcpRole   Role?   @relation(fields: [mcpRoleId], references: [id], onDelete: SetNull)
+
+  securityEventsAsActor    SecurityEvent[] @relation("SecurityEventActor")
+  securityEventsAsTarget   SecurityEvent[] @relation("SecurityEventTarget")
 
   memberships              OrganizationMember[]
   connectors               Connector[]
@@ -569,6 +597,58 @@ model ToolInvocation {
   @@index([organizationId, createdAt])
   @@index([connectorId, createdAt])
   @@map("tool_invocations")
+}
+
+// ── Security Audit Log ──────────────────────────────────────────────────────
+// Append-only trail for AUTHENTICATION and AUTHORIZATION events.
+//
+// `tool_invocations` cannot carry these: its `tool_id` is NOT NULL with an FK
+// to `mcp_tools`, so an event like "SSO login failed" or "role granted from an
+// IdP group" has nowhere to go and would only ever reach the Pino logs.
+//
+// `organization_id` is NULLABLE on purpose: some of the most important events
+// happen BEFORE an org can be resolved (a rejected token, a login attempt for
+// an unknown user). Dropping those would defeat the point, so they are kept
+// with a null org rather than lost.
+//
+// That nullability is also why this table is deliberately NOT registered in
+// `prisma/rls/enable-rls.sql`: the `org_isolation` policy compares
+// `organization_id = current_setting('app.current_org')`, and `NULL = NULL` is
+// never true, so every org-less security event would become invisible — the
+// exact rows an investigation needs most. Reads are scoped in the app layer.
+model SecurityEvent {
+  id String @id @default(cuid())
+
+  // Slug, e.g. 'SSO_LOGIN_SUCCESS'. A string rather than an enum so adding an
+  // event type never requires a migration.
+  event String
+
+  // Who acted: 'USER' | 'SYSTEM' | 'ANONYMOUS'.
+  actorType String @map("actor_type")
+
+  organizationId String?       @map("organization_id")
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  // SetNull, not Cascade: deleting a user must not erase the evidence of what
+  // was done to or by them.
+  actorUserId  String? @map("actor_user_id")
+  actorUser    User?   @relation("SecurityEventActor", fields: [actorUserId], references: [id], onDelete: SetNull)
+  targetUserId String? @map("target_user_id")
+  targetUser   User?   @relation("SecurityEventTarget", fields: [targetUserId], references: [id], onDelete: SetNull)
+
+  // Free-form, REDACTED before write — never tokens, secrets or full id_tokens.
+  metadata Json?
+
+  ip        String?
+  userAgent String? @map("user_agent")
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([organizationId, createdAt])
+  @@index([event, createdAt])
+  @@index([actorUserId, createdAt])
+  @@index([targetUserId, createdAt])
+  @@map("security_events")
 }
 
 // ── OAuth2 Authorization Server ─────────────────────────────────────────────

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -27,6 +27,9 @@ import { McpAuthMiddleware } from './auth/mcp-auth.middleware';
 import { McpRateLimitMiddleware } from './auth/mcp-rate-limit.middleware';
 import { ClientCredentialsMiddleware } from './auth/client-credentials.middleware';
 import { OAuthRegisterGuardMiddleware } from './auth/oauth-register-guard.middleware';
+import { AuthorizePkceMiddleware } from './auth/authorize-pkce.middleware';
+import { ResourceIndicatorMiddleware } from './auth/resource-indicator.middleware';
+import { AuthorizationIssuerMiddleware } from './auth/authorization-issuer.middleware';
 import { LocalOAuthProvider } from './auth/local-oauth.provider';
 import { PrismaOAuthStore } from './auth/prisma-oauth.store';
 import { PrismaService } from './common/prisma.service';
@@ -169,6 +172,20 @@ export class AppModule implements NestModule {
     // with a 500 on undefined.redirect_uris). Always on — the guard is
     // a pure body-shape validator and a no-op for valid JSON requests.
     consumer.apply(OAuthRegisterGuardMiddleware).forRoutes('register');
+
+    // Require PKCE with S256 on /authorize. Upstream only validates a code
+    // challenge when one is present and defaults the method to 'plain', which
+    // — with open DCR — leaves authorization codes replayable.
+    if (mode === 'oauth2' || mode === 'both') {
+      consumer.apply(AuthorizePkceMiddleware).forRoutes('authorize');
+
+      // MCP 2026-07-28 alignment. Capture the client's RFC 8707 `resource`
+      // (upstream ignores it) and append the RFC 9207 `iss` to authorization
+      // responses — the latter MUST stay in step with
+      // `authorization_response_iss_parameter_supported` in the metadata.
+      consumer.apply(ResourceIndicatorMiddleware).forRoutes('authorize');
+      consumer.apply(AuthorizationIssuerMiddleware).forRoutes('callback');
+    }
 
     // Apply legacy auth middleware for MCP endpoint
     if (mode === 'legacy' || mode === 'both') {

--- a/packages/backend/src/audit/audit.module.ts
+++ b/packages/backend/src/audit/audit.module.ts
@@ -1,11 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { AuditService } from './audit.service';
 import { AuditController } from './audit.controller';
+import { SecurityEventService } from './security-event.service';
 
 @Global()
 @Module({
   controllers: [AuditController],
-  providers: [AuditService],
-  exports: [AuditService],
+  providers: [AuditService, SecurityEventService],
+  exports: [AuditService, SecurityEventService],
 })
 export class AuditModule {}

--- a/packages/backend/src/audit/security-event.service.spec.ts
+++ b/packages/backend/src/audit/security-event.service.spec.ts
@@ -1,0 +1,156 @@
+import { SecurityEventService, SecurityEvents } from './security-event.service';
+import { PrismaService } from '../common/prisma.service';
+
+describe('SecurityEventService', () => {
+  let service: SecurityEventService;
+  let prisma: { securityEvent: { create: jest.Mock } };
+
+  const dataOf = () => prisma.securityEvent.create.mock.calls[0][0].data;
+
+  beforeEach(() => {
+    prisma = { securityEvent: { create: jest.fn().mockResolvedValue({}) } };
+    service = new SecurityEventService(prisma as unknown as PrismaService);
+  });
+
+  describe('log', () => {
+    it('persists an event with its actor, org and target', async () => {
+      await service.log({
+        event: SecurityEvents.ROLE_CHANGED,
+        actorType: 'USER',
+        organizationId: 'org-1',
+        actorUserId: 'admin-1',
+        targetUserId: 'user-2',
+        ip: '203.0.113.5',
+        userAgent: 'Claude/1.0',
+      });
+
+      expect(dataOf()).toMatchObject({
+        event: 'ROLE_CHANGED',
+        actorType: 'USER',
+        organizationId: 'org-1',
+        actorUserId: 'admin-1',
+        targetUserId: 'user-2',
+        ip: '203.0.113.5',
+        userAgent: 'Claude/1.0',
+      });
+    });
+
+    it('allows a null organization so pre-resolution events are not lost', async () => {
+      // A rejected token or a login for an unknown user happens before any org
+      // is known. Those are the rows an investigation needs most.
+      await service.log({
+        event: SecurityEvents.TOKEN_REJECTED,
+        actorType: 'ANONYMOUS',
+      });
+
+      expect(dataOf().organizationId).toBeNull();
+      expect(dataOf().actorUserId).toBeNull();
+    });
+
+    it('never throws when the write fails', async () => {
+      // An audit failure must not deny a legitimate request, nor give an
+      // attacker a way to break the flow by breaking the write.
+      prisma.securityEvent.create.mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.log({ event: SecurityEvents.SSO_LOGIN_SUCCESS, actorType: 'USER' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('redaction', () => {
+    it('redacts secret-bearing keys in every casing and separator style', async () => {
+      await service.log({
+        event: SecurityEvents.IDP_UPDATED,
+        actorType: 'USER',
+        metadata: {
+          clientId: 'keep-me',
+          clientSecret: 'sh-should-not-persist',
+          client_secret: 'sh-should-not-persist',
+          CLIENT_SECRET: 'sh-should-not-persist',
+          password: 'hunter2',
+          refresh_token: 'rt-abc',
+          id_token: 'eyJhbGciOi...',
+          code_verifier: 'v-abc',
+          apiKey: 'ak-1',
+          authorization: 'Bearer abc',
+        },
+      });
+
+      const md = dataOf().metadata;
+      expect(md.clientId).toBe('keep-me');
+      for (const key of [
+        'clientSecret',
+        'client_secret',
+        'CLIENT_SECRET',
+        'password',
+        'refresh_token',
+        'id_token',
+        'code_verifier',
+        'apiKey',
+        'authorization',
+      ]) {
+        expect(md[key]).toBe('[REDACTED]');
+      }
+      // Belt and braces: no secret value survives anywhere in the payload.
+      expect(JSON.stringify(md)).not.toContain('sh-should-not-persist');
+      expect(JSON.stringify(md)).not.toContain('hunter2');
+    });
+
+    it('redacts nested secrets', async () => {
+      await service.log({
+        event: SecurityEvents.IDP_UPDATED,
+        actorType: 'USER',
+        metadata: { before: { tenantId: 't1', clientSecret: 'old' }, after: { tenantId: 't2' } },
+      });
+
+      const md = dataOf().metadata;
+      expect(md.before.tenantId).toBe('t1');
+      expect(md.before.clientSecret).toBe('[REDACTED]');
+      expect(md.after.tenantId).toBe('t2');
+    });
+
+    it('truncates oversized strings', async () => {
+      // A 200-group Entra claim is ~7 KB; an id_token is larger. Rows must not
+      // become a dumping ground for whole token payloads.
+      await service.log({
+        event: SecurityEvents.SSO_LOGIN_SUCCESS,
+        actorType: 'USER',
+        metadata: { note: 'x'.repeat(5000) },
+      });
+
+      expect(dataOf().metadata.note).toHaveLength(512 + '…[truncated]'.length);
+      expect(dataOf().metadata.note.endsWith('…[truncated]')).toBe(true);
+    });
+
+    it('caps array length and recursion depth', async () => {
+      await service.log({
+        event: SecurityEvents.SSO_LOGIN_SUCCESS,
+        actorType: 'USER',
+        metadata: {
+          groups: Array.from({ length: 200 }, (_, i) => `g${i}`),
+          deep: { a: { b: { c: { d: { e: 'too far' } } } } },
+        },
+      });
+
+      const md = dataOf().metadata;
+      expect(md.groups).toHaveLength(50);
+      expect(JSON.stringify(md.deep)).not.toContain('too far');
+    });
+
+    it('leaves the identifiers an investigation needs intact', async () => {
+      // oid/tid are not secrets — they are exactly what you need to correlate.
+      await service.log({
+        event: SecurityEvents.SSO_LOGIN_SUCCESS,
+        actorType: 'USER',
+        metadata: { oid: 'a-guid', tid: 'tenant-guid', reason: 'iss_mismatch' },
+      });
+
+      expect(dataOf().metadata).toEqual({
+        oid: 'a-guid',
+        tid: 'tenant-guid',
+        reason: 'iss_mismatch',
+      });
+    });
+  });
+});

--- a/packages/backend/src/audit/security-event.service.ts
+++ b/packages/backend/src/audit/security-event.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * Stable event slugs. Strings (not a Prisma enum) so adding one never needs a
+ * migration. Grouped by plane, mirroring what an investigation actually asks:
+ * who changed the trust anchor, who got in, what were they allowed to do, and
+ * which client was authorized.
+ */
+export const SecurityEvents = {
+  // ── Config plane: who changed the trust anchor ──────────────────────────
+  IDP_CREATED: 'IDP_CREATED',
+  IDP_UPDATED: 'IDP_UPDATED',
+  IDP_DELETED: 'IDP_DELETED',
+  IDP_SECRET_ROTATED: 'IDP_SECRET_ROTATED',
+  IDP_ROLE_MAPPING_CHANGED: 'IDP_ROLE_MAPPING_CHANGED',
+  SSO_ENFORCEMENT_CHANGED: 'SSO_ENFORCEMENT_CHANGED',
+  RECOVERY_CODES_GENERATED: 'RECOVERY_CODES_GENERATED',
+  RECOVERY_CODE_USED: 'RECOVERY_CODE_USED',
+
+  // ── Auth plane: who got in, and who failed to ───────────────────────────
+  SSO_LOGIN_SUCCESS: 'SSO_LOGIN_SUCCESS',
+  SSO_LOGIN_FAILED: 'SSO_LOGIN_FAILED',
+  IDENTITY_LINKED: 'IDENTITY_LINKED',
+  IDENTITY_UNLINKED: 'IDENTITY_UNLINKED',
+  JIT_PROVISIONED: 'JIT_PROVISIONED',
+  /** A bearer token was refused — e.g. an MCP-issued token sent to the dashboard API. */
+  TOKEN_REJECTED: 'TOKEN_REJECTED',
+
+  // ── Authorization plane: what they were allowed to do ───────────────────
+  ROLE_CHANGED: 'ROLE_CHANGED',
+  LAST_ADMIN_PROTECTION_TRIGGERED: 'LAST_ADMIN_PROTECTION_TRIGGERED',
+  MEMBERSHIP_REMOVED_BY_SYNC: 'MEMBERSHIP_REMOVED_BY_SYNC',
+  /** Every token issued before now was invalidated for this user. */
+  SESSIONS_REVOKED: 'SESSIONS_REVOKED',
+  API_KEY_DEACTIVATED: 'API_KEY_DEACTIVATED',
+
+  // ── Consent plane: which AI client was authorized, by whom ──────────────
+  CONSENT_GRANTED: 'CONSENT_GRANTED',
+  CONSENT_DENIED: 'CONSENT_DENIED',
+  DCR_CLIENT_REGISTERED: 'DCR_CLIENT_REGISTERED',
+} as const;
+
+export type SecurityEventName =
+  (typeof SecurityEvents)[keyof typeof SecurityEvents];
+
+export type SecurityActorType = 'USER' | 'SYSTEM' | 'ANONYMOUS';
+
+export interface SecurityEventInput {
+  event: SecurityEventName | string;
+  actorType: SecurityActorType;
+  /** Null when the event happens before an org can be resolved. */
+  organizationId?: string | null;
+  actorUserId?: string | null;
+  targetUserId?: string | null;
+  /** Redacted before write — see `redact`. */
+  metadata?: Record<string, unknown> | null;
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+/**
+ * Keys whose VALUE must never be persisted. Matched case-insensitively as a
+ * substring, so `clientSecret`, `client_secret` and `CLIENT_SECRET` all hit.
+ *
+ * Note `authorization` is included: it catches a whole `Authorization` header
+ * being passed in wholesale.
+ */
+const REDACTED_KEY_PATTERN =
+  /secret|password|passwd|token|assertion|credential|code_verifier|code_challenge|authorization|cookie|private_key|api[-_]?key/i;
+
+const REDACTED = '[REDACTED]';
+const MAX_DEPTH = 4;
+const MAX_STRING = 512;
+
+/**
+ * Append-only audit trail for authentication and authorization events.
+ *
+ * Deliberately a sibling of `AuditService` rather than an extension of it:
+ * `AuditService` writes `tool_invocations`, whose `tool_id` is NOT NULL with an
+ * FK to `mcp_tools`, so it structurally cannot host an auth event.
+ *
+ * Writes are best-effort and NEVER throw: failing to record an event must not
+ * be able to break a login or deny a legitimate request.
+ */
+@Injectable()
+export class SecurityEventService {
+  private readonly logger = new Logger(SecurityEventService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async log(input: SecurityEventInput): Promise<void> {
+    try {
+      await this.prisma.securityEvent.create({
+        data: {
+          event: input.event,
+          actorType: input.actorType,
+          organizationId: input.organizationId ?? null,
+          actorUserId: input.actorUserId ?? null,
+          targetUserId: input.targetUserId ?? null,
+          metadata: (this.redact(input.metadata) ?? undefined) as any,
+          ip: input.ip ?? null,
+          userAgent: input.userAgent?.slice(0, MAX_STRING) ?? null,
+        },
+      });
+    } catch (error: any) {
+      // Never propagate: an audit failure must not deny a legitimate request,
+      // and must not hand an attacker a way to break the flow by breaking the
+      // write. Surfaced in the logs so it is still noticed.
+      this.logger.error(
+        `Failed to persist security event '${input.event}': ${error?.message}`,
+      );
+    }
+  }
+
+  /**
+   * Recursively replaces sensitive values. Depth- and length-bounded so a
+   * hostile or accidental payload (a 7 KB groups claim, a nested id_token)
+   * cannot bloat the row.
+   */
+  private redact(value: unknown, depth = 0): unknown {
+    if (value === null || value === undefined) return null;
+
+    if (depth >= MAX_DEPTH) return REDACTED;
+
+    if (typeof value === 'string') {
+      return value.length > MAX_STRING
+        ? `${value.slice(0, MAX_STRING)}…[truncated]`
+        : value;
+    }
+
+    if (typeof value !== 'object') return value;
+
+    if (Array.isArray(value)) {
+      return value.slice(0, 50).map((v) => this.redact(v, depth + 1));
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = REDACTED_KEY_PATTERN.test(key)
+        ? REDACTED
+        : this.redact(val, depth + 1);
+    }
+    return out;
+  }
+}

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -30,6 +30,7 @@ import { PrismaService } from '../common/prisma.service';
 import { EmailService } from '../settings/email.service';
 import { SiteSettingsService } from '../settings/site-settings.service';
 import { OrganizationsService } from '../organizations/organizations.service';
+import { SecurityEventService, SecurityEvents } from '../audit/security-event.service';
 import { LicenseService } from '../license/license.service';
 import { Roles, RolesGuard } from './roles.guard';
 
@@ -147,6 +148,7 @@ export class AuthController {
     private readonly siteSettings: SiteSettingsService,
     private readonly organizationsService: OrganizationsService,
     private readonly licenseService: LicenseService,
+    private readonly securityEvents: SecurityEventService,
   ) {}
 
   private getFrontendUrl(_req?: any): string {
@@ -198,6 +200,20 @@ export class AuthController {
   async login(@Req() req: any, @Body() dto: LoginDto) {
     const user = await this.usersService.findByEmail(dto.email);
     if (!user) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    // SSO-only account: refuse the password path entirely. Checked BEFORE the
+    // bcrypt compare so a disabled account cannot be used as a password oracle.
+    if (user.passwordLoginDisabled) {
+      throw new UnauthorizedException(
+        'Password sign-in is disabled for this account. Use your organization sign-in.',
+      );
+    }
+
+    // `passwordHash` is nullable for SSO-provisioned users — never hand null to
+    // bcrypt, which would throw a 500 instead of failing the login cleanly.
+    if (!user.passwordHash) {
       throw new UnauthorizedException('Invalid email or password');
     }
 
@@ -649,6 +665,18 @@ export class AuthController {
       return { message: 'If the email exists, a reset link has been sent.' };
     }
 
+    // SSO-only account: issue no reset token. Gating login alone would leave
+    // this endpoint as a way for anyone with mailbox access to set a password
+    // and walk past SSO, MFA and Conditional Access. The response is identical
+    // to the unknown-email case so this does not become an enumeration oracle
+    // for which accounts are SSO-only.
+    if (user.passwordLoginDisabled) {
+      this.logger.warn(
+        `Password reset refused for SSO-only account: ${user.email}`,
+      );
+      return { message: 'If the email exists, a reset link has been sent.' };
+    }
+
     // Generate secure token
     const resetToken = crypto.randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
@@ -684,7 +712,7 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
   @ApiOperation({ summary: 'Reset password using token' })
-  async resetPassword(@Body() dto: ResetPasswordDto) {
+  async resetPassword(@Req() req: any, @Body() dto: ResetPasswordDto) {
     const resetRecord = await this.prisma.passwordResetToken.findUnique({
       where: { token: dto.token },
     });
@@ -701,16 +729,30 @@ export class AuthController {
       throw new BadRequestException('This reset link has expired');
     }
 
-    // Update password
+    // Update the password AND revoke every session issued before now. A reset
+    // is the classic "someone else may be in my account" moment: leaving old
+    // tokens valid would let an attacker keep a live session for up to 24h
+    // (longer on an MCP refresh token) after the victim locks them out.
     const newHash = await this.authService.hashPassword(dto.newPassword);
-    await this.usersService.update(resetRecord.userId, {
-      passwordHash: newHash,
+    await this.prisma.user.update({
+      where: { id: resetRecord.userId },
+      data: { passwordHash: newHash, sessionsValidFrom: new Date() },
     });
 
     // Mark token as used
     await this.prisma.passwordResetToken.update({
       where: { id: resetRecord.id },
       data: { usedAt: new Date() },
+    });
+
+    await this.securityEvents.log({
+      event: SecurityEvents.SESSIONS_REVOKED,
+      actorType: 'USER',
+      actorUserId: resetRecord.userId,
+      targetUserId: resetRecord.userId,
+      metadata: { reason: 'password_reset' },
+      ip: req.ip,
+      userAgent: req.headers?.['user-agent'],
     });
 
     return { message: 'Password has been reset successfully' };

--- a/packages/backend/src/auth/auth.service.spec.ts
+++ b/packages/backend/src/auth/auth.service.spec.ts
@@ -1,5 +1,5 @@
 import { JwtService } from '@nestjs/jwt';
-import { AuthService } from './auth.service';
+import { AuthService, isTokenRevoked } from './auth.service';
 
 describe('AuthService', () => {
   let authService: AuthService;
@@ -46,6 +46,64 @@ describe('AuthService', () => {
     it('should throw on invalid token', () => {
       expect(() => authService.verifyToken('invalid.token.here')).toThrow(
         'Invalid or expired token',
+      );
+    });
+  });
+
+  describe('isTokenRevoked', () => {
+    const at = (iso: string) => Math.floor(new Date(iso).getTime() / 1000);
+
+    it('accepts everything when the user was never revoked', () => {
+      expect(isTokenRevoked({ iat: at('2020-01-01T00:00:00Z') }, null)).toBe(
+        false,
+      );
+      expect(isTokenRevoked({ iat: at('2020-01-01T00:00:00Z') }, undefined)).toBe(
+        false,
+      );
+    });
+
+    it('rejects a token minted before the cutover', () => {
+      expect(
+        isTokenRevoked(
+          { iat: at('2026-05-31T23:59:59Z') },
+          new Date('2026-06-01T00:00:00Z'),
+        ),
+      ).toBe(true);
+    });
+
+    it('accepts a token minted after the cutover', () => {
+      expect(
+        isTokenRevoked(
+          { iat: at('2026-06-01T00:00:01Z') },
+          new Date('2026-06-01T00:00:00Z'),
+        ),
+      ).toBe(false);
+    });
+
+    it('accepts a token minted in the same second as the cutover', () => {
+      // Deliberate: `iat` has second granularity, and the stricter comparison
+      // would reject a legitimate token issued moments after a password change.
+      expect(
+        isTokenRevoked(
+          { iat: at('2026-06-01T00:00:00Z') },
+          new Date('2026-06-01T00:00:00.400Z'),
+        ),
+      ).toBe(false);
+    });
+
+    it('fails CLOSED on a token with no iat', () => {
+      // If the token cannot be dated, a revocation cannot be honoured against
+      // it — so it must not be trusted.
+      expect(isTokenRevoked({}, new Date('2026-06-01T00:00:00Z'))).toBe(true);
+      expect(isTokenRevoked(null, new Date('2026-06-01T00:00:00Z'))).toBe(true);
+    });
+
+    it('works on an MCP-issued payload, which carries no marker of ours', () => {
+      // The whole reason revocation is a timestamp and not an epoch counter:
+      // mcp-nest mints these and would never echo a claim we invented.
+      const mcpPayload = { sub: 'u1', type: 'access', azp: 'c1', iat: at('2026-01-01T00:00:00Z') };
+      expect(isTokenRevoked(mcpPayload, new Date('2026-06-01T00:00:00Z'))).toBe(
+        true,
       );
     });
   });

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -8,6 +8,75 @@ export interface JwtPayload {
   role: string;
   organizationId: string | null;
   mcpRoleId?: string | null;
+  /** Marks a token minted for the dashboard API. See `isForeignIssuedToken`. */
+  tokenUse?: typeof DASHBOARD_TOKEN_USE;
+  /** Standard JWT issued-at (seconds). Set by the signer, read for revocation. */
+  iat?: number;
+  exp?: number;
+}
+
+/** `tokenUse` value stamped on every dashboard (app) token we issue. */
+export const DASHBOARD_TOKEN_USE = 'dashboard';
+
+/**
+ * Claims that only ever appear on tokens minted by the MCP OAuth authorization
+ * server (@rekog/mcp-nest `JwtTokenService`) or by `ClientCredentialsMiddleware`.
+ *
+ * SECURITY: those tokens are signed with the SAME `JWT_SECRET` as dashboard
+ * tokens (app.module.ts passes it straight to McpAuthModule), so the signature
+ * alone does not tell the two apart. Until this check existed, the only thing
+ * stopping an MCP access token — obtainable by anyone, since Dynamic Client
+ * Registration is open — from also authenticating against the whole dashboard
+ * API was that the OAuth `sub` happens to be an email, so the `findUnique({ id })`
+ * lookup missed. That is an accident, not a control, and it breaks the moment
+ * `sub` is normalised to the user's cuid.
+ *
+ * Every mcp-nest code path sets `type` ('access' | 'refresh' | 'user'), and the
+ * access/refresh payloads additionally carry `azp`/`client_id` and `resource`.
+ * Dashboard tokens carry none of them, so this is a complete separation with no
+ * backward-compatibility window.
+ */
+const FOREIGN_TOKEN_CLAIMS = [
+  'type',
+  'azp',
+  'client_id',
+  'resource',
+  'user_data',
+  'user_profile_id',
+] as const;
+
+/** True when the payload was minted by the MCP OAuth server, not by us. */
+export function isForeignIssuedToken(
+  payload: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!payload) return true;
+  return FOREIGN_TOKEN_CLAIMS.some((claim) => payload[claim] !== undefined);
+}
+
+/**
+ * True when a token predates the user's revocation cutover and must be refused.
+ *
+ * Works on ANY JWT because it reads `iat`, which both our dashboard tokens and
+ * the MCP tokens minted by @rekog/mcp-nest carry. That is why revocation is
+ * modelled as a timestamp rather than an epoch counter: a counter would have to
+ * be echoed back as a claim, and we do not control the MCP token payload.
+ *
+ * Compared at second granularity, since `iat` is in seconds. A token minted in
+ * the same second as the revocation therefore survives — accepted deliberately,
+ * because the stricter comparison would reject a legitimate token issued
+ * moments after a password change.
+ *
+ * Fails CLOSED on a token with no `iat`: if we cannot date it, we cannot honour
+ * a revocation against it.
+ */
+export function isTokenRevoked(
+  payload: { iat?: number } | null | undefined,
+  sessionsValidFrom: Date | null | undefined,
+): boolean {
+  if (!sessionsValidFrom) return false; // never revoked
+  const iat = payload?.iat;
+  if (typeof iat !== 'number') return true;
+  return iat < Math.floor(sessionsValidFrom.getTime() / 1000);
 }
 
 @Injectable()
@@ -23,7 +92,10 @@ export class AuthService {
   }
 
   generateToken(payload: JwtPayload): string {
-    return this.jwtService.sign(payload);
+    // Stamp the positive marker so dashboard tokens are identifiable by what
+    // they ARE, not only by what they lack. `JwtStrategy` will be able to
+    // require it once every token issued before this change has expired (24h).
+    return this.jwtService.sign({ ...payload, tokenUse: DASHBOARD_TOKEN_USE });
   }
 
   verifyToken(token: string): JwtPayload {

--- a/packages/backend/src/auth/authorization-issuer.middleware.spec.ts
+++ b/packages/backend/src/auth/authorization-issuer.middleware.spec.ts
@@ -1,0 +1,95 @@
+import { AuthorizationIssuerMiddleware } from './authorization-issuer.middleware';
+import { ConfigService } from '@nestjs/config';
+
+describe('AuthorizationIssuerMiddleware', () => {
+  let middleware: AuthorizationIssuerMiddleware;
+  let res: any;
+  let next: jest.Mock;
+  let redirected: string | undefined;
+
+  const req = (headers: Record<string, string> = { host: 'mcp.example.com' }) =>
+    ({ headers, secure: false }) as any;
+
+  beforeEach(() => {
+    const config = {
+      get: jest.fn().mockReturnValue('http://localhost:4000'),
+    } as unknown as ConfigService;
+    middleware = new AuthorizationIssuerMiddleware(config);
+    next = jest.fn();
+    redirected = undefined;
+    res = {
+      redirect: jest.fn((...args: any[]) => {
+        redirected = typeof args[0] === 'number' ? args[1] : args[0];
+      }),
+    };
+  });
+
+  it('appends iss to a successful authorization response', () => {
+    middleware.use(req(), res, next);
+    res.redirect('https://claude.ai/cb?code=abc&state=xyz');
+
+    const url = new URL(redirected!);
+    expect(url.searchParams.get('iss')).toBe('http://mcp.example.com');
+    // The original parameters must survive untouched.
+    expect(url.searchParams.get('code')).toBe('abc');
+    expect(url.searchParams.get('state')).toBe('xyz');
+  });
+
+  it('appends iss to an ERROR response too (RFC 9207 §2)', () => {
+    middleware.use(req(), res, next);
+    res.redirect('https://claude.ai/cb?error=access_denied');
+
+    expect(new URL(redirected!).searchParams.get('iss')).toBe(
+      'http://mcp.example.com',
+    );
+  });
+
+  it('leaves internal hops alone', () => {
+    // The strategy bounces /authorize to the login page; that is not an
+    // authorization response and must not gain an iss parameter.
+    middleware.use(req(), res, next);
+    res.redirect('http://mcp.example.com/auth/login');
+
+    expect(redirected).toBe('http://mcp.example.com/auth/login');
+  });
+
+  it('supports the redirect(status, url) overload', () => {
+    middleware.use(req(), res, next);
+    res.redirect(302, 'https://claude.ai/cb?code=abc');
+
+    expect(new URL(redirected!).searchParams.get('iss')).toBe(
+      'http://mcp.example.com',
+    );
+  });
+
+  it('does not double-append when iss is already present', () => {
+    middleware.use(req(), res, next);
+    res.redirect('https://claude.ai/cb?code=abc&iss=https%3A%2F%2Fother');
+
+    expect(new URL(redirected!).searchParams.getAll('iss')).toEqual([
+      'https://other',
+    ]);
+  });
+
+  it('honours the forwarded proto and host, matching the metadata document', () => {
+    // If the issuer emitted here disagreed with the one advertised in
+    // /.well-known, every conforming client would reject every response.
+    middleware.use(
+      req({ host: 'internal:4000', 'x-forwarded-proto': 'https', 'x-forwarded-host': 'mcp.example.com' }),
+      res,
+      next,
+    );
+    res.redirect('https://claude.ai/cb?code=abc');
+
+    expect(new URL(redirected!).searchParams.get('iss')).toBe(
+      'https://mcp.example.com',
+    );
+  });
+
+  it('leaves an unparseable target untouched rather than break the flow', () => {
+    middleware.use(req(), res, next);
+    res.redirect('::::not a url');
+
+    expect(redirected).toBe('::::not a url');
+  });
+});

--- a/packages/backend/src/auth/authorization-issuer.middleware.ts
+++ b/packages/backend/src/auth/authorization-issuer.middleware.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Request, Response, NextFunction } from 'express';
+
+/**
+ * Appends the RFC 9207 `iss` parameter to authorization responses.
+ *
+ * The MCP 2026-07-28 authorization spec says an authorization server SHOULD
+ * include `iss` on the redirect back to the client — including on error
+ * responses — so the client can bind the authorization code to the issuer it
+ * discovered and detect a mix-up attack before redeeming it.
+ *
+ * @rekog/mcp-nest builds that redirect itself and has no notion of `iss`, so we
+ * wrap `res.redirect` on the callback route rather than fork the controller —
+ * the same approach already used for the token and register endpoints.
+ *
+ * CRITICAL PAIRING: `authorization_response_iss_parameter_supported: true` in
+ * the authorization-server metadata and this middleware MUST ship together. A
+ * client that reads that flag and then receives a response WITHOUT `iss` is
+ * required by the spec to reject it. For the same reason the issuer value is
+ * derived here exactly as the metadata document derives it — if the two
+ * disagreed (behind a proxy, say) every client would reject every response.
+ */
+@Injectable()
+export class AuthorizationIssuerMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(AuthorizationIssuerMiddleware.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    const issuer = this.baseUrl(req);
+    const originalRedirect = res.redirect.bind(res);
+
+    // Express overloads redirect(url) and redirect(status, url).
+    (res as any).redirect = (...args: any[]) => {
+      const urlIndex = typeof args[0] === 'number' ? 1 : 0;
+      const target = args[urlIndex];
+
+      if (typeof target === 'string') {
+        args[urlIndex] = this.withIssuer(target, issuer);
+      }
+
+      return originalRedirect(...(args as [any]));
+    };
+
+    next();
+  }
+
+  /**
+   * Adds `iss` only to an actual authorization RESPONSE — the redirect that
+   * carries `code` or `error` back to the client. Internal hops (the strategy
+   * bouncing to /auth/login, for instance) must be left untouched.
+   */
+  private withIssuer(target: string, issuer: string): string {
+    try {
+      const url = new URL(target, issuer);
+      const isAuthorizationResponse =
+        url.searchParams.has('code') || url.searchParams.has('error');
+      if (!isAuthorizationResponse || url.searchParams.has('iss')) {
+        return target;
+      }
+      url.searchParams.set('iss', issuer);
+      return url.toString();
+    } catch {
+      // Not a URL we can parse — leave the redirect exactly as it was rather
+      // than risk breaking the flow for the sake of an optional parameter.
+      this.logger.debug(`Could not parse redirect target for iss: ${target}`);
+      return target;
+    }
+  }
+
+  /** Must mirror WellKnownOAuthController.baseUrl exactly. */
+  private baseUrl(req: Request): string {
+    const proto =
+      (req.headers['x-forwarded-proto'] as string) ||
+      (req.secure ? 'https' : 'http');
+    const host =
+      (req.headers['x-forwarded-host'] as string) || req.headers.host;
+    return host
+      ? `${proto}://${host}`
+      : this.config.get<string>('SERVER_URL') || 'http://localhost:4000';
+  }
+}

--- a/packages/backend/src/auth/authorize-pkce.middleware.spec.ts
+++ b/packages/backend/src/auth/authorize-pkce.middleware.spec.ts
@@ -1,0 +1,100 @@
+import { AuthorizePkceMiddleware } from './authorize-pkce.middleware';
+import { createHash, randomBytes } from 'crypto';
+
+describe('AuthorizePkceMiddleware', () => {
+  let middleware: AuthorizePkceMiddleware;
+  let next: jest.Mock;
+  let res: any;
+
+  /** A genuine S256 challenge, derived the way a conforming client would. */
+  const s256 = (verifier: string) =>
+    createHash('sha256').update(verifier).digest('base64url');
+
+  const req = (query: Record<string, unknown>, method = 'GET') =>
+    ({ method, query }) as any;
+
+  beforeEach(() => {
+    middleware = new AuthorizePkceMiddleware();
+    next = jest.fn();
+    res = {
+      status: jest.fn().mockReturnThis(),
+      header: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  const bodyOf = () => res.json.mock.calls[0][0];
+
+  it('allows a conforming S256 authorization request', () => {
+    const challenge = s256(randomBytes(32).toString('base64url'));
+
+    middleware.use(
+      req({ client_id: 'c1', code_challenge: challenge, code_challenge_method: 'S256' }),
+      res,
+      next,
+    );
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with no code_challenge', () => {
+    middleware.use(req({ client_id: 'c1' }), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(bodyOf().error).toBe('invalid_request');
+    expect(bodyOf().error_description).toMatch(/code_challenge is required/);
+  });
+
+  it("rejects code_challenge_method 'plain'", () => {
+    // `plain` puts the verifier in the clear on the authorization request, so
+    // it defends against nothing an attacker who can read the request cannot
+    // already do. Upstream defaults to exactly this when the method is absent.
+    middleware.use(
+      req({ code_challenge: s256('v'), code_challenge_method: 'plain' }),
+      res,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(bodyOf().error_description).toMatch(/S256/);
+  });
+
+  it('rejects a challenge with no method (upstream would assume plain)', () => {
+    middleware.use(req({ code_challenge: s256('v') }), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a malformed challenge', () => {
+    middleware.use(
+      req({ code_challenge: 'too-short', code_challenge_method: 'S256' }),
+      res,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(bodyOf().error_description).toMatch(/base64url/);
+  });
+
+  it('never redirects to a client-supplied redirect_uri', () => {
+    // Redirecting on error would mean trusting an unvalidated client URI,
+    // which is how an authorization endpoint becomes an open redirector.
+    middleware.use(
+      req({ client_id: 'c1', redirect_uri: 'https://evil.tld/cb' }),
+      res,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.header).toHaveBeenCalledWith('Content-Type', 'application/json');
+    expect(JSON.stringify(bodyOf())).not.toContain('evil.tld');
+  });
+
+  it('leaves non-GET requests alone', () => {
+    middleware.use(req({}, 'POST'), res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/auth/authorize-pkce.middleware.ts
+++ b/packages/backend/src/auth/authorize-pkce.middleware.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+
+/**
+ * Enforces PKCE with S256 on GET /authorize.
+ *
+ * @rekog/mcp-nest validates a code challenge only when one happens to be
+ * present (`if (authCode.code_challenge)` in its token handler), never requires
+ * it at /authorize, and defaults the method to `plain`. Combined with open
+ * Dynamic Client Registration that leaves the authorization code — which
+ * travels in a query string, through browser history and proxy logs —
+ * interceptable and replayable by any client that can register.
+ *
+ * `plain` is rejected as well as absent: it stores the verifier in the clear on
+ * the authorization request, so it defends against nothing an attacker who can
+ * read the request cannot already do.
+ *
+ * This is what the MCP authorization spec requires of clients, so a conforming
+ * client is unaffected. Runs as middleware for the same reason
+ * ClientCredentialsMiddleware and OAuthRegisterGuardMiddleware do: it lets us
+ * hold the line without forking the upstream controller.
+ *
+ * Errors are returned as a 400 JSON body rather than redirected to
+ * `redirect_uri`. Redirecting would require trusting a client-supplied URI
+ * before it has been validated against a registration, which is exactly how an
+ * authorization endpoint becomes an open redirector.
+ */
+@Injectable()
+export class AuthorizePkceMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(AuthorizePkceMiddleware.name);
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    // Only the authorization request itself carries PKCE parameters.
+    if (req.method !== 'GET') {
+      return next();
+    }
+
+    const query = req.query as Record<string, unknown>;
+    const challenge = query.code_challenge;
+    const method = query.code_challenge_method;
+
+    if (typeof challenge !== 'string' || challenge.trim() === '') {
+      this.logger.warn(
+        `Rejecting /authorize without PKCE (client_id=${String(query.client_id ?? '<none>')})`,
+      );
+      return this.reject(
+        res,
+        'code_challenge is required. This server requires PKCE with S256.',
+      );
+    }
+
+    if (method !== 'S256') {
+      this.logger.warn(
+        `Rejecting /authorize with code_challenge_method='${String(method ?? '<none>')}'`,
+      );
+      return this.reject(
+        res,
+        "code_challenge_method must be 'S256'. 'plain' and an absent method are not accepted.",
+      );
+    }
+
+    // S256 challenges are the base64url encoding of a SHA-256 digest: 43
+    // characters, no padding. Checking the shape stops a malformed value from
+    // silently never matching any verifier at the token endpoint.
+    if (!/^[A-Za-z0-9\-._~]{43}$/.test(challenge)) {
+      return this.reject(
+        res,
+        'code_challenge is not a valid base64url-encoded SHA-256 digest.',
+      );
+    }
+
+    next();
+  }
+
+  private reject(res: Response, description: string): void {
+    res
+      .status(400)
+      .header('Content-Type', 'application/json')
+      .json({ error: 'invalid_request', error_description: description });
+  }
+}

--- a/packages/backend/src/auth/jwt.strategy.spec.ts
+++ b/packages/backend/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,175 @@
+import { ConfigService } from '@nestjs/config';
+import { JwtStrategy } from './jwt.strategy';
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * Regression guard for the dashboard/MCP token separation.
+ *
+ * The MCP OAuth authorization server (@rekog/mcp-nest) signs its tokens with
+ * the SAME JWT_SECRET as the dashboard API. Anyone can obtain such a token —
+ * Dynamic Client Registration is open. If JwtStrategy ever accepts one, an MCP
+ * access token becomes a full dashboard session.
+ *
+ * These tests must keep failing loudly if that separation regresses.
+ */
+describe('JwtStrategy', () => {
+  const SECRET = 'a-test-secret-that-is-at-least-32-chars-long';
+
+  let strategy: JwtStrategy;
+  let prisma: { user: { findUnique: jest.Mock; update: jest.Mock }; organizationMember: { findFirst: jest.Mock } };
+
+  const dbUser = {
+    id: 'user-cuid-1',
+    email: 'alice@example.com',
+    role: 'EDITOR',
+    organizationId: 'org-1',
+  };
+
+  beforeEach(() => {
+    prisma = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue(dbUser),
+        update: jest.fn(),
+      },
+      organizationMember: { findFirst: jest.fn() },
+    };
+
+    const configService = {
+      get: jest.fn().mockReturnValue(SECRET),
+    } as unknown as ConfigService;
+
+    strategy = new JwtStrategy(
+      configService,
+      prisma as unknown as PrismaService,
+    );
+  });
+
+  describe('dashboard tokens', () => {
+    it('accepts a dashboard payload and returns the principal', async () => {
+      const result = await strategy.validate({
+        sub: 'user-cuid-1',
+        email: 'alice@example.com',
+        role: 'EDITOR',
+        organizationId: 'org-1',
+        tokenUse: 'dashboard',
+      } as any);
+
+      expect(result).toEqual({
+        sub: 'user-cuid-1',
+        email: 'alice@example.com',
+        role: 'EDITOR',
+        organizationId: 'org-1',
+      });
+    });
+
+    it('still accepts tokens issued before the tokenUse marker existed', async () => {
+      // Tokens minted before this change have no `tokenUse` and stay valid for
+      // their remaining 24h lifetime. The rejection is driven by the presence
+      // of MCP-side claims, not by the absence of the marker.
+      const result = await strategy.validate({
+        sub: 'user-cuid-1',
+        email: 'alice@example.com',
+        role: 'EDITOR',
+        organizationId: 'org-1',
+      } as any);
+
+      expect(result.sub).toBe('user-cuid-1');
+    });
+  });
+
+  describe('MCP-issued tokens are rejected', () => {
+    // Shapes taken verbatim from @rekog/mcp-nest JwtTokenService.generateTokenPair
+    // and from ClientCredentialsMiddleware.
+    const foreignPayloads: Array<[string, Record<string, unknown>]> = [
+      [
+        'mcp-nest access token',
+        {
+          sub: 'user-cuid-1',
+          azp: 'client-abc',
+          iss: 'https://mcp.example.com',
+          aud: 'https://mcp.example.com/mcp',
+          resource: 'https://mcp.example.com/mcp',
+          type: 'access',
+          scope: '',
+        },
+      ],
+      [
+        'mcp-nest refresh token',
+        {
+          sub: 'user-cuid-1',
+          client_id: 'client-abc',
+          scope: '',
+          resource: 'https://mcp.example.com/mcp',
+          type: 'refresh',
+          jti: 'refresh_deadbeef',
+        },
+      ],
+      [
+        'client-credentials token',
+        {
+          sub: 'client:client-abc',
+          azp: 'client-abc',
+          scope: '',
+          resource: 'https://mcp.example.com/mcp',
+          type: 'access',
+        },
+      ],
+      [
+        'token carrying an embedded OAuth user profile',
+        {
+          sub: 'user-cuid-1',
+          user_data: { id: 'user-cuid-1', email: 'alice@example.com' },
+          user_profile_id: 'profile-1',
+        },
+      ],
+    ];
+
+    it.each(foreignPayloads)('rejects a %s', async (_label, payload) => {
+      await expect(strategy.validate(payload as any)).rejects.toThrow(
+        'Token is not valid for this API',
+      );
+    });
+
+    it('rejects before touching the database', async () => {
+      // The lookup must never run for a foreign token: a payload whose `sub`
+      // is a real user id must not be able to probe or self-heal user records.
+      await expect(
+        strategy.validate({ sub: 'user-cuid-1', type: 'access' } as any),
+      ).rejects.toThrow();
+
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects even when the MCP sub is the user cuid rather than an email', async () => {
+      // This is the case that the pre-existing code got right only by accident:
+      // it relied on `findUnique({ id: <an email> })` missing. Normalising the
+      // OAuth `sub` to a cuid removes that accident, so the explicit claim
+      // check is what has to hold.
+      await expect(
+        strategy.validate({
+          sub: dbUser.id,
+          type: 'access',
+          azp: 'client-abc',
+        } as any),
+      ).rejects.toThrow('Token is not valid for this API');
+
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unknown users', () => {
+    it('rejects when the user no longer exists', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        strategy.validate({
+          sub: 'ghost',
+          email: 'g@example.com',
+          role: 'EDITOR',
+          organizationId: null,
+        } as any),
+      ).rejects.toThrow('User no longer exists');
+    });
+  });
+});

--- a/packages/backend/src/auth/jwt.strategy.ts
+++ b/packages/backend/src/auth/jwt.strategy.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
-import { JwtPayload } from './auth.service';
+import { JwtPayload, isForeignIssuedToken, isTokenRevoked } from './auth.service';
 import { PrismaService } from '../common/prisma.service';
 import { getRequiredSecret } from '../common/secrets.util';
 
@@ -23,11 +23,26 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
+    // SECURITY: the MCP OAuth authorization server signs its access/refresh
+    // tokens with the same JWT_SECRET as this strategy, so a valid signature
+    // does not imply a dashboard token. Reject anything bearing the MCP-side
+    // claims before it can be traded for a dashboard session.
+    if (isForeignIssuedToken(payload as unknown as Record<string, unknown>)) {
+      throw new UnauthorizedException('Token is not valid for this API');
+    }
+
     const user = await this.prisma.user.findUnique({
       where: { id: payload.sub },
     });
     if (!user) {
       throw new UnauthorizedException('User no longer exists');
+    }
+
+    // Revocation: refuse tokens minted before the user's cutover instant (set
+    // on password change, demotion, deprovisioning or an SSO config change).
+    // Free to check — the user row is already loaded.
+    if (isTokenRevoked(payload, user.sessionsValidFrom)) {
+      throw new UnauthorizedException('Session has been revoked');
     }
 
     // Self-heal a NULL active org by snapping to the oldest remaining membership.

--- a/packages/backend/src/auth/local-oauth.provider.ts
+++ b/packages/backend/src/auth/local-oauth.provider.ts
@@ -18,9 +18,21 @@ export const LocalOAuthProvider: OAuthProviderConfig = {
     callbackPath: callbackPath || '/callback',
   }),
   scope: [],
+  // SECURITY: `username` becomes `authCode.user_id` and therefore the `sub` of
+  // every issued MCP access token. It MUST be the local `users.id` cuid, never
+  // an email.
+  //
+  // Emails are mutable, reassignable and — once an external IdP can populate
+  // this profile — attacker-controllable. A `sub` that is an email forced every
+  // downstream consumer to resolve the caller with an "id OR email" lookup,
+  // which turns an email claim into an authentication assertion: set one user's
+  // mail to a victim's address and the token resolves to the victim's row, in
+  // the victim's organization. Keying on the cuid removes that whole class.
+  //
+  // `displayName`/`email` still carry the human-readable values for the UI.
   profileMapper: (profile: any) => ({
     id: profile.id,
-    username: profile.email || profile.username,
+    username: profile.id,
     email: profile.email,
     displayName: profile.name || profile.displayName || profile.email,
     avatarUrl: profile.avatarUrl,

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -127,6 +127,25 @@ export class LoginController {
       );
     }
 
+    // SSO-only account: this consent page has its own bcrypt path, so the gate
+    // in POST /api/auth/login does not cover it. Without this, an SSO-enforced
+    // user could still authorize an AI client with a password — bypassing the
+    // IdP's MFA and Conditional Access on exactly the surface that matters.
+    if (user.passwordLoginDisabled) {
+      this.logger.warn(`Password login refused for SSO-only account: ${email}`);
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Password sign-in is disabled for this account. Use your organization sign-in.')}`,
+      );
+    }
+
+    // Nullable for IdP-provisioned users — never hand null to bcrypt.
+    if (!user.passwordHash) {
+      this.logger.warn(`Login attempt for passwordless account: ${email}`);
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Invalid email or password')}`,
+      );
+    }
+
     // Verify password
     const passwordValid = await this.authService.comparePassword(
       password,

--- a/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.spec.ts
@@ -26,7 +26,10 @@ describe('McpCombinedAuthGuard', () => {
     mockConfig = { get: jest.fn() };
     mockAuth = { verifyToken: jest.fn() };
     mockApiKeys = { resolveUserByKey: jest.fn() };
-    mockPrisma = { user: { findUnique: jest.fn(), findFirst: jest.fn() } };
+    mockPrisma = {
+      user: { findUnique: jest.fn(), findFirst: jest.fn() },
+      oAuthUserProfile: { findUnique: jest.fn().mockResolvedValue(null) },
+    };
     guard = new McpCombinedAuthGuard(
       mockConfig,
       mockAuth,
@@ -36,7 +39,11 @@ describe('McpCombinedAuthGuard', () => {
   });
 
   describe('organization resolution for JWT/OAuth tokens', () => {
-    it('keeps organizationId from an app JWT without a DB lookup', async () => {
+    it('keeps organizationId from an app JWT, and still loads the user for revocation', async () => {
+      // The old zero-query fast path was given up deliberately: revocation
+      // needs `sessionsValidFrom`, and skipping the lookup here would leave a
+      // dashboard JWT presented to /mcp unrevocable, since JwtStrategy (which
+      // does check) never runs on this route.
       mockConfig.get.mockReturnValue(undefined);
       mockAuth.verifyToken.mockReturnValue({
         sub: 'u1',
@@ -44,13 +51,63 @@ describe('McpCombinedAuthGuard', () => {
         role: 'ADMIN',
         organizationId: 'org-A',
       });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'u1',
+        organizationId: 'org-A',
+        email: 'a@b.com',
+        role: 'ADMIN',
+        sessionsValidFrom: null,
+      });
 
       const ctx = mockContext({ authorization: 'Bearer app-jwt' });
       const result = await guard.canActivate(ctx);
 
       expect(result).toBe(true);
-      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+      // The claim still wins for the org — the lookup is only for revocation.
       expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-A');
+    });
+
+    it('rejects a token issued before the user revocation cutover', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'u1',
+        email: 'a@b.com',
+        role: 'ADMIN',
+        organizationId: 'org-A',
+        iat: Math.floor(new Date('2026-01-01T00:00:00Z').getTime() / 1000),
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'u1',
+        organizationId: 'org-A',
+        email: 'a@b.com',
+        role: 'ADMIN',
+        // Password changed after the token was minted.
+        sessionsValidFrom: new Date('2026-06-01T00:00:00Z'),
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer stale-jwt' });
+      expect(await guard.canActivate(ctx)).toBe(false);
+    });
+
+    it('accepts a token issued after the revocation cutover', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'u1',
+        email: 'a@b.com',
+        role: 'ADMIN',
+        organizationId: 'org-A',
+        iat: Math.floor(new Date('2026-06-02T00:00:00Z').getTime() / 1000),
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'u1',
+        organizationId: 'org-A',
+        email: 'a@b.com',
+        role: 'ADMIN',
+        sessionsValidFrom: new Date('2026-06-01T00:00:00Z'),
+      });
+
+      const ctx = mockContext({ authorization: 'Bearer fresh-jwt' });
+      expect(await guard.canActivate(ctx)).toBe(true);
     });
 
     it('resolves organizationId from the user record for an OAuth token whose sub is a cuid', async () => {
@@ -61,7 +118,7 @@ describe('McpCombinedAuthGuard', () => {
         type: 'access',
         user_data: { id: 'u-finance', email: 'finance@helpcode.ai' },
       });
-      mockPrisma.user.findFirst.mockResolvedValue({
+      mockPrisma.user.findUnique.mockResolvedValue({
         id: 'u-finance',
         organizationId: 'org-B',
         email: 'finance@helpcode.ai',
@@ -72,52 +129,108 @@ describe('McpCombinedAuthGuard', () => {
       const result = await guard.canActivate(ctx);
 
       expect(result).toBe(true);
-      // Resolves by id OR email — the user_data.email is also a candidate.
-      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
-        where: {
-          OR: [{ id: 'u-finance' }, { email: 'finance@helpcode.ai' }],
+      // Resolved by primary key only — the user_data.email is NOT a candidate.
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'u-finance' },
+        select: {
+          id: true,
+          organizationId: true,
+          email: true,
+          role: true,
+          sessionsValidFrom: true,
         },
-        select: { id: true, organizationId: true, email: true, role: true },
       });
       expect(ctx.switchToHttp().getRequest().user.organizationId).toBe('org-B');
     });
 
-    it('resolves organizationId when the OAuth token sub IS the email (rekog/mcp-nest)', async () => {
-      // Regression test for the production 403 incident: rekog signs `sub`
-      // with the email, not the users.id cuid. The guard must still resolve
-      // the org (by email) so legitimate owners are not locked out.
+    it('resolves a LEGACY token whose sub is an email via its stored profile', async () => {
+      // Tokens minted before `sub` became the cuid carry the email there, but
+      // they also carry `user_profile_id`, and oauth_user_profiles.external_id
+      // has always held the cuid. Resolving through that keeps already-issued
+      // sessions working WITHOUT an email-keyed lookup — no forced re-auth.
       mockConfig.get.mockReturnValue(undefined);
       mockAuth.verifyToken.mockReturnValue({
-        sub: 'jjstrick9@gmail.com',
+        sub: 'owner@example.com',
         type: 'access',
-        user_data: {},
+        user_profile_id: 'local:cmpzj8mm9007j1ymn5mo2y3eq',
+        user_data: { email: 'owner@example.com' },
       });
-      mockPrisma.user.findFirst.mockResolvedValue({
+      mockPrisma.oAuthUserProfile.findUnique.mockResolvedValue({
+        externalId: 'cmpzj8mm9007j1ymn5mo2y3eq',
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
         id: 'cmpzj8mm9007j1ymn5mo2y3eq',
-        organizationId: 'cmpzj8mds007i1ymntpyjngdp',
-        email: 'jjstrick9@gmail.com',
+        organizationId: 'org-legacy',
+        email: 'owner@example.com',
         role: 'ADMIN',
       });
 
-      const ctx = mockContext({ authorization: 'Bearer oauth-token' });
-      const result = await guard.canActivate(ctx);
+      const ctx = mockContext({ authorization: 'Bearer legacy-token' });
+      expect(await guard.canActivate(ctx)).toBe(true);
 
-      expect(result).toBe(true);
-      // sub is an email → matched via the email branch, not id.
-      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
-        where: { OR: [{ email: 'jjstrick9@gmail.com' }] },
-        select: { id: true, organizationId: true, email: true, role: true },
+      expect(mockPrisma.oAuthUserProfile.findUnique).toHaveBeenCalledWith({
+        where: { profileId: 'local:cmpzj8mm9007j1ymn5mo2y3eq' },
+        select: { externalId: true },
       });
       const u = ctx.switchToHttp().getRequest().user;
-      expect(u.organizationId).toBe('cmpzj8mds007i1ymntpyjngdp');
-      // sub is normalised back to the real cuid for downstream ownership checks.
+      expect(u.organizationId).toBe('org-legacy');
       expect(u.sub).toBe('cmpzj8mm9007j1ymn5mo2y3eq');
+    });
+
+    it('does NOT resolve a user from the token email claim', async () => {
+      // SECURITY regression guard. `user_data` is the stored OAuth profile
+      // copied verbatim into the signed token. If the guard matched its email
+      // against users.email, anyone able to influence that profile — an
+      // external IdP, once SSO lands — could mint a token bearing a victim's
+      // address and inherit the victim's organization. With no recoverable
+      // profile, an email-shaped `sub` must fail closed rather than fall back.
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'victim@example.com',
+        type: 'access',
+        user_data: { email: 'victim@example.com' },
+      });
+      mockPrisma.oAuthUserProfile.findUnique.mockResolvedValue(null);
+
+      const ctx = mockContext({ authorization: 'Bearer forged-token' });
+      await guard.canActivate(ctx);
+
+      // The users table is never queried by email — in fact not at all here.
+      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
+      // No org inherited → the per-server tenant check downstream fails closed.
+      expect(
+        ctx.switchToHttp().getRequest().user.organizationId,
+      ).toBeUndefined();
+    });
+
+    it('never queries users by email', async () => {
+      mockConfig.get.mockReturnValue(undefined);
+      mockAuth.verifyToken.mockReturnValue({
+        sub: 'u-1',
+        type: 'access',
+        email: 'someone@example.com',
+        user_data: { email: 'other@example.com' },
+      });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'u-1',
+        organizationId: 'org-A',
+        email: 'u1@example.com',
+        role: 'EDITOR',
+      });
+
+      await guard.canActivate(mockContext({ authorization: 'Bearer t' }));
+
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
+      for (const call of mockPrisma.user.findUnique.mock.calls) {
+        expect(JSON.stringify(call[0].where)).not.toContain('email');
+      }
     });
 
     it('leaves organizationId undefined when the user cannot be resolved (fail closed downstream)', async () => {
       mockConfig.get.mockReturnValue(undefined);
       mockAuth.verifyToken.mockReturnValue({ sub: 'ghost', user_data: {} });
-      mockPrisma.user.findFirst.mockResolvedValue(null);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
 
       const ctx = mockContext({ authorization: 'Bearer oauth-token' });
       await guard.canActivate(ctx);

--- a/packages/backend/src/auth/mcp-combined-auth.guard.ts
+++ b/packages/backend/src/auth/mcp-combined-auth.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { AuthService } from './auth.service';
+import { AuthService, isTokenRevoked } from './auth.service';
 import { McpApiKeysService } from '../roles/mcp-api-keys.service';
 import { PrismaService } from '../common/prisma.service';
 
@@ -105,41 +105,46 @@ export class McpCombinedAuthGuard implements CanActivate {
         // allowing cross-organization access to any /mcp/:serverId endpoint.
         let organizationId: string | undefined =
           payload.organizationId ?? undefined;
-        // The MCP OAuth flow (rekog/mcp-nest) signs `sub` with whatever
-        // identifier the auth code carried — in our integration that's the
-        // user's EMAIL, not the `users.id` cuid. App JWTs, by contrast, put
-        // the cuid in `sub`. So we can't assume `sub` is a primary key:
-        // resolve the user by id OR email, trying every identifier the token
-        // exposes. Without this, OAuth callers resolve to `organizationId ===
-        // undefined` and the downstream per-server tenant check fails closed
-        // with 403 — locking legitimate owners out of their own servers.
-        const subId: string | undefined = payload.sub || payload.user_data?.id;
-        const email: string | undefined =
-          payload.email ?? payload.user_data?.email ?? undefined;
-        if (!organizationId && (subId || email)) {
-          // `sub` may itself be an email; collect every candidate and match
-          // on id OR email in a single query.
-          const ids = [subId].filter(
-            (v): v is string => !!v && !v.includes('@'),
+        // SECURITY: resolve the caller by `users.id` ONLY — never by matching
+        // an email claim against `users.email`. `user_data` is the stored OAuth
+        // profile copied verbatim into the signed token, so an email-based
+        // lookup would let anyone able to influence that profile — an external
+        // IdP, once SSO lands — resolve to another organization's user and
+        // inherit their `organizationId`, defeating the tenant check below.
+        const subId = await this.resolveUserId(payload);
+
+        // The user row is loaded whenever we can identify the caller — not only
+        // when the org is missing. Revocation needs `sessionsValidFrom`, and
+        // skipping the lookup on the org-present fast path would leave a
+        // dashboard JWT presented to /mcp unrevocable (JwtStrategy, which does
+        // check, never runs on this route).
+        const dbUser = subId
+          ? await this.prisma.user.findUnique({
+              where: { id: subId },
+              select: {
+                id: true,
+                organizationId: true,
+                email: true,
+                role: true,
+                sessionsValidFrom: true,
+              },
+            })
+          : null;
+
+        if (dbUser && isTokenRevoked(payload, dbUser.sessionsValidFrom)) {
+          this.logger.warn(
+            `Rejected revoked token for user ${dbUser.id} on ${reqPath}`,
           );
-          const emails = [email, subId].filter(
-            (v): v is string => !!v && v.includes('@'),
-          );
-          const dbUser = await this.prisma.user.findFirst({
-            where: {
-              OR: [
-                ...ids.map((id) => ({ id })),
-                ...emails.map((e) => ({ email: e })),
-              ],
-            },
-            select: { id: true, organizationId: true, email: true, role: true },
-          });
+          return this.deny(req, res, reqPath);
+        }
+
+        if (!organizationId && subId) {
           organizationId = dbUser?.organizationId ?? undefined;
           req.user = {
             ...payload,
             sub: dbUser?.id ?? subId,
             organizationId,
-            email: dbUser?.email ?? email,
+            email: dbUser?.email ?? payload.email,
             role: payload.role ?? dbUser?.role,
             authMethod: 'jwt',
           };
@@ -172,7 +177,14 @@ export class McpCombinedAuthGuard implements CanActivate {
     }
 
     // Auth failed — build proper WWW-Authenticate header for MCP OAuth flow
-    // The MCP spec requires resource_metadata pointing to the protected resource metadata
+    return this.deny(req, res, reqPath);
+  }
+
+  /**
+   * Emits the spec-compliant 401. The MCP spec requires `resource_metadata`
+   * pointing at the protected-resource metadata document.
+   */
+  private deny(req: any, res: any, reqPath: string): boolean {
     const proto =
       (req.headers['x-forwarded-proto'] as string) ||
       (req.secure ? 'https' : 'http');
@@ -196,5 +208,45 @@ export class McpCombinedAuthGuard implements CanActivate {
       id: null,
     });
     return false;
+  }
+
+  /**
+   * Resolves the `users.id` cuid a token belongs to, WITHOUT ever trusting an
+   * email claim.
+   *
+   * Tokens minted after LocalOAuthProvider started mapping the profile
+   * `username` to the cuid carry it directly in `sub`.
+   *
+   * Tokens minted BEFORE that carry the user's email in `sub` — but they also
+   * carry `user_profile_id`, and `oauth_user_profiles.external_id` has always
+   * stored the cuid (PrismaOAuthStore.upsertUserProfile writes
+   * `externalId: profile.id`, and `profile.id` comes from the login cookie's
+   * `user.id`). So the cuid is recoverable from authoritative server state,
+   * keyed by an opaque identifier that is bound to the signed token.
+   *
+   * That is why no legacy email fallback is needed: previously-issued sessions
+   * keep working, and the mutable, IdP-supplied `email` claim never takes part
+   * in identity resolution.
+   */
+  private async resolveUserId(payload: any): Promise<string | undefined> {
+    const sub: string | undefined = payload?.sub;
+
+    // Modern tokens: `sub` is already the cuid. Emails are the only other
+    // shape we have ever put there, so an '@' is a reliable discriminator.
+    if (sub && !sub.includes('@')) return sub;
+
+    const profileId: string | undefined = payload?.user_profile_id;
+    if (profileId) {
+      const profile = await this.prisma.oAuthUserProfile.findUnique({
+        where: { profileId },
+        select: { externalId: true },
+      });
+      if (profile?.externalId) return profile.externalId;
+    }
+
+    // Legacy token with no recoverable profile → fail closed. Returning the
+    // email here would reintroduce the email-keyed lookup this method exists
+    // to remove.
+    return undefined;
   }
 }

--- a/packages/backend/src/auth/oauth-register-guard.middleware.spec.ts
+++ b/packages/backend/src/auth/oauth-register-guard.middleware.spec.ts
@@ -120,4 +120,51 @@ describe('OAuthRegisterGuardMiddleware', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
   });
+
+  describe('redirect_uri content validation', () => {
+    const register = (redirect_uris: unknown[]) => {
+      const next = jest.fn();
+      const res = makeRes();
+      guard.use(
+        makeReq({
+          headers: { 'content-type': 'application/json' },
+          body: { redirect_uris },
+        }),
+        res,
+        next,
+      );
+      return { next, res };
+    };
+
+    it.each([
+      ['a wildcard', 'https://*.evil.tld/cb'],
+      ['path traversal', 'https://example.com/cb/../../admin'],
+      ['a fragment', 'https://example.com/cb#t'],
+      ['cleartext http to a public host', 'http://example.com/cb'],
+    ])('rejects %s', (_label, uri) => {
+      const { next, res } = register([uri]);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(400);
+      expect((res.body as any).error).toBe('invalid_redirect_uri');
+    });
+
+    it('still accepts the URI shapes real MCP clients register', () => {
+      const { next, res } = register([
+        'https://claude.ai/api/mcp/auth_callback',
+        'http://localhost:33418/callback',
+        'vscode://anthropic.claude/authenticate',
+      ]);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('rejects the whole registration when any URI is bad', () => {
+      const { next, res } = register([
+        'https://claude.ai/api/mcp/auth_callback',
+        'https://*.evil.tld/cb',
+      ]);
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });

--- a/packages/backend/src/auth/oauth-register-guard.middleware.ts
+++ b/packages/backend/src/auth/oauth-register-guard.middleware.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
 import type { Request, Response, NextFunction } from 'express';
+import { validateRedirectUris } from './redirect-uri.util';
 
 /**
  * Guards the POST /register OAuth Dynamic Client Registration endpoint
@@ -72,6 +73,34 @@ export class OAuthRegisterGuardMiddleware implements NestMiddleware {
       return;
     }
 
+    // Content validation, not just shape. Registration here is open, so this
+    // cannot stop an attacker registering their own host — the consent screen
+    // is what does that. It does stop the cases where the URI itself is the
+    // weapon: wildcards, path traversal, fragments, and cleartext http to a
+    // non-loopback host. See redirect-uri.util.ts.
+    const rejections = validateRedirectUris(redirectUris);
+    if (rejections.length > 0) {
+      this.logger.warn(
+        `Rejecting /register: ${rejections
+          .map((r) => `'${r.uri}' ${r.reason}`)
+          .join('; ')}`,
+      );
+      res
+        .status(400)
+        .header('Content-Type', 'application/json')
+        .json({
+          error: 'invalid_redirect_uri',
+          error_description: rejections
+            .map((r) => `redirect_uri '${r.uri}': ${r.reason}`)
+            .join('; '),
+        });
+      return;
+    }
+
+    // Deliberately NOT audit-logged here: /register is unauthenticated and
+    // open, so writing a row per attempt would let anyone flood the security
+    // audit table. The detection value for the phishing class lives on the
+    // consent decision, which is behind a login.
     next();
   }
 }

--- a/packages/backend/src/auth/oauth-url-rewrite.interceptor.ts
+++ b/packages/backend/src/auth/oauth-url-rewrite.interceptor.ts
@@ -42,18 +42,56 @@ export class OAuthUrlRewriteInterceptor implements NestInterceptor {
 
     const externalUrl = `${proto}://${host}`;
 
-    // If the external URL matches the internal URL, no rewrite needed
-    if (externalUrl === internalUrl) {
-      return next.handle();
-    }
-
     return next.handle().pipe(
       map((data) => {
         if (!data || typeof data !== 'object') return data;
-        return JSON.parse(
-          JSON.stringify(data).replaceAll(internalUrl, externalUrl),
-        );
+        const rewritten =
+          externalUrl === internalUrl
+            ? data
+            : JSON.parse(
+                JSON.stringify(data).replaceAll(internalUrl, externalUrl),
+              );
+        return alignAuthorizationMetadata(rewritten, path);
       }),
     );
   }
+}
+
+/**
+ * Brings the ROOT discovery documents — which @rekog/mcp-nest builds itself —
+ * in line with what this server actually does.
+ *
+ * WellKnownOAuthController only owns the per-server variants
+ * (`/.well-known/oauth-authorization-server/mcp/:id` and friends). The root
+ * documents come from upstream, and most clients discover those first. Without
+ * this, the two disagree: the root one would still advertise `plain` PKCE that
+ * AuthorizePkceMiddleware refuses, and `offline_access` that the MCP
+ * 2026-07-28 spec says a resource should not list — so a client would follow
+ * the advertised contract and get a 400.
+ */
+export function alignAuthorizationMetadata(data: any, path: string): any {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return data;
+
+  const out = { ...data };
+
+  if (Array.isArray(out.code_challenge_methods_supported)) {
+    // We require S256; advertising `plain` would promise what we reject.
+    out.code_challenge_methods_supported = ['S256'];
+  }
+
+  // Refresh tokens are a client concern, not a requirement of the resource.
+  if (Array.isArray(out.scopes_supported)) {
+    out.scopes_supported = out.scopes_supported.filter(
+      (s: unknown) => s !== 'offline_access',
+    );
+  }
+
+  // RFC 9207. Only claim this on an authorization-SERVER document, and only
+  // because AuthorizationIssuerMiddleware really does append `iss`: a client
+  // that reads this flag and then sees a response without `iss` MUST reject it.
+  if (path.startsWith('/.well-known/oauth-authorization-server')) {
+    out.authorization_response_iss_parameter_supported = true;
+  }
+
+  return out;
 }

--- a/packages/backend/src/auth/redirect-uri.util.spec.ts
+++ b/packages/backend/src/auth/redirect-uri.util.spec.ts
@@ -1,0 +1,81 @@
+import { validateRedirectUri, validateRedirectUris } from './redirect-uri.util';
+
+describe('validateRedirectUri', () => {
+  const accepted = (uri: string) => expect(validateRedirectUri(uri)).toBeNull();
+  const rejected = (uri: string) => expect(validateRedirectUri(uri)).not.toBeNull();
+
+  describe('real MCP clients must keep working', () => {
+    // Breaking any of these locks users out of the product, so they are
+    // asserted explicitly rather than left to the general rules.
+    it.each([
+      ['claude.ai', 'https://claude.ai/api/mcp/auth_callback'],
+      ['Claude Desktop loopback', 'http://localhost:33418/callback'],
+      ['loopback by IP', 'http://127.0.0.1:8080/oauth/callback'],
+      ['IPv6 loopback', 'http://[::1]:8080/cb'],
+      ['VS Code private-use scheme', 'vscode://anthropic.claude/authenticate'],
+      ['Cursor private-use scheme', 'cursor://anysphere.cursor-mcp/callback'],
+      ['https with query', 'https://app.example.com/cb?tenant=acme'],
+    ])('accepts %s', (_label, uri) => accepted(uri));
+  });
+
+  describe('rejects URIs where the URI itself is the weapon', () => {
+    it('rejects wildcards', () => {
+      rejected('https://*.evil.tld/cb');
+      rejected('https://example.com/*');
+    });
+
+    it('rejects path traversal', () => {
+      rejected('https://example.com/cb/../../admin');
+    });
+
+    it('rejects fragments (RFC 6749 §3.1.2)', () => {
+      rejected('https://example.com/cb#token');
+    });
+
+    it('rejects cleartext http to a non-loopback host', () => {
+      // The authorization code would cross the network in the clear.
+      expect(validateRedirectUri('http://example.com/cb')).toMatch(/loopback/);
+      expect(validateRedirectUri('http://192.168.1.10/cb')).toMatch(/loopback/);
+    });
+
+    it('rejects non-absolute or empty values', () => {
+      rejected('/callback');
+      rejected('');
+      rejected('   ');
+      rejected(undefined as unknown as string);
+      rejected(42 as unknown as string);
+    });
+  });
+
+  describe('scope: what this deliberately does NOT block', () => {
+    it('accepts an attacker-controlled https host', () => {
+      // Registration is open, so this cannot be stopped here. The consent
+      // screen — which shows the destination host before a code is issued —
+      // is the control for this case. Asserted so nobody mistakes this
+      // validator for protection it does not provide.
+      accepted('https://evil.tld/steal');
+    });
+  });
+
+  describe('validateRedirectUris', () => {
+    it('returns no rejections when every URI is fine', () => {
+      expect(
+        validateRedirectUris(['https://a.example/cb', 'http://localhost:1/cb']),
+      ).toEqual([]);
+    });
+
+    it('collects every offending URI, not just the first', () => {
+      const rejections = validateRedirectUris([
+        'https://ok.example/cb',
+        'https://*.bad.tld/cb',
+        'http://plain.tld/cb',
+      ]);
+
+      expect(rejections).toHaveLength(2);
+      expect(rejections.map((r) => r.uri)).toEqual([
+        'https://*.bad.tld/cb',
+        'http://plain.tld/cb',
+      ]);
+    });
+  });
+});

--- a/packages/backend/src/auth/redirect-uri.util.ts
+++ b/packages/backend/src/auth/redirect-uri.util.ts
@@ -1,0 +1,88 @@
+/**
+ * Validation for OAuth `redirect_uri` values accepted through Dynamic Client
+ * Registration.
+ *
+ * SCOPE — be honest about what this does and does not buy:
+ *
+ * DCR on this server is open, so an attacker can always register a client
+ * pointing at a host they control (`https://evil.tld/cb`) and these rules will
+ * ALLOW it. The defence against that is the consent screen, which shows the
+ * user the destination host before any code is issued — not URI syntax.
+ *
+ * What this closes is the narrower set where the URI itself is the weapon:
+ *   - wildcards, which turn one registration into a family of destinations
+ *   - path traversal, which can escape a vetted callback path
+ *   - fragments, which OAuth forbids on a redirect target
+ *   - cleartext http to a non-loopback host, where the code is interceptable
+ *
+ * Private-use schemes (`vscode://`, `cursor://`, …) are permitted on purpose:
+ * RFC 8252 §7.1 makes them the standard mechanism for native clients, and
+ * rejecting them would lock out real MCP clients.
+ */
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', '[::1]', 'localhost']);
+
+export interface RedirectUriRejection {
+  uri: string;
+  reason: string;
+}
+
+/**
+ * Returns a rejection reason, or null when the URI is acceptable.
+ */
+export function validateRedirectUri(uri: unknown): string | null {
+  if (typeof uri !== 'string' || uri.trim() === '') {
+    return 'must be a non-empty string';
+  }
+
+  // Checked on the RAW string: a wildcard can sit in a position the URL parser
+  // would silently normalise or accept.
+  if (uri.includes('*')) {
+    return 'must not contain a wildcard';
+  }
+  if (uri.includes('..')) {
+    return 'must not contain a path traversal segment';
+  }
+  if (uri.includes('#')) {
+    return 'must not contain a fragment (RFC 6749 §3.1.2)';
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return 'must be an absolute URI';
+  }
+
+  const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
+
+  if (scheme === 'https') return null;
+
+  if (scheme === 'http') {
+    // RFC 8252 §7.3: cleartext loopback is the sanctioned native-client
+    // pattern. Anywhere else the authorization code crosses the network in
+    // the clear and is interceptable.
+    const host = parsed.hostname.toLowerCase();
+    return LOOPBACK_HOSTS.has(host)
+      ? null
+      : 'http is only allowed for loopback hosts (RFC 8252 §7.3); use https';
+  }
+
+  // Private-use scheme for a native client (RFC 8252 §7.1). Require it to look
+  // like a real scheme so a typo does not register something unusable.
+  if (/^[a-z][a-z0-9+.-]*$/.test(scheme)) return null;
+
+  return `unsupported URI scheme '${scheme}'`;
+}
+
+/** Validates a whole `redirect_uris` array, collecting every rejection. */
+export function validateRedirectUris(uris: unknown[]): RedirectUriRejection[] {
+  const rejections: RedirectUriRejection[] = [];
+  for (const uri of uris) {
+    const reason = validateRedirectUri(uri);
+    if (reason) {
+      rejections.push({ uri: typeof uri === 'string' ? uri : String(uri), reason });
+    }
+  }
+  return rejections;
+}

--- a/packages/backend/src/auth/resource-indicator.middleware.spec.ts
+++ b/packages/backend/src/auth/resource-indicator.middleware.spec.ts
@@ -1,0 +1,92 @@
+import {
+  ResourceIndicatorMiddleware,
+  parseServerId,
+  MCP_RESOURCE_COOKIE,
+} from './resource-indicator.middleware';
+
+describe('parseServerId', () => {
+  const CUID = 'cmpzj8mm9007j1ymn5mo2y3eq';
+
+  it('extracts the server id from a per-server resource', () => {
+    expect(parseServerId(`https://mcp.example.com/mcp/${CUID}`)).toBe(CUID);
+  });
+
+  it('returns null for the instance-wide resource', () => {
+    // This is what @rekog/mcp-nest records for every flow today.
+    expect(parseServerId('https://mcp.example.com/mcp')).toBeNull();
+  });
+
+  it.each([
+    ['a non-URL', 'not-a-url'],
+    ['an unrelated path', 'https://mcp.example.com/other/x'],
+    ['extra path segments', `https://mcp.example.com/mcp/${CUID}/extra`],
+    ['a traversal attempt', 'https://mcp.example.com/mcp/..%2Fadmin'],
+    ['a non-cuid id', 'https://mcp.example.com/mcp/short'],
+    ['an injection attempt', 'https://mcp.example.com/mcp/<script>'],
+  ])('returns null for %s', (_label, value) => {
+    expect(parseServerId(value)).toBeNull();
+  });
+});
+
+describe('ResourceIndicatorMiddleware', () => {
+  const CUID = 'cmpzj8mm9007j1ymn5mo2y3eq';
+  let middleware: ResourceIndicatorMiddleware;
+  let res: any;
+  let next: jest.Mock;
+
+  const req = (query: Record<string, unknown>, method = 'GET') =>
+    ({ method, query, headers: {}, secure: false }) as any;
+
+  beforeEach(() => {
+    middleware = new ResourceIndicatorMiddleware();
+    next = jest.fn();
+    res = { cookie: jest.fn(), clearCookie: jest.fn() };
+  });
+
+  it('stores the server id in a signed httpOnly cookie', () => {
+    middleware.use(
+      req({ resource: `https://mcp.example.com/mcp/${CUID}` }),
+      res,
+      next,
+    );
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      MCP_RESOURCE_COOKIE,
+      CUID,
+      expect.objectContaining({ httpOnly: true, signed: true }),
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('clears a stale cookie when the resource is the global one', () => {
+    // Otherwise a previous flow's server would still drive which identity
+    // provider buttons get rendered.
+    middleware.use(req({ resource: 'https://mcp.example.com/mcp' }), res, next);
+
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.clearCookie).toHaveBeenCalledWith(MCP_RESOURCE_COOKIE);
+  });
+
+  it('clears the cookie when no resource is sent at all', () => {
+    middleware.use(req({}), res, next);
+
+    expect(res.clearCookie).toHaveBeenCalledWith(MCP_RESOURCE_COOKIE);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('never lets a malformed resource reach the cookie', () => {
+    middleware.use(
+      req({ resource: 'https://mcp.example.com/mcp/<script>alert(1)</script>' }),
+      res,
+      next,
+    );
+
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('always calls next — it must never block the authorization flow', () => {
+    middleware.use(req({ resource: 12345 }), res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/auth/resource-indicator.middleware.ts
+++ b/packages/backend/src/auth/resource-indicator.middleware.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+
+/** Name of the signed cookie carrying the client's requested resource. */
+export const MCP_RESOURCE_COOKIE = 'mcp_resource';
+
+/**
+ * Captures the RFC 8707 `resource` indicator the client sends to /authorize.
+ *
+ * The MCP 2026-07-28 authorization spec makes `resource` mandatory on both the
+ * authorization and token requests, and tells clients to send "the most
+ * specific URI that they can" — explicitly blessing the
+ * `https://host/mcp/<serverId>` form when the path is what identifies an
+ * individual MCP server.
+ *
+ * @rekog/mcp-nest throws that away: its /authorize handler does
+ * `const resource = this.options.resource`, ignoring the query parameter, so
+ * every session and every token records the same instance-wide value. The
+ * consequence worth knowing is that token audiences are NOT per-server — a
+ * token minted for one workspace's server is audience-valid for another's, and
+ * only the application-level tenant check in McpEndpointController stops it.
+ * Fixing that properly means owning the authorization server; capturing the
+ * value here is the fork-free half we can do now.
+ *
+ * WHAT THIS VALUE MAY BE USED FOR: choosing which identity-provider button to
+ * render on the login page. Nothing else. It is unauthenticated client input —
+ * it must never influence which organization a session belongs to, which role
+ * a user receives, or any authorization decision. The authoritative org comes
+ * from the identity provider record after authentication.
+ *
+ * Stored in a signed, httpOnly cookie so it survives the redirect to
+ * /auth/login without a schema change, and cannot be forged by a script.
+ */
+@Injectable()
+export class ResourceIndicatorMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(ResourceIndicatorMiddleware.name);
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    if (req.method !== 'GET') return next();
+
+    const raw = (req.query as Record<string, unknown>).resource;
+    const serverId = typeof raw === 'string' ? parseServerId(raw) : null;
+
+    if (serverId) {
+      const isSecure =
+        req.secure || req.headers['x-forwarded-proto'] === 'https';
+      res.cookie(MCP_RESOURCE_COOKIE, serverId, {
+        httpOnly: true,
+        secure: isSecure,
+        // Long enough to survive the hop to the login page and back, short
+        // enough that a stale value cannot influence a later flow.
+        maxAge: 10 * 60 * 1000,
+        sameSite: isSecure ? 'none' : 'lax',
+        signed: true,
+      });
+    } else {
+      // Clear any value left by an earlier flow, so a previous server's IdP
+      // buttons are never shown for this one.
+      res.clearCookie(MCP_RESOURCE_COOKIE);
+    }
+
+    next();
+  }
+}
+
+/**
+ * Extracts the MCP server id from a resource indicator, or null when the value
+ * is the instance-wide `/mcp` resource or anything unrecognised.
+ *
+ * Only the shape is checked here. Whether the server exists — and which
+ * organization owns it — is resolved later, at the point of use.
+ */
+export function parseServerId(resource: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(resource);
+  } catch {
+    return null;
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  // Expect exactly ['mcp', '<serverId>']; bare ['mcp'] is the global resource.
+  if (segments.length !== 2 || segments[0] !== 'mcp') return null;
+
+  const serverId = segments[1];
+  // Server ids are cuids. Constrain the shape so a hostile value cannot be
+  // smuggled into a downstream lookup or a rendered page.
+  return /^[a-z0-9]{20,40}$/i.test(serverId) ? serverId : null;
+}

--- a/packages/backend/src/knowledge-graph/kg.service.ts
+++ b/packages/backend/src/knowledge-graph/kg.service.ts
@@ -40,7 +40,10 @@ export class KgService {
     organizationId: string,
     userId: string,
   ): Promise<string[] | null> {
-    const allowedToolIds = await this.roles.getAllowedToolIds(userId);
+    const allowedToolIds = await this.roles.getAllowedToolIds(
+      userId,
+      organizationId,
+    );
     if (allowedToolIds === null) return null;
     if (allowedToolIds.length === 0) return [];
     const tools = await this.prisma.mcpTool.findMany({

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -298,10 +298,15 @@ export class McpEndpointController {
     const allTools = this.toolRegistry.getAllTools();
     const serverTools = allTools.filter((t) => connectorIds.includes(t.connectorId));
 
-    // 4. Further filter by role-based access if user is identified
+    // 4. Further filter by role-based access if user is identified. Scope to
+    // THIS server's organization so the caller's role is read from their
+    // membership of it, not from the cached active-org role.
     let allowedToolIds: string[] | null = null;
     if (user?.sub) {
-      allowedToolIds = await this.rolesService.getAllowedToolIds(user.sub);
+      allowedToolIds = await this.rolesService.getAllowedToolIds(
+        user.sub,
+        mcpServerConfig.organizationId,
+      );
     }
 
     // 5. Create a per-request MCP server with only the assigned tools
@@ -357,6 +362,7 @@ export class McpEndpointController {
     if (McpSessionManager.isEnabled()) {
       await this.handleStatefulRequest(
         serverId,
+        mcpServerConfig.organizationId,
         req,
         res,
         body,
@@ -474,6 +480,7 @@ export class McpEndpointController {
    */
   private async handleStatefulRequest(
     serverId: string,
+    serverOrganizationId: string,
     req: Request,
     res: Response,
     body: unknown,
@@ -505,6 +512,7 @@ export class McpEndpointController {
           rebuild: this.makeRebuild(
             sid,
             serverId,
+            serverOrganizationId,
             user,
             captureIntent,
             kgEnabled,
@@ -559,6 +567,7 @@ export class McpEndpointController {
   private makeRebuild(
     sessionId: string,
     serverId: string,
+    serverOrganizationId: string,
     user: any,
     captureIntent: boolean,
     kgEnabled: boolean,
@@ -575,7 +584,13 @@ export class McpEndpointController {
         .filter((t) => connectorIds.includes(t.connectorId));
       let allowedToolIds: string[] | null = null;
       if (user?.sub) {
-        allowedToolIds = await this.rolesService.getAllowedToolIds(user.sub);
+        // Scope to the SERVER's org, not `invocationContext.organizationId`
+        // (which is the caller's active org and may differ for a multi-org
+        // member).
+        allowedToolIds = await this.rolesService.getAllowedToolIds(
+          user.sub,
+          serverOrganizationId,
+        );
       }
 
       const entries = this.planToolSet({

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -234,7 +234,13 @@ export class McpServerService implements OnModuleInit {
         // Check role-based tool access if user is identified
         const user = request?.user;
         if (user?.sub) {
-          const allowedToolIds = await this.rolesService.getAllowedToolIds(user.sub);
+          // Global /mcp registry: there is no server-scoped org here, so the
+          // caller's active org is the relevant one — same org used by
+          // getToolForOrg below.
+          const allowedToolIds = await this.rolesService.getAllowedToolIds(
+            user.sub,
+            user.organizationId,
+          );
           if (allowedToolIds !== null) {
             // User has restricted access — check if this tool is allowed.
             // Resolve by org first so we don't read the wrong org's tool

--- a/packages/backend/src/mcp-server/well-known-oauth.controller.ts
+++ b/packages/backend/src/mcp-server/well-known-oauth.controller.ts
@@ -57,8 +57,19 @@ export class WellKnownOAuthController {
         'client_secret_post',
         'none',
       ],
-      code_challenge_methods_supported: ['S256', 'plain'],
-      scopes_supported: ['offline_access'],
+      // `plain` is no longer accepted: AuthorizePkceMiddleware requires S256 on
+      // /authorize, so advertising `plain` would promise something we refuse.
+      code_challenge_methods_supported: ['S256'],
+      // RFC 9207: we append `iss` to authorization responses
+      // (AuthorizationIssuerMiddleware), so clients may validate it. Per the
+      // MCP 2026-07-28 authorization spec, a client that sees this set to true
+      // and NO `iss` in the response MUST reject that response — so this flag
+      // and the middleware have to ship together, and stay together.
+      authorization_response_iss_parameter_supported: true,
+      // MCP 2026-07-28: resource servers SHOULD NOT advertise `offline_access`
+      // here, because refresh tokens are a client concern and not a
+      // requirement of the resource. Clients that want one still request it.
+      scopes_supported: [],
       // Minimal OIDC fields so clients that probe openid-configuration accept
       // the document. Tokens are HS256-signed (symmetric), so there is no jwks_uri.
       subject_types_supported: ['public'],
@@ -70,8 +81,16 @@ export class WellKnownOAuthController {
     return {
       resource: `${base}${resourcePath}`,
       authorization_servers: [base],
-      scopes_supported: ['offline_access'],
+      // See the note in authServerMetadata: the MCP authorization spec says a
+      // protected resource SHOULD NOT list `offline_access` in scopes_supported.
+      scopes_supported: [],
       bearer_methods_supported: ['header'],
+      // `2025-06-18` remains first because it is what the transport in this
+      // build actually implements. `2026-07-28` removed protocol sessions, the
+      // initialize handshake and the GET endpoint, and added `server/discover`
+      // — that migration is a separate workstream; only its AUTHORIZATION
+      // requirements (RFC 9207 `iss`, S256 PKCE, resource indicators,
+      // scopes_supported) are honoured here.
       mcp_versions_supported: ['2025-06-18'],
     };
   }

--- a/packages/backend/src/roles/roles.service.spec.ts
+++ b/packages/backend/src/roles/roles.service.spec.ts
@@ -31,6 +31,9 @@ describe('RolesService', () => {
       mcpTool: {
         count: jest.fn(),
       },
+      organizationMember: {
+        findUnique: jest.fn(),
+      },
       $transaction: jest.fn(),
     };
     service = new RolesService(mockPrisma);
@@ -207,23 +210,93 @@ describe('RolesService', () => {
       expect(result).toEqual(['t1', 't2']);
     });
 
-    it('should fall back to email lookup when id lookup fails', async () => {
-      mockPrisma.user.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ role: 'ADMIN', mcpRoleId: null });
-      const result = await service.getAllowedToolIds('user@example.com');
-      expect(result).toBeNull();
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
-      expect(mockPrisma.user.findUnique).toHaveBeenLastCalledWith({
-        where: { email: 'user@example.com' },
-        select: { role: true, mcpRoleId: true },
+    it('reads the role from the membership of the org being acted on, not the cache', async () => {
+      // V3 regression guard. `users.role` is the cache of the ACTIVE org's
+      // role. In cloud every self-registered user is ADMIN of their own
+      // workspace, so reading the cache handed them the ADMIN bypass — and
+      // therefore EVERY tool — inside any other org they could reach.
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'ADMIN', // cached: ADMIN of their personal workspace
+        mcpRoleId: 'restricted-role',
+        organizationId: 'org-personal',
+      });
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({
+        role: 'VIEWER', // authoritative: only a VIEWER in the corporate org
+      });
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue([{ toolId: 't1' }]);
+
+      const result = await service.getAllowedToolIds('user-1', 'org-corporate');
+
+      expect(mockPrisma.organizationMember.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_organizationId: {
+            userId: 'user-1',
+            organizationId: 'org-corporate',
+          },
+        },
+        select: { role: true },
+      });
+      // Restricted to the role's whitelist — NOT null/unrestricted.
+      expect(result).toEqual(['t1']);
+    });
+
+    it('grants the ADMIN bypass only to an ADMIN of that same org', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'VIEWER',
+        mcpRoleId: 'restricted-role',
+        organizationId: 'org-a',
+      });
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({
+        role: 'ADMIN',
+      });
+
+      expect(await service.getAllowedToolIds('user-1', 'org-a')).toBeNull();
+    });
+
+    it('fails closed when the user is not a member of the org', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'ADMIN',
+        mcpRoleId: null,
+        organizationId: 'org-personal',
+      });
+      mockPrisma.organizationMember.findUnique.mockResolvedValue(null);
+
+      // Not null (unrestricted) and not the ADMIN bypass — no tools at all.
+      expect(await service.getAllowedToolIds('user-1', 'org-other')).toEqual([]);
+    });
+
+    it('falls back to the cached role when no org can be resolved', async () => {
+      // Self-host / instance-level path: no org context anywhere.
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'ADMIN',
+        mcpRoleId: null,
+        organizationId: null,
+      });
+
+      expect(await service.getAllowedToolIds('user-1')).toBeNull();
+      expect(mockPrisma.organizationMember.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('never falls back to an email lookup', async () => {
+      // SECURITY regression guard. The old implementation retried
+      // `findUnique({ where: { email: userId } })` when the id lookup missed,
+      // which made a mutable, IdP-supplied email a key for TOOL authorization:
+      // a token bearing a victim's address inherited the victim's grants.
+      // An email-shaped principal must now simply fail closed.
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.getAllowedToolIds('victim@example.com');
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'victim@example.com' },
+        select: { role: true, mcpRoleId: true, organizationId: true },
       });
     });
 
     it('should return empty array when user not found', async () => {
-      mockPrisma.user.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
       const result = await service.getAllowedToolIds('ghost');
       expect(result).toEqual([]);
     });

--- a/packages/backend/src/roles/roles.service.ts
+++ b/packages/backend/src/roles/roles.service.ts
@@ -137,25 +137,52 @@ export class RolesService {
    * Get the list of tool IDs a user is allowed to use.
    * Returns null if user has unrestricted access (no role assigned or ADMIN).
    */
-  async getAllowedToolIds(userId: string): Promise<string[] | null> {
-    // The MCP OAuth JWT sets `sub` to the user's email/username (not the DB UUID).
-    // Try lookup by ID first, then fall back to email.
-    let user = await this.prisma.user.findUnique({
+  async getAllowedToolIds(
+    userId: string,
+    organizationId?: string,
+  ): Promise<string[] | null> {
+    // SECURITY: `userId` is the `users.id` cuid on every auth path — app JWTs
+    // carry it in `sub`, and so do MCP OAuth tokens (LocalOAuthProvider maps
+    // the profile `username` to the cuid). There is deliberately NO fallback
+    // to `where: { email: userId }`: that turned a mutable, IdP-supplied email
+    // into a lookup key for tool authorization, so a token bearing a victim's
+    // email would inherit the victim's tool grants.
+    const user = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { role: true, mcpRoleId: true },
+      select: { role: true, mcpRoleId: true, organizationId: true },
     });
 
-    if (!user) {
-      user = await this.prisma.user.findUnique({
-        where: { email: userId },
-        select: { role: true, mcpRoleId: true },
-      });
-    }
-
+    // Unknown principal — fail closed (no tools), never `null`/unrestricted.
     if (!user) return [];
 
-    // ADMIN always has full access
-    if (user.role === 'ADMIN') return null;
+    // SECURITY: `users.role` is only a CACHE of the role in the user's active
+    // organization (OrganizationsService refreshes it on switchOrg). Reading it
+    // here granted unrestricted tool access across org boundaries: in cloud
+    // every self-registered user is ADMIN of their own workspace, so anyone who
+    // had ever signed up carried ADMIN in the cache and, when calling a
+    // corporate org's /mcp/:serverId where they are merely a VIEWER, matched
+    // the `=== 'ADMIN'` bypass below and received EVERY tool — straight past
+    // that org's ToolRoleAccess whitelist.
+    //
+    // The authoritative per-org role lives in organization_members, so resolve
+    // against the organization actually being acted on.
+    const orgId = organizationId ?? user.organizationId ?? null;
+    let effectiveRole: string = user.role;
+    if (orgId) {
+      const membership = await this.prisma.organizationMember.findUnique({
+        where: {
+          userId_organizationId: { userId, organizationId: orgId },
+        },
+        select: { role: true },
+      });
+      // Not a member of this org — fail closed. The endpoint-level tenant check
+      // denies this case first; this is defense in depth, not the only gate.
+      if (!membership) return [];
+      effectiveRole = membership.role;
+    }
+
+    // ADMIN of THIS organization always has full access
+    if (effectiveRole === 'ADMIN') return null;
 
     // No custom role = full access (backward compat)
     if (!user.mcpRoleId) return null;

--- a/packages/backend/src/users/users.controller.ts
+++ b/packages/backend/src/users/users.controller.ts
@@ -146,6 +146,15 @@ export class UsersController {
     const user = await this.usersService.findById(req.user.sub);
     if (!user) throw new UnauthorizedException('User not found');
 
+    // An IdP-provisioned user has no password to confirm with. Refuse rather
+    // than hand null to bcrypt — and rather than skip the confirmation, which
+    // would make account deletion a one-click action on a stolen session.
+    if (!user.passwordHash) {
+      throw new UnauthorizedException(
+        'This account has no password. Account deletion is not available for SSO-only accounts.',
+      );
+    }
+
     const isValid = await this.authService.comparePassword(dto.password, user.passwordHash);
     if (!isValid) throw new UnauthorizedException('Invalid password');
 
@@ -159,6 +168,15 @@ export class UsersController {
     const user = await this.usersService.findById(req.user.sub);
     if (!user) return { error: 'User not found' };
 
+    // SSO-only accounts must not be able to grow a password: that would create
+    // a second way in that bypasses the IdP's MFA and Conditional Access.
+    if (user.passwordLoginDisabled || !user.passwordHash) {
+      return {
+        error:
+          'Password sign-in is disabled for this account. Manage credentials through your organization sign-in.',
+      };
+    }
+
     const isValid = await this.authService.comparePassword(
       dto.currentPassword,
       user.passwordHash,
@@ -167,9 +185,19 @@ export class UsersController {
       return { error: 'Current password is incorrect' };
     }
 
+    // Revoke every session issued before now, exactly as the reset flow does.
+    // Changing a password is a "lock everyone else out" action; leaving old
+    // tokens alive would keep an attacker's session valid for up to 24h (longer
+    // on an MCP refresh token) after the user thinks they have shut it down.
     const newHash = await this.authService.hashPassword(dto.newPassword);
-    await this.usersService.update(req.user.sub, { passwordHash: newHash });
-    return { message: 'Password changed successfully' };
+    await this.usersService.update(req.user.sub, {
+      passwordHash: newHash,
+      sessionsValidFrom: new Date(),
+    });
+    return {
+      message:
+        'Password changed successfully. Other sessions have been signed out.',
+    };
   }
 
   // ── Admin endpoints ──────────────────────────────────────────────────────


### PR DESCRIPTION
Security hardening of the existing authentication and MCP authorization paths. No new user-facing features — this is the groundwork that the Microsoft Entra SSO work builds on, and it is deliberately released on its own so each fix can be verified in isolation.

## What this fixes

**Nothing could be revoked.** Tokens are stateless JWTs and `/revoke` was advertised but unimplemented, so a demoted user's session, a deprovisioned account and an MCP token all survived until natural expiry. `users.sessions_valid_from` is now a cutover instant: any token issued before it is refused. A timestamp rather than a counter, because MCP access tokens are minted by the library and cannot be asked to carry a custom claim — every JWT already has `iat`, so one field revokes both token families.

**MCP-issued tokens were accepted by the dashboard API.** The two token families are now separated: a token carrying MCP-only claims is rejected on the dashboard, and the MCP guard resolves the user id from `oauth_user_profiles.external_id` instead of trusting an email claim. Existing sessions keep working — `user_profile_id` is already written on every authorization code, so no client has to re-authenticate.

**Tool access could fail open.** `getAllowedToolIds` now reads the caller's role from `organization_members` and fails closed for a non-member, instead of falling back to the user's global role.

**PKCE was optional in practice.** The upstream `/authorize` validated a code challenge only when one happened to be present, and defaulted the method to `plain` — which, combined with open dynamic client registration, left authorization codes replayable. S256 is now required.

**Alignment with MCP 2026-07-28 authorization.** The client's RFC 8707 `resource` parameter is captured (upstream discards it) and the RFC 9207 `iss` parameter is appended to authorization responses, kept in step with `authorization_response_iss_parameter_supported` in the metadata.

**Malformed registration bodies crashed the server.** A `POST /register` without `redirect_uris` produced a 500 from inside the upstream controller; it is now rejected as a 4xx before reaching it.

## Audit trail

Adds `security_events`, an append-only trail for the authentication, authorization and consent planes. Writes are best-effort and never throw — failing to record an event must not be able to deny a legitimate request, nor hand an attacker a way to break a flow by breaking the write. Values are redacted by key, depth- and length-bounded so a hostile or accidental payload cannot bloat a row.

## Migrations

- `20260731120000_add_security_events`
- `20260731130000_add_session_revocation`

Both additive. `sessions_valid_from` is nullable and null means "nothing revoked", so existing rows need no backfill.

## Verification

Rebased onto current `main` (65 commits of drift) with no conflicts. 3714 tests pass; `tsc --noEmit` clean on backend and frontend. Migration timestamps sort after the newest on main.

Not yet verified against the cloud database — worth an audit of production rows before merge, since this changes behaviour on the MCP authorization path every tenant uses.