### PR TITLE
feat(sso): Microsoft Entra ID single sign-on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "concurrently": "^9.2.4"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -957,17 +957,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.3"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -18728,9 +18717,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -21118,6 +21107,15 @@
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
       "license": "MIT"
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.8",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.8.tgz",
+      "integrity": "sha512-8N28E+a/oxfXWBgOMt+ZP/JUf/XR+IFbvkAEPP3gznXOMv9BpAAwiIj0TFNz3tGTPc0ZQ8zmWBNgN1nAys0gng==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -21316,6 +21314,19 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.8.tgz",
+      "integrity": "sha512-ZsucJA5Ad04Uv7YN4ql+s4GXNmb9uAYQwyJTsJx7CH/MX3JZioLE2pVKi1SC+YrbSLA4Px3Gi30dMjgOZtb6pA==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.12",
+        "oauth4webapi": "^3.8.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -26459,6 +26470,7 @@
         "mysql2": "^3.24.3",
         "nestjs-pino": "^4.6.1",
         "nodemailer": "^8.0.11",
+        "openid-client": "^6.8.8",
         "oracledb": "^6.10.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12"
   },
   "workspaces": [
     "packages/backend",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -67,6 +67,7 @@
     "mysql2": "^3.24.3",
     "nestjs-pino": "^4.6.1",
     "nodemailer": "^8.0.11",
+    "openid-client": "^6.8.8",
     "oracledb": "^6.10.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/packages/backend/prisma/migrations/20260731140000_expand_user_roles_m2m/migration.sql
+++ b/packages/backend/prisma/migrations/20260731140000_expand_user_roles_m2m/migration.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- Migration: Expand User→Role to a per-organization many-to-many (user_roles)
+-- =============================================================================
+-- EXPAND phase. `users.mcp_role_id` and `invitation_tokens.mcp_role_id` are
+-- KEPT and dropped in a CONTRACT migration a release later. Dropping them now
+-- would break a still-running old container on every query against the User
+-- model — Prisma emits an explicit column list, never SELECT * — including the
+-- login path, and a redeploy would not restore the column.
+--
+-- Why `users.mcp_role_id` had to go:
+--   * single-valued — a user in several IdP groups must accumulate the UNION of
+--     those groups' tool whitelists;
+--   * GLOBAL — one role across every workspace, so per-org governance was
+--     impossible and one org's admin could overwrite another org's assignment.
+--
+-- NO sync trigger and NO dual-write, unlike the usual expand/contract recipe.
+-- Those protect live traffic on existing data during a rolling deploy, and that
+-- combination does not occur here: the cloud deploys rolling but holds zero
+-- rows (0 tool_role_access, 0 users with mcp_role_id — measured), while
+-- self-hosted installs may hold data but recreate the container rather than
+-- rolling. The backfill below is what serves those installs.
+-- =============================================================================
+
+CREATE TABLE "user_roles" (
+    "id"              TEXT NOT NULL,
+    "user_id"         TEXT NOT NULL,
+    "role_id"         TEXT NOT NULL,
+    -- Nullable by design: a null-org grant applies in every organization, which
+    -- is how a grant of an `is_system` role behaves. Forcing NOT NULL would
+    -- make the backfill drop rows it cannot attribute, and a dropped grant
+    -- fails OPEN (no grant at all = unrestricted), so strict would be weaker.
+    "organization_id" TEXT,
+    -- 'manual' = set by an admin, 'entra' = derived from an IdP group claim.
+    "source"          TEXT NOT NULL DEFAULT 'manual',
+    "external_ref"    TEXT,
+    "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_roles_pkey" PRIMARY KEY ("id")
+);
+
+-- `source` is part of the unique key so revoking an IdP-derived grant can never
+-- silently delete one an admin created by hand for the same (user, role).
+CREATE UNIQUE INDEX "user_roles_user_id_role_id_source_key"
+    ON "user_roles"("user_id", "role_id", "source");
+CREATE INDEX "user_roles_user_id_idx"         ON "user_roles"("user_id");
+CREATE INDEX "user_roles_role_id_idx"         ON "user_roles"("role_id");
+CREATE INDEX "user_roles_organization_id_idx" ON "user_roles"("organization_id");
+
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_role_id_fkey"
+    FOREIGN KEY ("role_id") REFERENCES "roles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Multi-role invitations. The scalar column stays for invites created by the
+-- previous release, which remain valid for their 48h lifetime.
+ALTER TABLE "invitation_tokens"
+    ADD COLUMN "mcp_role_ids" TEXT[] NOT NULL DEFAULT '{}';
+
+-- Backfill. A no-op on the cloud database (zero rows) and the whole point of
+-- this migration for self-hosted installs. `organization_id` falls back to the
+-- role's own org, and stays NULL when neither is known — which is exactly the
+-- "applies everywhere" semantics, so nothing is lost.
+INSERT INTO "user_roles" (id, user_id, role_id, organization_id, source, created_at)
+SELECT gen_random_uuid()::text,
+       u.id,
+       u.mcp_role_id,
+       COALESCE(u.organization_id, r.organization_id),
+       'manual',
+       u.updated_at
+FROM users u
+JOIN roles r ON r.id = u.mcp_role_id
+WHERE u.mcp_role_id IS NOT NULL
+ON CONFLICT ("user_id", "role_id", "source") DO NOTHING;
+
+UPDATE invitation_tokens
+SET mcp_role_ids = ARRAY[mcp_role_id]
+WHERE mcp_role_id IS NOT NULL AND used_at IS NULL;

--- a/packages/backend/prisma/migrations/20260731150000_add_identity_providers/migration.sql
+++ b/packages/backend/prisma/migrations/20260731150000_add_identity_providers/migration.sql
@@ -1,0 +1,87 @@
+-- =============================================================================
+-- Migration: Identity providers (SSO configuration) + role mappings
+-- =============================================================================
+-- Per-organization SSO configuration. Generic across provider types from the
+-- start: adding Google or Okta later must not require a migration on a table
+-- that carries authentication trust anchors. Per-type settings live in the
+-- `config` JSONB, validated by a Zod schema keyed on `type` — the same
+-- shape-in-Json approach the connector engines already use.
+--
+-- `organization_id` is the authority on which workspace a session belongs to,
+-- so it is never reassigned; the application layer treats it as immutable.
+--
+-- `client_secret_enc` holds AES-256-GCM ciphertext whose AAD is bound to
+-- (provider id, organization id), so a blob cannot be copied into another row
+-- and still decrypt. It is never returned by the API.
+--
+-- `initiate_id` is the opaque entry point for /sso/<id>. Deliberately not a
+-- readable slug: that would allow workspace enumeration, squatting on names
+-- like `admin`, and homoglyph typosquatting on the very URL a human is asked
+-- to trust.
+-- =============================================================================
+
+CREATE TYPE "IdentityProviderType" AS ENUM ('ENTRA', 'GOOGLE', 'OKTA', 'AUTH0', 'GITHUB', 'OIDC');
+CREATE TYPE "RoleSyncSource"       AS ENUM ('APP_ROLES', 'GROUPS');
+CREATE TYPE "RoleSyncFallback"     AS ENUM ('DENY_ALL', 'KEEP_EXISTING', 'DEFAULT_ROLE');
+
+CREATE TABLE "identity_providers" (
+    "id"                        TEXT NOT NULL,
+    "organization_id"           TEXT NOT NULL,
+    "type"                      "IdentityProviderType" NOT NULL,
+    "name"                      TEXT NOT NULL,
+    "is_active"                 BOOLEAN NOT NULL DEFAULT true,
+    "issuer"                    TEXT NOT NULL,
+    "client_id"                 TEXT NOT NULL,
+    "client_secret_enc"         TEXT,
+    "client_secret_expires_at"  TIMESTAMP(3),
+    "initiate_id"               TEXT NOT NULL,
+    "jit_provisioning"          BOOLEAN NOT NULL DEFAULT false,
+    -- Capped at VIEWER in the service layer, never ADMIN or EDITOR.
+    "jit_default_role"          "UserRole" NOT NULL DEFAULT 'VIEWER',
+    "role_sync_enabled"         BOOLEAN NOT NULL DEFAULT false,
+    "role_sync_source"          "RoleSyncSource" NOT NULL DEFAULT 'GROUPS',
+    -- DENY_ALL by default: the alternative fails OPEN, because a user with no
+    -- role assignment is unrestricted.
+    "role_sync_fallback"        "RoleSyncFallback" NOT NULL DEFAULT 'DENY_ALL',
+    "enforce_sso"               BOOLEAN NOT NULL DEFAULT false,
+    -- Guards `enforce_sso`: it cannot be switched on before a real sign-in has
+    -- succeeded, so a misconfiguration cannot lock a whole workspace out.
+    "last_successful_login_at"  TIMESTAMP(3),
+    "config"                    JSONB NOT NULL DEFAULT '{}',
+    "created_at"                TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"                TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "identity_providers_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "identity_providers_initiate_id_key"          ON "identity_providers"("initiate_id");
+CREATE UNIQUE INDEX "identity_providers_organization_id_name_key" ON "identity_providers"("organization_id", "name");
+CREATE INDEX "identity_providers_organization_id_idx"             ON "identity_providers"("organization_id");
+
+ALTER TABLE "identity_providers" ADD CONSTRAINT "identity_providers_organization_id_fkey"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Maps an external group / application role onto AnythingMCP roles.
+-- `external_id` is the group OBJECT ID or the app role `value`, never the
+-- display name: Microsoft states group names are not unique, so any user able
+-- to create a group could otherwise mint one matching a privileged mapping.
+CREATE TABLE "identity_provider_role_mappings" (
+    "id"           TEXT NOT NULL,
+    "provider_id"  TEXT NOT NULL,
+    "external_id"  TEXT NOT NULL,
+    "label"        TEXT,
+    "user_role"    "UserRole",
+    "mcp_role_ids" TEXT[] NOT NULL DEFAULT '{}',
+    "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"   TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "identity_provider_role_mappings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "identity_provider_role_mappings_provider_id_external_id_key"
+    ON "identity_provider_role_mappings"("provider_id", "external_id");
+CREATE INDEX "identity_provider_role_mappings_provider_id_idx"
+    ON "identity_provider_role_mappings"("provider_id");
+
+ALTER TABLE "identity_provider_role_mappings" ADD CONSTRAINT "identity_provider_role_mappings_provider_id_fkey"
+    FOREIGN KEY ("provider_id") REFERENCES "identity_providers"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/migrations/20260731160000_add_sso_login/migration.sql
+++ b/packages/backend/prisma/migrations/20260731160000_add_sso_login/migration.sql
@@ -1,0 +1,73 @@
+-- =============================================================================
+-- Migration: SSO sign-in — federated identities + per-attempt server state
+-- =============================================================================
+-- `user_identities` links a local user to an identity at an external provider.
+-- The key is (provider_id, external_subject) and NEVER the email: Entra's
+-- `mail` attribute is mutable, unverified and not unique, and Microsoft states
+-- plainly that it must not be used for authorization or as a primary
+-- identifier. Keying on it is the nOAuth vulnerability.
+--
+-- `sso_login_attempts` holds everything security-relevant for one round trip to
+-- the provider — the CSRF `state`, the replay-guarding `nonce` and the PKCE
+-- verifier — rather than putting it in a cookie that must survive the hop to
+-- the IdP and back. Consumed atomically exactly once.
+--
+-- The minted session token is never stored: on success the row records only
+-- `resolved_user_id`, and the JWT is created when the one-time `handoff_code`
+-- is exchanged. Nothing bearer-shaped sits at rest.
+-- =============================================================================
+
+CREATE TABLE "user_identities" (
+    "id"               TEXT NOT NULL,
+    "user_id"          TEXT NOT NULL,
+    "provider_id"      TEXT NOT NULL,
+    -- Entra: the `oid` claim.
+    "external_subject" TEXT NOT NULL,
+    -- Entra: the `tid` claim, so a tenant change becomes detectable.
+    "external_tid"     TEXT,
+    "last_login_at"    TIMESTAMP(3),
+    "created_at"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_identities_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "user_identities_provider_id_external_subject_key"
+    ON "user_identities"("provider_id", "external_subject");
+CREATE INDEX "user_identities_user_id_idx" ON "user_identities"("user_id");
+
+ALTER TABLE "user_identities" ADD CONSTRAINT "user_identities_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "user_identities" ADD CONSTRAINT "user_identities_provider_id_fkey"
+    FOREIGN KEY ("provider_id") REFERENCES "identity_providers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "sso_login_attempts" (
+    "id"                TEXT NOT NULL,
+    "state"             TEXT NOT NULL,
+    "nonce"             TEXT NOT NULL,
+    "code_verifier"     TEXT NOT NULL,
+    "provider_id"       TEXT NOT NULL,
+    "surface"           TEXT NOT NULL DEFAULT 'DASHBOARD',
+    -- Validated against an allowlist of internal paths before use; an
+    -- unchecked value here is an open redirect.
+    "return_to"         TEXT,
+    -- PR 4: recorded so the callback can ASSERT the browser is the same one
+    -- that started the MCP flow — never to restore the cookies, which would
+    -- reduce mcp-nest's only binding check to `x === x`.
+    "oauth_session_id"  TEXT,
+    "oauth_state_value" TEXT,
+    "handoff_code"      TEXT,
+    "resolved_user_id"  TEXT,
+    "expires_at"        TIMESTAMP(3) NOT NULL,
+    "consumed_at"       TIMESTAMP(3),
+    "created_at"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "sso_login_attempts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "sso_login_attempts_state_key"        ON "sso_login_attempts"("state");
+CREATE UNIQUE INDEX "sso_login_attempts_handoff_code_key" ON "sso_login_attempts"("handoff_code");
+CREATE INDEX "sso_login_attempts_provider_id_idx"         ON "sso_login_attempts"("provider_id");
+CREATE INDEX "sso_login_attempts_expires_at_idx"          ON "sso_login_attempts"("expires_at");
+
+ALTER TABLE "sso_login_attempts" ADD CONSTRAINT "sso_login_attempts_provider_id_fkey"
+    FOREIGN KEY ("provider_id") REFERENCES "identity_providers"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/migrations/20260907130000_add_sso_identity_linking/migration.sql
+++ b/packages/backend/prisma/migrations/20260907130000_add_sso_identity_linking/migration.sql
@@ -1,0 +1,27 @@
+-- =============================================================================
+-- Migration: link an existing account to an external identity
+-- =============================================================================
+-- With just-in-time provisioning off — the default, and the safe one — a member
+-- who already has an account could never sign in through the provider: the
+-- callback looks up `user_identities` by (provider_id, external_subject), finds
+-- nothing, and refuses. Deliberately so, because the alternative is matching on
+-- the IdP-supplied email, which is the nOAuth takeover.
+--
+-- The missing half is an explicit, authenticated link. `link_user_id` records
+-- WHO started that round trip, taken from their session at start time. It is
+-- never read from the callback: everything arriving there is under the control
+-- of whoever holds the authorization code.
+-- =============================================================================
+
+ALTER TABLE "sso_login_attempts" ADD COLUMN "link_user_id" TEXT;
+
+-- One identity per provider per user. Without it a user could accumulate
+-- several accounts at the same provider and `DELETE /link/:providerId` would
+-- have no single row to remove, silently leaving one behind — an unlink that
+-- reports success while access survives.
+--
+-- Safe to add unconditionally: the feature has never shipped, so no row exists
+-- that could violate it. Should that ever stop being true, this statement fails
+-- loudly rather than dropping data.
+CREATE UNIQUE INDEX "user_identities_user_id_provider_id_key"
+    ON "user_identities"("user_id", "provider_id");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -148,6 +148,7 @@ model User {
   mcpRole   Role?   @relation(fields: [mcpRoleId], references: [id], onDelete: SetNull)
 
   roleAssignments          UserRoleAssignment[]
+  identities               UserIdentity[]
   securityEventsAsActor    SecurityEvent[] @relation("SecurityEventActor")
   securityEventsAsTarget   SecurityEvent[] @relation("SecurityEventTarget")
 
@@ -746,7 +747,9 @@ model IdentityProvider {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  roleMappings IdentityProviderRoleMapping[]
+  roleMappings  IdentityProviderRoleMapping[]
+  identities    UserIdentity[]
+  loginAttempts SsoLoginAttempt[]
 
   @@unique([organizationId, name])
   @@index([organizationId])
@@ -777,6 +780,91 @@ model IdentityProviderRoleMapping {
   @@unique([providerId, externalId])
   @@index([providerId])
   @@map("identity_provider_role_mappings")
+}
+
+/// Links a local user to an identity at an external provider.
+///
+/// SECURITY: the key is (provider, externalSubject) — NEVER the email. Entra's
+/// `mail` attribute is mutable, unverified and not unique, and Microsoft is
+/// explicit that it must not be used for authorization or as a primary
+/// identifier. Keying on it is the nOAuth vulnerability.
+model UserIdentity {
+  id     String @id @default(cuid())
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  providerId String           @map("provider_id")
+  provider   IdentityProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+
+  /// The provider's immutable subject. Entra: the `oid` claim.
+  externalSubject String  @map("external_subject")
+  /// Entra: the `tid` claim. Stored so a tenant change becomes detectable.
+  externalTid     String? @map("external_tid")
+
+  lastLoginAt DateTime? @map("last_login_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+
+  @@unique([providerId, externalSubject])
+  /// One identity per provider per user. Without this a user could accumulate
+  /// several accounts at the same provider, and `DELETE /link/:providerId`
+  /// would have no single row to remove — deprovisioning would silently leave
+  /// one of them behind.
+  @@unique([userId, providerId])
+  @@index([userId])
+  @@map("user_identities")
+}
+
+/// Server-side state for one round trip to the identity provider.
+///
+/// Everything security-relevant lives here rather than in a cookie that has to
+/// survive the hop to the IdP and back: the CSRF `state`, the replay-guarding
+/// `nonce`, and the PKCE verifier. Consumed atomically exactly once.
+model SsoLoginAttempt {
+  id String @id @default(cuid())
+
+  /// Opaque, single-use. Echoed by the provider and matched on return.
+  state        String @unique
+  /// Compared against the id_token `nonce` claim to stop token replay.
+  nonce        String
+  /// PKCE (S256). Never leaves the server.
+  codeVerifier String @map("code_verifier")
+
+  providerId String           @map("provider_id")
+  provider   IdentityProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+
+  /// 'DASHBOARD', 'LINK' or 'MCP'. The MCP surface lands in PR 4.
+  surface String @default("DASHBOARD")
+
+  /// LINK only: the already-authenticated user this round trip will attach the
+  /// external identity to. Captured when the flow STARTS, from the JWT — never
+  /// from the callback, where an attacker controls what comes back. A null here
+  /// on a LINK attempt is a bug, and the callback refuses rather than guessing.
+  linkUserId String? @map("link_user_id")
+
+  /// Internal path to return to. Validated against an allowlist before use —
+  /// an unchecked value here is an open redirect.
+  returnTo String? @map("return_to")
+
+  /// PR 4: the pending mcp-nest cookie values, recorded so the callback can
+  /// ASSERT the browser is the same one that started the flow. Deliberately
+  /// not for restoring them — re-planting both would turn mcp-nest's only
+  /// binding check into `x === x` and create a session-fixation primitive.
+  oauthSessionId  String? @map("oauth_session_id")
+  oauthStateValue String? @map("oauth_state_value")
+
+  /// Set once authentication has succeeded: a one-time code the SPA exchanges
+  /// for a session. The JWT itself is never stored — it is minted at exchange
+  /// time from `resolvedUserId`, so no token sits at rest.
+  handoffCode    String? @unique @map("handoff_code")
+  resolvedUserId String? @map("resolved_user_id")
+
+  expiresAt  DateTime  @map("expires_at")
+  consumedAt DateTime? @map("consumed_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  @@index([providerId])
+  @@index([expiresAt])
+  @@map("sso_login_attempts")
 }
 
 // ── Security Audit Log ──────────────────────────────────────────────────────

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Organization {
   kgValueSeen      KgValueSeen[]
   kgSkills         KgSkillSuggestion[]
   securityEvents   SecurityEvent[]
+  userRoleAssignments UserRoleAssignment[]
 
   @@map("organizations")
 }
@@ -138,10 +139,14 @@ model User {
   // could set a password and walk straight past SSO, MFA and Conditional Access.
   passwordLoginDisabled Boolean @default(false) @map("password_login_disabled")
 
-  // MCP tool governance — optional custom role for tool access control
+  // MCP tool governance.
+  /// @deprecated Single, GLOBAL role. Superseded by `roleAssignments`
+  /// (per-organization, many-to-many). Still written so a rollback to the
+  /// previous release keeps working; dropped in the contract migration.
   mcpRoleId String? @map("mcp_role_id")
   mcpRole   Role?   @relation(fields: [mcpRoleId], references: [id], onDelete: SetNull)
 
+  roleAssignments          UserRoleAssignment[]
   securityEventsAsActor    SecurityEvent[] @relation("SecurityEventActor")
   securityEventsAsTarget   SecurityEvent[] @relation("SecurityEventTarget")
 
@@ -226,7 +231,10 @@ model InvitationToken {
   email          String
   token          String    @unique
   role           UserRole  @default(EDITOR)
+  /// @deprecated Superseded by `mcpRoleIds`; kept for invites created by the
+  /// previous release, which stay valid for their 48h lifetime.
   mcpRoleId      String?   @map("mcp_role_id")
+  mcpRoleIds     String[]  @default([]) @map("mcp_role_ids")
   invitedBy      String    @map("invited_by") // admin user id
   organizationId String    @map("organization_id")
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -249,11 +257,53 @@ model Role {
   createdAt      DateTime      @default(now()) @map("created_at")
   updatedAt      DateTime      @updatedAt @map("updated_at")
 
-  users      User[]
-  toolAccess ToolRoleAccess[]
+  /// @deprecated Single-FK back-relation of `User.mcpRoleId`. Superseded by
+  /// `assignments`; removed with the column in the contract migration.
+  users       User[]
+  assignments UserRoleAssignment[]
+  toolAccess  ToolRoleAccess[]
 
   @@unique([organizationId, name])
   @@map("roles")
+}
+
+// ── User ↔ Role (per-organization, many-to-many) ────────────────────────────
+// Replaces the single `users.mcp_role_id` FK, which was both single-valued and
+// GLOBAL: a user could hold one MCP role across every workspace they belonged
+// to, so per-org governance was structurally impossible and one org's admin
+// could overwrite another's assignment.
+//
+// A user in several Entra groups must accumulate the UNION of those groups'
+// tool whitelists, which a single FK cannot express either.
+model UserRoleAssignment {
+  id     String @id @default(cuid())
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  roleId String @map("role_id")
+  role   Role   @relation(fields: [roleId], references: [id], onDelete: Cascade)
+
+  // NULLABLE on purpose. A null-org grant applies in every organization, which
+  // is how a grant of an `isSystem` role behaves. Forcing NOT NULL would mean
+  // the backfill has to drop rows it cannot attribute — and dropping a grant
+  // fails OPEN here (no grant at all = unrestricted), so a stricter column
+  // would be the less safe choice.
+  organizationId String?       @map("organization_id")
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  /// 'manual' = set by an admin, 'entra' = derived from an IdP group claim.
+  /// Part of the unique key so that revoking an IdP-derived grant can never
+  /// silently delete one an admin made by hand.
+  source      String  @default("manual")
+  /// Provenance for synced grants — the Entra group object id or app role.
+  externalRef String? @map("external_ref")
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([userId, roleId, source])
+  @@index([userId])
+  @@index([roleId])
+  @@index([organizationId])
+  @@map("user_roles")
 }
 
 // ── Tool ↔ Role Access (whitelist) ──────────────────────────────────────────

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Organization {
   kgSkills         KgSkillSuggestion[]
   securityEvents   SecurityEvent[]
   userRoleAssignments UserRoleAssignment[]
+  identityProviders   IdentityProvider[]
 
   @@map("organizations")
 }
@@ -647,6 +648,135 @@ model ToolInvocation {
   @@index([organizationId, createdAt])
   @@index([connectorId, createdAt])
   @@map("tool_invocations")
+}
+
+// ── Identity Providers (SSO) ────────────────────────────────────────────────
+
+enum IdentityProviderType {
+  ENTRA
+  GOOGLE
+  OKTA
+  AUTH0
+  GITHUB
+  /// Any spec-compliant OIDC provider (Keycloak, …). Self-host only: a
+  /// free-form issuer supplied by a workspace admin is a server-side fetch to
+  /// a host they choose, which is a disproportionate surface in cloud.
+  OIDC
+}
+
+/// What a role sync reads. Which values are meaningful depends on the type —
+/// Entra can emit app roles or group object ids, GitHub has neither and uses
+/// org teams.
+enum RoleSyncSource {
+  APP_ROLES
+  GROUPS
+}
+
+/// What to do when no mapping matches the claims presented at login.
+enum RoleSyncFallback {
+  /// Grant nothing. Default: the alternative fails OPEN, because a user with
+  /// no role assignment is unrestricted.
+  DENY_ALL
+  KEEP_EXISTING
+  DEFAULT_ROLE
+}
+
+model IdentityProvider {
+  id String @id @default(cuid())
+
+  /// IMMUTABLE. The provider — not the request — is the authority on which
+  /// organization a session belongs to, so this may never be reassigned.
+  organizationId String       @map("organization_id")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  type     IdentityProviderType
+  /// Shown on the sign-in button.
+  name     String
+  isActive Boolean              @default(true) @map("is_active")
+
+  /// Exact issuer expected in the id_token. Derived from `config.tenantId` for
+  /// ENTRA, fixed for GOOGLE/GITHUB, admin-supplied for OKTA/AUTH0/OIDC — and
+  /// always validated against a hardcoded per-type host allowlist before use.
+  issuer String
+
+  clientId        String  @map("client_id")
+  /// AES-256-GCM, with the AAD bound to (provider, organization) so a
+  /// ciphertext cannot be replayed into another row. Never returned by the API.
+  clientSecretEnc String? @map("client_secret_enc")
+  /// Microsoft caps secrets at 24 months and recommends under 12; surfaced in
+  /// the UI so an expiry does not lock a whole workspace out by surprise.
+  clientSecretExpiresAt DateTime? @map("client_secret_expires_at")
+
+  /// Opaque entry point for /sso/<initiateId>. The route itself lands in PR 3;
+  /// generated here so it is stable from the moment a provider exists. There is
+  /// no rotation endpoint yet — deleting and recreating the provider is the
+  /// only way to change it today. Deliberately NOT a
+  /// readable slug — that would allow workspace enumeration, squatting on
+  /// names like `admin`, and homoglyph typosquatting on the very URL a human
+  /// is asked to trust.
+  initiateId String @unique @map("initiate_id")
+
+  /// Provision an account on first successful sign-in. Default OFF: with it on,
+  /// everyone in the external tenant can enter the workspace.
+  jitProvisioning Boolean  @default(false) @map("jit_provisioning")
+  /// Capped at VIEWER in the service layer — never ADMIN or EDITOR.
+  jitDefaultRole  UserRole @default(VIEWER) @map("jit_default_role")
+
+  roleSyncEnabled  Boolean          @default(false) @map("role_sync_enabled")
+  roleSyncSource   RoleSyncSource   @default(GROUPS) @map("role_sync_source")
+  roleSyncFallback RoleSyncFallback @default(DENY_ALL) @map("role_sync_fallback")
+
+  /// PLACEHOLDER — column exists, NOTHING reads or writes it yet (PR 6).
+  /// Intended to disable password sign-in for members of this organization.
+  /// Deliberately not exposed by the API: switching it on without the recovery
+  /// codes and the soak period below would let an admin lock a whole workspace
+  /// out with no way back in.
+  enforceSso Boolean @default(false) @map("enforce_sso")
+  /// PLACEHOLDER — written by the SSO login flow (PR 3), unused until then.
+  /// Will guard `enforceSso`: it cannot be switched on until a real sign-in
+  /// through this provider has succeeded.
+  lastSuccessfulLoginAt DateTime? @map("last_successful_login_at")
+
+  /// Per-type settings, validated by a Zod schema keyed on `type` — the same
+  /// shape-in-Json approach as connector engines. ENTRA: { tenantId }.
+  /// OKTA: { authorizationServerId? }. AUTH0: { rolesClaimNamespace }.
+  /// GITHUB: { organization? }. OIDC: { groupsClaimName? }.
+  config Json @default("{}")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  roleMappings IdentityProviderRoleMapping[]
+
+  @@unique([organizationId, name])
+  @@index([organizationId])
+  @@map("identity_providers")
+}
+
+/// Maps an external group or application role onto AnythingMCP roles.
+model IdentityProviderRoleMapping {
+  id         String           @id @default(cuid())
+  providerId String           @map("provider_id")
+  provider   IdentityProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+
+  /// The group's OBJECT ID or the app role's `value` — never the display name.
+  /// Microsoft is explicit that group names are not unique, so any user able to
+  /// create a group could otherwise mint one matching a privileged mapping.
+  externalId String  @map("external_id")
+  /// Display-only, for the admin UI. Carries no authorization meaning.
+  label      String?
+
+  /// Organization role granted by this mapping. Null leaves it untouched.
+  userRole UserRole? @map("user_role")
+  /// MCP role ids granted. The user receives the UNION across all matches.
+  mcpRoleIds String[] @default([]) @map("mcp_role_ids")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([providerId, externalId])
+  @@index([providerId])
+  @@map("identity_provider_role_mappings")
 }
 
 // ── Security Audit Log ──────────────────────────────────────────────────────

--- a/packages/backend/scripts/seed-entra-idp.ts
+++ b/packages/backend/scripts/seed-entra-idp.ts
@@ -1,0 +1,81 @@
+/**
+ * DEV ONLY — seeds an Entra identity provider from environment variables.
+ *
+ * The product configures identity providers through the dashboard and stores
+ * them in the database; there is deliberately no env-var path at runtime. This
+ * script exists purely so a developer does not have to retype a client secret
+ * into the UI after every database reset. It writes through the same service
+ * as the UI, so the secret is encrypted with the same AAD binding and the same
+ * validation applies — it is an input channel, not a second source of truth.
+ *
+ *   ENTRA_SSO_TENANT_ID       tenant GUID
+ *   ENTRA_SSO_CLIENT_ID       application (client) id
+ *   ENTRA_SSO_CLIENT_SECRET   the secret VALUE (never logged by this script)
+ *   ENTRA_SSO_CLIENT_SECRET_EXPIRY_DATE   ISO date, optional
+ *   ENTRA_SSO_ORG_ID          target organization; defaults to the oldest one
+ *
+ * Usage:  npx tsx scripts/seed-entra-idp.ts
+ */
+import { PrismaClient } from '../src/generated/prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { IdentityProvidersService } from '../src/identity-providers/identity-providers.service';
+import { DeploymentService } from '../src/common/deployment.service';
+
+async function main() {
+  const required = ['ENTRA_SSO_TENANT_ID', 'ENTRA_SSO_CLIENT_ID', 'ENTRA_SSO_CLIENT_SECRET'];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length) {
+    console.error(`Missing environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+  });
+  const service = new IdentityProvidersService(
+    prisma as any,
+    new DeploymentService(),
+  );
+
+  const orgId =
+    process.env.ENTRA_SSO_ORG_ID ??
+    (await prisma.organization.findFirst({ orderBy: { createdAt: 'asc' }, select: { id: true } }))?.id;
+  if (!orgId) {
+    console.error('No organization found. Create one first.');
+    process.exit(1);
+  }
+
+  const input = {
+    type: 'ENTRA' as const,
+    name: process.env.ENTRA_SSO_NAME ?? 'Sign in with Microsoft',
+    clientId: process.env.ENTRA_SSO_CLIENT_ID!,
+    clientSecret: process.env.ENTRA_SSO_CLIENT_SECRET!,
+    clientSecretExpiresAt: process.env.ENTRA_SSO_CLIENT_SECRET_EXPIRY_DATE || undefined,
+    config: { tenantId: process.env.ENTRA_SSO_TENANT_ID! },
+    jitProvisioning: process.env.ENTRA_SSO_JIT === 'true',
+    jitDefaultRole: process.env.ENTRA_SSO_JIT === 'true' ? ('VIEWER' as const) : undefined,
+  };
+
+  const existing = await prisma.identityProvider.findFirst({
+    where: { organizationId: orgId, type: 'ENTRA' },
+    select: { id: true },
+  });
+
+  const result = existing
+    ? await service.update(existing.id, orgId, input)
+    : await service.create(orgId, input);
+
+  // Never print the secret — only the identifiers, which are public.
+  console.log(existing ? 'Updated Entra provider:' : 'Created Entra provider:');
+  console.log(`  organization : ${orgId}`);
+  console.log(`  issuer       : ${result?.issuer}`);
+  console.log(`  JIT          : ${result?.jitProvisioning ? 'on (VIEWER)' : 'off'}`);
+  console.log(`  sign-in link : /sso/${result?.initiateId}`);
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { OAuthRegisterGuardMiddleware } from './auth/oauth-register-guard.middle
 import { AuthorizePkceMiddleware } from './auth/authorize-pkce.middleware';
 import { ResourceIndicatorMiddleware } from './auth/resource-indicator.middleware';
 import { AuthorizationIssuerMiddleware } from './auth/authorization-issuer.middleware';
+import { IdentityProvidersModule } from './identity-providers/identity-providers.module';
 import { LocalOAuthProvider } from './auth/local-oauth.provider';
 import { PrismaOAuthStore } from './auth/prisma-oauth.store';
 import { PrismaService } from './common/prisma.service';
@@ -118,6 +119,7 @@ if (useOAuth) {
 
     OrganizationsModule,
     AuditModule,
+    IdentityProvidersModule,
     HealthModule,
     SettingsModule,
     RolesModule,

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -18,7 +18,7 @@ import {
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { Throttle } from '@nestjs/throttler';
-import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsBoolean, Equals, Matches } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsBoolean, Equals, Matches, IsArray } from 'class-validator';
 import { UserRole } from '../generated/prisma/client';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
@@ -32,6 +32,7 @@ import { SiteSettingsService } from '../settings/site-settings.service';
 import { OrganizationsService } from '../organizations/organizations.service';
 import { SecurityEventService, SecurityEvents } from '../audit/security-event.service';
 import { LicenseService } from '../license/license.service';
+import { RolesService } from '../roles/roles.service';
 import { Roles, RolesGuard } from './roles.guard';
 
 class LoginDto {
@@ -115,6 +116,16 @@ class InviteUserDto {
   @IsOptional()
   @IsString()
   mcpRoleId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'MCP role ids to attach. Supersedes mcpRoleId; the invitee receives the UNION of these roles\' tool whitelists.',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mcpRoleIds?: string[];
 }
 
 class AcceptInviteDto {
@@ -149,6 +160,7 @@ export class AuthController {
     private readonly organizationsService: OrganizationsService,
     private readonly licenseService: LicenseService,
     private readonly securityEvents: SecurityEventService,
+    private readonly rolesService: RolesService,
   ) {}
 
   private getFrontendUrl(_req?: any): string {
@@ -499,6 +511,12 @@ export class AuthController {
       ? existingInvite.token
       : crypto.randomBytes(32).toString('hex');
 
+    // `mcpRoleIds` supersedes the single `mcpRoleId`; accept either so an older
+    // frontend bundle keeps working.
+    const invitedMcpRoleIds = [
+      ...new Set(dto.mcpRoleIds ?? (dto.mcpRoleId ? [dto.mcpRoleId] : [])),
+    ];
+
     if (!existingInvite) {
       const expiresAt = new Date(Date.now() + 48 * 60 * 60 * 1000); // 48 hours
       await this.prisma.invitationToken.create({
@@ -506,7 +524,8 @@ export class AuthController {
           email: dto.email,
           token: inviteToken,
           role: dto.role,
-          mcpRoleId: dto.mcpRoleId || null,
+          mcpRoleId: invitedMcpRoleIds[0] ?? null,
+          mcpRoleIds: invitedMcpRoleIds,
           invitedBy: req.user.sub,
           organizationId: req.user.organizationId,
           expiresAt,
@@ -527,9 +546,14 @@ export class AuthController {
 
     // Build role label
     let roleName: string = dto.role;
-    if (dto.mcpRoleId) {
-      const mcpRole = await this.prisma.role.findUnique({ where: { id: dto.mcpRoleId } });
-      if (mcpRole) roleName = `${dto.role} (MCP: ${mcpRole.name})`;
+    if (invitedMcpRoleIds.length > 0) {
+      const mcpRoles = await this.prisma.role.findMany({
+        where: { id: { in: invitedMcpRoleIds } },
+        select: { name: true },
+      });
+      if (mcpRoles.length > 0) {
+        roleName = `${dto.role} (MCP: ${mcpRoles.map((r) => r.name).join(', ')})`;
+      }
     }
 
     // Send email
@@ -617,11 +641,25 @@ export class AuthController {
 
       // Create default MCP server for new user
       await this.mcpServersService.createDefaultForUser(user.id, invite.organizationId);
+    }
 
-      // Assign MCP role if specified
-      if (invite.mcpRoleId) {
-        await this.usersService.update(user.id, { mcpRoleId: invite.mcpRoleId });
-      }
+    // Apply the MCP roles the inviting admin chose. This sits OUTSIDE the
+    // branch on purpose: it used to live in the new-user path only, so an
+    // EXISTING user joining a second organization silently lost the roles the
+    // admin had selected — and losing a role fails OPEN here (no role at all
+    // means unrestricted), which is the wrong direction to fail.
+    const invitedRoleIds =
+      invite.mcpRoleIds.length > 0
+        ? invite.mcpRoleIds
+        : invite.mcpRoleId
+          ? [invite.mcpRoleId]
+          : [];
+    if (invitedRoleIds.length > 0) {
+      await this.rolesService.setUserRoles(
+        user.id,
+        invitedRoleIds,
+        invite.organizationId,
+      );
     }
 
     // Mark invitation as used

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -18,6 +18,7 @@ import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 import { OrganizationsModule } from '../organizations/organizations.module';
 import { LicenseModule } from '../license/license.module';
 import { getRequiredSecret } from '../common/secrets.util';
+import { IdentityProvidersModule } from '../identity-providers/identity-providers.module';
 
 @Global()
 @Module({
@@ -27,6 +28,9 @@ import { getRequiredSecret } from '../common/secrets.util';
     McpServersModule,
     OrganizationsModule,
     LicenseModule,
+    // LoginController offers the workspace's identity providers on the MCP
+    // authorization page, so it needs SsoService.
+    IdentityProvidersModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/packages/backend/src/auth/login.controller.spec.ts
+++ b/packages/backend/src/auth/login.controller.spec.ts
@@ -1,4 +1,9 @@
+// `openid-client` is ESM-only and this suite reaches it transitively through
+// LoginController -> SsoService. Nothing here exercises the network half.
+jest.mock('openid-client', () => ({}));
+
 import { LoginController } from './login.controller';
+import type { SsoService } from '../identity-providers/sso.service';
 import type { Request, Response } from 'express';
 import type { AuthService } from './auth.service';
 import type { PrismaService } from '../common/prisma.service';
@@ -67,17 +72,21 @@ describe('LoginController', () => {
     Pick<PrismaOAuthStore, 'getOAuthSession' | 'getClient'>
   >;
 
+  let sso: { startMcp: jest.Mock };
+
   beforeEach(() => {
     authService = { comparePassword: jest.fn() };
     prisma = { user: { findUnique: jest.fn() } };
     config = { get: jest.fn().mockReturnValue(undefined) };
     store = { getOAuthSession: jest.fn(), getClient: jest.fn() };
+    sso = { startMcp: jest.fn() };
 
     controller = new LoginController(
       authService as unknown as AuthService,
       prisma as unknown as PrismaService,
       config as unknown as ConfigService,
       store as unknown as PrismaOAuthStore,
+      sso as unknown as SsoService,
     );
   });
 

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -15,6 +15,8 @@ import { randomBytes, timingSafeEqual } from 'crypto';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../common/prisma.service';
 import { PrismaOAuthStore } from './prisma-oauth.store';
+import { SsoService } from '../identity-providers/sso.service';
+import { MCP_RESOURCE_COOKIE } from './resource-indicator.middleware';
 
 /**
  * Context describing the OAuth client that initiated the current authorize
@@ -38,6 +40,7 @@ export class LoginController {
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
     private readonly oauthStore: PrismaOAuthStore,
+    private readonly sso: SsoService,
   ) {}
 
   @Get('login')
@@ -67,8 +70,12 @@ export class LoginController {
       signed: true,
     });
 
+    const ssoProviders = await this.loadSsoProviders(req);
+
     res.setHeader('Content-Type', 'text/html');
-    res.send(this.renderLoginPage({ error, serverName, consent, csrfToken }));
+    res.send(
+      this.renderLoginPage({ error, serverName, consent, csrfToken, ssoProviders }),
+    );
   }
 
   @Post('login')
@@ -105,6 +112,27 @@ export class LoginController {
       res.clearCookie('oauth_state');
       res.setHeader('Content-Type', 'text/html');
       return res.send(this.renderDeniedPage(serverName));
+    }
+
+    // "Sign in with <provider>" is a submit button on the same form, so it
+    // arrives here having already passed the CSRF check above rather than as a
+    // bare GET that any page could trigger.
+    if (body.action?.startsWith('sso:')) {
+      const providerId = body.action.slice(4);
+      const oauthSessionId = req.cookies?.oauth_session;
+      try {
+        const { authorizationUrl } = await this.sso.startMcp(
+          providerId,
+          oauthSessionId,
+        );
+        res.clearCookie('login_csrf');
+        return res.redirect(authorizationUrl);
+      } catch (error: any) {
+        this.logger.warn(`MCP SSO start failed: ${error?.reason ?? error}`);
+        return res.redirect(
+          `/auth/login?error=${encodeURIComponent('Single sign-on is unavailable. Please contact your administrator.')}`,
+        );
+      }
     }
 
     const { email, password } = body;
@@ -264,16 +292,69 @@ export class LoginController {
     );
   }
 
+  /**
+   * The identity providers offered on this page.
+   *
+   * Scoped to the ONE workspace this authorization is for, resolved from the
+   * `mcp_resource` cookie that `ResourceIndicatorMiddleware` captured from the
+   * client's RFC 8707 `resource` parameter at /authorize.
+   *
+   * Deliberately not "every active provider": this page is unauthenticated, so
+   * an unscoped list would let anyone read off every customer's workspace and
+   * directory — the same enumeration oracle that keeps the provider list off
+   * /health/server-info in cloud. Scoping to the resource leaks nothing,
+   * because reaching here already required that tenant's own server id.
+   *
+   * Returns nothing when the client sent no `resource`, which leaves the page
+   * exactly as it is today: password only.
+   */
+  private async loadSsoProviders(
+    req: Request,
+  ): Promise<{ id: string; name: string }[]> {
+    // SIGNED cookie, so it lives in `signedCookies` — reading `req.cookies`
+    // here silently yields undefined and the buttons never render.
+    const serverId = (req as any).signedCookies?.[MCP_RESOURCE_COOKIE];
+    if (!serverId) return [];
+    try {
+      const server = await this.prisma.mcpServerConfig.findUnique({
+        where: { id: serverId },
+        select: { organizationId: true },
+      });
+      if (!server?.organizationId) return [];
+      return await this.prisma.identityProvider.findMany({
+        where: { organizationId: server.organizationId, isActive: true },
+        select: { id: true, name: true },
+        orderBy: { createdAt: 'asc' },
+      });
+    } catch (error: any) {
+      // Never let this break the password path — it is only an extra option.
+      this.logger.warn(`Could not load SSO providers: ${error?.message}`);
+      return [];
+    }
+  }
+
   private renderLoginPage(params: {
     error: string | undefined;
     serverName: string;
     consent: ConsentContext | null;
     csrfToken: string;
+    ssoProviders: { id: string; name: string }[];
   }): string {
-    const { error, serverName, consent, csrfToken } = params;
+    const { error, serverName, consent, csrfToken, ssoProviders } = params;
 
     const errorHtml = error
       ? `<div class="error">${this.escapeHtml(error)}</div>`
+      : '';
+
+    // `formnovalidate` matters: without it the browser blocks the submit
+    // because the still-empty email and password inputs are `required`.
+    const ssoHtml = ssoProviders.length
+      ? ssoProviders
+          .map(
+            (p) =>
+              `<button type="submit" name="action" value="sso:${this.escapeHtml(p.id)}" formnovalidate class="sso">${this.escapeHtml(p.name)}</button>`,
+          )
+          .join('') + '<div class="divider"><span>or</span></div>'
       : '';
 
     const consentHtml = consent
@@ -409,6 +490,27 @@ export class LoginController {
       margin-top: 8px;
     }
     button.secondary:hover { background: #f1f5f9; }
+    button.sso {
+      background: #fff;
+      color: #0f172a;
+      border: 1px solid #cbd5e1;
+      margin-bottom: 4px;
+    }
+    button.sso:hover { background: #f8fafc; }
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 14px 0 4px;
+      color: #94a3b8;
+      font-size: 12px;
+    }
+    .divider::before, .divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: #e2e8f0;
+    }
   </style>
 </head>
 <body>
@@ -419,6 +521,7 @@ export class LoginController {
     ${consentHtml}
     <form method="POST" action="/auth/login">
       <input type="hidden" name="csrf" value="${this.escapeHtml(csrfToken)}">
+      ${ssoHtml}
       <label for="email">Email</label>
       <input type="email" id="email" name="email" required autofocus placeholder="you@example.com">
       <label for="password">Password</label>

--- a/packages/backend/src/common/crypto/encryption.util.spec.ts
+++ b/packages/backend/src/common/crypto/encryption.util.spec.ts
@@ -43,4 +43,33 @@ describe('Encryption Utility', () => {
     const wrongKey = 'different-key-exactly-32-chars!!';
     expect(() => decrypt(encrypted, wrongKey)).toThrow();
   });
+
+  describe('additional authenticated data (AAD)', () => {
+    // The encryption key is instance-wide, so without AAD a stored ciphertext
+    // could be copied into another row — another organization's identity
+    // provider, say — and would still decrypt happily.
+    const aad = 'idp_client_secret:provider-1:org-1';
+
+    it('round-trips when the AAD matches', () => {
+      const encrypted = encrypt('client-secret', key, aad);
+      expect(decrypt(encrypted, key, aad)).toBe('client-secret');
+    });
+
+    it('refuses to decrypt a ciphertext moved to another row', () => {
+      const encrypted = encrypt('client-secret', key, aad);
+      const otherRow = 'idp_client_secret:provider-1:org-2';
+      expect(() => decrypt(encrypted, key, otherRow)).toThrow();
+    });
+
+    it('refuses to decrypt without the AAD it was bound to', () => {
+      const encrypted = encrypt('client-secret', key, aad);
+      expect(() => decrypt(encrypted, key)).toThrow();
+    });
+
+    it('stays compatible with data encrypted before AAD existed', () => {
+      // Connector credentials were written without it and must keep working.
+      const legacy = encrypt('legacy-value', key);
+      expect(decrypt(legacy, key)).toBe('legacy-value');
+    });
+  });
 });

--- a/packages/backend/src/common/crypto/encryption.util.ts
+++ b/packages/backend/src/common/crypto/encryption.util.ts
@@ -7,12 +7,25 @@ const TAG_LENGTH = 16;
 /**
  * Encrypt sensitive data (API keys, credentials) using AES-256-GCM.
  * Returns: base64(iv + ciphertext + authTag)
+ *
+ * `aad` is optional Additional Authenticated Data. It is not stored, and it is
+ * not secret — it binds the ciphertext to its context, so a blob copied into a
+ * different row (another provider, another organization) fails to decrypt
+ * instead of silently succeeding. Callers that omit it keep the previous
+ * behaviour and remain wire-compatible with data encrypted before it existed.
  */
-export function encrypt(plaintext: string, encryptionKey: string): string {
+export function encrypt(
+  plaintext: string,
+  encryptionKey: string,
+  aad?: string,
+): string {
   const key = Buffer.from(encryptionKey, 'utf-8').subarray(0, 32);
   const iv = randomBytes(IV_LENGTH);
 
   const cipher = createCipheriv(ALGORITHM, key, iv);
+  // `!== undefined`, not truthiness: an empty-string AAD must bind to the
+  // empty string, not silently degrade to no AAD at all.
+  if (aad !== undefined) cipher.setAAD(Buffer.from(aad, 'utf-8'));
   const encrypted = Buffer.concat([
     cipher.update(plaintext, 'utf8'),
     cipher.final(),
@@ -24,8 +37,16 @@ export function encrypt(plaintext: string, encryptionKey: string): string {
 
 /**
  * Decrypt data encrypted with encrypt().
+ *
+ * `aad` must match what was passed at encryption time, or the authentication
+ * tag check fails and this throws — which is the point: it is what stops a
+ * ciphertext being moved between rows.
  */
-export function decrypt(ciphertext: string, encryptionKey: string): string {
+export function decrypt(
+  ciphertext: string,
+  encryptionKey: string,
+  aad?: string,
+): string {
   const key = Buffer.from(encryptionKey, 'utf-8').subarray(0, 32);
   const data = Buffer.from(ciphertext, 'base64');
 
@@ -34,6 +55,7 @@ export function decrypt(ciphertext: string, encryptionKey: string): string {
   const encrypted = data.subarray(IV_LENGTH, data.length - TAG_LENGTH);
 
   const decipher = createDecipheriv(ALGORITHM, key, iv);
+  if (aad !== undefined) decipher.setAAD(Buffer.from(aad, 'utf-8'));
   decipher.setAuthTag(tag);
 
   return decipher.update(encrypted) + decipher.final('utf8');

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -30,7 +30,27 @@ export class HealthController {
     const serverUrl = this.configService.get<string>('SERVER_URL') || '';
     const userCount = await this.usersService.count();
     const allowOpen = this.configService.get<string>('ALLOW_OPEN_REGISTRATION') === 'true';
+
+    // Sign-in buttons for the login page — SELF-HOST ONLY.
+    //
+    // This endpoint is unauthenticated. On a self-hosted instance there is
+    // effectively one organization, so listing its providers is the expected
+    // behaviour. In cloud it would be a workspace ENUMERATION oracle: anyone
+    // could read off every customer's provider names and entry links. There,
+    // users reach sign-in through the opaque /sso/<initiateId> link their
+    // admin distributes, which is exactly why that id is opaque.
+    const ssoProviders = this.deployment.isSelfHosted()
+      ? (
+          await this.prisma.identityProvider.findMany({
+            where: { isActive: true },
+            select: { name: true, type: true, initiateId: true },
+            orderBy: { createdAt: 'asc' },
+          })
+        ).map((p) => ({ name: p.name, type: p.type, startUrl: `/sso/${p.initiateId}` }))
+      : [];
+
     return {
+      ssoProviders,
       mcpAuthMode: authMode,
       serverUrl,
       mcpEndpoint: '/mcp',

--- a/packages/backend/src/identity-providers/identity-providers.controller.spec.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.spec.ts
@@ -1,0 +1,98 @@
+import { IdentityProvidersController } from './identity-providers.controller';
+import { SecurityEventService } from '../audit/security-event.service';
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * These tests drive the controller through the REAL SecurityEventService so the
+ * audit row is what actually reaches the database, redaction included.
+ *
+ * A mocked event service would pass while the persisted row was wrong: the
+ * redaction happens inside `log()`, after the controller has handed over its
+ * metadata, so nothing the controller can be asserted on in isolation reflects
+ * what an auditor would later read.
+ */
+describe('IdentityProvidersController audit trail', () => {
+  let controller: IdentityProvidersController;
+  let service: any;
+  let created: any[];
+
+  const provider = {
+    id: 'p1',
+    type: 'ENTRA',
+    name: 'Sign in with Microsoft',
+    issuer: 'https://login.microsoftonline.com/tid/v2.0',
+    clientId: 'c1',
+    config: { tenantId: 'tid' },
+    isActive: true,
+    jitProvisioning: false,
+    roleSyncEnabled: false,
+    clientSecretExpiresAt: null,
+  };
+
+  const req = {
+    user: { organizationId: 'org-1', sub: 'user-1' },
+    ip: '203.0.113.1',
+    headers: { 'user-agent': 'jest' },
+  };
+
+  beforeEach(() => {
+    created = [];
+    const prisma = {
+      securityEvent: {
+        create: jest.fn(async (args: any) => {
+          created.push(args.data);
+          return args.data;
+        }),
+      },
+    };
+    service = {
+      findByIdForOrg: jest.fn().mockResolvedValue(provider),
+      update: jest.fn().mockResolvedValue(provider),
+    };
+    controller = new IdentityProvidersController(
+      service,
+      new SecurityEventService(prisma as unknown as PrismaService),
+    );
+  });
+
+  const dto = (over: Record<string, unknown> = {}) =>
+    ({
+      type: 'ENTRA',
+      name: 'Sign in with Microsoft',
+      clientId: 'c1',
+      ...over,
+    }) as any;
+
+  it('records a credential rotation as a readable boolean, not "[REDACTED]"', async () => {
+    // REGRESSION GUARD, and the second time this exact bug shipped. The flag was
+    // first named `secretRotated`, renamed to `credentialRotated` to dodge the
+    // redaction pattern — but that pattern lists BOTH "secret" and "credential"
+    // and matches the KEY, so it kept persisting as the string "[REDACTED]".
+    // The audit trail silently lost the answer to "did an admin swap the
+    // client secret?", which is precisely the event worth alerting on.
+    await controller.update(req, 'p1', dto({ clientSecret: 'NEW-SECRET' }));
+
+    const updateEvent = created.find((e) => e.event === 'IDP_UPDATED');
+    expect(updateEvent.metadata.rotated).toBe(true);
+
+    // Guards the general failure mode rather than only today's key name: no
+    // value anywhere in the metadata may have collapsed to the redaction
+    // marker, which is what a banned substring in a key silently produces.
+    expect(JSON.stringify(updateEvent.metadata)).not.toContain('[REDACTED]');
+  });
+
+  it('records a save that leaves the credential alone as rotated: false', async () => {
+    await controller.update(req, 'p1', dto());
+
+    const updateEvent = created.find((e) => e.event === 'IDP_UPDATED');
+    expect(updateEvent.metadata.rotated).toBe(false);
+    // No rotation happened, so no rotation event may be claimed.
+    expect(created.some((e) => e.event === 'IDP_SECRET_ROTATED')).toBe(false);
+  });
+
+  it('never writes the client secret itself into the audit row', async () => {
+    await controller.update(req, 'p1', dto({ clientSecret: 'SUPER-SECRET' }));
+
+    expect(JSON.stringify(created)).not.toContain('SUPER-SECRET');
+  });
+});

--- a/packages/backend/src/identity-providers/identity-providers.controller.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.ts
@@ -214,10 +214,12 @@ export class IdentityProvidersController {
         roleSyncEnabled: updated.roleSyncEnabled,
         isActive: updated.isActive,
       },
-      // NOT named `*secret*`: SecurityEventService.redact matches the KEY
-      // against /secret/i, so `secretRotated` would persist as the string
-      // "[REDACTED]" instead of a boolean — the signal would never arrive.
-      credentialRotated: Boolean(dto.clientSecret),
+      // The key must avoid EVERY word in SecurityEventService's redaction
+      // pattern, which matches the KEY, not the value. Both `secretRotated`
+      // and `credentialRotated` hit it ("secret" and "credential" are both
+      // listed) and persisted as the string "[REDACTED]" instead of a boolean,
+      // silently losing the record of whether an admin rotated the credential.
+      rotated: Boolean(dto.clientSecret),
     });
 
     if (dto.clientSecret) {

--- a/packages/backend/src/identity-providers/identity-providers.controller.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.ts
@@ -1,0 +1,297 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsIn,
+  IsObject,
+  IsISO8601,
+} from 'class-validator';
+import { IdentityProviderType } from '../generated/prisma/client';
+import { Roles, RolesGuard } from '../auth/roles.guard';
+import {
+  IdentityProvidersService,
+  IdentityProviderError,
+} from './identity-providers.service';
+import {
+  SecurityEventService,
+  SecurityEvents,
+} from '../audit/security-event.service';
+
+// Derived from the Prisma enum rather than hand-kept: a new provider type is
+// then accepted automatically and cannot drift out of sync with the database.
+const PROVIDER_TYPES = Object.values(IdentityProviderType);
+
+class UpsertProviderDto {
+  @ApiProperty({ enum: PROVIDER_TYPES, description: 'Identity provider type. Immutable after creation.' })
+  @IsIn(PROVIDER_TYPES)
+  type: IdentityProviderType;
+
+  @ApiProperty({ description: 'Label shown on the sign-in button.' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({ description: 'OAuth client id from the provider.' })
+  @IsString()
+  clientId: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Client secret. Required on create. Omit on update to keep the stored one — the API never returns it.',
+  })
+  @IsOptional()
+  @IsString()
+  clientSecret?: string;
+
+  @ApiPropertyOptional({ description: 'When the client secret expires, for the renewal reminder.' })
+  @IsOptional()
+  // `strict` rejects the compact and week-date forms validator.js otherwise
+  // accepts ("20260101", "2026-W01-1"), which reach `new Date()` as Invalid
+  // Date and then Prisma as a 500. `strictSeparator` pins the T.
+  @IsISO8601({ strict: true, strictSeparator: true })
+  clientSecretExpiresAt?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Issuer URL. Only for OKTA, AUTH0 and OIDC; derived automatically for the others.',
+  })
+  @IsOptional()
+  @IsString()
+  issuer?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Type-specific settings. ENTRA: { tenantId }. GOOGLE: { hostedDomain }. OKTA: { authorizationServerId }. AUTH0: { rolesClaimNamespace }. GITHUB: { organization }. OIDC: { groupsClaimName }.',
+  })
+  @IsOptional()
+  @IsObject()
+  config?: Record<string, unknown>;
+
+  @ApiPropertyOptional() @IsOptional() @IsBoolean() isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Create an account on first sign-in. Off by default: with it on, everyone in the external tenant can enter this workspace.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  jitProvisioning?: boolean;
+
+  @ApiPropertyOptional({ description: 'Only VIEWER is accepted.' })
+  @IsOptional()
+  @IsIn(['VIEWER'])
+  jitDefaultRole?: 'VIEWER';
+
+  @ApiPropertyOptional() @IsOptional() @IsBoolean() roleSyncEnabled?: boolean;
+
+  @ApiPropertyOptional({ enum: ['APP_ROLES', 'GROUPS'] })
+  @IsOptional()
+  @IsIn(['APP_ROLES', 'GROUPS'])
+  roleSyncSource?: 'APP_ROLES' | 'GROUPS';
+
+  @ApiPropertyOptional({
+    enum: ['DENY_ALL', 'KEEP_EXISTING', 'DEFAULT_ROLE'],
+    description:
+      'What to do when no mapping matches. DENY_ALL by default, because the alternatives fail open: a user holding NO MCP role is unrestricted, so granting nothing is safer than granting a default.',
+  })
+  @IsOptional()
+  @IsIn(['DENY_ALL', 'KEEP_EXISTING', 'DEFAULT_ROLE'])
+  roleSyncFallback?: 'DENY_ALL' | 'KEEP_EXISTING' | 'DEFAULT_ROLE';
+}
+
+/**
+ * Identity provider configuration.
+ *
+ * Every route is scoped by `req.user.organizationId`, like the SMTP settings —
+ * and deliberately NOT like `PUT /api/admin/settings/ssrf-allowed-hosts`, which
+ * lets any workspace admin edit an instance-wide list. There is no service-admin
+ * role in this product, so `@Roles('ADMIN')` means "admin of one workspace" and
+ * nothing here may reach beyond it.
+ */
+@ApiTags('Identity Providers')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles('ADMIN')
+@Controller('api/identity-providers')
+export class IdentityProvidersController {
+  constructor(
+    private readonly service: IdentityProvidersService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List identity providers for this workspace (ADMIN)' })
+  async list(@Req() req: any) {
+    return this.service.findAll(req.user.organizationId);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get one identity provider (ADMIN)' })
+  async get(@Req() req: any, @Param('id') id: string) {
+    const provider = await this.service.findByIdForOrg(
+      id,
+      req.user.organizationId,
+    );
+    if (!provider) throw new NotFoundException('Identity provider not found');
+    return provider;
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create an identity provider (ADMIN)' })
+  async create(@Req() req: any, @Body() dto: UpsertProviderDto) {
+    const created = await this.run(() =>
+      this.service.create(req.user.organizationId, dto),
+    );
+    await this.audit(req, SecurityEvents.IDP_CREATED, created.id, {
+      type: dto.type,
+      name: dto.name,
+      issuer: created.issuer,
+      jitProvisioning: created.jitProvisioning,
+    });
+    return created;
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update an identity provider (ADMIN)' })
+  async update(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: UpsertProviderDto,
+  ) {
+    const before = await this.service.findByIdForOrg(
+      id,
+      req.user.organizationId,
+    );
+    if (!before) throw new NotFoundException('Identity provider not found');
+
+    const updated = await this.run(() =>
+      this.service.update(id, req.user.organizationId, dto),
+    );
+    if (!updated) throw new NotFoundException('Identity provider not found');
+
+    // Diff of the trust anchor. The secret is never included — not even a
+    // prefix — and SecurityEventService redacts it again on the way in.
+    await this.audit(req, SecurityEvents.IDP_UPDATED, id, {
+      type: updated.type,
+      // `config` is diffed too: for GOOGLE, GITHUB and OIDC the issuer is a
+      // constant, so the real restriction on who may sign in (hostedDomain,
+      // organization, groupsClaimName) lives there. Without it a change that
+      // widens access would produce an event whose before/after are identical.
+      before: {
+        issuer: before.issuer,
+        clientId: before.clientId,
+        config: before.config,
+        jitProvisioning: before.jitProvisioning,
+        roleSyncEnabled: before.roleSyncEnabled,
+        isActive: before.isActive,
+      },
+      after: {
+        issuer: updated.issuer,
+        clientId: updated.clientId,
+        config: updated.config,
+        jitProvisioning: updated.jitProvisioning,
+        roleSyncEnabled: updated.roleSyncEnabled,
+        isActive: updated.isActive,
+      },
+      // NOT named `*secret*`: SecurityEventService.redact matches the KEY
+      // against /secret/i, so `secretRotated` would persist as the string
+      // "[REDACTED]" instead of a boolean — the signal would never arrive.
+      credentialRotated: Boolean(dto.clientSecret),
+    });
+
+    if (dto.clientSecret) {
+      await this.audit(req, SecurityEvents.IDP_SECRET_ROTATED, id, {
+        expiresAt: updated.clientSecretExpiresAt,
+      });
+    }
+    return updated;
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an identity provider (ADMIN)' })
+  async remove(@Req() req: any, @Param('id') id: string) {
+    // Read it first: deleting a workspace's whole SSO trust anchor must leave
+    // a record of WHAT was removed, not just that something was.
+    const before = await this.service.findByIdForOrg(
+      id,
+      req.user.organizationId,
+    );
+    const deleted = await this.service.delete(id, req.user.organizationId);
+    if (!deleted) throw new NotFoundException('Identity provider not found');
+    await this.audit(req, SecurityEvents.IDP_DELETED, id, {
+      type: before?.type,
+      name: before?.name,
+      issuer: before?.issuer,
+      clientId: before?.clientId,
+    });
+    return { message: 'Identity provider deleted' };
+  }
+
+  @Post(':id/test')
+  @ApiOperation({
+    summary:
+      'Fetch the provider discovery document and verify the issuer matches (ADMIN)',
+  })
+  async test(@Req() req: any, @Param('id') id: string) {
+    return this.service.testConnection(id, req.user.organizationId);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  /** Turns configuration and constraint errors into 4xx rather than 500s. */
+  private async run<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error: any) {
+      if (error instanceof IdentityProviderError) {
+        throw new BadRequestException(error.message);
+      }
+      // A duplicate name hits @@unique([organizationId, name]). Without this it
+      // surfaces as a 500 with the whole Prisma error in the logs.
+      if (error?.code === 'P2002') {
+        throw new ConflictException(
+          'An identity provider with this name already exists in this workspace',
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async audit(
+    req: any,
+    event: string,
+    providerId: string,
+    metadata: Record<string, unknown>,
+  ) {
+    await this.securityEvents.log({
+      event,
+      actorType: 'USER',
+      organizationId: req.user.organizationId,
+      actorUserId: req.user.sub,
+      metadata: { providerId, ...metadata },
+      ip: req.ip,
+      userAgent: req.headers?.['user-agent'],
+    });
+  }
+}

--- a/packages/backend/src/identity-providers/identity-providers.module.ts
+++ b/packages/backend/src/identity-providers/identity-providers.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { IdentityProvidersService } from './identity-providers.service';
+import { IdentityProvidersController } from './identity-providers.controller';
+
+// `DeploymentService` and `PrismaService` come from the @Global() PrismaModule,
+// and `SecurityEventService` from the @Global() AuditModule — providing any of
+// them here would shadow the shared instance for no reason.
+@Module({
+  controllers: [IdentityProvidersController],
+  providers: [IdentityProvidersService],
+  exports: [IdentityProvidersService],
+})
+export class IdentityProvidersModule {}

--- a/packages/backend/src/identity-providers/identity-providers.module.ts
+++ b/packages/backend/src/identity-providers/identity-providers.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { IdentityProvidersService } from './identity-providers.service';
 import { IdentityProvidersController } from './identity-providers.controller';
+import { SsoController } from './sso.controller';
+import { SsoService } from './sso.service';
 
 // `DeploymentService` and `PrismaService` come from the @Global() PrismaModule,
 // and `SecurityEventService` from the @Global() AuditModule — providing any of
 // them here would shadow the shared instance for no reason.
 @Module({
-  controllers: [IdentityProvidersController],
-  providers: [IdentityProvidersService],
-  exports: [IdentityProvidersService],
+  controllers: [IdentityProvidersController, SsoController],
+  providers: [IdentityProvidersService, SsoService],
+  exports: [IdentityProvidersService, SsoService],
 })
 export class IdentityProvidersModule {}

--- a/packages/backend/src/identity-providers/identity-providers.service.spec.ts
+++ b/packages/backend/src/identity-providers/identity-providers.service.spec.ts
@@ -1,0 +1,267 @@
+import {
+  IdentityProvidersService,
+  IdentityProviderError,
+} from './identity-providers.service';
+import { PrismaService } from '../common/prisma.service';
+import { DeploymentService } from '../common/deployment.service';
+
+const TENANT = 'aaaabbbb-cccc-dddd-eeee-ffff11112222';
+
+describe('IdentityProvidersService', () => {
+  let service: IdentityProvidersService;
+  let prisma: any;
+  let deployment: DeploymentService;
+
+  const baseInput = () => ({
+    type: 'ENTRA' as any,
+    name: 'Entra',
+    clientId: 'client-1',
+    clientSecret: 'SUPER-SECRET',
+    config: { tenantId: TENANT },
+  });
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = 'a-test-encryption-key-of-32-chars!!';
+    prisma = {
+      identityProvider: {
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      $transaction: jest.fn((fn: any) => fn(prisma)),
+    };
+    deployment = { mode: 'cloud', isCloud: () => true, isSelfHosted: () => false } as any;
+    service = new IdentityProvidersService(
+      prisma as unknown as PrismaService,
+      deployment,
+    );
+  });
+
+  describe('client secret at rest', () => {
+    it('round-trips through the AAD it binds on write', async () => {
+      // The highest-value test in this file: a typo in `aadFor` would make
+      // every stored client secret permanently undecryptable, and nothing else
+      // would catch it — the write and the read would each look fine alone.
+      prisma.identityProvider.create.mockResolvedValue({ id: 'p1' });
+      let stored: string | undefined;
+      prisma.identityProvider.update.mockImplementation(({ data }: any) => {
+        stored = data.clientSecretEnc;
+        return { id: 'p1' };
+      });
+
+      await service.create('org-1', baseInput());
+      expect(stored).toBeDefined();
+
+      prisma.identityProvider.findFirst.mockResolvedValue({
+        clientSecretEnc: stored,
+      });
+      expect(await service.getClientSecret('p1', 'org-1')).toBe('SUPER-SECRET');
+    });
+
+    it('refuses to decrypt a secret belonging to another organization', async () => {
+      prisma.identityProvider.create.mockResolvedValue({ id: 'p1' });
+      let stored: string | undefined;
+      prisma.identityProvider.update.mockImplementation(({ data }: any) => {
+        stored = data.clientSecretEnc;
+        return { id: 'p1' };
+      });
+      await service.create('org-1', baseInput());
+
+      // Same ciphertext, read as if it belonged to another workspace: the AAD
+      // no longer matches and GCM rejects it. Without the binding it would
+      // decrypt happily, because the encryption key is instance-wide.
+      prisma.identityProvider.findFirst.mockResolvedValue({
+        clientSecretEnc: stored,
+      });
+      await expect(service.getClientSecret('p1', 'org-2')).rejects.toThrow();
+    });
+
+    it('never stores the plaintext', async () => {
+      prisma.identityProvider.create.mockResolvedValue({ id: 'p1' });
+      let stored = '';
+      prisma.identityProvider.update.mockImplementation(({ data }: any) => {
+        stored = data.clientSecretEnc;
+        return { id: 'p1' };
+      });
+
+      await service.create('org-1', baseInput());
+
+      expect(stored).not.toContain('SUPER-SECRET');
+    });
+
+    it('requires a secret on create', async () => {
+      await expect(
+        service.create('org-1', { ...baseInput(), clientSecret: undefined }),
+      ).rejects.toThrow(IdentityProviderError);
+    });
+  });
+
+  describe('update', () => {
+    const existing = {
+      id: 'p1',
+      type: 'GOOGLE',
+      config: { hostedDomain: 'corp.example.com' },
+    };
+
+    it('preserves the stored config when the caller omits it', async () => {
+      // REGRESSION GUARD. `config` used to be written unconditionally, and
+      // `parseProviderConfig` returns {} for a type whose fields are all
+      // optional — so a PUT that only toggled `isActive` erased
+      // `hostedDomain`, the one thing making Google authoritative for a
+      // non-gmail address. Sign-in silently widened to every Google account.
+      prisma.identityProvider.findFirst
+        .mockResolvedValueOnce(existing) // the pre-read inside update()
+        .mockResolvedValueOnce({ id: 'p1' }); // the read-back afterwards
+
+      await service.update('p1', 'org-1', {
+        type: 'GOOGLE' as any,
+        name: 'Google',
+        clientId: 'c',
+        isActive: false,
+      });
+
+      expect(prisma.identityProvider.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            config: { hostedDomain: 'corp.example.com' },
+          }),
+        }),
+      );
+    });
+
+    it('replaces the config when one IS supplied', async () => {
+      prisma.identityProvider.findFirst
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce({ id: 'p1' });
+
+      await service.update('p1', 'org-1', {
+        type: 'GOOGLE' as any,
+        name: 'Google',
+        clientId: 'c',
+        config: { hostedDomain: 'other.example.com' },
+      });
+
+      expect(prisma.identityProvider.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            config: { hostedDomain: 'other.example.com' },
+          }),
+        }),
+      );
+    });
+
+    it('scopes the write itself by organization, not just the check', async () => {
+      prisma.identityProvider.findFirst
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce({ id: 'p1' });
+
+      await service.update('p1', 'org-1', {
+        type: 'GOOGLE' as any,
+        name: 'Google',
+        clientId: 'c',
+      });
+
+      expect(prisma.identityProvider.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'p1', organizationId: 'org-1' },
+        }),
+      );
+    });
+
+    it('refuses to change the provider type', async () => {
+      // The stored config was validated against the old schema and the issuer
+      // against the old host allowlist; neither survives a type change.
+      prisma.identityProvider.findFirst.mockResolvedValue(existing);
+
+      await expect(
+        service.update('p1', 'org-1', {
+          type: 'ENTRA' as any,
+          name: 'x',
+          clientId: 'c',
+        }),
+      ).rejects.toThrow(/type cannot be changed/);
+    });
+
+    it('returns null for an id in another organization', async () => {
+      prisma.identityProvider.findFirst.mockResolvedValue(null);
+      expect(
+        await service.update('p1', 'org-2', {
+          type: 'GOOGLE' as any,
+          name: 'x',
+          clientId: 'c',
+        }),
+      ).toBeNull();
+      expect(prisma.identityProvider.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('JIT role capping', () => {
+    it('rejects anything above VIEWER rather than downgrading silently', async () => {
+      await expect(
+        service.create('org-1', { ...baseInput(), jitDefaultRole: 'EDITOR' as any }),
+      ).rejects.toThrow(/only grant VIEWER/);
+    });
+
+    it('accepts VIEWER', async () => {
+      prisma.identityProvider.create.mockResolvedValue({ id: 'p1' });
+      prisma.identityProvider.update.mockResolvedValue({ id: 'p1' });
+      await expect(
+        service.create('org-1', { ...baseInput(), jitDefaultRole: 'VIEWER' as any }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('issuer resolution', () => {
+    it('derives a single-tenant Entra authority and ignores a supplied issuer', async () => {
+      prisma.identityProvider.create.mockResolvedValue({ id: 'p1' });
+      prisma.identityProvider.update.mockResolvedValue({ id: 'p1' });
+
+      await service.create('org-1', {
+        ...baseInput(),
+        issuer: 'https://evil.tld/tenant/v2.0',
+      });
+
+      expect(prisma.identityProvider.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            issuer: `https://login.microsoftonline.com/${TENANT}/v2.0`,
+          }),
+        }),
+      );
+    });
+
+    it('refuses a generic OIDC issuer in cloud', async () => {
+      await expect(
+        service.create('org-1', {
+          type: 'OIDC' as any,
+          name: 'Keycloak',
+          clientId: 'c',
+          clientSecret: 's',
+          issuer: 'https://keycloak.internal/realms/x',
+        }),
+      ).rejects.toThrow(/self-hosted/);
+    });
+  });
+
+  describe('PUBLIC_SELECT', () => {
+    it('never selects the encrypted secret on any read path', async () => {
+      // Guarded today only by a hand-maintained field list, so an added
+      // `include` or a spread could leak it silently.
+      prisma.identityProvider.findMany.mockResolvedValue([]);
+      await service.findAll('org-1');
+      prisma.identityProvider.findFirst.mockResolvedValue(null);
+      await service.findByIdForOrg('p1', 'org-1');
+
+      const selects = [
+        prisma.identityProvider.findMany.mock.calls[0][0].select,
+        prisma.identityProvider.findFirst.mock.calls[0][0].select,
+      ];
+      for (const select of selects) {
+        expect(select).not.toHaveProperty('clientSecretEnc');
+      }
+    });
+  });
+});

--- a/packages/backend/src/identity-providers/identity-providers.service.ts
+++ b/packages/backend/src/identity-providers/identity-providers.service.ts
@@ -1,0 +1,432 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { PrismaService } from '../common/prisma.service';
+import type {
+  IdentityProviderType,
+  RoleSyncSource,
+  RoleSyncFallback,
+  UserRole,
+} from '../generated/prisma/client';
+import { DeploymentService } from '../common/deployment.service';
+import { encrypt, decrypt } from '../common/crypto/encryption.util';
+import { getRequiredSecret } from '../common/secrets.util';
+import { assertSafeOutboundUrl } from '../common/ssrf.util';
+import {
+  parseProviderConfig,
+  deriveIssuer,
+  assertIssuerAllowed,
+  ProviderConfigError,
+  IssuerNotAllowedError,
+} from './provider-config';
+
+export class IdentityProviderError extends Error {}
+
+export interface UpsertProviderInput {
+  // Typed from the generated Prisma enum, not `string`: a typo or a new enum
+  // value then fails at COMPILE time instead of surfacing as a runtime Prisma
+  // error, and the controller's list is derived from the same source.
+  type: IdentityProviderType;
+  name: string;
+  clientId: string;
+  /** Omitted on update = keep the stored secret. */
+  clientSecret?: string;
+  clientSecretExpiresAt?: string | null;
+  /** Only used by types with no derivable issuer (OKTA, AUTH0, OIDC). */
+  issuer?: string;
+  config?: Record<string, unknown>;
+  isActive?: boolean;
+  jitProvisioning?: boolean;
+  jitDefaultRole?: UserRole;
+  roleSyncEnabled?: boolean;
+  roleSyncSource?: RoleSyncSource;
+  roleSyncFallback?: RoleSyncFallback;
+}
+
+/** Shape returned to the API. Never carries the client secret. */
+const PUBLIC_SELECT = {
+  id: true,
+  type: true,
+  name: true,
+  isActive: true,
+  issuer: true,
+  clientId: true,
+  clientSecretExpiresAt: true,
+  initiateId: true,
+  jitProvisioning: true,
+  jitDefaultRole: true,
+  roleSyncEnabled: true,
+  roleSyncSource: true,
+  roleSyncFallback: true,
+  enforceSso: true,
+  lastSuccessfulLoginAt: true,
+  config: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+@Injectable()
+export class IdentityProvidersService {
+  private readonly logger = new Logger(IdentityProvidersService.name);
+  private readonly encryptionKey: string;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly deployment: DeploymentService,
+  ) {
+    this.encryptionKey = getRequiredSecret(
+      'ENCRYPTION_KEY',
+      process.env.ENCRYPTION_KEY,
+    );
+  }
+
+  /**
+   * Binds a ciphertext to the row it belongs to. Without it, a client secret
+   * blob could be copied into another organization's provider and would still
+   * decrypt — the key is instance-wide.
+   */
+  /**
+   * Parses an expiry, refusing anything `new Date()` cannot make sense of.
+   *
+   * `@IsISO8601({strict:true})` is not enough: validator.js's `strict` checks
+   * that the DATE is real (rejecting 2026-02-30), not that the format is the
+   * extended one, so compact forms like "20260101" and week dates like
+   * "2026-W01-1" pass validation and then reach Prisma as an Invalid Date —
+   * a 500 instead of a 400.
+   */
+  private parseExpiry(value: string): Date {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new IdentityProviderError(
+        'clientSecretExpiresAt must be an ISO 8601 date, e.g. 2027-01-31T00:00:00Z',
+      );
+    }
+    return parsed;
+  }
+
+  private aadFor(providerId: string, organizationId: string): string {
+    return `idp_client_secret:${providerId}:${organizationId}`;
+  }
+
+  async findAll(organizationId: string) {
+    return this.prisma.identityProvider.findMany({
+      where: { organizationId },
+      select: { ...PUBLIC_SELECT, _count: { select: { roleMappings: true } } },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  /** Always resolve by (id, org) so an id from another workspace 404s. */
+  async findByIdForOrg(id: string, organizationId: string) {
+    return this.prisma.identityProvider.findFirst({
+      where: { id, organizationId },
+      select: PUBLIC_SELECT,
+    });
+  }
+
+  async create(organizationId: string, input: UpsertProviderInput) {
+    const { issuer, config } = this.resolveIssuerAndConfig(input);
+
+    if (!input.clientSecret) {
+      throw new IdentityProviderError('clientSecret is required');
+    }
+
+    // The row must exist before the secret can be bound to its id, so create
+    // it without the secret and attach the ciphertext immediately after. Both
+    // happen in one transaction, so a provider is never persisted in a
+    // half-configured state.
+    return this.prisma.$transaction(async (tx) => {
+      const created = await tx.identityProvider.create({
+        data: {
+          organizationId,
+          type: input.type,
+          name: input.name,
+          issuer,
+          clientId: input.clientId,
+          initiateId: randomBytes(24).toString('base64url'),
+          config: config as any,
+          isActive: input.isActive ?? true,
+          jitProvisioning: input.jitProvisioning ?? false,
+          jitDefaultRole: this.cappedJitRole(input.jitDefaultRole),
+          roleSyncEnabled: input.roleSyncEnabled ?? false,
+          roleSyncSource: input.roleSyncSource ?? 'GROUPS',
+          roleSyncFallback: input.roleSyncFallback ?? 'DENY_ALL',
+          clientSecretExpiresAt: input.clientSecretExpiresAt
+            ? this.parseExpiry(input.clientSecretExpiresAt)
+            : null,
+        },
+        select: { id: true },
+      });
+
+      const updated = await tx.identityProvider.update({
+        where: { id: created.id },
+        data: {
+          clientSecretEnc: encrypt(
+            input.clientSecret!,
+            this.encryptionKey,
+            this.aadFor(created.id, organizationId),
+          ),
+        },
+        select: PUBLIC_SELECT,
+      });
+      return updated;
+    });
+  }
+
+  async update(id: string, organizationId: string, input: UpsertProviderInput) {
+    const existing = await this.prisma.identityProvider.findFirst({
+      where: { id, organizationId },
+      select: { id: true, type: true, config: true },
+    });
+    if (!existing) return null;
+
+    // The type is fixed after creation: changing it would leave the stored
+    // `config` validated against the wrong schema, and the issuer pointing at
+    // a host the new type does not permit.
+    if (input.type && input.type !== existing.type) {
+      throw new IdentityProviderError(
+        'Provider type cannot be changed. Create a new provider instead.',
+      );
+    }
+
+    // SECURITY: fall back to the STORED config when the caller omits it.
+    // Every other optional field here is `undefined` when omitted, so Prisma
+    // skips it and the stored value survives — `config` was the one field
+    // where omission destroyed. For GOOGLE that silently dropped
+    // `hostedDomain`, the only thing making Google authoritative for a
+    // non-gmail address, so toggling `isActive` off and on would widen sign-in
+    // to every Google account on the internet. Same shape for GitHub's
+    // `organization` and OIDC's `groupsClaimName`.
+    const { issuer, config } = this.resolveIssuerAndConfig({
+      ...input,
+      type: existing.type,
+      config: input.config ?? (existing.config as Record<string, unknown>),
+    });
+
+    // Org scope in the WRITE, not only in the check above: `delete()` already
+    // does this, and check-then-act is one careless refactor from a
+    // cross-tenant write.
+    await this.prisma.identityProvider.updateMany({
+      where: { id, organizationId },
+      data: {
+        name: input.name,
+        issuer,
+        clientId: input.clientId,
+        config: config as any,
+        isActive: input.isActive,
+        jitProvisioning: input.jitProvisioning,
+        jitDefaultRole: this.cappedJitRole(input.jitDefaultRole),
+        roleSyncEnabled: input.roleSyncEnabled,
+        roleSyncSource: input.roleSyncSource,
+        roleSyncFallback: input.roleSyncFallback,
+        // `null` clears it; omitting the key keeps the stored value. Without
+        // the null branch a stale expiry could never be removed and the
+        // renewal reminder would keep reporting a date that no longer applies
+        // after a rotation.
+        clientSecretExpiresAt:
+          input.clientSecretExpiresAt === null
+            ? null
+            : input.clientSecretExpiresAt
+              ? this.parseExpiry(input.clientSecretExpiresAt)
+              : undefined,
+        // An empty secret means "keep the stored one", so an admin can edit the
+        // name or a toggle without re-entering a credential the API never
+        // returned to them in the first place.
+        ...(input.clientSecret
+          ? {
+              clientSecretEnc: encrypt(
+                input.clientSecret,
+                this.encryptionKey,
+                this.aadFor(id, organizationId),
+              ),
+            }
+          : {}),
+      },
+    });
+
+    // `updateMany` cannot `select`, so read the row back through the same
+    // org-scoped helper every other read path uses.
+    return this.findByIdForOrg(id, organizationId);
+  }
+
+  async delete(id: string, organizationId: string): Promise<boolean> {
+    const result = await this.prisma.identityProvider.deleteMany({
+      where: { id, organizationId },
+    });
+    return result.count > 0;
+  }
+
+  /** Decrypts the stored secret. Only ever called server-side. */
+  async getClientSecret(
+    id: string,
+    organizationId: string,
+  ): Promise<string | null> {
+    const row = await this.prisma.identityProvider.findFirst({
+      where: { id, organizationId },
+      select: { clientSecretEnc: true },
+    });
+    if (!row?.clientSecretEnc) return null;
+    return decrypt(
+      row.clientSecretEnc,
+      this.encryptionKey,
+      this.aadFor(id, organizationId),
+    );
+  }
+
+  /**
+   * Fetches the provider's discovery document, proving the issuer is reachable
+   * and really is who it claims to be. The equivalent of `POST smtp/test`:
+   * misconfiguration should surface here, not at a user's first sign-in.
+   */
+  async testConnection(
+    id: string,
+    organizationId: string,
+  ): Promise<{ ok: boolean; message: string; details?: Record<string, unknown> }> {
+    const provider = await this.findByIdForOrg(id, organizationId);
+    if (!provider) return { ok: false, message: 'Provider not found' };
+
+    if (provider.type === 'GITHUB') {
+      return {
+        ok: true,
+        message:
+          'GitHub is not an OIDC provider and publishes no discovery document, so there is nothing to probe. Credentials are verified at first sign-in.',
+      };
+    }
+
+    const discoveryUrl = `${provider.issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
+
+    try {
+      // Re-check the host even though it was checked on write: the allowlist
+      // may have tightened since, and this is the call that actually leaves
+      // the server.
+      assertIssuerAllowed(provider.type, provider.issuer, {
+        allowArbitraryIssuer: this.deployment.isSelfHosted(),
+      });
+      // Blocks loopback, link-local (including cloud metadata) and private
+      // ranges, resolving DNS so a public name pointing inward is caught too.
+      await assertSafeOutboundUrl(discoveryUrl);
+
+      const response = await fetch(discoveryUrl, {
+        redirect: 'error', // a redirect could walk us off the allowlisted host
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        return {
+          ok: false,
+          message: `Discovery document returned HTTP ${response.status}`,
+        };
+      }
+
+      // Cap the body. `AbortSignal.timeout` bounds wall-clock, not bytes, so a
+      // hostile endpoint answering with an endless chunked body would be
+      // buffered whole into the heap of a shared, multi-tenant process. A
+      // discovery document is a couple of kilobytes.
+      const body = await this.readCapped(response, 256 * 1024);
+      const doc: any = JSON.parse(body);
+      if (doc.issuer !== provider.issuer) {
+        return {
+          ok: false,
+          message: `Issuer mismatch: the document declares '${doc.issuer}' but this provider is configured for '${provider.issuer}'`,
+        };
+      }
+
+      return {
+        ok: true,
+        message: 'Discovery document reachable and issuer matches',
+        details: {
+          authorizationEndpoint: doc.authorization_endpoint,
+          tokenEndpoint: doc.token_endpoint,
+          jwksUri: doc.jwks_uri,
+        },
+      };
+    } catch (error: any) {
+      // The detail stays in the logs. SsrfBlockedError messages embed the
+      // RESOLVED address ("resolves to non-public address '10.0.3.7'"), so
+      // returning them verbatim would turn this endpoint into an internal DNS
+      // and address-range oracle for any workspace admin.
+      this.logger.warn(
+        `Identity provider test failed for ${id}: ${error?.message}`,
+      );
+      return {
+        ok: false,
+        message:
+          'Could not reach the provider discovery document. Check the issuer and credentials.',
+      };
+    }
+  }
+
+  /** Reads a response body, refusing anything over `maxBytes`. */
+  private async readCapped(response: Response, maxBytes: number) {
+    const reader = response.body?.getReader();
+    if (!reader) return '';
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error(`Discovery document exceeded ${maxBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  /**
+   * JIT provisioning may never mint an ADMIN or EDITOR. Anyone able to
+   * authenticate at the external tenant would otherwise arrive with write
+   * access — or, as ADMIN, with the power to rewrite the SSO configuration
+   * that let them in.
+   *
+   * Rejected rather than silently downgraded: an admin who asked for EDITOR
+   * should learn that it is refused, not discover later that it did not stick.
+   */
+  private cappedJitRole(role?: UserRole): UserRole | undefined {
+    if (role === undefined) return undefined;
+    if (role !== 'VIEWER') {
+      throw new IdentityProviderError(
+        'Just-in-time provisioning can only grant VIEWER. Promote users explicitly after they first sign in.',
+      );
+    }
+    return 'VIEWER';
+  }
+
+  private resolveIssuerAndConfig(input: UpsertProviderInput) {
+    let config: Record<string, unknown>;
+    try {
+      config = parseProviderConfig(input.type, input.config);
+    } catch (e) {
+      if (e instanceof ProviderConfigError) {
+        throw new IdentityProviderError(e.message);
+      }
+      throw e;
+    }
+
+    const derived = deriveIssuer(input.type, config);
+    const issuer = derived ?? input.issuer;
+    if (!issuer) {
+      throw new IdentityProviderError(
+        `An issuer is required for provider type ${input.type}`,
+      );
+    }
+
+    try {
+      assertIssuerAllowed(input.type, issuer, {
+        // A free-form issuer means a server-side fetch to a host the workspace
+        // admin picked. Acceptable where they already own the infrastructure;
+        // disproportionate in a shared, multi-tenant deployment.
+        allowArbitraryIssuer: this.deployment.isSelfHosted(),
+      });
+    } catch (e) {
+      if (e instanceof IssuerNotAllowedError) {
+        throw new IdentityProviderError(e.message);
+      }
+      throw e;
+    }
+
+    return { issuer, config };
+  }
+}

--- a/packages/backend/src/identity-providers/provider-config.spec.ts
+++ b/packages/backend/src/identity-providers/provider-config.spec.ts
@@ -1,0 +1,147 @@
+import {
+  parseProviderConfig,
+  deriveIssuer,
+  assertIssuerAllowed,
+  ProviderConfigError,
+  IssuerNotAllowedError,
+  MSA_TENANT_ID,
+} from './provider-config';
+
+describe('parseProviderConfig — ENTRA tenantId', () => {
+  const GUID = 'aaaabbbb-cccc-dddd-eeee-ffff11112222';
+
+  it('accepts a tenant GUID', () => {
+    expect(parseProviderConfig('ENTRA', { tenantId: GUID })).toEqual({
+      tenantId: GUID,
+    });
+  });
+
+  it.each([
+    ['a directory name', 'contoso.onmicrosoft.com'],
+    ['the /common authority', 'common'],
+    ['a path traversal', '../../evil.tld/x'],
+    ['a full URL', 'https://evil.tld/.well-known/openid-configuration'],
+    ['an empty value', ''],
+  ])('rejects %s', (_label, tenantId) => {
+    // SECURITY: a non-GUID here becomes part of a URL the server fetches, so a
+    // loose field is a path to an attacker-chosen JWKS — i.e. forged id_tokens.
+    expect(() => parseProviderConfig('ENTRA', { tenantId })).toThrow(
+      ProviderConfigError,
+    );
+  });
+
+  it('rejects the personal-account tenant', () => {
+    // Every consumer Microsoft account lives in this one tenant, so `tid`
+    // stops discriminating between customers.
+    expect(() =>
+      parseProviderConfig('ENTRA', { tenantId: MSA_TENANT_ID }),
+    ).toThrow(/personal Microsoft account/);
+  });
+
+  it('rejects a missing tenantId', () => {
+    expect(() => parseProviderConfig('ENTRA', {})).toThrow(ProviderConfigError);
+  });
+});
+
+describe('parseProviderConfig — other types', () => {
+  it('requires an Auth0 roles namespace to be a URL', () => {
+    // Auth0 drops non-namespaced custom claims SILENTLY: the login succeeds and
+    // the roles are simply absent. Validating here turns that into a config
+    // error instead of an authorization one.
+    expect(() =>
+      parseProviderConfig('AUTH0', { rolesClaimNamespace: 'roles' }),
+    ).toThrow(ProviderConfigError);
+    expect(
+      parseProviderConfig('AUTH0', {
+        rolesClaimNamespace: 'https://app.example.com/roles',
+      }),
+    ).toEqual({ rolesClaimNamespace: 'https://app.example.com/roles' });
+  });
+
+  it('accepts an empty config for types with only optional settings', () => {
+    expect(parseProviderConfig('GOOGLE', {})).toEqual({});
+    expect(parseProviderConfig('OIDC', undefined)).toEqual({});
+  });
+
+  it('rejects an unknown type', () => {
+    expect(() => parseProviderConfig('LDAP', {})).toThrow(ProviderConfigError);
+  });
+});
+
+describe('deriveIssuer', () => {
+  it('builds a SINGLE-TENANT Entra authority', () => {
+    // Never /common or /organizations: those publish a TEMPLATED issuer, and
+    // validating a token against a template is the wildcard-issuer pitfall
+    // that lets any tenant's token through.
+    expect(
+      deriveIssuer('ENTRA', { tenantId: 'AAAABBBB-CCCC-DDDD-EEEE-FFFF11112222' }),
+    ).toBe(
+      'https://login.microsoftonline.com/aaaabbbb-cccc-dddd-eeee-ffff11112222/v2.0',
+    );
+  });
+
+  it('fixes the issuer for Google and GitHub', () => {
+    expect(deriveIssuer('GOOGLE', {})).toBe('https://accounts.google.com');
+    expect(deriveIssuer('GITHUB', {})).toBe('https://github.com');
+  });
+
+  it('returns null where the admin must supply one', () => {
+    expect(deriveIssuer('OKTA', {})).toBeNull();
+    expect(deriveIssuer('AUTH0', {})).toBeNull();
+    expect(deriveIssuer('OIDC', {})).toBeNull();
+  });
+});
+
+describe('assertIssuerAllowed', () => {
+  const cloud = { allowArbitraryIssuer: false };
+  const selfHost = { allowArbitraryIssuer: true };
+
+  it('accepts the Microsoft login host', () => {
+    expect(() =>
+      assertIssuerAllowed(
+        'ENTRA',
+        'https://login.microsoftonline.com/aaaabbbb-cccc-dddd-eeee-ffff11112222/v2.0',
+        cloud,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects another host claiming to be Entra', () => {
+    expect(() =>
+      assertIssuerAllowed('ENTRA', 'https://evil.tld/tenant/v2.0', cloud),
+    ).toThrow(IssuerNotAllowedError);
+  });
+
+  it('accepts an Okta subdomain and rejects a lookalike', () => {
+    expect(() =>
+      assertIssuerAllowed('OKTA', 'https://acme.okta.com', cloud),
+    ).not.toThrow();
+    expect(() =>
+      assertIssuerAllowed('OKTA', 'https://acme.okta.com.evil.tld', cloud),
+    ).toThrow(IssuerNotAllowedError);
+  });
+
+  it('rejects http', () => {
+    expect(() =>
+      assertIssuerAllowed('OKTA', 'http://acme.okta.com', cloud),
+    ).toThrow(/https/);
+  });
+
+  it('refuses a free-form issuer in cloud but allows it self-hosted', () => {
+    // An arbitrary issuer is a server-side fetch to a host the workspace admin
+    // picked — fine where they own the infrastructure, disproportionate in a
+    // shared deployment.
+    expect(() =>
+      assertIssuerAllowed('OIDC', 'https://keycloak.internal/realms/x', cloud),
+    ).toThrow(/self-hosted/);
+    expect(() =>
+      assertIssuerAllowed('OIDC', 'https://keycloak.internal/realms/x', selfHost),
+    ).not.toThrow();
+  });
+
+  it('rejects a malformed issuer', () => {
+    expect(() => assertIssuerAllowed('OIDC', 'not a url', selfHost)).toThrow(
+      IssuerNotAllowedError,
+    );
+  });
+});

--- a/packages/backend/src/identity-providers/provider-config.ts
+++ b/packages/backend/src/identity-providers/provider-config.ts
@@ -1,0 +1,243 @@
+import { z } from 'zod';
+
+/**
+ * Per-type validation for identity-provider configuration.
+ *
+ * This file is the trust boundary for SSO configuration. Everything here is
+ * supplied by a workspace admin, and the values end up driving a server-side
+ * fetch (OIDC discovery, JWKS) and the issuer check on a signed token — so a
+ * loose field is not a usability problem, it is a forgery primitive.
+ */
+
+/** Exactly the Entra tenant GUID shape. Nothing else may reach a URL. */
+export const ENTRA_TENANT_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The consumer/personal-account tenant. A B2B workspace must not accept it:
+ * every personal Microsoft account lives in this one tenant, so `tid` stops
+ * discriminating between customers entirely.
+ */
+export const MSA_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
+
+/**
+ * Hosts allowed to serve discovery and JWKS, per provider type.
+ *
+ * HARDCODED on purpose. The instance already has `SsrfPolicyService`, but its
+ * allowlist is instance-wide and editable by ANY workspace admin through
+ * `PUT /api/admin/settings/ssrf-allowed-hosts` — using it here would let the
+ * attacker choose their own destination. A fixed list per type cannot be
+ * widened from inside the product.
+ *
+ * `null` means "no fixed host" and is only reachable for the generic OIDC type,
+ * which is self-host only.
+ */
+const ALLOWED_ISSUER_HOSTS: Record<string, string[] | null> = {
+  // Only the commercial cloud. Sovereign clouds are NOT reachable: `deriveIssuer`
+  // hardcodes this host for ENTRA and discards any admin-supplied issuer, so
+  // listing them here would be dead entries implying support that does not
+  // exist. Supporting them means changing `deriveIssuer`, not this list.
+  ENTRA: ['login.microsoftonline.com'],
+  GOOGLE: ['accounts.google.com'],
+  GITHUB: ['github.com'],
+  OKTA: null, // customer-specific subdomain; suffix-checked below
+  AUTH0: null, // customer-specific subdomain, plus custom domains
+  OIDC: null,
+};
+
+/** Suffixes accepted when a type has no fixed host but a known domain family. */
+const ALLOWED_ISSUER_SUFFIXES: Record<string, string[] | undefined> = {
+  OKTA: ['.okta.com', '.oktapreview.com', '.okta-emea.com'],
+  // No suffix list: Auth0 custom domains are the norm, so `.auth0.com` would
+  // reject most real tenants. The consequence is that AUTH0 falls through to
+  // the `allowArbitraryIssuer` gate below and is therefore SELF-HOST ONLY,
+  // exactly like OIDC. Offering it in cloud requires a domain-verification
+  // step, not a wider suffix list.
+  AUTH0: undefined,
+};
+
+export const entraConfigSchema = z.object({
+  tenantId: z
+    .string()
+    // Lowercased here so the stored config and the derived issuer can never
+    // disagree in case. Entra emits `tid` lowercase, and a later comparison
+    // against a stored uppercase GUID would silently fail to match.
+    .transform((v) => v.toLowerCase())
+    .pipe(z.string().regex(
+      ENTRA_TENANT_ID_RE,
+      'tenantId must be the tenant GUID (a directory name or URL is not accepted)',
+    ))
+    .refine(
+      (v) => v.toLowerCase() !== MSA_TENANT_ID,
+      'The personal Microsoft account tenant cannot be used: every consumer account shares it, so it identifies no organization',
+    ),
+});
+
+export const googleConfigSchema = z.object({
+  /**
+   * Google Workspace `hd` claim. Without it Google is NOT authoritative for a
+   * non-gmail.com address, so leaving this empty means any Google account can
+   * sign in — which is almost never what a workspace wants.
+   */
+  hostedDomain: z.string().min(1).optional(),
+});
+
+export const oktaConfigSchema = z.object({
+  /** Custom authorization server; omitted means the org server. */
+  authorizationServerId: z.string().min(1).optional(),
+});
+
+export const auth0ConfigSchema = z.object({
+  /**
+   * Auth0 drops custom claims that are not namespaced, SILENTLY — the login
+   * still succeeds, the roles simply are not there. Requiring the namespace
+   * up front turns that into a configuration error instead of an
+   * authorization one.
+   */
+  rolesClaimNamespace: z
+    .string()
+    .url('Must be a URL you control, e.g. https://your-app.example.com/roles')
+    .optional(),
+});
+
+export const githubConfigSchema = z.object({
+  /** Restrict sign-in to members of one GitHub organization. */
+  organization: z.string().min(1).optional(),
+});
+
+export const oidcConfigSchema = z.object({
+  /** Keycloak and friends let the operator name this claim; it is not fixed. */
+  groupsClaimName: z.string().min(1).optional(),
+});
+
+const SCHEMAS: Record<string, z.ZodTypeAny> = {
+  ENTRA: entraConfigSchema,
+  GOOGLE: googleConfigSchema,
+  OKTA: oktaConfigSchema,
+  AUTH0: auth0ConfigSchema,
+  GITHUB: githubConfigSchema,
+  OIDC: oidcConfigSchema,
+};
+
+export class ProviderConfigError extends Error {}
+
+/** Validates the `config` blob for a provider type, returning the parsed value. */
+export function parseProviderConfig(
+  type: string,
+  config: unknown,
+): Record<string, unknown> {
+  const schema = SCHEMAS[type];
+  if (!schema) throw new ProviderConfigError(`Unknown provider type '${type}'`);
+
+  const result = schema.safeParse(config ?? {});
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${i.path.join('.') || 'config'}: ${i.message}`)
+      .join('; ');
+    throw new ProviderConfigError(detail);
+  }
+  return result.data as Record<string, unknown>;
+}
+
+/**
+ * Derives the issuer for types where we — not the admin — decide it, so there
+ * is nothing to get wrong or to smuggle a hostile URL through.
+ *
+ * Returns null when the type genuinely needs an admin-supplied issuer.
+ */
+export function deriveIssuer(
+  type: string,
+  config: Record<string, unknown>,
+): string | null {
+  switch (type) {
+    case 'ENTRA':
+      // Single-tenant authority. Never `/common` or `/organizations`: those
+      // return a TEMPLATED issuer, and validating against a template is the
+      // "wildcard issuer" pitfall that lets any tenant's token through.
+      return `https://login.microsoftonline.com/${String(config.tenantId).toLowerCase()}/v2.0`;
+    case 'GOOGLE':
+      return 'https://accounts.google.com';
+    case 'GITHUB':
+      // Not an OIDC issuer — GitHub does not issue id_tokens for user sign-in.
+      // Recorded for consistency; the GitHub adapter identifies the user
+      // through the REST API instead.
+      return 'https://github.com';
+    default:
+      return null;
+  }
+}
+
+export class IssuerNotAllowedError extends Error {}
+
+/**
+ * Rejects an issuer whose host is not permitted for the provider type.
+ *
+ * Runs BEFORE any network call, so a hostile value never becomes a request.
+ */
+export function assertIssuerAllowed(
+  type: string,
+  issuer: string,
+  opts: { allowArbitraryIssuer: boolean },
+): void {
+  let url: URL;
+  try {
+    url = new URL(issuer);
+  } catch {
+    throw new IssuerNotAllowedError('Issuer must be an absolute https URL');
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new IssuerNotAllowedError('Issuer must use https');
+  }
+
+  // The issuer is concatenated with `/.well-known/openid-configuration` and is
+  // compared byte-for-byte against the `iss` claim, so anything beyond scheme,
+  // host and path either breaks that probe or weakens the comparison:
+  //   - a query string swallows the well-known path (`…?a=b/.well-known/…`),
+  //     so the probe silently hits the wrong URL and "test passed" means nothing;
+  //   - userinfo would attach admin-supplied credentials to the outbound call;
+  //   - a port reaches a different service on an allowlisted host.
+  if (url.username || url.password) {
+    throw new IssuerNotAllowedError('Issuer must not contain credentials');
+  }
+  if (url.port) {
+    throw new IssuerNotAllowedError('Issuer must not specify a port');
+  }
+  if (url.search || url.hash) {
+    throw new IssuerNotAllowedError(
+      'Issuer must not contain a query string or fragment',
+    );
+  }
+
+  const host = url.hostname.toLowerCase();
+  const exact = ALLOWED_ISSUER_HOSTS[type];
+
+  if (exact) {
+    if (!exact.includes(host)) {
+      throw new IssuerNotAllowedError(
+        `Issuer host '${host}' is not valid for ${type}. Expected one of: ${exact.join(', ')}`,
+      );
+    }
+    return;
+  }
+
+  const suffixes = ALLOWED_ISSUER_SUFFIXES[type];
+  if (suffixes) {
+    if (!suffixes.some((s) => host.endsWith(s))) {
+      throw new IssuerNotAllowedError(
+        `Issuer host '${host}' is not valid for ${type}. Expected a host ending in: ${suffixes.join(', ')}`,
+      );
+    }
+    return;
+  }
+
+  // No fixed host for this type. An arbitrary, admin-supplied issuer means a
+  // server-side fetch to a host they chose, which is a disproportionate
+  // surface in a multi-tenant deployment — allowed only where the admin
+  // already controls the infrastructure.
+  if (!opts.allowArbitraryIssuer) {
+    throw new IssuerNotAllowedError(
+      `${type} requires an operator-configured issuer and is only available on self-hosted deployments`,
+    );
+  }
+}

--- a/packages/backend/src/identity-providers/sso.controller.ts
+++ b/packages/backend/src/identity-providers/sso.controller.ts
@@ -1,0 +1,274 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Req,
+  Res,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  UseGuards,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiProperty,
+  ApiPropertyOptional,
+  ApiExcludeEndpoint,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { Throttle } from '@nestjs/throttler';
+import { IsString, IsOptional } from 'class-validator';
+import { ConfigService } from '@nestjs/config';
+import type { Request, Response } from 'express';
+import { SsoService, SsoError } from './sso.service';
+import { SecurityEventService, SecurityEvents } from '../audit/security-event.service';
+
+class SsoExchangeDto {
+  @ApiProperty({ description: 'One-time code from the sign-in redirect.' })
+  @IsString()
+  code: string;
+}
+
+class SsoLinkStartDto {
+  @ApiPropertyOptional({
+    description: 'Internal path to return to. Anything external is ignored.',
+  })
+  @IsOptional()
+  @IsString()
+  redirect?: string;
+}
+
+/**
+ * Link failures that must return the user to their settings page, with wording
+ * that tells them what to do. Every other reason keeps the deliberately generic
+ * sign-in message: those routes are unauthenticated and must not become an
+ * oracle for which workspaces and accounts exist.
+ */
+const LINK_FAILURE_REASONS = new Map<string, string>([
+  [
+    'identity_already_linked_to_another_user',
+    'That directory account is already connected to a different user.',
+  ],
+  [
+    'user_already_linked_at_provider',
+    'Your account is already connected to this provider. Disconnect it first to use a different directory account.',
+  ],
+  ['not_a_member', 'You are no longer a member of this workspace.'],
+  ['link_without_user', 'The link request expired. Please try again.'],
+]);
+
+/**
+ * Public sign-in routes. No JWT guard: this IS the authentication.
+ *
+ * Every failure returns the same generic message and redirects to the same
+ * place. The specific reason goes to the audit trail, never to the caller —
+ * distinguishing "unknown provider" from "you are not a member" would turn
+ * these endpoints into an enumeration oracle for workspaces and accounts.
+ */
+@ApiTags('SSO')
+@Controller()
+export class SsoController {
+  private readonly logger = new Logger(SsoController.name);
+
+  constructor(
+    private readonly sso: SsoService,
+    private readonly config: ConfigService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  private frontendUrl(): string {
+    return (
+      this.config.get<string>('FRONTEND_URL') ||
+      this.config.get<string>('SERVER_URL') ||
+      'http://localhost:3000'
+    ).replace(/\/$/, '');
+  }
+
+  @Get('sso/:initiateId')
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Start sign-in with an identity provider' })
+  async start(
+    @Param('initiateId') initiateId: string,
+    @Query('redirect') redirect: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    try {
+      const { authorizationUrl } = await this.sso.start(initiateId, redirect);
+      return res.redirect(authorizationUrl);
+    } catch (error) {
+      await this.logFailure(error, req, { initiateId });
+      return res.redirect(
+        `${this.frontendUrl()}/login?error=${encodeURIComponent('Sign-in is unavailable. Please contact your administrator.')}`,
+      );
+    }
+  }
+
+  @Get('auth/sso/callback')
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @ApiExcludeEndpoint()
+  async callback(@Req() req: Request, @Res() res: Response) {
+    const frontend = this.frontendUrl();
+    try {
+      // Rebuilt from server-side config, never from the request host: a spoofed
+      // `x-forwarded-host` must not be able to influence the URL the OIDC
+      // library validates the response against.
+      const currentUrl = new URL(
+        `${frontend}${req.originalUrl}`.replace(/([^:]\/)\/+/g, '$1'),
+      );
+
+      const result = await this.sso.complete(currentUrl, {
+        ip: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+
+      res.setHeader('Referrer-Policy', 'no-referrer');
+
+      if (result.kind === 'LINK') {
+        // The caller was already signed in, so there is no session to hand
+        // over — just report the outcome on the page they came from.
+        const target = new URL(
+          `${frontend}${result.returnTo === '/' ? '/settings' : result.returnTo}`,
+        );
+        target.searchParams.set('linked', '1');
+        return res.redirect(303, target.href);
+      }
+
+      // The session token is NOT in this URL — only a 30-second, single-use
+      // code the SPA trades for it. A JWT here would land in browser history,
+      // the Referer header and every proxy log on the way.
+      const target = new URL(`${frontend}/login`);
+      target.searchParams.set('sso', result.handoffCode);
+      if (result.returnTo && result.returnTo !== '/') {
+        target.searchParams.set('redirect', result.returnTo);
+      }
+      return res.redirect(303, target.href);
+    } catch (error) {
+      const reason = error instanceof SsoError ? error.reason : 'unexpected';
+      await this.logFailure(error, req, {});
+      // A link failure must land back on the settings page, not the sign-in
+      // page: bouncing an already-authenticated user to /login looks like
+      // being signed out and invites them to re-enter their password.
+      if (LINK_FAILURE_REASONS.has(reason)) {
+        return res.redirect(
+          303,
+          `${frontend}/settings?linkError=${encodeURIComponent(LINK_FAILURE_REASONS.get(reason)!)}`,
+        );
+      }
+      return res.redirect(
+        `${frontend}/login?error=${encodeURIComponent('Sign-in failed. Please try again or contact your administrator.')}`,
+      );
+    }
+  }
+
+  @Post('api/auth/sso/link/:providerId')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @ApiOperation({
+    summary: 'Begin connecting an identity provider to your own account',
+  })
+  async startLink(
+    @Req() req: any,
+    @Param('providerId') providerId: string,
+    @Body() dto: SsoLinkStartDto,
+  ) {
+    try {
+      // Returns the URL instead of redirecting: the browser must arrive at the
+      // provider through a top-level navigation the SPA performs, and a
+      // redirect on an XHR would be followed invisibly by fetch instead.
+      return await this.sso.startLink(req.user.sub, providerId, dto?.redirect);
+    } catch (error) {
+      await this.logFailure(error, req, { providerId });
+      throw new BadRequestException(
+        'This identity provider is not available for your account.',
+      );
+    }
+  }
+
+  @Delete('api/auth/sso/link/:providerId')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Disconnect an identity provider from your account' })
+  async unlink(@Req() req: any, @Param('providerId') providerId: string) {
+    try {
+      await this.sso.unlink(req.user.sub, providerId, {
+        ip: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+      return { message: 'Identity disconnected' };
+    } catch (error) {
+      const reason = error instanceof SsoError ? error.reason : 'unexpected';
+      await this.logFailure(error, req, { providerId });
+      // Specific on purpose, unlike the sign-in routes: the caller is
+      // authenticated and acting on their own account, so there is nothing to
+      // enumerate — and "it failed" would leave them with no idea what to do.
+      if (reason === 'would_lock_account_out') {
+        throw new BadRequestException(
+          'Set a password first — disconnecting this provider would leave you with no way to sign in.',
+        );
+      }
+      if (reason === 'identity_not_linked') {
+        throw new NotFoundException('That provider is not connected.');
+      }
+      throw new BadRequestException('Could not disconnect this provider.');
+    }
+  }
+
+  @Get('api/auth/sso/providers')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Identity providers you can connect, and whether you have',
+  })
+  async myProviders(@Req() req: any) {
+    if (!req.user.organizationId) return [];
+    return this.sso.availableForUser(req.user.sub, req.user.organizationId);
+  }
+
+  @Post('api/auth/sso/exchange')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Trade a one-time sign-in code for a session' })
+  async exchange(@Body() dto: SsoExchangeDto, @Req() req: Request) {
+    try {
+      return await this.sso.exchange(dto.code);
+    } catch (error) {
+      await this.logFailure(error, req, {});
+      // Deliberately the same 401 for expired, replayed and forged codes.
+      return { error: 'Sign-in code is invalid or has expired' };
+    }
+  }
+
+  private async logFailure(
+    error: unknown,
+    req: Request,
+    metadata: Record<string, unknown>,
+  ) {
+    const reason =
+      error instanceof SsoError ? error.reason : 'unexpected_error';
+    this.logger.warn(
+      `SSO failure (${reason}): ${(error as Error)?.message ?? error}`,
+    );
+    // The service already wrote a richer event for this one — with the
+    // organization, provider and subject. Writing again here would add a
+    // second, context-free row for the same refusal.
+    if (error instanceof SsoError && error.audited) return;
+    await this.securityEvents.log({
+      event: SecurityEvents.SSO_LOGIN_FAILED,
+      actorType: 'ANONYMOUS',
+      metadata: { ...metadata, reason },
+      ip: req.ip,
+      userAgent: req.headers['user-agent'],
+    });
+  }
+}

--- a/packages/backend/src/identity-providers/sso.controller.ts
+++ b/packages/backend/src/identity-providers/sso.controller.ts
@@ -128,9 +128,34 @@ export class SsoController {
       const result = await this.sso.complete(currentUrl, {
         ip: req.ip,
         userAgent: req.headers['user-agent'],
+        // Read from the cookie the browser is presenting NOW, so the service
+        // can assert it against the one recorded when the flow started.
+        oauthSessionId: (req as any).cookies?.oauth_session,
       });
 
       res.setHeader('Referrer-Policy', 'no-referrer');
+
+      if (result.kind === 'MCP') {
+        // Hand the OAuth strategy exactly what the password path hands it: a
+        // short-lived, signed, httpOnly profile cookie, then the redirect to
+        // /callback. Everything downstream is identical, so SSO and password
+        // authorization converge on one code path.
+        const isSecure =
+          (req.headers['x-forwarded-proto'] as string) === 'https' || req.secure;
+        res.cookie(
+          'login_user',
+          Buffer.from(JSON.stringify(result.profile)).toString('base64url'),
+          {
+            httpOnly: true,
+            secure: isSecure,
+            maxAge: 60 * 1000,
+            sameSite: isSecure ? 'none' : 'lax',
+            signed: true,
+          },
+        );
+        res.clearCookie('login_csrf');
+        return res.redirect(303, `${this.mcpBaseUrl(req)}/callback`);
+      }
 
       if (result.kind === 'LINK') {
         // The caller was already signed in, so there is no session to hand
@@ -247,6 +272,24 @@ export class SsoController {
       // Deliberately the same 401 for expired, replayed and forged codes.
       return { error: 'Sign-in code is invalid or has expired' };
     }
+  }
+
+  /**
+   * Base URL for the MCP authorization leg.
+   *
+   * Mirrors `LoginController.getBaseUrl`: it trusts `x-forwarded-host` because
+   * the MCP flow must work behind a tunnel or reverse proxy, and `/callback`
+   * has to land on the same origin the client is talking to. This is only used
+   * to continue an already-bound flow — the OIDC `redirect_uri` is still built
+   * from server-side config alone, where a spoofed header would matter.
+   */
+  private mcpBaseUrl(req: Request): string {
+    const proto =
+      (req.headers['x-forwarded-proto'] as string) ||
+      (req.secure ? 'https' : 'http');
+    const host =
+      (req.headers['x-forwarded-host'] as string) || req.headers.host;
+    return host ? `${proto}://${host}` : this.frontendUrl();
   }
 
   private async logFailure(

--- a/packages/backend/src/identity-providers/sso.service.spec.ts
+++ b/packages/backend/src/identity-providers/sso.service.spec.ts
@@ -354,6 +354,108 @@ describe('SsoService', () => {
     });
   });
 
+  describe('the MCP authorization surface', () => {
+    const attempt = {
+      id: 'a1',
+      surface: 'MCP',
+      oauthSessionId: 'oauth-session-abc',
+      returnTo: null,
+      linkUserId: null,
+    };
+
+    const bind = (attemptSession: string | null, cookieSession?: string) =>
+      service.assertMcpBinding(
+        { oauthSessionId: attemptSession },
+        { id: 'p1', organizationId: 'org-1' },
+        'oid-1',
+        { oauthSessionId: cookieSession },
+      );
+
+    it('accepts a return from the browser that started the authorization', async () => {
+      await expect(bind('sess-1', 'sess-1')).resolves.toBeUndefined();
+    });
+
+    it('refuses a return carrying a DIFFERENT OAuth session', async () => {
+      // The attack this exists to stop: an attacker opens an authorization on
+      // their own machine, gets the victim to finish the identity-provider leg,
+      // and ends up holding a token for the victim's workspace.
+      await expect(bind('sess-attacker', 'sess-victim')).rejects.toThrow(
+        expect.objectContaining({ reason: 'mcp_session_binding_mismatch' }),
+      );
+    });
+
+    it('refuses a return carrying NO OAuth session', async () => {
+      // Dropping the cookie must not be a way to skip the check.
+      await expect(bind('sess-1', undefined)).rejects.toThrow(
+        expect.objectContaining({ reason: 'mcp_session_binding_mismatch' }),
+      );
+    });
+
+    it('refuses when the attempt recorded no session either', async () => {
+      // Two missing values must not compare equal and wave the request through.
+      await expect(bind(null, undefined)).rejects.toThrow(
+        expect.objectContaining({ reason: 'mcp_session_binding_mismatch' }),
+      );
+    });
+
+    it('audits the mismatch once, with the provider and subject attached', async () => {
+      await bind('sess-attacker', 'sess-victim').catch(() => {});
+      expect(securityEvents.log).toHaveBeenCalledTimes(1);
+      expect(securityEvents.log.mock.calls[0][0].metadata).toMatchObject({
+        reason: 'mcp_session_binding_mismatch',
+        surface: 'MCP',
+        providerId: 'p1',
+        oid: 'oid-1',
+      });
+    });
+
+    it('refuses to start without a pending OAuth session', async () => {
+      // Without one there is nothing to bind the returning identity to, so the
+      // result could be attached to any authorization that happens to be open.
+      await expect(service.startMcp('p1', '')).rejects.toThrow(
+        expect.objectContaining({ reason: 'mcp_without_oauth_session' }),
+      );
+    });
+
+    it('refuses a provider that is inactive or unknown', async () => {
+      prisma.identityProvider = { findUnique: jest.fn().mockResolvedValue(null) };
+      await expect(service.startMcp('p1', 'oauth-session-abc')).rejects.toThrow(
+        expect.objectContaining({ reason: 'unknown_or_inactive_provider' }),
+      );
+    });
+
+    it('records the OAuth session on the attempt so the callback can assert it', async () => {
+      prisma.identityProvider = {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'p1',
+          type: 'ENTRA',
+          issuer: provider.issuer,
+          clientId: 'c',
+          isActive: true,
+          organizationId: 'org-1',
+          config: provider.config,
+        }),
+      };
+      prisma.ssoLoginAttempt.create = jest.fn();
+      // The network half is mocked away; we only care about what gets stored.
+      service.beginAuthorization = jest.fn(async (_p: any, opts: any) => {
+        await prisma.ssoLoginAttempt.create({ data: { surface: opts.surface, oauthSessionId: opts.oauthSessionId } });
+        return { authorizationUrl: 'https://idp.example/authorize' };
+      });
+
+      await service.startMcp('p1', 'oauth-session-abc');
+
+      expect(prisma.ssoLoginAttempt.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            surface: 'MCP',
+            oauthSessionId: 'oauth-session-abc',
+          }),
+        }),
+      );
+    });
+  });
+
   describe('starting a link', () => {
     it('refuses a provider belonging to another workspace', async () => {
       // `identityProvider.id` is a cuid, not the opaque initiateId, so it is

--- a/packages/backend/src/identity-providers/sso.service.spec.ts
+++ b/packages/backend/src/identity-providers/sso.service.spec.ts
@@ -1,0 +1,379 @@
+// `openid-client` v6 is ESM-only. Jest transforms this suite to CommonJS and
+// cannot parse it, and these tests do not exercise the network half anyway —
+// discovery and the token exchange belong to the library and are covered by the
+// end-to-end run against a real tenant.
+jest.mock('openid-client', () => ({}));
+
+import { SsoService, SsoError } from './sso.service';
+
+/**
+ * These tests exercise the validation and identity-resolution logic directly.
+ * The network half (discovery, token exchange) belongs to openid-client and is
+ * covered by the end-to-end run against a real tenant.
+ */
+describe('SsoService', () => {
+  let service: any;
+  let prisma: any;
+  let securityEvents: { log: jest.Mock };
+
+  const provider = {
+    id: 'p1',
+    type: 'ENTRA',
+    issuer: 'https://login.microsoftonline.com/aaaabbbb-cccc-dddd-eeee-ffff11112222/v2.0',
+    organizationId: 'org-1',
+    jitProvisioning: false,
+    jitDefaultRole: 'VIEWER',
+    config: { tenantId: 'aaaabbbb-cccc-dddd-eeee-ffff11112222' },
+  };
+
+  const goodClaims = {
+    iss: provider.issuer,
+    tid: 'aaaabbbb-cccc-dddd-eeee-ffff11112222',
+    oid: 'a-stable-object-id',
+    sub: 'pairwise-subject',
+    email: 'user@kochfreiburg.de',
+    acct: 0,
+  };
+
+  beforeEach(() => {
+    prisma = {
+      userIdentity: { findUnique: jest.fn(), update: jest.fn(), create: jest.fn() },
+      user: { findUnique: jest.fn(), create: jest.fn() },
+      organizationMember: { create: jest.fn() },
+      ssoLoginAttempt: { updateMany: jest.fn(), findUnique: jest.fn() },
+      $transaction: jest.fn((fn: any) => fn(prisma)),
+    };
+    securityEvents = { log: jest.fn() };
+    service = new SsoService(
+      prisma,
+      { get: () => 'http://localhost:3000' } as any,
+      { isSelfHosted: () => true, isCloud: () => false, mode: 'self-hosted' } as any,
+      { getClientSecret: jest.fn() } as any,
+      { generateToken: jest.fn(() => 'jwt') } as any,
+      securityEvents as any,
+    );
+  });
+
+  const check = (claims: Record<string, any>, p = provider) =>
+    service.assertClaimsAcceptable(p, claims);
+
+  describe('claim validation', () => {
+    it('accepts a member of the configured tenant', () => {
+      expect(() => check(goodClaims)).not.toThrow();
+    });
+
+    it('rejects a token from a different tenant', () => {
+      // openid-client already checked the signature and issuer. This is the
+      // tenant policy, which is ours: a token from another directory must not
+      // be able to sign in here even though it is perfectly valid.
+      expect(() => check({ ...goodClaims, tid: 'ffffffff-0000-0000-0000-000000000000' }))
+        .toThrow(expect.objectContaining({ reason: 'tid_mismatch' }));
+    });
+
+    it('rejects the personal-account tenant', () => {
+      const msa = '9188040d-6c67-4c5b-b112-36a304b66dad';
+      expect(() =>
+        check({ ...goodClaims, tid: msa }, { ...provider, config: { tenantId: msa } } as any),
+      ).toThrow(expect.objectContaining({ reason: 'msa_tenant' }));
+    });
+
+    it.each([
+      ['acct === 1', { acct: 1 }, 'guest_account'],
+      ['an external idp', { idp: 'https://sts.windows.net/other/' }, 'guest_external_idp'],
+      ['an #EXT# UPN', { preferred_username: 'victim_gmail.com#EXT#@koch.onmicrosoft.com' }, 'guest_ext_upn'],
+    ])('rejects a B2B guest identified by %s', (_l, extra, reason) => {
+      // A tenant admin can invite ANY address as a guest, so a guest token
+      // carries an email the inviting tenant does not own. That is exactly the
+      // primitive behind nOAuth.
+      expect(() => check({ ...goodClaims, ...extra })).toThrow(
+        expect.objectContaining({ reason }),
+      );
+    });
+
+    it('rejects a token with no subject at all', () => {
+      const { oid, sub, ...rest } = goodClaims;
+      expect(() => check(rest)).toThrow(
+        expect.objectContaining({ reason: 'missing_subject' }),
+      );
+    });
+  });
+
+  describe('identity resolution', () => {
+    const resolve = (p = provider) =>
+      service.resolveUser(p, 'a-stable-object-id', goodClaims.tid, goodClaims, {});
+
+    it('returns the user behind a known identity', async () => {
+      prisma.userIdentity.findUnique.mockResolvedValue({ id: 'i1', userId: 'u1' });
+      expect(await resolve()).toBe('u1');
+      expect(prisma.userIdentity.update).toHaveBeenCalled();
+    });
+
+    it('keys the lookup on (provider, subject) — never the email', async () => {
+      prisma.userIdentity.findUnique.mockResolvedValue({ id: 'i1', userId: 'u1' });
+      await resolve();
+
+      expect(prisma.userIdentity.findUnique).toHaveBeenCalledWith({
+        where: {
+          providerId_externalSubject: {
+            providerId: 'p1',
+            externalSubject: 'a-stable-object-id',
+          },
+        },
+        select: { id: true, userId: true },
+      });
+      // The users table is never consulted by email on the known-identity path.
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('refuses an unknown identity when JIT is off', async () => {
+      prisma.userIdentity.findUnique.mockResolvedValue(null);
+      await expect(resolve()).rejects.toThrow(
+        expect.objectContaining({ reason: 'no_identity_and_jit_disabled' }),
+      );
+      expect(prisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('refuses to claim an existing account that owns the email', async () => {
+      // THE takeover this design exists to prevent: anyone who controls any
+      // tenant could otherwise assert a victim's address and be handed their
+      // account. Linking must be a deliberate, authenticated action.
+      prisma.userIdentity.findUnique.mockResolvedValue(null);
+      prisma.user.findUnique.mockResolvedValue({ id: 'victim' });
+
+      await expect(resolve({ ...provider, jitProvisioning: true })).rejects.toThrow(
+        expect.objectContaining({ reason: 'email_belongs_to_existing_account' }),
+      );
+      expect(prisma.user.create).not.toHaveBeenCalled();
+      expect(prisma.userIdentity.create).not.toHaveBeenCalled();
+    });
+
+    it('provisions a passwordless VIEWER when JIT is on', async () => {
+      prisma.userIdentity.findUnique.mockResolvedValue(null);
+      prisma.user.findUnique.mockResolvedValue(null);
+      prisma.user.create.mockResolvedValue({ id: 'new-user' });
+
+      expect(await resolve({ ...provider, jitProvisioning: true })).toBe('new-user');
+
+      const created = prisma.user.create.mock.calls[0][0].data;
+      // No password: the account exists only through the provider, so there is
+      // no second way in that bypasses its MFA and Conditional Access.
+      expect(created.passwordHash).toBeNull();
+      expect(created.role).toBe('VIEWER');
+      expect(created.organizationId).toBe('org-1');
+      expect(prisma.organizationMember.create).toHaveBeenCalled();
+      expect(prisma.userIdentity.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('returnTo', () => {
+    it.each([
+      ['an absolute URL', 'https://evil.tld'],
+      ['a protocol-relative URL', '//evil.tld'],
+      ['a backslash variant', '/\\evil.tld'],
+      ['a bare word', 'evil'],
+    ])('refuses %s', (_l, value) => {
+      expect(service.safeReturnTo(value)).toBe('/');
+    });
+
+    it('keeps an internal path', () => {
+      expect(service.safeReturnTo('/connectors/abc')).toBe('/connectors/abc');
+    });
+  });
+
+  describe('handoff exchange', () => {
+    it('refuses an expired code', async () => {
+      prisma.ssoLoginAttempt.findUnique.mockResolvedValue({
+        id: 'a1',
+        resolvedUserId: 'u1',
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      await expect(service.exchange('code')).rejects.toThrow(
+        expect.objectContaining({ reason: 'handoff_invalid_or_expired' }),
+      );
+    });
+
+    it('refuses a code for an attempt that never completed', async () => {
+      prisma.ssoLoginAttempt.findUnique.mockResolvedValue({
+        id: 'a1',
+        resolvedUserId: null,
+        expiresAt: new Date(Date.now() + 10_000),
+      });
+      await expect(service.exchange('code')).rejects.toThrow(SsoError);
+    });
+  });
+
+  describe('linking an identity to an existing account', () => {
+    const attempt = { id: 'a1', linkUserId: 'u1', returnTo: '/settings' };
+    const link = (over: Record<string, any> = {}) =>
+      service.completeLink(
+        { ...attempt, ...over },
+        { id: 'p1', organizationId: 'org-1' },
+        'oid-123',
+        'tid-1',
+        {},
+      );
+
+    beforeEach(() => {
+      prisma.organizationMember.findFirst = jest.fn().mockResolvedValue({ id: 'm1' });
+      prisma.userIdentity.findUnique.mockResolvedValue(null);
+      prisma.userIdentity.count = jest.fn().mockResolvedValue(0);
+      prisma.userIdentity.delete = jest.fn();
+    });
+
+    it('links the identity to the user captured when the flow started', async () => {
+      await link();
+      expect(prisma.userIdentity.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ userId: 'u1', externalSubject: 'oid-123' }),
+        }),
+      );
+    });
+
+    it('refuses a LINK attempt carrying no user instead of signing someone in', async () => {
+      // Falling through to the sign-in path here would authenticate whoever
+      // completed the round trip, which is the whole attack this flow avoids.
+      await expect(link({ linkUserId: null })).rejects.toThrow(
+        expect.objectContaining({ reason: 'link_without_user' }),
+      );
+      expect(prisma.userIdentity.create).not.toHaveBeenCalled();
+    });
+
+    it('re-checks membership on return, not only at start', async () => {
+      // The round trip takes minutes. A member removed in between must not
+      // still be able to attach an identity to the workspace.
+      prisma.organizationMember.findFirst.mockResolvedValue(null);
+      await expect(link()).rejects.toThrow(
+        expect.objectContaining({ reason: 'not_a_member' }),
+      );
+      expect(prisma.userIdentity.create).not.toHaveBeenCalled();
+    });
+
+    it("refuses to steal an identity already linked to somebody else", async () => {
+      prisma.userIdentity.findUnique.mockResolvedValue({ userId: 'someone-else' });
+      await expect(link()).rejects.toThrow(
+        expect.objectContaining({ reason: 'identity_already_linked_to_another_user' }),
+      );
+      expect(prisma.userIdentity.create).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when the same user re-links the same identity', async () => {
+      prisma.userIdentity.findUnique.mockResolvedValue({ userId: 'u1' });
+      await expect(link()).resolves.toBe('/settings');
+      expect(prisma.userIdentity.create).not.toHaveBeenCalled();
+    });
+
+    it('refuses a second directory account at the same provider', async () => {
+      // Replacing it silently would change who can sign in as this user
+      // without ever telling them.
+      prisma.userIdentity.findUnique
+        .mockResolvedValueOnce(null) // by (provider, subject)
+        .mockResolvedValueOnce({ externalSubject: 'a-different-oid' }); // by (user, provider)
+      await expect(link()).rejects.toThrow(
+        expect.objectContaining({ reason: 'user_already_linked_at_provider' }),
+      );
+      expect(prisma.userIdentity.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unlinking', () => {
+    beforeEach(() => {
+      prisma.userIdentity.count = jest.fn().mockResolvedValue(0);
+      prisma.userIdentity.delete = jest.fn();
+      prisma.userIdentity.findUnique.mockResolvedValue({
+        id: 'i1',
+        externalSubject: 'oid-123',
+        provider: { organizationId: 'org-1' },
+      });
+    });
+
+    it('refuses when it would leave the account with no way to sign in', async () => {
+      // A JIT-provisioned user has no password. Unlinking their only identity
+      // would report success and lock them out permanently.
+      prisma.user.findUnique.mockResolvedValue({
+        passwordHash: null,
+        passwordLoginDisabled: false,
+      });
+      await expect(service.unlink('u1', 'p1', {})).rejects.toThrow(
+        expect.objectContaining({ reason: 'would_lock_account_out' }),
+      );
+      expect(prisma.userIdentity.delete).not.toHaveBeenCalled();
+    });
+
+    it('refuses when a password exists but password sign-in is disabled', async () => {
+      // Having a hash is not the same as being able to use it.
+      prisma.user.findUnique.mockResolvedValue({
+        passwordHash: 'hash',
+        passwordLoginDisabled: true,
+      });
+      await expect(service.unlink('u1', 'p1', {})).rejects.toThrow(
+        expect.objectContaining({ reason: 'would_lock_account_out' }),
+      );
+    });
+
+    it('allows it when a usable password remains', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        passwordHash: 'hash',
+        passwordLoginDisabled: false,
+      });
+      await service.unlink('u1', 'p1', {});
+      expect(prisma.userIdentity.delete).toHaveBeenCalledWith({ where: { id: 'i1' } });
+    });
+
+    it('allows it when another provider is still connected', async () => {
+      prisma.user.findUnique.mockResolvedValue({
+        passwordHash: null,
+        passwordLoginDisabled: false,
+      });
+      prisma.userIdentity.count.mockResolvedValue(1);
+      await service.unlink('u1', 'p1', {});
+      expect(prisma.userIdentity.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('audit de-duplication', () => {
+    it('marks the rejections it has already logged, so the controller does not log them twice', async () => {
+      // Observed live: one refused sign-in produced TWO SSO_LOGIN_FAILED rows,
+      // the service's (with organization, provider and oid) and the
+      // controller's (with only the reason). An auditor counting refusals
+      // would have double-counted every one of them.
+      prisma.userIdentity.findUnique.mockResolvedValue(null);
+      const err = await service
+        .resolveUser(provider, 'oid-1', 'tid-1', goodClaims, {})
+        .catch((e: any) => e);
+
+      expect(err.reason).toBe('no_identity_and_jit_disabled');
+      expect(err.audited).toBe(true);
+      expect(securityEvents.log).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves rejections it did NOT log unmarked, so they still reach the trail', async () => {
+      // The controller is the only writer for these; marking them by mistake
+      // would make the refusal vanish from the audit trail entirely.
+      const err = new SsoError('state_replayed_or_expired');
+      expect(err.audited).toBe(false);
+    });
+  });
+
+  describe('starting a link', () => {
+    it('refuses a provider belonging to another workspace', async () => {
+      // `identityProvider.id` is a cuid, not the opaque initiateId, so it is
+      // guessable — membership is what stops a cross-workspace link.
+      prisma.identityProvider = {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'p1',
+          type: 'ENTRA',
+          issuer: provider.issuer,
+          clientId: 'c',
+          isActive: true,
+          organizationId: 'org-2',
+          config: provider.config,
+        }),
+      };
+      prisma.organizationMember.findFirst = jest.fn().mockResolvedValue(null);
+
+      await expect(service.startLink('u1', 'p1')).rejects.toThrow(
+        expect.objectContaining({ reason: 'not_a_member' }),
+      );
+    });
+  });
+});

--- a/packages/backend/src/identity-providers/sso.service.ts
+++ b/packages/backend/src/identity-providers/sso.service.ts
@@ -40,7 +40,17 @@ export class SsoError extends Error {
  */
 export type SsoCompletion =
   | { kind: 'LOGIN'; handoffCode: string; returnTo: string }
-  | { kind: 'LINK'; returnTo: string };
+  | { kind: 'LINK'; returnTo: string }
+  /**
+   * The MCP authorization surface. Carries the profile the OAuth strategy
+   * expects in the short-lived `login_user` cookie — the same shape the
+   * password path produces, so the rest of the authorization flow cannot tell
+   * the two apart.
+   */
+  | {
+      kind: 'MCP';
+      profile: { id: string; email: string; name: string | null; username: string };
+    };
 
 /** How long a user has to complete the trip to the provider and back. */
 const ATTEMPT_TTL_MS = 5 * 60 * 1000;
@@ -175,6 +185,46 @@ export class SsoService {
     });
   }
 
+  /**
+   * Begins a sign-in from the MCP authorization page.
+   *
+   * This is the surface that matters most: it is where a user authorizes an AI
+   * client, and until now it accepted only a password — so an SSO-enforced
+   * account could not connect a client at all, and everyone else bypassed the
+   * IdP's MFA and Conditional Access on exactly the flow worth protecting.
+   *
+   * `oauthSessionId` is the pending mcp-nest session this login belongs to. It
+   * is recorded now and ASSERTED on return, so the identity can only ever be
+   * attached to the authorization that the same browser started.
+   */
+  async startMcp(
+    providerId: string,
+    oauthSessionId: string,
+  ): Promise<{ authorizationUrl: string }> {
+    if (!oauthSessionId) throw new SsoError('mcp_without_oauth_session');
+
+    const provider = await this.prisma.identityProvider.findUnique({
+      where: { id: providerId },
+      select: {
+        id: true,
+        type: true,
+        issuer: true,
+        clientId: true,
+        isActive: true,
+        organizationId: true,
+        config: true,
+      },
+    });
+    if (!provider || !provider.isActive) {
+      throw new SsoError('unknown_or_inactive_provider');
+    }
+
+    return this.beginAuthorization(provider, {
+      surface: 'MCP',
+      oauthSessionId,
+    });
+  }
+
   /** Shared by both entry points: PKCE, state, nonce and the stored attempt. */
   private async beginAuthorization(
     provider: {
@@ -185,7 +235,12 @@ export class SsoService {
       organizationId: string;
       config: any;
     },
-    opts: { surface: string; returnTo?: string; linkUserId?: string },
+    opts: {
+      surface: string;
+      returnTo?: string;
+      linkUserId?: string;
+      oauthSessionId?: string;
+    },
   ): Promise<{ authorizationUrl: string }> {
     const clientSecret = await this.providers.getClientSecret(
       provider.id,
@@ -208,6 +263,7 @@ export class SsoService {
         providerId: provider.id,
         surface: opts.surface,
         linkUserId: opts.linkUserId ?? null,
+        oauthSessionId: opts.oauthSessionId ?? null,
         returnTo: this.safeReturnTo(opts.returnTo),
         expiresAt: new Date(Date.now() + ATTEMPT_TTL_MS),
       },
@@ -248,7 +304,7 @@ export class SsoService {
    */
   async complete(
     currentUrl: URL,
-    ctx: { ip?: string; userAgent?: string },
+    ctx: { ip?: string; userAgent?: string; oauthSessionId?: string },
   ): Promise<SsoCompletion> {
     const state = currentUrl.searchParams.get('state');
     if (!state) throw new SsoError('missing_state');
@@ -322,6 +378,44 @@ export class SsoService {
         ctx,
       );
       return { kind: 'LINK', returnTo };
+    }
+
+    if (attempt.surface === 'MCP') {
+      // Bind the return to the browser that started it. Without this an
+      // attacker could open an authorization on their own machine, get the
+      // victim to complete the IdP leg, and have the victim's identity
+      // attached to the attacker's pending authorization.
+      //
+      // ASSERTED, never restored: re-planting the cookie would reduce
+      // mcp-nest's own binding check to comparing a value against itself.
+      await this.assertMcpBinding(attempt, provider, subject, ctx);
+
+      const userId = await this.resolveUser(provider, subject, tid, claims, ctx);
+      const user = await this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, email: true, name: true },
+      });
+      if (!user) throw new SsoError('user_vanished');
+
+      await this.securityEvents.log({
+        event: SecurityEvents.SSO_LOGIN_SUCCESS,
+        actorType: 'USER',
+        organizationId: provider.organizationId,
+        actorUserId: user.id,
+        metadata: { providerId: provider.id, oid: subject, tid, surface: 'MCP' },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+
+      return {
+        kind: 'MCP',
+        profile: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          username: user.email,
+        },
+      };
     }
 
     const userId = await this.resolveUser(provider, subject, tid, claims, ctx);
@@ -538,6 +632,46 @@ export class SsoService {
       linkedAt: linked.get(p.id)?.createdAt ?? null,
       lastLoginAt: linked.get(p.id)?.lastLoginAt ?? null,
     }));
+  }
+
+  /**
+   * The returning browser must be the one that started this authorization.
+   *
+   * Without it an attacker could open an authorization on their own machine,
+   * get a victim to complete the identity-provider leg, and end up with the
+   * victim's identity attached to the attacker's pending authorization — and
+   * therefore an access token for the victim's workspace.
+   *
+   * The recorded value is ASSERTED against the cookie the browser presents
+   * now, never restored onto the response. Re-planting it would reduce
+   * mcp-nest's own session check to comparing a value with itself.
+   */
+  private async assertMcpBinding(
+    attempt: { oauthSessionId: string | null },
+    provider: { id: string; organizationId: string },
+    subject: string,
+    ctx: { ip?: string; userAgent?: string; oauthSessionId?: string },
+  ): Promise<void> {
+    if (
+      !attempt.oauthSessionId ||
+      !ctx.oauthSessionId ||
+      attempt.oauthSessionId !== ctx.oauthSessionId
+    ) {
+      await this.securityEvents.log({
+        event: SecurityEvents.SSO_LOGIN_FAILED,
+        actorType: 'ANONYMOUS',
+        organizationId: provider.organizationId,
+        metadata: {
+          providerId: provider.id,
+          reason: 'mcp_session_binding_mismatch',
+          oid: subject,
+          surface: 'MCP',
+        },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+      throw new SsoError('mcp_session_binding_mismatch', 'Sign-in failed', true);
+    }
   }
 
   /** Fails closed: a non-member is treated exactly like an unknown provider. */

--- a/packages/backend/src/identity-providers/sso.service.ts
+++ b/packages/backend/src/identity-providers/sso.service.ts
@@ -1,0 +1,776 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes } from 'crypto';
+import * as client from 'openid-client';
+import { PrismaService } from '../common/prisma.service';
+import { DeploymentService } from '../common/deployment.service';
+import { AuthService } from '../auth/auth.service';
+import { assertSafeOutboundUrl } from '../common/ssrf.util';
+import {
+  SecurityEventService,
+  SecurityEvents,
+} from '../audit/security-event.service';
+import { IdentityProvidersService } from './identity-providers.service';
+import { assertIssuerAllowed, MSA_TENANT_ID } from './provider-config';
+
+/**
+ * Thrown for every rejection. The `reason` is audited; the message is generic.
+ *
+ * `audited` marks the reasons the service has ALREADY written a security event
+ * for, with the organization, provider and subject attached. The controller
+ * logs everything else, but only knows the reason — without this flag those
+ * rejections produced two rows for one event, the second one context-free, and
+ * an auditor reading the trail would double-count every refusal.
+ */
+export class SsoError extends Error {
+  constructor(
+    readonly reason: string,
+    message = 'Sign-in failed',
+    readonly audited = false,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * What the callback produced.
+ *
+ * Discriminated rather than an optional `handoffCode`, so the controller cannot
+ * accidentally mint a session for a link: forgetting to check would not compile.
+ */
+export type SsoCompletion =
+  | { kind: 'LOGIN'; handoffCode: string; returnTo: string }
+  | { kind: 'LINK'; returnTo: string };
+
+/** How long a user has to complete the trip to the provider and back. */
+const ATTEMPT_TTL_MS = 5 * 60 * 1000;
+/** How long the SPA has to trade the one-time code for a session. */
+const HANDOFF_TTL_MS = 30 * 1000;
+
+@Injectable()
+export class SsoService {
+  private readonly logger = new Logger(SsoService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+    private readonly deployment: DeploymentService,
+    private readonly providers: IdentityProvidersService,
+    private readonly authService: AuthService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  /**
+   * The redirect URI registered at the provider.
+   *
+   * Built from server-side config ONLY. `login.controller.ts` has a sibling
+   * helper that trusts `x-forwarded-host` because the MCP flow must work behind
+   * tunnels — using that one here would let a spoofed header redirect the OIDC
+   * callback to a host of the attacker's choosing. It must also match the
+   * registered value byte-for-byte, which a header-derived value cannot promise.
+   */
+  private redirectUri(): string {
+    const base =
+      this.config.get<string>('FRONTEND_URL') ||
+      this.config.get<string>('SERVER_URL') ||
+      'http://localhost:3000';
+    return `${base.replace(/\/$/, '')}/auth/sso/callback`;
+  }
+
+  /** Builds an openid-client configuration, guarding the outbound fetch. */
+  private async discoverFor(provider: {
+    id: string;
+    type: string;
+    issuer: string;
+    clientId: string;
+    organizationId?: string;
+  }, clientSecret: string) {
+    // Re-checked here, not only on write: the allowlist may have tightened
+    // since the provider was configured, and this is the call that leaves.
+    assertIssuerAllowed(provider.type, provider.issuer, {
+      allowArbitraryIssuer: this.deployment.isSelfHosted(),
+    });
+    await assertSafeOutboundUrl(provider.issuer);
+
+    return client.discovery(
+      new URL(provider.issuer),
+      provider.clientId,
+      clientSecret,
+    );
+  }
+
+  // ── Step 1: start ─────────────────────────────────────────────────────────
+
+  /**
+   * Begins a sign-in. Returns the provider URL to send the browser to.
+   *
+   * `initiateId` is opaque and rotatable; an unknown one is refused with the
+   * same shape as any other failure so this cannot enumerate workspaces.
+   */
+  async start(
+    initiateId: string,
+    returnTo?: string,
+  ): Promise<{ authorizationUrl: string }> {
+    const provider = await this.prisma.identityProvider.findUnique({
+      where: { initiateId },
+      select: {
+        id: true,
+        type: true,
+        issuer: true,
+        clientId: true,
+        isActive: true,
+        organizationId: true,
+        config: true,
+      },
+    });
+    if (!provider || !provider.isActive) {
+      throw new SsoError('unknown_or_inactive_provider');
+    }
+
+    return this.beginAuthorization(provider, {
+      surface: 'DASHBOARD',
+      returnTo,
+    });
+  }
+
+  /**
+   * Begins a link: attaches an external identity to the CALLER'S OWN account.
+   *
+   * The user id comes from the caller's session and is written into the attempt
+   * now, before the browser ever leaves. The callback then has nothing to
+   * decide — which is the point, because everything that arrives there travels
+   * through the user agent and is attacker-influenced.
+   */
+  async startLink(
+    userId: string,
+    providerId: string,
+    returnTo?: string,
+  ): Promise<{ authorizationUrl: string }> {
+    const provider = await this.prisma.identityProvider.findUnique({
+      where: { id: providerId },
+      select: {
+        id: true,
+        type: true,
+        issuer: true,
+        clientId: true,
+        isActive: true,
+        organizationId: true,
+        config: true,
+      },
+    });
+    if (!provider || !provider.isActive) {
+      throw new SsoError('unknown_or_inactive_provider');
+    }
+
+    // Membership, not just authentication: a signed-in user from workspace A
+    // must not be able to start a link against workspace B's provider by
+    // guessing its id. `identityProvider.id` is a cuid rather than the opaque
+    // `initiateId`, and cuids are not secrets.
+    await this.assertMember(userId, provider.organizationId);
+
+    return this.beginAuthorization(provider, {
+      surface: 'LINK',
+      returnTo,
+      linkUserId: userId,
+    });
+  }
+
+  /** Shared by both entry points: PKCE, state, nonce and the stored attempt. */
+  private async beginAuthorization(
+    provider: {
+      id: string;
+      type: string;
+      issuer: string;
+      clientId: string;
+      organizationId: string;
+      config: any;
+    },
+    opts: { surface: string; returnTo?: string; linkUserId?: string },
+  ): Promise<{ authorizationUrl: string }> {
+    const clientSecret = await this.providers.getClientSecret(
+      provider.id,
+      provider.organizationId,
+    );
+    if (!clientSecret) throw new SsoError('provider_missing_secret');
+
+    const config = await this.discoverFor(provider, clientSecret);
+
+    const codeVerifier = client.randomPKCECodeVerifier();
+    const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+    const state = client.randomState();
+    const nonce = client.randomNonce();
+
+    await this.prisma.ssoLoginAttempt.create({
+      data: {
+        state,
+        nonce,
+        codeVerifier,
+        providerId: provider.id,
+        surface: opts.surface,
+        linkUserId: opts.linkUserId ?? null,
+        returnTo: this.safeReturnTo(opts.returnTo),
+        expiresAt: new Date(Date.now() + ATTEMPT_TTL_MS),
+      },
+    });
+
+    const params: Record<string, string> = {
+      redirect_uri: this.redirectUri(),
+      scope: 'openid profile email offline_access',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      state,
+      nonce,
+      // `query` rather than `form_post`: the response then arrives as a
+      // same-site top-level GET, so SameSite=Lax cookies survive it. The only
+      // advantage of form_post — keeping the code out of the URL — is covered
+      // by consuming the code immediately and redirecting to a query-less URL.
+      response_mode: 'query',
+    };
+
+    // Entra: pin the tenant so the account picker cannot wander to another one.
+    const tenantId = (provider.config as any)?.tenantId;
+    if (provider.type === 'ENTRA' && tenantId) {
+      params.domain_hint = 'organizations';
+    }
+
+    const url = client.buildAuthorizationUrl(config, params);
+    return { authorizationUrl: url.href };
+  }
+
+  // ── Step 2: callback ──────────────────────────────────────────────────────
+
+  /**
+   * Completes the round trip. Returns a one-time code for the SPA.
+   *
+   * The JWT is deliberately NOT minted here: putting it in the redirect would
+   * write a bearer token into browser history, the `Referer` header and every
+   * proxy log between here and the user.
+   */
+  async complete(
+    currentUrl: URL,
+    ctx: { ip?: string; userAgent?: string },
+  ): Promise<SsoCompletion> {
+    const state = currentUrl.searchParams.get('state');
+    if (!state) throw new SsoError('missing_state');
+
+    // Atomic single-use consumption. A findFirst-then-update would leave a
+    // replay window between the two statements.
+    const claimed = await this.prisma.ssoLoginAttempt.updateMany({
+      where: { state, consumedAt: null, expiresAt: { gt: new Date() } },
+      data: { consumedAt: new Date() },
+    });
+    if (claimed.count !== 1) throw new SsoError('state_replayed_or_expired');
+
+    const attempt = await this.prisma.ssoLoginAttempt.findUnique({
+      where: { state },
+      include: {
+        provider: {
+          select: {
+            id: true,
+            type: true,
+            issuer: true,
+            clientId: true,
+            organizationId: true,
+            jitProvisioning: true,
+            jitDefaultRole: true,
+            config: true,
+          },
+        },
+      },
+    });
+    if (!attempt) throw new SsoError('attempt_vanished');
+    const provider = attempt.provider;
+
+    const clientSecret = await this.providers.getClientSecret(
+      provider.id,
+      provider.organizationId,
+    );
+    if (!clientSecret) throw new SsoError('provider_missing_secret');
+
+    const config = await this.discoverFor(provider, clientSecret);
+
+    let claims: Record<string, any>;
+    try {
+      const tokens = await client.authorizationCodeGrant(config, currentUrl, {
+        pkceCodeVerifier: attempt.codeVerifier,
+        expectedNonce: attempt.nonce,
+        expectedState: attempt.state,
+        // RFC 9207: openid-client compares a present `iss` against the
+        // discovered issuer for us.
+      });
+      claims = tokens.claims() as Record<string, any>;
+    } catch (e: any) {
+      this.logger.warn(`SSO token exchange failed: ${e?.message}`);
+      throw new SsoError('token_exchange_failed');
+    }
+
+    this.assertClaimsAcceptable(provider, claims);
+
+    const subject = String(claims.oid ?? claims.sub);
+    const tid = claims.tid ? String(claims.tid) : null;
+
+    // A link attaches an identity to a session that already exists, so it must
+    // NOT mint a second one. Returning a handoff code here would turn "connect
+    // your Microsoft account" into a login — and, for an admin who linked the
+    // wrong directory, into a way to hand out a session they never intended.
+    if (attempt.surface === 'LINK') {
+      const returnTo = await this.completeLink(
+        attempt,
+        provider,
+        subject,
+        tid,
+        ctx,
+      );
+      return { kind: 'LINK', returnTo };
+    }
+
+    const userId = await this.resolveUser(provider, subject, tid, claims, ctx);
+
+    const handoffCode = randomBytes(32).toString('base64url');
+    await this.prisma.ssoLoginAttempt.update({
+      where: { id: attempt.id },
+      data: {
+        handoffCode,
+        resolvedUserId: userId,
+        expiresAt: new Date(Date.now() + HANDOFF_TTL_MS),
+      },
+    });
+
+    await this.securityEvents.log({
+      event: SecurityEvents.SSO_LOGIN_SUCCESS,
+      actorType: 'USER',
+      organizationId: provider.organizationId,
+      actorUserId: userId,
+      metadata: { providerId: provider.id, oid: subject, tid, surface: 'DASHBOARD' },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+
+    return { kind: 'LOGIN', handoffCode, returnTo: attempt.returnTo ?? '/' };
+  }
+
+  // ── Linking ───────────────────────────────────────────────────────────────
+
+  /**
+   * Attaches the authenticated identity to the user recorded at start time.
+   *
+   * Returns the path to send the browser back to. Never returns a session:
+   * the caller already had one before the round trip began.
+   */
+  private async completeLink(
+    attempt: { id: string; linkUserId: string | null; returnTo: string | null },
+    provider: { id: string; organizationId: string },
+    subject: string,
+    tid: string | null,
+    ctx: { ip?: string; userAgent?: string },
+  ): Promise<string> {
+    // A LINK attempt without a user is a bug, not a login. Falling through to
+    // the sign-in path here would authenticate whoever completed the round
+    // trip, so refuse instead of guessing.
+    if (!attempt.linkUserId) throw new SsoError('link_without_user');
+
+    // Re-checked on return, not only at start: the round trip is minutes long
+    // and the member could have been removed from the workspace in between.
+    await this.assertMember(attempt.linkUserId, provider.organizationId);
+
+    const existing = await this.prisma.userIdentity.findUnique({
+      where: {
+        providerId_externalSubject: {
+          providerId: provider.id,
+          externalSubject: subject,
+        },
+      },
+      select: { userId: true },
+    });
+
+    if (existing && existing.userId !== attempt.linkUserId) {
+      // This directory account is already somebody else's way in. Re-pointing
+      // it would silently transfer their access, so the losing party has to
+      // unlink first.
+      await this.logLinkFailure(
+        'identity_already_linked_to_another_user',
+        provider,
+        attempt.linkUserId,
+        subject,
+        ctx,
+      );
+      throw new SsoError('identity_already_linked_to_another_user', 'Sign-in failed', true);
+    }
+
+    if (existing) {
+      // Already linked to this same user: nothing to do. Idempotent rather
+      // than an error, because a double-click must not look like a failure.
+      await this.prisma.userIdentity.update({
+        where: {
+          providerId_externalSubject: {
+            providerId: provider.id,
+            externalSubject: subject,
+          },
+        },
+        data: { externalTid: tid },
+      });
+      return this.safeReturnTo(attempt.returnTo ?? undefined);
+    }
+
+    const otherAtSameProvider = await this.prisma.userIdentity.findUnique({
+      where: {
+        userId_providerId: {
+          userId: attempt.linkUserId,
+          providerId: provider.id,
+        },
+      },
+      select: { externalSubject: true },
+    });
+    if (otherAtSameProvider) {
+      // Silently replacing it would change which directory account can sign in
+      // without the user being told, so require an explicit unlink.
+      await this.logLinkFailure(
+        'user_already_linked_at_provider',
+        provider,
+        attempt.linkUserId,
+        subject,
+        ctx,
+      );
+      throw new SsoError('user_already_linked_at_provider', 'Sign-in failed', true);
+    }
+
+    await this.prisma.userIdentity.create({
+      data: {
+        userId: attempt.linkUserId,
+        providerId: provider.id,
+        externalSubject: subject,
+        externalTid: tid,
+        lastLoginAt: new Date(),
+      },
+    });
+
+    await this.securityEvents.log({
+      event: SecurityEvents.IDENTITY_LINKED,
+      actorType: 'USER',
+      organizationId: provider.organizationId,
+      actorUserId: attempt.linkUserId,
+      targetUserId: attempt.linkUserId,
+      metadata: { providerId: provider.id, oid: subject, tid },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+
+    return this.safeReturnTo(attempt.returnTo ?? undefined);
+  }
+
+  /**
+   * Detaches an external identity from the caller's own account.
+   *
+   * Refuses when it would leave the account with no way in at all — an unlink
+   * that reports success and locks the user out is worse than a refusal.
+   */
+  async unlink(
+    userId: string,
+    providerId: string,
+    ctx: { ip?: string; userAgent?: string },
+  ): Promise<void> {
+    const identity = await this.prisma.userIdentity.findUnique({
+      where: { userId_providerId: { userId, providerId } },
+      select: { id: true, externalSubject: true, provider: { select: { organizationId: true } } },
+    });
+    if (!identity) throw new SsoError('identity_not_linked');
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { passwordHash: true, passwordLoginDisabled: true },
+    });
+    const remaining = await this.prisma.userIdentity.count({
+      where: { userId, providerId: { not: providerId } },
+    });
+    const canUsePassword = Boolean(user?.passwordHash) && !user?.passwordLoginDisabled;
+    if (!canUsePassword && remaining === 0) {
+      throw new SsoError('would_lock_account_out');
+    }
+
+    await this.prisma.userIdentity.delete({ where: { id: identity.id } });
+
+    await this.securityEvents.log({
+      event: SecurityEvents.IDENTITY_UNLINKED,
+      actorType: 'USER',
+      organizationId: identity.provider.organizationId,
+      actorUserId: userId,
+      targetUserId: userId,
+      metadata: { providerId, oid: identity.externalSubject },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+  }
+
+  /** The identities the caller has already connected, for the settings page. */
+  async listIdentities(userId: string) {
+    return this.prisma.userIdentity.findMany({
+      where: { userId },
+      select: {
+        providerId: true,
+        externalTid: true,
+        lastLoginAt: true,
+        createdAt: true,
+        provider: { select: { name: true, type: true, isActive: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  /** Providers the caller may connect, with whether they already have. */
+  async availableForUser(userId: string, organizationId: string) {
+    const [providers, identities] = await Promise.all([
+      this.prisma.identityProvider.findMany({
+        where: { organizationId, isActive: true },
+        // Never the client id or issuer: this is a member-level endpoint, and
+        // the configuration belongs to the admin page behind @Roles('ADMIN').
+        select: { id: true, name: true, type: true },
+        orderBy: { createdAt: 'asc' },
+      }),
+      this.prisma.userIdentity.findMany({
+        where: { userId },
+        select: { providerId: true, lastLoginAt: true, createdAt: true },
+      }),
+    ]);
+    const linked = new Map(identities.map((i) => [i.providerId, i]));
+    return providers.map((p) => ({
+      ...p,
+      linked: linked.has(p.id),
+      linkedAt: linked.get(p.id)?.createdAt ?? null,
+      lastLoginAt: linked.get(p.id)?.lastLoginAt ?? null,
+    }));
+  }
+
+  /** Fails closed: a non-member is treated exactly like an unknown provider. */
+  private async assertMember(userId: string, organizationId: string) {
+    const member = await this.prisma.organizationMember.findFirst({
+      where: { userId, organizationId },
+      select: { id: true },
+    });
+    if (!member) throw new SsoError('not_a_member');
+  }
+
+  private async logLinkFailure(
+    reason: string,
+    provider: { id: string; organizationId: string },
+    userId: string,
+    subject: string,
+    ctx: { ip?: string; userAgent?: string },
+  ) {
+    await this.securityEvents.log({
+      event: SecurityEvents.SSO_LOGIN_FAILED,
+      actorType: 'USER',
+      organizationId: provider.organizationId,
+      actorUserId: userId,
+      metadata: { providerId: provider.id, reason, oid: subject, surface: 'LINK' },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+  }
+
+  // ── Step 3: exchange ──────────────────────────────────────────────────────
+
+  /** Trades the one-time code for a session. Single-use, 30 seconds. */
+  async exchange(handoffCode: string) {
+    const attempt = await this.prisma.ssoLoginAttempt.findUnique({
+      where: { handoffCode },
+      select: { id: true, resolvedUserId: true, expiresAt: true },
+    });
+    if (
+      !attempt?.resolvedUserId ||
+      attempt.expiresAt.getTime() < Date.now()
+    ) {
+      throw new SsoError('handoff_invalid_or_expired');
+    }
+
+    // Burn the code before minting, so a replay finds nothing.
+    await this.prisma.ssoLoginAttempt.delete({ where: { id: attempt.id } });
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: attempt.resolvedUserId },
+    });
+    if (!user) throw new SsoError('user_vanished');
+
+    return {
+      accessToken: this.authService.generateToken({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+        organizationId: user.organizationId,
+      }),
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        organizationId: user.organizationId,
+        emailVerified: user.emailVerified,
+      },
+    };
+  }
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  /**
+   * Rejects a token that is technically valid but must not be trusted here.
+   *
+   * openid-client has already checked the signature, `aud`, `nonce`, `exp` and
+   * that `iss` matches the discovered issuer. What remains is the tenant and
+   * guest policy, which is ours to decide.
+   */
+  private assertClaimsAcceptable(
+    provider: { type: string; issuer: string; config: any },
+    claims: Record<string, any>,
+  ) {
+    if (provider.type === 'ENTRA') {
+      const tid = String(claims.tid ?? '');
+      const expected = String(provider.config?.tenantId ?? '');
+      if (!tid || tid.toLowerCase() !== expected.toLowerCase()) {
+        throw new SsoError('tid_mismatch');
+      }
+      // Every consumer Microsoft account lives in this single tenant, so it
+      // identifies no organization.
+      if (tid.toLowerCase() === MSA_TENANT_ID) throw new SsoError('msa_tenant');
+
+      // Guests. A tenant admin can invite ANY address as a B2B guest, so a
+      // guest token carries an `email` the inviting tenant does not own — the
+      // exact primitive behind nOAuth. `acct: 1` marks a guest; `idp` differing
+      // from `iss` and a UPN containing #EXT# are the other tells.
+      if (claims.acct === 1) throw new SsoError('guest_account');
+      if (claims.idp && claims.idp !== claims.iss) {
+        throw new SsoError('guest_external_idp');
+      }
+      const upn = String(claims.preferred_username ?? claims.upn ?? '');
+      if (upn.includes('#EXT#')) throw new SsoError('guest_ext_upn');
+    }
+
+    if (!claims.oid && !claims.sub) throw new SsoError('missing_subject');
+  }
+
+  /**
+   * Finds the local user behind this identity, or provisions one.
+   *
+   * SECURITY: there is deliberately NO lookup by email. `User.email` is globally
+   * unique and users are shared across workspaces, so matching on an
+   * IdP-supplied address would let anyone who controls any tenant bind their
+   * identity to another workspace's user. Linking an existing account happens
+   * through an explicit, authenticated action instead (PR 6).
+   */
+  private async resolveUser(
+    provider: {
+      id: string;
+      organizationId: string;
+      jitProvisioning: boolean;
+      jitDefaultRole: any;
+    },
+    subject: string,
+    tid: string | null,
+    claims: Record<string, any>,
+    ctx: { ip?: string; userAgent?: string },
+  ): Promise<string> {
+    const existing = await this.prisma.userIdentity.findUnique({
+      where: {
+        providerId_externalSubject: { providerId: provider.id, externalSubject: subject },
+      },
+      select: { id: true, userId: true },
+    });
+
+    if (existing) {
+      await this.prisma.userIdentity.update({
+        where: { id: existing.id },
+        data: { lastLoginAt: new Date(), externalTid: tid },
+      });
+      return existing.userId;
+    }
+
+    if (!provider.jitProvisioning) {
+      await this.securityEvents.log({
+        event: SecurityEvents.SSO_LOGIN_FAILED,
+        actorType: 'ANONYMOUS',
+        organizationId: provider.organizationId,
+        metadata: { providerId: provider.id, reason: 'no_identity_and_jit_disabled', oid: subject },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+      throw new SsoError('no_identity_and_jit_disabled', 'Sign-in failed', true);
+    }
+
+    // Provision. The email is used ONLY to populate a display field on a
+    // brand-new row — never to find or claim an existing account.
+    const email = String(claims.email ?? claims.preferred_username ?? '').toLowerCase();
+    if (!email) throw new SsoError('jit_without_email');
+
+    const collision = await this.prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+    if (collision) {
+      // A local account already owns this address. Auto-linking here is the
+      // takeover we refuse; the user must link it deliberately while signed in.
+      await this.securityEvents.log({
+        event: SecurityEvents.SSO_LOGIN_FAILED,
+        actorType: 'ANONYMOUS',
+        organizationId: provider.organizationId,
+        metadata: { providerId: provider.id, reason: 'email_belongs_to_existing_account', oid: subject },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+      throw new SsoError('email_belongs_to_existing_account', 'Sign-in failed', true);
+    }
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const user = await tx.user.create({
+        data: {
+          email,
+          name: claims.name ? String(claims.name) : null,
+          // No password: this account exists only through the provider.
+          passwordHash: null,
+          emailVerified: true,
+          role: provider.jitDefaultRole,
+          organizationId: provider.organizationId,
+        },
+        select: { id: true },
+      });
+      await tx.organizationMember.create({
+        data: {
+          userId: user.id,
+          organizationId: provider.organizationId,
+          role: provider.jitDefaultRole,
+        },
+      });
+      await tx.userIdentity.create({
+        data: {
+          userId: user.id,
+          providerId: provider.id,
+          externalSubject: subject,
+          externalTid: tid,
+          lastLoginAt: new Date(),
+        },
+      });
+      return user;
+    });
+
+    await this.securityEvents.log({
+      event: SecurityEvents.JIT_PROVISIONED,
+      actorType: 'SYSTEM',
+      organizationId: provider.organizationId,
+      targetUserId: created.id,
+      metadata: { providerId: provider.id, oid: subject, tid, role: provider.jitDefaultRole },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+
+    return created.id;
+  }
+
+  /**
+   * Only an internal, absolute path may be returned to. Anything else — a full
+   * URL, a protocol-relative `//evil.tld`, a backslash variant — would make the
+   * callback an open redirect.
+   */
+  private safeReturnTo(value?: string): string {
+    if (!value) return '/';
+    if (!value.startsWith('/')) return '/';
+    if (value.startsWith('//') || value.startsWith('/\\')) return '/';
+    return value;
+  }
+}

--- a/packages/backend/src/roles/roles.controller.ts
+++ b/packages/backend/src/roles/roles.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
-import { IsString, IsOptional, IsArray } from 'class-validator';
+import { IsString, IsOptional, IsArray, ArrayMaxSize } from 'class-validator';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 import { RolesService } from './roles.service';
 
@@ -59,6 +59,20 @@ class AssignRoleDto {
   @IsOptional()
   @IsString()
   roleId?: string | null;
+}
+
+class SetUserRolesDto {
+  @ApiProperty({
+    description:
+      'MCP role ids to attach. Pass an empty array to clear the manual assignments. The user receives the UNION of these roles\' tool whitelists.',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  // Bounded because an IdP group sync will drive this endpoint: a misconfigured
+  // mapping should fail validation, not write thousands of rows.
+  @ArrayMaxSize(100)
+  roleIds: string[];
 }
 
 @ApiTags('Roles')
@@ -141,7 +155,10 @@ export class RolesController {
   // ── User assignment ───────────────────────────────────────────────────────
 
   @Put('assign/:userId')
-  @ApiOperation({ summary: 'Assign MCP role to a user (ADMIN)' })
+  @ApiOperation({
+    summary:
+      'DEPRECATED — assign a single MCP role to a user (ADMIN). Use PUT /api/roles/assignments/:userId, which supports several roles.',
+  })
   async assignRole(
     @Req() req: any,
     @Param('userId') userId: string,
@@ -154,5 +171,38 @@ export class RolesController {
     );
     if (!result) throw new NotFoundException('User or role not found');
     return { message: 'Role assigned' };
+  }
+
+  @Get('assignments/:userId')
+  @ApiOperation({ summary: 'List the MCP roles assigned to a user (ADMIN)' })
+  async getAssignments(@Req() req: any, @Param('userId') userId: string) {
+    const assignments = await this.rolesService.getUserRoles(
+      userId,
+      req.user.organizationId,
+    );
+    return {
+      roleIds: [...new Set(assignments.map((a) => a.roleId))],
+      roles: assignments.map((a) => ({
+        id: a.role.id,
+        name: a.role.name,
+        source: a.source,
+      })),
+    };
+  }
+
+  @Put('assignments/:userId')
+  @ApiOperation({ summary: 'Set the MCP roles assigned to a user (ADMIN)' })
+  async setAssignments(
+    @Req() req: any,
+    @Param('userId') userId: string,
+    @Body() dto: SetUserRolesDto,
+  ) {
+    const result = await this.rolesService.setUserRoles(
+      userId,
+      dto.roleIds,
+      req.user.organizationId,
+    );
+    if (!result) throw new NotFoundException('User or role not found');
+    return { message: 'Roles updated', roleIds: result.roleIds };
   }
 }

--- a/packages/backend/src/roles/roles.service.spec.ts
+++ b/packages/backend/src/roles/roles.service.spec.ts
@@ -7,6 +7,7 @@ describe('RolesService', () => {
   beforeEach(() => {
     mockPrisma = {
       role: {
+        count: jest.fn(),
         findMany: jest.fn(),
         findUnique: jest.fn(),
         findFirst: jest.fn(),
@@ -23,7 +24,7 @@ describe('RolesService', () => {
         update: jest.fn(),
       },
       toolRoleAccess: {
-        findMany: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
         create: jest.fn(),
         deleteMany: jest.fn(),
         upsert: jest.fn(),
@@ -34,21 +35,38 @@ describe('RolesService', () => {
       organizationMember: {
         findUnique: jest.fn(),
       },
-      $transaction: jest.fn(),
+      userRoleAssignment: {
+        findMany: jest.fn().mockResolvedValue([]),
+        deleteMany: jest.fn(),
+        createMany: jest.fn(),
+      },
+      // setUserRoles uses the callback form; run it against the same mock.
+      $transaction: jest.fn((arg: any) =>
+        typeof arg === 'function' ? arg(mockPrisma) : Promise.all(arg),
+      ),
     };
     service = new RolesService(mockPrisma);
   });
 
   describe('findAll', () => {
-    it('should return roles with user/tool counts, ordered by isSystem then name', async () => {
-      const roles = [{ id: 'r1', name: 'Full Access', _count: { users: 2, toolAccess: 5 } }];
-      mockPrisma.role.findMany.mockResolvedValue(roles);
+    it('counts DISTINCT users per role, not assignment rows', async () => {
+      // user_roles is unique on (user, role, SOURCE), so one person holding a
+      // role both manually and through an IdP sync would otherwise count twice.
+      mockPrisma.role.findMany.mockResolvedValue([
+        { id: 'r1', name: 'Full Access', _count: { toolAccess: 5 } },
+        { id: 'r2', name: 'Viewer', _count: { toolAccess: 1 } },
+      ]);
+      mockPrisma.userRoleAssignment.findMany.mockResolvedValue([
+        { roleId: 'r1', userId: 'u1' },
+        { roleId: 'r1', userId: 'u1' }, // same person, second source
+        { roleId: 'r1', userId: 'u2' },
+      ]);
+
       const result = await service.findAll();
-      expect(result).toBe(roles);
-      expect(mockPrisma.role.findMany).toHaveBeenCalledWith({
-        include: { _count: { select: { users: true, toolAccess: true } } },
-        orderBy: [{ isSystem: 'desc' }, { name: 'asc' }],
-      });
+
+      expect(result[0]._count.users).toBe(2);
+      expect(result[0]._count.toolAccess).toBe(5);
+      expect(result[1]._count.users).toBe(0);
     });
   });
 
@@ -200,15 +218,69 @@ describe('RolesService', () => {
       expect(result).toBeNull();
     });
 
-    it('should return tool IDs for user with role', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ role: 'USER', mcpRoleId: 'r1' });
+    it('returns the UNION of every assigned role, deduplicated', async () => {
+      // The core new behaviour: being in more groups can only widen access.
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'EDITOR',
+        organizationId: 'org-1',
+      });
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ role: 'EDITOR' });
+      mockPrisma.userRoleAssignment.findMany.mockResolvedValue([
+        { roleId: 'sales' },
+        { roleId: 'support' },
+        { roleId: 'sales' }, // duplicate source rows collapse
+      ]);
       mockPrisma.toolRoleAccess.findMany.mockResolvedValue([
         { toolId: 't1' },
         { toolId: 't2' },
+        { toolId: 't1' }, // overlapping whitelists collapse
       ]);
-      const result = await service.getAllowedToolIds('user-1');
+
+      const result = await service.getAllowedToolIds('user-1', 'org-1');
+
+      expect(mockPrisma.toolRoleAccess.findMany).toHaveBeenCalledWith({
+        where: { roleId: { in: ['sales', 'support'] } },
+        select: { toolId: true },
+      });
       expect(result).toEqual(['t1', 't2']);
     });
+
+    it('a role granting nothing does not shrink the union', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'EDITOR',
+        organizationId: 'org-1',
+      });
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ role: 'EDITOR' });
+      mockPrisma.userRoleAssignment.findMany.mockResolvedValue([
+        { roleId: 'empty' },
+        { roleId: 'sales' },
+      ]);
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue([{ toolId: 't1' }]);
+
+      expect(await service.getAllowedToolIds('user-1', 'org-1')).toEqual(['t1']);
+    });
+
+    it('applies grants with no organization in every org', async () => {
+      // That is how a grant of an isSystem role behaves.
+      mockPrisma.user.findUnique.mockResolvedValue({
+        role: 'EDITOR',
+        organizationId: 'org-1',
+      });
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ role: 'EDITOR' });
+      mockPrisma.userRoleAssignment.findMany.mockResolvedValue([{ roleId: 'sys' }]);
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue([{ toolId: 't9' }]);
+
+      await service.getAllowedToolIds('user-1', 'org-1');
+
+      expect(mockPrisma.userRoleAssignment.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 'user-1',
+          OR: [{ organizationId: 'org-1' }, { organizationId: null }],
+        },
+        select: { roleId: true },
+      });
+    });
+
 
     it('reads the role from the membership of the org being acted on, not the cache', async () => {
       // V3 regression guard. `users.role` is the cache of the ACTIVE org's
@@ -217,12 +289,14 @@ describe('RolesService', () => {
       // therefore EVERY tool — inside any other org they could reach.
       mockPrisma.user.findUnique.mockResolvedValue({
         role: 'ADMIN', // cached: ADMIN of their personal workspace
-        mcpRoleId: 'restricted-role',
         organizationId: 'org-personal',
       });
       mockPrisma.organizationMember.findUnique.mockResolvedValue({
         role: 'VIEWER', // authoritative: only a VIEWER in the corporate org
       });
+      mockPrisma.userRoleAssignment.findMany.mockResolvedValue([
+        { roleId: 'restricted-role' },
+      ]);
       mockPrisma.toolRoleAccess.findMany.mockResolvedValue([{ toolId: 't1' }]);
 
       const result = await service.getAllowedToolIds('user-1', 'org-corporate');
@@ -243,7 +317,6 @@ describe('RolesService', () => {
     it('grants the ADMIN bypass only to an ADMIN of that same org', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         role: 'VIEWER',
-        mcpRoleId: 'restricted-role',
         organizationId: 'org-a',
       });
       mockPrisma.organizationMember.findUnique.mockResolvedValue({
@@ -256,7 +329,6 @@ describe('RolesService', () => {
     it('fails closed when the user is not a member of the org', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         role: 'ADMIN',
-        mcpRoleId: null,
         organizationId: 'org-personal',
       });
       mockPrisma.organizationMember.findUnique.mockResolvedValue(null);
@@ -269,7 +341,6 @@ describe('RolesService', () => {
       // Self-host / instance-level path: no org context anywhere.
       mockPrisma.user.findUnique.mockResolvedValue({
         role: 'ADMIN',
-        mcpRoleId: null,
         organizationId: null,
       });
 
@@ -291,7 +362,7 @@ describe('RolesService', () => {
       expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
       expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
         where: { id: 'victim@example.com' },
-        select: { role: true, mcpRoleId: true, organizationId: true },
+        select: { role: true, organizationId: true },
       });
     });
 
@@ -302,61 +373,160 @@ describe('RolesService', () => {
     });
   });
 
-  describe('assignRoleToUser', () => {
-    it('should update user mcpRoleId when both user and role belong to the org', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
-      mockPrisma.role.findFirst.mockResolvedValue({ id: 'r1' });
-      const updated = { id: 'user-1', mcpRoleId: 'r1' };
-      mockPrisma.user.update.mockResolvedValue(updated);
-      const result = await service.assignRoleToUser('user-1', 'r1', 'org-1');
-      expect(result).toBe(updated);
+  describe('setUserRoles', () => {
+    const memberOf = (org = 'org-1') =>
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ userId: 'user-1' });
+
+    it('replaces the manual grants and leaves IdP-derived ones alone', async () => {
+      // An admin editing roles by hand must never silently undo what a group
+      // mapping granted — and vice versa. Hence the source-scoped delete.
+      memberOf();
+      mockPrisma.role.count.mockResolvedValue(2);
+
+      const result = await service.setUserRoles('user-1', ['r1', 'r2'], 'org-1');
+
+      expect(mockPrisma.userRoleAssignment.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', organizationId: 'org-1', source: 'manual' },
+      });
+      expect(mockPrisma.userRoleAssignment.createMany).toHaveBeenCalledWith({
+        data: [
+          { userId: 'user-1', roleId: 'r1', organizationId: 'org-1', source: 'manual' },
+          { userId: 'user-1', roleId: 'r2', organizationId: 'org-1', source: 'manual' },
+        ],
+        skipDuplicates: true,
+      });
+      expect(result).toEqual({ userId: 'user-1', roleIds: ['r1', 'r2'] });
+    });
+
+    it('deduplicates the requested ids', async () => {
+      memberOf();
+      mockPrisma.role.count.mockResolvedValue(1);
+
+      const result = await service.setUserRoles('user-1', ['r1', 'r1'], 'org-1');
+
+      expect(result).toEqual({ userId: 'user-1', roleIds: ['r1'] });
+      expect(mockPrisma.role.count).toHaveBeenCalledWith({
+        where: { id: { in: ['r1'] }, OR: [{ organizationId: 'org-1' }, { isSystem: true }] },
+      });
+    });
+
+    it('clears the manual grants on an empty array without touching roles', async () => {
+      memberOf();
+
+      const result = await service.setUserRoles('user-1', [], 'org-1');
+
+      expect(mockPrisma.role.count).not.toHaveBeenCalled();
+      expect(mockPrisma.userRoleAssignment.createMany).not.toHaveBeenCalled();
+      expect(result).toEqual({ userId: 'user-1', roleIds: [] });
+    });
+
+    it('keeps the deprecated scalar in step for rollback safety', async () => {
+      memberOf();
+      mockPrisma.role.count.mockResolvedValue(2);
+
+      await service.setUserRoles('user-1', ['r1', 'r2'], 'org-1');
+
+      // Lossy by definition — one of N — but a rollback to the previous
+      // release must still see a sensible value.
       expect(mockPrisma.user.update).toHaveBeenCalledWith({
         where: { id: 'user-1' },
         data: { mcpRoleId: 'r1' },
       });
     });
 
-    it('should allow setting roleId to null without role lookup', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
-      mockPrisma.user.update.mockResolvedValue({ id: 'user-1', mcpRoleId: null });
-      await service.assignRoleToUser('user-1', null, 'org-1');
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-1' },
-        data: { mcpRoleId: null },
+    it('checks membership, not the cached active org', async () => {
+      // users.organizationId is only the ACTIVE org, so using it would make a
+      // multi-org user editable or not depending on what they are looking at.
+      memberOf();
+      mockPrisma.role.count.mockResolvedValue(1);
+
+      await service.setUserRoles('user-1', ['r1'], 'org-1');
+
+      expect(mockPrisma.organizationMember.findUnique).toHaveBeenCalledWith({
+        where: { userId_organizationId: { userId: 'user-1', organizationId: 'org-1' } },
+        select: { userId: true },
       });
+      expect(mockPrisma.user.findFirst).not.toHaveBeenCalled();
     });
 
-    it('returns null when user belongs to a different org', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue(null);
-      const result = await service.assignRoleToUser('user-1', 'r1', 'org-2');
-      expect(result).toBeNull();
-      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    it('returns null when the user is not a member of the org', async () => {
+      mockPrisma.organizationMember.findUnique.mockResolvedValue(null);
+
+      expect(await service.setUserRoles('user-1', ['r1'], 'org-2')).toBeNull();
+      expect(mockPrisma.userRoleAssignment.deleteMany).not.toHaveBeenCalled();
     });
 
-    it('returns null when role belongs to a different org', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
-      mockPrisma.role.findFirst.mockResolvedValue(null);
-      const result = await service.assignRoleToUser('user-1', 'r1', 'org-1');
-      expect(result).toBeNull();
-      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    it('returns null when any role is not visible to the org', async () => {
+      memberOf();
+      mockPrisma.role.count.mockResolvedValue(1); // asked for 2, only 1 valid
+
+      expect(await service.setUserRoles('user-1', ['r1', 'foreign'], 'org-1')).toBeNull();
+      expect(mockPrisma.userRoleAssignment.deleteMany).not.toHaveBeenCalled();
     });
   });
 
-  describe('ensureSystemRoles', () => {
-    it.skip('should upsert Full Access system role', async () => {
-      // Implementation switched from upsert to findFirst+create. Test left
-      // as documentation of historical behaviour; skip to keep CI green.
-      mockPrisma.role.upsert.mockResolvedValue({});
-      await service.ensureSystemRoles();
-      expect(mockPrisma.role.upsert).toHaveBeenCalledWith({
-        where: { name: 'Full Access' },
-        create: {
-          name: 'Full Access',
-          description: 'Unrestricted access to all MCP tools',
-          isSystem: true,
-        },
-        update: {},
-      });
+  describe('assignRoleToUser (deprecated adapter)', () => {
+    it('delegates a single role to setUserRoles', async () => {
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ userId: 'user-1' });
+      mockPrisma.role.count.mockResolvedValue(1);
+
+      const result = await service.assignRoleToUser('user-1', 'r1', 'org-1');
+
+      expect(result).toEqual({ userId: 'user-1', roleIds: ['r1'] });
+    });
+
+    it('maps a null roleId to an empty set', async () => {
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ userId: 'user-1' });
+
+      const result = await service.assignRoleToUser('user-1', null, 'org-1');
+
+      expect(result).toEqual({ userId: 'user-1', roleIds: [] });
+      expect(mockPrisma.role.count).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the user is not in the org', async () => {
+      mockPrisma.organizationMember.findUnique.mockResolvedValue(null);
+      expect(await service.assignRoleToUser('user-1', 'r1', 'org-2')).toBeNull();
+    });
+  });
+
+  describe('empty-role safety', () => {
+    it('warns when a user is given a role that grants no tools', async () => {
+      // An empty whitelist denies EVERYTHING rather than allowing everything,
+      // which reads backwards — so it must not happen silently.
+      const warn = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ userId: 'user-1' });
+      mockPrisma.role.count.mockResolvedValue(2);
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue([{ roleId: 'has-tools' }]);
+
+      await service.setUserRoles('user-1', ['has-tools', 'empty'], 'org-1');
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('empty'));
+      warn.mockRestore();
+    });
+
+    it('stays quiet when every assigned role grants something', async () => {
+      const warn = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+      mockPrisma.organizationMember.findUnique.mockResolvedValue({ userId: 'user-1' });
+      mockPrisma.role.count.mockResolvedValue(1);
+      mockPrisma.toolRoleAccess.findMany.mockResolvedValue([{ roleId: 'r1' }]);
+
+      await service.setUserRoles('user-1', ['r1'], 'org-1');
+
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+  });
+
+  describe('setToolAccess on system roles', () => {
+    it('refuses, matching updateRole and deleteRole', async () => {
+      // System roles are global and visible to every org; without this any org
+      // admin could rewrite a whitelist every other organization shares.
+      mockPrisma.role.findUnique.mockResolvedValue({ isSystem: true });
+
+      await expect(service.setToolAccess('sys', ['t1'], 'org-1')).rejects.toThrow(
+        'system role',
+      );
     });
   });
 });

--- a/packages/backend/src/roles/roles.service.ts
+++ b/packages/backend/src/roles/roles.service.ts
@@ -8,15 +8,38 @@ export class RolesService {
   constructor(private readonly prisma: PrismaService) {}
 
   async findAll(organizationId?: string) {
-    return this.prisma.role.findMany({
+    const roles = await this.prisma.role.findMany({
       where: organizationId
         ? { OR: [{ organizationId }, { isSystem: true }] }
         : undefined,
       include: {
-        _count: { select: { users: true, toolAccess: true } },
+        _count: { select: { toolAccess: true } },
       },
       orderBy: [{ isSystem: 'desc' }, { name: 'asc' }],
     });
+
+    // `_count.users` cannot come from the relation: `user_roles` is unique on
+    // (user, role, SOURCE), so one person holding a role both manually and via
+    // an IdP sync counts twice. Count DISTINCT users instead. Roles per org are
+    // few, so one query and a Set is cheaper than a raw aggregate.
+    const assignments = await this.prisma.userRoleAssignment.findMany({
+      where: { roleId: { in: roles.map((r) => r.id) } },
+      select: { roleId: true, userId: true },
+    });
+    const usersByRole = new Map<string, Set<string>>();
+    for (const a of assignments) {
+      const set = usersByRole.get(a.roleId) ?? new Set<string>();
+      set.add(a.userId);
+      usersByRole.set(a.roleId, set);
+    }
+
+    return roles.map((r) => ({
+      ...r,
+      _count: {
+        ...r._count,
+        users: usersByRole.get(r.id)?.size ?? 0,
+      },
+    }));
   }
 
   async findById(id: string) {
@@ -26,7 +49,7 @@ export class RolesService {
         toolAccess: {
           include: { tool: { select: { id: true, name: true, connector: { select: { name: true } } } } },
         },
-        _count: { select: { users: true } },
+        _count: { select: { toolAccess: true } },
       },
     });
   }
@@ -46,7 +69,7 @@ export class RolesService {
         toolAccess: {
           include: { tool: { select: { id: true, name: true, connector: { select: { name: true } } } } },
         },
-        _count: { select: { users: true } },
+        _count: { select: { toolAccess: true } },
       },
     });
   }
@@ -92,6 +115,18 @@ export class RolesService {
   }
 
   async setToolAccess(roleId: string, toolIds: string[], organizationId: string) {
+    // System roles are global (organizationId is null), and `findByIdForOrg`
+    // deliberately makes them visible to every org. `updateRole` and
+    // `deleteRole` both refuse them; this path did not, so any org admin could
+    // rewrite the tool whitelist of a role every other organization shares.
+    const role = await this.prisma.role.findUnique({
+      where: { id: roleId },
+      select: { isSystem: true },
+    });
+    if (role?.isSystem) {
+      throw new Error('Cannot modify tool access on a system role');
+    }
+
     // Validate that every tool ID belongs to the given organization. This
     // prevents an admin from assigning tools owned by another org to a role
     // they control.
@@ -134,8 +169,14 @@ export class RolesService {
   // ── Tool access query for MCP filtering ───────────────────────────────────
 
   /**
-   * Get the list of tool IDs a user is allowed to use.
-   * Returns null if user has unrestricted access (no role assigned or ADMIN).
+   * Tool IDs a user may use in the given organization.
+   *
+   *   null = unrestricted (ADMIN of that org, or no role assigned)
+   *   []   = the assigned role(s) grant nothing, or the caller is unknown /
+   *          not a member — always fail closed, never `null`
+   *
+   * With many-to-many roles the result is the UNION of every assigned role's
+   * whitelist.
    */
   async getAllowedToolIds(
     userId: string,
@@ -149,7 +190,7 @@ export class RolesService {
     // email would inherit the victim's tool grants.
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { role: true, mcpRoleId: true, organizationId: true },
+      select: { role: true, organizationId: true },
     });
 
     // Unknown principal — fail closed (no tools), never `null`/unrestricted.
@@ -184,67 +225,171 @@ export class RolesService {
     // ADMIN of THIS organization always has full access
     if (effectiveRole === 'ADMIN') return null;
 
-    // No custom role = full access (backward compat)
-    if (!user.mcpRoleId) return null;
+    // Every role assigned to the user IN THIS ORG, plus grants with no org,
+    // which apply everywhere (that is how an `isSystem` role behaves).
+    const assignments = await this.prisma.userRoleAssignment.findMany({
+      where: {
+        userId,
+        ...(orgId
+          ? { OR: [{ organizationId: orgId }, { organizationId: null }] }
+          : {}),
+      },
+      select: { roleId: true },
+    });
 
-    // Get tools assigned to this role
+    // Deduplicated in JS rather than with Prisma's `distinct`, which for a
+    // non-unique column is emulated client-side anyway — a Set is clearer.
+    const roleIds = [...new Set(assignments.map((a) => a.roleId))];
+
+    // No role assigned = unrestricted. Preserved from the single-FK behaviour:
+    // tightening it here would silently revoke access from every user who has
+    // simply never been given a role, which is currently everyone.
+    if (roleIds.length === 0) return null;
+
+    // UNION of the assigned roles' whitelists: being in more groups can only
+    // ever widen access, never narrow it.
     const access = await this.prisma.toolRoleAccess.findMany({
-      where: { roleId: user.mcpRoleId },
+      where: { roleId: { in: roleIds } },
       select: { toolId: true },
     });
 
-    return access.map((a) => a.toolId);
+    return [...new Set(access.map((a) => a.toolId))];
   }
 
   // ── User role assignment ──────────────────────────────────────────────────
 
+  /**
+   * Replaces the user's MANUAL role assignments in one organization.
+   *
+   * Grants with `source` other than 'manual' — an IdP sync, for instance — are
+   * left alone, so an admin editing roles by hand never silently undoes what a
+   * group mapping granted, and vice versa.
+   *
+   * Returns null when the user is not in the org or a role is not visible to
+   * it, which the controller turns into a 404.
+   */
+  async setUserRoles(
+    userId: string,
+    roleIds: string[],
+    organizationId: string,
+  ): Promise<{ userId: string; roleIds: string[] } | null> {
+    // Membership check against organization_members, not `users.organizationId`
+    // — the latter is only the ACTIVE org, so a multi-org user would be
+    // editable or not depending on which workspace they happen to be viewing.
+    const membership = await this.prisma.organizationMember.findUnique({
+      where: { userId_organizationId: { userId, organizationId } },
+      select: { userId: true },
+    });
+    if (!membership) return null;
+
+    const unique = [...new Set(roleIds)];
+    if (unique.length > 0) {
+      // Every role must be org-owned or a system role, so an admin cannot
+      // attach a role belonging to a different organization.
+      const valid = await this.prisma.role.count({
+        where: {
+          id: { in: unique },
+          OR: [{ organizationId }, { isSystem: true }],
+        },
+      });
+      if (valid !== unique.length) return null;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.userRoleAssignment.deleteMany({
+        where: { userId, organizationId, source: 'manual' },
+      });
+      if (unique.length > 0) {
+        await tx.userRoleAssignment.createMany({
+          data: unique.map((roleId) => ({
+            userId,
+            roleId,
+            organizationId,
+            source: 'manual',
+          })),
+          skipDuplicates: true,
+        });
+      }
+      // Keep the deprecated scalar in step so a rollback to the previous
+      // release still sees a sensible value. Lossy by definition — one of N.
+      await tx.user.update({
+        where: { id: userId },
+        data: { mcpRoleId: unique[0] ?? null },
+      });
+    });
+
+    await this.warnOnEmptyRoles(unique, userId);
+
+    return { userId, roleIds: unique };
+  }
+
+  /**
+   * @deprecated Single-role adapter kept for the previous API shape. A browser
+   * tab holding a stale frontend bundle is the real caller here, since frontend
+   * and backend ship in the same container.
+   */
   async assignRoleToUser(
     userId: string,
     roleId: string | null,
     organizationId: string,
   ) {
-    // The user must belong to the requesting org, and the role must be
-    // visible to that org (system roles or org-owned). Otherwise an admin
-    // could assign someone else's user a role from their own org.
-    const user = await this.prisma.user.findFirst({
-      where: { id: userId, organizationId },
-      select: { id: true },
-    });
-    if (!user) return null;
+    return this.setUserRoles(userId, roleId ? [roleId] : [], organizationId);
+  }
 
-    if (roleId !== null) {
-      const role = await this.prisma.role.findFirst({
-        where: {
-          id: roleId,
-          OR: [{ organizationId }, { isSystem: true }],
-        },
-        select: { id: true },
-      });
-      if (!role) return null;
-    }
-
-    return this.prisma.user.update({
-      where: { id: userId },
-      data: { mcpRoleId: roleId },
+  /** Role ids assigned to a user in an organization, with their provenance. */
+  async getUserRoles(userId: string, organizationId: string) {
+    return this.prisma.userRoleAssignment.findMany({
+      where: {
+        userId,
+        OR: [{ organizationId }, { organizationId: null }],
+      },
+      select: {
+        roleId: true,
+        source: true,
+        role: { select: { id: true, name: true } },
+      },
     });
   }
 
   // ── Seed system roles ─────────────────────────────────────────────────────
 
-  async ensureSystemRoles() {
-    const systemRoles = [
-      { name: 'Full Access', description: 'Unrestricted access to all MCP tools' },
-    ];
+  // `ensureSystemRoles()` used to live here, seeding a system role named
+  // "Full Access" with NO tool access rows. That is the exact inverse of its
+  // name: a role with an empty whitelist grants ZERO tools, so assigning it
+  // locked the user out of everything.
+  //
+  // It was never called outside its own spec, which is the only reason it never
+  // bit. Removed rather than repaired because the product already has a "full
+  // access" state and it is the ABSENCE of a role — `getAllowedToolIds` returns
+  // null (unrestricted) when a user has no assignment. A role that has to be
+  // assigned in order to grant everything would be strictly worse than that.
+  //
+  // The lockout shape itself still exists for any hand-made empty role, which
+  // is why `setUserRoles` warns about it — see `warnOnEmptyRoles`.
 
-    for (const role of systemRoles) {
-      const existing = await this.prisma.role.findFirst({
-        where: { name: role.name, isSystem: true },
-      });
-      if (!existing) {
-        await this.prisma.role.create({
-          data: { ...role, isSystem: true },
-        });
-      }
+  /**
+   * Logs when a user is given a role that grants no tools at all.
+   *
+   * Not blocked: an admin may legitimately create a role and populate it
+   * afterwards. But an empty role denies EVERYTHING rather than allowing
+   * everything, which reads backwards to most people, so it should not happen
+   * silently. Production currently holds four such roles, all leftovers.
+   */
+  private async warnOnEmptyRoles(roleIds: string[], userId: string) {
+    if (roleIds.length === 0) return;
+    const withTools = await this.prisma.toolRoleAccess.findMany({
+      where: { roleId: { in: roleIds } },
+      select: { roleId: true },
+      distinct: ['roleId'],
+    });
+    const granting = new Set(withTools.map((t) => t.roleId));
+    const empty = roleIds.filter((id) => !granting.has(id));
+    if (empty.length > 0) {
+      this.logger.warn(
+        `User ${userId} assigned role(s) with an empty tool whitelist (${empty.join(', ')}) — ` +
+          'an empty role grants NO tools. Add tools to it, or remove the assignment ' +
+          'to restore unrestricted access.',
+      );
     }
   }
 }

--- a/packages/frontend/next.config.ts
+++ b/packages/frontend/next.config.ts
@@ -24,6 +24,8 @@ const nextConfig: NextConfig = {
       { source: '/mcp/:path*', destination: `${BACKEND_URL}/mcp/:path*` },
       { source: '/.well-known/:path*', destination: `${BACKEND_URL}/.well-known/:path*` },
       { source: '/auth/:path*', destination: `${BACKEND_URL}/auth/:path*` },
+      // SSO entry point. The OIDC callback already arrives under /auth/*.
+      { source: '/sso/:path*', destination: `${BACKEND_URL}/sso/:path*` },
       { source: '/authorize', destination: `${BACKEND_URL}/authorize` },
       { source: '/callback', destination: `${BACKEND_URL}/callback` },
       { source: '/token', destination: `${BACKEND_URL}/token` },

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { auth, license, server } from '@/lib/api';
+import { auth, license, server, sso, type SsoProviderButton } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { buildPricingUrl } from '@/lib/marketing';
 import { LogoIcon } from '@/components/logo-icon';
@@ -65,11 +65,17 @@ function LoginForm() {
   const redirectTo = searchParams.get('redirect') || '/';
   const emailVerifiedParam = searchParams.get('emailVerified');
   const modeParam = searchParams.get('mode'); // 'register' or 'login'
+  const ssoCode = searchParams.get('sso');
+  const errorParam = searchParams.get('error');
+  const [ssoProviders, setSsoProviders] = useState<SsoProviderButton[]>([]);
+  const [ssoExchanging, setSsoExchanging] = useState(Boolean(ssoCode));
 
   useEffect(() => {
     server.info().then((info) => {
       setRegistrationEnabled(info.registrationEnabled);
       setIsCloudMode(info.deploymentMode === 'cloud');
+      // Empty in cloud by design — see the comment on the backend endpoint.
+      setSsoProviders(info.ssoProviders ?? []);
       if (!info.hasUsers) {
         setIsRegister(true);
       } else if (modeParam === 'register' && info.registrationEnabled) {
@@ -79,6 +85,39 @@ function LoginForm() {
       }
     }).catch(() => {});
   }, [modeParam]);
+
+  // Surface a failure the SSO callback redirected back with.
+  useEffect(() => {
+    if (errorParam) setError(errorParam);
+  }, [errorParam]);
+
+  // Trade the one-time code from the sign-in redirect for a session. The code
+  // is single-use and lives 30 seconds; the token itself never travels in a URL.
+  useEffect(() => {
+    if (!ssoCode) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await sso.exchange(ssoCode);
+        if (cancelled) return;
+        if (!result.accessToken) {
+          setError(result.error || 'Sign-in code is invalid or has expired');
+          setSsoExchanging(false);
+          return;
+        }
+        login(result.accessToken, result.user);
+        router.replace(redirectTo);
+      } catch (err: any) {
+        if (cancelled) return;
+        setError(err.message || 'Sign-in failed');
+        setSsoExchanging(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ssoCode]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -583,7 +622,35 @@ function LoginForm() {
 
         {error && <div className={alertDanger}>{error}</div>}
 
-        <form className="space-y-4" onSubmit={handleSubmit}>
+        {ssoExchanging && (
+          <p className="text-center text-sm text-[var(--text-2)] py-6">
+            Signing you in…
+          </p>
+        )}
+
+        {!ssoExchanging && !isRegister && ssoProviders.length > 0 && (
+          <div className="space-y-2 mb-4">
+            {ssoProviders.map((p) => (
+              <a
+                key={p.startUrl}
+                href={p.startUrl}
+                className="flex items-center justify-center w-full h-10 rounded-[9px] border border-[var(--border)] bg-[var(--surface)] text-sm font-medium text-[var(--text)] hover:border-[var(--brand)] transition-colors"
+              >
+                {p.name}
+              </a>
+            ))}
+            <div className="flex items-center gap-3 pt-1">
+              <div className="h-px flex-1 bg-[var(--border)]" />
+              <span className="text-[11.5px] text-[var(--text-3)]">or</span>
+              <div className="h-px flex-1 bg-[var(--border)]" />
+            </div>
+          </div>
+        )}
+
+        <form
+          className={`space-y-4${ssoExchanging ? ' hidden' : ''}`}
+          onSubmit={handleSubmit}
+        >
           {isRegister && (
             <div>
               <label htmlFor="auth-name" className="block text-sm font-medium mb-1 text-[var(--text)]">Name</label>

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useEffect, useCallback } from 'react';
+import { Suspense, useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { auth, license, server, sso, type SsoProviderButton } from '@/lib/api';
@@ -93,13 +93,21 @@ function LoginForm() {
 
   // Trade the one-time code from the sign-in redirect for a session. The code
   // is single-use and lives 30 seconds; the token itself never travels in a URL.
+  //
+  // Guarded by a ref rather than the usual `cancelled` flag, because the code
+  // is spent by the REQUEST, not by what we do with the response. Under React
+  // StrictMode the effect runs twice: the first call burns the code, its
+  // result is discarded as stale, and the second call reports "invalid or
+  // expired" for a sign-in that actually succeeded. The same race can strand a
+  // user on any remount. Recording the code before awaiting makes the exchange
+  // happen at most once per code.
+  const exchangedCode = useRef<string | null>(null);
   useEffect(() => {
-    if (!ssoCode) return;
-    let cancelled = false;
+    if (!ssoCode || exchangedCode.current === ssoCode) return;
+    exchangedCode.current = ssoCode;
     (async () => {
       try {
         const result = await sso.exchange(ssoCode);
-        if (cancelled) return;
         if (!result.accessToken) {
           setError(result.error || 'Sign-in code is invalid or has expired');
           setSsoExchanging(false);
@@ -108,14 +116,10 @@ function LoginForm() {
         login(result.accessToken, result.user);
         router.replace(redirectTo);
       } catch (err: any) {
-        if (cancelled) return;
         setError(err.message || 'Sign-in failed');
         setSsoExchanging(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ssoCode]);
 

--- a/packages/frontend/src/app/settings/identity-providers/page.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/page.tsx
@@ -128,6 +128,7 @@ export default function IdentityProvidersPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -228,6 +229,23 @@ export default function IdentityProvidersPage() {
     }
   };
 
+  const handleCopyLink = async (p: IdentityProvider) => {
+    try {
+      await navigator.clipboard.writeText(signInUrl(p));
+      setCopiedId(p.id);
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch {
+      // navigator.clipboard is undefined on a non-HTTPS origin, which is the
+      // normal case for a self-hosted deployment on a LAN address. Falling back
+      // to a toast keeps the link reachable instead of failing silently.
+      toast.show({
+        tone: 'error',
+        title: 'Could not copy',
+        description: signInUrl(p),
+      });
+    }
+  };
+
   const handleTest = async (p: IdentityProvider) => {
     if (!token) return;
     setTesting(p.id);
@@ -262,6 +280,12 @@ export default function IdentityProvidersPage() {
   const labelClass = 'block text-[12.5px] font-medium text-[var(--text-2)] mb-1';
   const helpClass = 'text-[11.5px] text-[var(--text-3)] mt-1 max-w-sm';
 
+  // Built from the browser's own origin rather than a configured base URL:
+  // self-hosted deployments have no reliable public URL to read, and getting it
+  // wrong hands the admin a link that silently sends members nowhere.
+  const signInUrl = (p: IdentityProvider) =>
+    `${typeof window === 'undefined' ? '' : window.location.origin}/sso/${p.initiateId}`;
+
   const spec = PROVIDER_TYPES[form.type];
   const expiringSoon = (p: IdentityProvider) => {
     if (!p.clientSecretExpiresAt) return false;
@@ -281,8 +305,8 @@ export default function IdentityProvidersPage() {
               <h3 className="text-base font-semibold text-[var(--text)]">Single sign-on</h3>
               <p className="text-[13px] text-[var(--text-2)] mt-1 max-w-2xl">
                 Let members sign in with your organization&apos;s identity provider instead of
-                a password. Sign-in itself is not enabled yet — this page configures the
-                providers that will be offered.
+                a password. Share the sign-in link below with them — it is the entry point
+                for this workspace.
               </p>
             </div>
             <Button size="sm" onClick={showForm ? () => setShowForm(false) : openCreate}>
@@ -471,6 +495,25 @@ export default function IdentityProvidersPage() {
                         Creates accounts on first sign-in
                       </p>
                     )}
+                    {/*
+                      The only way an admin can reach this link. Providers are
+                      deliberately NOT listed on the public sign-in page in
+                      cloud — that would let anyone enumerate which workspaces
+                      exist and which directory each belongs to — so without
+                      showing it here the configured provider is unreachable.
+                    */}
+                    <div className="flex items-center gap-2 mt-2">
+                      <code className="text-[11.5px] text-[var(--text-2)] bg-[var(--surface-2)] rounded px-1.5 py-0.5 truncate">
+                        {signInUrl(p)}
+                      </code>
+                      <button
+                        type="button"
+                        className="text-[11.5px] text-[var(--brand)] hover:underline shrink-0"
+                        onClick={() => handleCopyLink(p)}
+                      >
+                        {copiedId === p.id ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
                   </div>
                   <div className="flex gap-2 shrink-0">
                     <Button

--- a/packages/frontend/src/app/settings/identity-providers/page.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/page.tsx
@@ -1,0 +1,499 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useAuth } from '@/lib/auth-context';
+import {
+  identityProviders,
+  type IdentityProvider,
+  type IdentityProviderInput,
+} from '@/lib/api';
+import { AppSelect } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/components/toast';
+
+/**
+ * Per-type configuration fields.
+ *
+ * `issuer: true` means the type has no derivable issuer, so the admin must
+ * supply one — for the others the server builds it and ignores anything sent,
+ * which is what keeps a hostile URL out of the discovery fetch.
+ */
+const PROVIDER_TYPES: Record<
+  string,
+  {
+    label: string;
+    issuer: boolean;
+    hint?: string;
+    fields: { key: string; label: string; placeholder: string; help?: string }[];
+  }
+> = {
+  ENTRA: {
+    label: 'Microsoft Entra ID',
+    issuer: false,
+    fields: [
+      {
+        key: 'tenantId',
+        label: 'Directory (tenant) ID',
+        placeholder: '00000000-0000-0000-0000-000000000000',
+        help: 'The tenant GUID from your app registration overview. A directory name such as contoso.onmicrosoft.com is not accepted.',
+      },
+    ],
+  },
+  GOOGLE: {
+    label: 'Google Workspace',
+    issuer: false,
+    fields: [
+      {
+        key: 'hostedDomain',
+        label: 'Workspace domain',
+        placeholder: 'example.com',
+        help: 'Strongly recommended. Without it Google is not authoritative for a non-gmail.com address, so any Google account could sign in.',
+      },
+    ],
+  },
+  OKTA: {
+    label: 'Okta',
+    issuer: true,
+    hint: 'Use your Okta domain, e.g. https://acme.okta.com. Custom domains are not yet supported.',
+    fields: [
+      {
+        key: 'authorizationServerId',
+        label: 'Authorization server ID (optional)',
+        placeholder: 'default',
+      },
+    ],
+  },
+  AUTH0: {
+    label: 'Auth0',
+    issuer: true,
+    hint: 'Self-hosted deployments only.',
+    fields: [
+      {
+        key: 'rolesClaimNamespace',
+        label: 'Roles claim namespace',
+        placeholder: 'https://your-app.example.com/roles',
+        help: 'Auth0 silently drops custom claims that are not namespaced — the sign-in succeeds and the roles are simply missing.',
+      },
+    ],
+  },
+  GITHUB: {
+    label: 'GitHub',
+    issuer: false,
+    hint: 'GitHub is not an OpenID Connect provider, so there is no discovery document to test.',
+    fields: [
+      {
+        key: 'organization',
+        label: 'Restrict to organization (optional)',
+        placeholder: 'my-org',
+      },
+    ],
+  },
+  OIDC: {
+    label: 'Generic OpenID Connect',
+    issuer: true,
+    hint: 'Self-hosted deployments only.',
+    fields: [
+      {
+        key: 'groupsClaimName',
+        label: 'Groups claim name (optional)',
+        placeholder: 'groups',
+      },
+    ],
+  },
+};
+
+const emptyForm = (): IdentityProviderInput & { config: Record<string, string> } => ({
+  type: 'ENTRA',
+  name: '',
+  clientId: '',
+  clientSecret: '',
+  clientSecretExpiresAt: '',
+  issuer: '',
+  config: {},
+  isActive: true,
+  jitProvisioning: false,
+  roleSyncEnabled: false,
+  roleSyncSource: 'GROUPS',
+  roleSyncFallback: 'DENY_ALL',
+});
+
+export default function IdentityProvidersPage() {
+  const { token, user: currentUser } = useAuth();
+  const toast = useToast();
+
+  const [providers, setProviders] = useState<IdentityProvider[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState(emptyForm());
+
+  const loadData = async () => {
+    if (!token) return;
+    try {
+      setProviders(await identityProviders.list(token));
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not load providers', description: err.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const openCreate = () => {
+    setForm(emptyForm());
+    setEditingId(null);
+    setShowForm(true);
+  };
+
+  const openEdit = (p: IdentityProvider) => {
+    setForm({
+      type: p.type,
+      name: p.name,
+      clientId: p.clientId,
+      // Never prefilled: the API does not return it, and an empty value means
+      // "keep the stored one".
+      clientSecret: '',
+      clientSecretExpiresAt: p.clientSecretExpiresAt?.slice(0, 10) ?? '',
+      issuer: p.issuer,
+      config: (p.config ?? {}) as Record<string, string>,
+      isActive: p.isActive,
+      jitProvisioning: p.jitProvisioning,
+      roleSyncEnabled: p.roleSyncEnabled,
+      roleSyncSource: p.roleSyncSource,
+      roleSyncFallback: p.roleSyncFallback,
+    });
+    setEditingId(p.id);
+    setShowForm(true);
+  };
+
+  const handleSave = async () => {
+    if (!token) return;
+    setSaving(true);
+    try {
+      const spec = PROVIDER_TYPES[form.type];
+      const payload: IdentityProviderInput = {
+        ...form,
+        // Drop blanks so an optional field left empty is absent rather than "".
+        config: Object.fromEntries(
+          Object.entries(form.config).filter(([, v]) => v.trim() !== ''),
+        ),
+        ...(spec.issuer ? { issuer: form.issuer } : { issuer: undefined }),
+        clientSecret: form.clientSecret?.trim() ? form.clientSecret : undefined,
+        clientSecretExpiresAt: form.clientSecretExpiresAt?.trim()
+          ? new Date(form.clientSecretExpiresAt).toISOString()
+          : null,
+      };
+
+      if (editingId) {
+        await identityProviders.update(editingId, payload, token);
+        toast.show({ tone: 'success', title: 'Provider updated' });
+      } else {
+        await identityProviders.create(payload, token);
+        toast.show({ tone: 'success', title: 'Provider created' });
+      }
+      setShowForm(false);
+      setEditingId(null);
+      await loadData();
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not save', description: err.message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (p: IdentityProvider) => {
+    if (
+      !token ||
+      !confirm(
+        `Delete "${p.name}"? Anyone who signs in through it will lose access, and members with password sign-in disabled will be locked out.`,
+      )
+    )
+      return;
+    try {
+      await identityProviders.delete(p.id, token);
+      toast.show({ tone: 'success', title: 'Provider deleted' });
+      await loadData();
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not delete', description: err.message });
+    }
+  };
+
+  const handleTest = async (p: IdentityProvider) => {
+    if (!token) return;
+    setTesting(p.id);
+    try {
+      const result = await identityProviders.test(p.id, token);
+      toast.show({
+        tone: result.ok ? 'success' : 'error',
+        title: result.ok ? 'Connection OK' : 'Connection failed',
+        description: result.message,
+      });
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Test failed', description: err.message });
+    } finally {
+      setTesting(null);
+    }
+  };
+
+  if (currentUser?.role !== 'ADMIN') {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-center">
+          <h2 className="text-xl font-bold text-[var(--text)] mb-2">Access Denied</h2>
+          <p className="text-[var(--text-2)] mb-4">Only administrators can access this page.</p>
+          <Link href="/settings" className="text-[var(--brand)] hover:underline">Back to Settings</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const inputClass =
+    'w-full max-w-sm h-9 rounded-[9px] border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--text)] outline-none focus:border-[var(--brand)]';
+  const labelClass = 'block text-[12.5px] font-medium text-[var(--text-2)] mb-1';
+  const helpClass = 'text-[11.5px] text-[var(--text-3)] mt-1 max-w-sm';
+
+  const spec = PROVIDER_TYPES[form.type];
+  const expiringSoon = (p: IdentityProvider) => {
+    if (!p.clientSecretExpiresAt) return false;
+    const days =
+      (new Date(p.clientSecretExpiresAt).getTime() - Date.now()) / 86_400_000;
+    return days < 30;
+  };
+
+  return (
+    <div className="space-y-6">
+      {loading ? (
+        <p className="text-center text-[var(--text-3)] py-16">Loading...</p>
+      ) : (
+        <Card className="p-[22px]">
+          <div className="flex items-start justify-between mb-4">
+            <div>
+              <h3 className="text-base font-semibold text-[var(--text)]">Single sign-on</h3>
+              <p className="text-[13px] text-[var(--text-2)] mt-1 max-w-2xl">
+                Let members sign in with your organization&apos;s identity provider instead of
+                a password. Sign-in itself is not enabled yet — this page configures the
+                providers that will be offered.
+              </p>
+            </div>
+            <Button size="sm" onClick={showForm ? () => setShowForm(false) : openCreate}>
+              {showForm ? 'Cancel' : 'Add provider'}
+            </Button>
+          </div>
+
+          {showForm && (
+            <div className="mb-5 p-4 rounded-[9px] bg-[var(--surface-2)] space-y-3">
+              <div>
+                <label className={labelClass}>Provider</label>
+                <div className="max-w-sm">
+                  <AppSelect
+                    value={form.type}
+                    onValueChange={(v) =>
+                      // Reset the config: the fields belong to the old type and
+                      // would fail validation against the new one.
+                      setForm({ ...form, type: v, config: {}, issuer: '' })
+                    }
+                    options={Object.entries(PROVIDER_TYPES).map(([value, t]) => ({
+                      value,
+                      label: t.label,
+                    }))}
+                    disabled={Boolean(editingId)}
+                  />
+                </div>
+                {editingId && (
+                  <p className={helpClass}>
+                    The provider type cannot be changed after creation — the stored settings
+                    were validated against it. Create a new provider instead.
+                  </p>
+                )}
+                {spec.hint && <p className={helpClass}>{spec.hint}</p>}
+              </div>
+
+              <div>
+                <label className={labelClass}>Display name</label>
+                <input
+                  className={inputClass}
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder="Sign in with Microsoft"
+                />
+                <p className={helpClass}>Shown on the sign-in button.</p>
+              </div>
+
+              {spec.issuer && (
+                <div>
+                  <label className={labelClass}>Issuer URL</label>
+                  <input
+                    className={inputClass}
+                    value={form.issuer ?? ''}
+                    onChange={(e) => setForm({ ...form, issuer: e.target.value })}
+                    placeholder="https://acme.okta.com"
+                  />
+                </div>
+              )}
+
+              {spec.fields.map((f) => (
+                <div key={f.key}>
+                  <label className={labelClass}>{f.label}</label>
+                  <input
+                    className={inputClass}
+                    value={form.config[f.key] ?? ''}
+                    onChange={(e) =>
+                      setForm({
+                        ...form,
+                        config: { ...form.config, [f.key]: e.target.value },
+                      })
+                    }
+                    placeholder={f.placeholder}
+                  />
+                  {f.help && <p className={helpClass}>{f.help}</p>}
+                </div>
+              ))}
+
+              <div>
+                <label className={labelClass}>Client ID</label>
+                <input
+                  className={inputClass}
+                  value={form.clientId}
+                  onChange={(e) => setForm({ ...form, clientId: e.target.value })}
+                />
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Client secret {editingId && <span className="font-normal">(leave blank to keep)</span>}
+                </label>
+                <input
+                  type="password"
+                  className={inputClass}
+                  value={form.clientSecret ?? ''}
+                  onChange={(e) => setForm({ ...form, clientSecret: e.target.value })}
+                  placeholder={editingId ? '••••••••' : ''}
+                  autoComplete="new-password"
+                />
+                {editingId && (
+                  <p className={helpClass}>
+                    The secret is never sent back to the browser, so it cannot be shown here.
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label className={labelClass}>Secret expires on (optional)</label>
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={form.clientSecretExpiresAt ?? ''}
+                  onChange={(e) =>
+                    setForm({ ...form, clientSecretExpiresAt: e.target.value })
+                  }
+                />
+                <p className={helpClass}>
+                  Microsoft caps client secrets at 24 months. Recording the date here turns a
+                  silent expiry into a warning.
+                </p>
+              </div>
+
+              <label className="flex items-start gap-2 text-[13px] text-[var(--text)] max-w-sm">
+                <input
+                  type="checkbox"
+                  className="mt-[3px] accent-[var(--brand)]"
+                  checked={form.jitProvisioning ?? false}
+                  onChange={(e) =>
+                    setForm({ ...form, jitProvisioning: e.target.checked })
+                  }
+                />
+                <span>
+                  Create accounts on first sign-in
+                  <span className="block text-[11.5px] text-[var(--text-3)]">
+                    Off by default. With this on, anyone who can authenticate at your identity
+                    provider joins this workspace as a Viewer — including guests you may have
+                    invited there for other reasons.
+                  </span>
+                </span>
+              </label>
+
+              <label className="flex items-center gap-2 text-[13px] text-[var(--text)]">
+                <input
+                  type="checkbox"
+                  className="accent-[var(--brand)]"
+                  checked={form.isActive ?? true}
+                  onChange={(e) => setForm({ ...form, isActive: e.target.checked })}
+                />
+                Active
+              </label>
+
+              <div className="flex gap-2 pt-1">
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={saving || !form.name.trim() || !form.clientId.trim()}
+                >
+                  {saving ? 'Saving...' : editingId ? 'Save changes' : 'Create provider'}
+                </Button>
+                <Button size="sm" variant="secondary" onClick={() => setShowForm(false)}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {providers.length === 0 && !showForm ? (
+            <p className="text-[13px] text-[var(--text-3)] py-6 text-center">
+              No identity providers configured. Members sign in with a password.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {providers.map((p) => (
+                <div
+                  key={p.id}
+                  className="rounded-[9px] border border-[var(--border)] p-3 flex items-start justify-between gap-3"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-[var(--text)]">{p.name}</span>
+                      <Badge tone="neutral">{PROVIDER_TYPES[p.type]?.label ?? p.type}</Badge>
+                      {!p.isActive && <Badge tone="warn">Inactive</Badge>}
+                      {expiringSoon(p) && <Badge tone="danger">Secret expiring</Badge>}
+                    </div>
+                    <p className="text-[12px] text-[var(--text-3)] mt-1 truncate">{p.issuer}</p>
+                    {p.jitProvisioning && (
+                      <p className="text-[11.5px] text-[var(--text-3)] mt-0.5">
+                        Creates accounts on first sign-in
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <Button
+                      size="sm"
+                      variant="outlineBrand"
+                      onClick={() => handleTest(p)}
+                      disabled={testing === p.id}
+                    >
+                      {testing === p.id ? 'Testing...' : 'Test'}
+                    </Button>
+                    <Button size="sm" variant="secondary" onClick={() => openEdit(p)}>
+                      Edit
+                    </Button>
+                    <Button size="sm" variant="danger" onClick={() => handleDelete(p)}>
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -35,6 +35,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
       { href: '/settings/organization', label: 'General', description: 'Workspace and new orgs', icon: BuildingIcon },
       { href: '/settings/users', label: 'Users', description: 'Members and invitations', icon: UsersIcon, adminOnly: true },
       { href: '/settings/roles', label: 'Roles', description: 'MCP tool access control', icon: ShieldIcon, adminOnly: true },
+      { href: '/settings/identity-providers', label: 'Single sign-on', description: 'Microsoft, Google, Okta', icon: FingerprintIcon, adminOnly: true },
       { href: '/settings/license', label: 'License', description: 'Plan, features', icon: KeyIcon, adminOnly: true },
       { href: '/settings/admin', label: 'Administration', description: 'SMTP, footer links', icon: WrenchIcon, adminOnly: true },
     ],
@@ -151,6 +152,22 @@ function WrenchIcon({ size = 16 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+    </svg>
+  );
+}
+
+function FingerprintIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 10a2 2 0 0 0-2 2c0 1.02-.1 2.51-.26 4" />
+      <path d="M14 13.12c0 2.38 0 6.38-1 8.88" />
+      <path d="M17.29 21.02c.12-.6.43-2.3.5-3.02" />
+      <path d="M2 12a10 10 0 0 1 18-6" />
+      <path d="M2 16h.01" />
+      <path d="M21.8 16c.2-2 .131-5.354 0-6" />
+      <path d="M5 19.5C5.5 18 6 15 6 12a6 6 0 0 1 .34-2" />
+      <path d="M8.65 22c.21-.66.45-1.32.57-2" />
+      <path d="M9 6.8a6 6 0 0 1 9 5.2v2" />
     </svg>
   );
 }

--- a/packages/frontend/src/app/settings/page.tsx
+++ b/packages/frontend/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
-import { users, server, ApiError } from '@/lib/api';
+import { users, server, sso, ApiError, type LinkableProvider } from '@/lib/api';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useToast } from '@/components/toast';
 import { Button } from '@/components/ui/button';
@@ -39,6 +39,10 @@ export default function SettingsPage() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [blockingOrgs, setBlockingOrgs] = useState<{ id: string; name: string }[] | null>(null);
 
+  // Connected accounts
+  const [linkable, setLinkable] = useState<LinkableProvider[]>([]);
+  const [linkBusy, setLinkBusy] = useState<string | null>(null);
+
   // Load server info
   useEffect(() => {
     server.info().then((info) => {
@@ -47,6 +51,70 @@ export default function SettingsPage() {
       setServerUrl(info.serverUrl);
     }).catch(() => {});
   }, []);
+
+  const loadLinkable = () => {
+    if (!token) return;
+    // Silently empty when the workspace has no provider: this card should not
+    // announce a feature the workspace has not configured.
+    sso.myProviders(token).then(setLinkable).catch(() => setLinkable([]));
+  };
+
+  useEffect(() => {
+    loadLinkable();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  // The callback lands back here with the outcome in the query string. Read it
+  // once and strip it, so a refresh does not replay the same toast.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const linked = params.get('linked');
+    const linkError = params.get('linkError');
+    if (!linked && !linkError) return;
+
+    if (linkError) {
+      toast.show({ tone: 'error', title: 'Could not connect', description: linkError });
+    } else {
+      toast.show({ tone: 'success', title: 'Account connected' });
+      loadLinkable();
+    }
+    window.history.replaceState({}, '', window.location.pathname);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleLink = async (p: LinkableProvider) => {
+    if (!token) return;
+    setLinkBusy(p.id);
+    try {
+      const { authorizationUrl } = await sso.startLink(p.id, '/settings', token);
+      // Top-level navigation, not fetch: the provider needs to render its own
+      // sign-in page to the user.
+      window.location.href = authorizationUrl;
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not connect', description: err.message });
+      setLinkBusy(null);
+    }
+  };
+
+  const handleUnlink = async (p: LinkableProvider) => {
+    if (!token) return;
+    if (
+      !confirm(
+        `Disconnect "${p.name}"? You will need your password to sign in afterwards.`,
+      )
+    )
+      return;
+    setLinkBusy(p.id);
+    try {
+      await sso.unlink(p.id, token);
+      toast.show({ tone: 'success', title: 'Account disconnected' });
+      loadLinkable();
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not disconnect', description: err.message });
+    } finally {
+      setLinkBusy(null);
+    }
+  };
 
   const handleSaveProfile = async () => {
     if (!token) return;
@@ -213,6 +281,49 @@ export default function SettingsPage() {
           </Button>
         </div>
       </Card>
+
+      {/* Connected accounts */}
+      {linkable.length > 0 && (
+        <Card className="p-[22px]">
+          <h3 className="text-sm font-semibold text-[var(--text)] mb-2">Connected accounts</h3>
+          <p className="text-sm text-[var(--text-2)] mb-4">
+            Connect your directory account to sign in without a password. Your
+            administrator cannot do this for you — the connection is only
+            trusted because you made it while signed in.
+          </p>
+          <div className="space-y-2 max-w-md">
+            {linkable.map((p) => (
+              <div
+                key={p.id}
+                className="rounded-[9px] border border-[var(--border)] p-3 flex items-center justify-between gap-3"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-[var(--text)]">{p.name}</div>
+                  <div className="text-[11.5px] text-[var(--text-3)] mt-0.5">
+                    {p.linked
+                      ? p.lastLoginAt
+                        ? `Connected · last used ${new Date(p.lastLoginAt).toLocaleDateString()}`
+                        : 'Connected'
+                      : 'Not connected'}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant={p.linked ? 'secondary' : 'primary'}
+                  disabled={linkBusy === p.id}
+                  onClick={() => (p.linked ? handleUnlink(p) : handleLink(p))}
+                >
+                  {linkBusy === p.id
+                    ? 'Working...'
+                    : p.linked
+                      ? 'Disconnect'
+                      : 'Connect'}
+                </Button>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
 
       {/* MCP Auth */}
       <Card className="p-[22px]">

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -686,6 +686,62 @@ export const adminSettings = {
 };
 
 // Roles (Admin)
+export interface IdentityProvider {
+  id: string;
+  type: 'ENTRA' | 'GOOGLE' | 'OKTA' | 'AUTH0' | 'GITHUB' | 'OIDC';
+  name: string;
+  isActive: boolean;
+  issuer: string;
+  clientId: string;
+  clientSecretExpiresAt: string | null;
+  initiateId: string;
+  jitProvisioning: boolean;
+  jitDefaultRole: string;
+  roleSyncEnabled: boolean;
+  roleSyncSource: 'APP_ROLES' | 'GROUPS';
+  roleSyncFallback: 'DENY_ALL' | 'KEEP_EXISTING' | 'DEFAULT_ROLE';
+  enforceSso: boolean;
+  lastSuccessfulLoginAt: string | null;
+  config: Record<string, string>;
+  _count?: { roleMappings: number };
+}
+
+export interface IdentityProviderInput {
+  type: string;
+  name: string;
+  clientId: string;
+  /**
+   * Omit (or send empty) on update to keep the stored secret — the API never
+   * returns it, so there is nothing to round-trip. Same contract as the SMTP
+   * password in `adminSettings.updateSmtp`.
+   */
+  clientSecret?: string;
+  clientSecretExpiresAt?: string | null;
+  issuer?: string;
+  config?: Record<string, string>;
+  isActive?: boolean;
+  jitProvisioning?: boolean;
+  roleSyncEnabled?: boolean;
+  roleSyncSource?: string;
+  roleSyncFallback?: string;
+}
+
+export const identityProviders = {
+  list: (token: string) =>
+    request<IdentityProvider[]>('/api/identity-providers', { token }),
+  create: (data: IdentityProviderInput, token: string) =>
+    request<IdentityProvider>('/api/identity-providers', { method: 'POST', body: data, token }),
+  update: (id: string, data: IdentityProviderInput, token: string) =>
+    request<IdentityProvider>(`/api/identity-providers/${id}`, { method: 'PUT', body: data, token }),
+  delete: (id: string, token: string) =>
+    request<{ message: string }>(`/api/identity-providers/${id}`, { method: 'DELETE', token }),
+  test: (id: string, token: string) =>
+    request<{ ok: boolean; message: string; details?: Record<string, string> }>(
+      `/api/identity-providers/${id}/test`,
+      { method: 'POST', token },
+    ),
+};
+
 export const roles = {
   list: (token: string) =>
     request<any[]>('/api/roles', { token }),

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -655,6 +655,8 @@ export const server = {
       deploymentMode: string;
       hasUsers: boolean;
       registrationEnabled: boolean;
+      /** Empty in cloud: listing providers publicly would enumerate workspaces. */
+      ssoProviders: SsoProviderButton[];
       oauthEndpoints: { wellKnown: string; authorize: string; token: string; register: string } | null;
     }>('/health/server-info'),
 };
@@ -725,6 +727,51 @@ export interface IdentityProviderInput {
   roleSyncSource?: string;
   roleSyncFallback?: string;
 }
+
+export interface SsoProviderButton {
+  name: string;
+  type: string;
+  startUrl: string;
+}
+
+export interface LinkableProvider {
+  id: string;
+  name: string;
+  type: string;
+  linked: boolean;
+  linkedAt: string | null;
+  lastLoginAt: string | null;
+}
+
+export const sso = {
+  /** Trades the one-time code from the sign-in redirect for a session. */
+  exchange: (code: string) =>
+    request<{ accessToken: string; user: any; error?: string }>(
+      '/api/auth/sso/exchange',
+      { method: 'POST', body: { code } },
+    ),
+
+  /** Providers the signed-in user may connect, and whether they already have. */
+  myProviders: (token: string) =>
+    request<LinkableProvider[]>('/api/auth/sso/providers', { token }),
+
+  /**
+   * Begins a link. Returns the provider URL for the caller to navigate to —
+   * the browser has to arrive there as a top-level navigation, so this
+   * deliberately does not redirect.
+   */
+  startLink: (providerId: string, redirect: string | undefined, token: string) =>
+    request<{ authorizationUrl: string }>(
+      `/api/auth/sso/link/${providerId}`,
+      { method: 'POST', body: { redirect }, token },
+    ),
+
+  unlink: (providerId: string, token: string) =>
+    request<{ message: string }>(`/api/auth/sso/link/${providerId}`, {
+      method: 'DELETE',
+      token,
+    }),
+};
 
 export const identityProviders = {
   list: (token: string) =>

--- a/packages/frontend/src/proxy.ts
+++ b/packages/frontend/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const PUBLIC_PATHS = ['/login', '/register', '/forgot-password', '/reset-password', '/accept-invite'];
+const PUBLIC_PATHS = ['/login', '/register', '/forgot-password', '/reset-password', '/accept-invite', '/verify-email'];
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -13,6 +13,12 @@ export function proxy(request: NextRequest) {
     pathname.startsWith('/api') ||
     pathname.startsWith('/health') ||
     pathname.startsWith('/mcp') ||
+    // Sign-in entry point and OIDC callback. Both are rewritten to the backend
+    // in next.config, but this gate runs on the INCOMING pathname, before the
+    // rewrite — without these an unauthenticated sign-in would be bounced to
+    // /login, which is the page the user is trying to reach through.
+    pathname.startsWith('/sso') ||
+    pathname.startsWith('/auth') ||
     pathname.startsWith('/.well-known') ||
     pathname === '/authorize' ||
     pathname === '/token' ||


### PR DESCRIPTION
Adds single sign-on with an external identity provider, configurable per workspace from the dashboard. Covers both places a user authenticates: the dashboard, and the page that authorizes an AI client.

Role synchronisation from directory groups is the next change; this one delivers sign-in.

## The rule everything else follows

**Identity is keyed on `(provider, subject)` — never on email.** Entra's `mail` attribute is mutable, unverified and not unique, and a tenant admin can invite *any* address as a B2B guest. Keying on it is the nOAuth vulnerability: anyone controlling any directory could assert a victim's address and be handed their account.

So an existing member is never matched automatically. They link their directory account deliberately, while signed in, from Settings. Just-in-time provisioning is off by default; with it on, a *new* account is created, and if the address already belongs to someone the sign-in is refused rather than resolved.

## What lands

**Many-to-many MCP roles** (`user_roles`), replacing the single `users.mcp_role_id`. Expand/contract: the old column still exists and is still written, so nothing depends on this landing atomically. Assignments carry a `source` (`manual` / `entra`) so a later sync can replace what it owns without touching what an admin set by hand.

**Per-workspace provider configuration** with the client secret encrypted under AES-256-GCM, its AAD bound to `(providerId, organizationId)` so a ciphertext lifted into another workspace simply fails to decrypt. The issuer is derived server-side per provider type and validated against a host allowlist; a supplied one is ignored where it can be derived.

**Dashboard sign-in and account linking.** Sign-in stores the CSRF state, nonce and PKCE verifier server-side rather than in a cookie that must survive the hop to the provider and back, and consumes the attempt atomically so a replayed state finds nothing. No token is minted in the redirect — it carries a single-use 30-second code the SPA trades for a session, keeping bearer material out of browser history, the `Referer` header and proxy logs.

**Sign-in on the MCP authorization page.** Until now that page took only a password, so an SSO-enforced account could not connect a client at all and everyone else bypassed the directory's MFA and Conditional Access on the flow most worth protecting. The button is a submit on the existing form, so it inherits that page's CSRF protection rather than being a bare GET.

## Two decisions worth reviewing

**Which providers a pre-authentication page may list.** On `/health/server-info` the list is populated on self-hosted deployments only: that endpoint is unauthenticated, and in cloud an unscoped list would let anyone enumerate every customer's workspace and directory. On the MCP authorization page the same risk is avoided differently — the list is scoped to the one workspace being authorized, resolved from the `mcp_resource` cookie captured from the client's RFC 8707 `resource`. That leaks nothing, because reaching the page already required that tenant's own server id.

**Binding the MCP round trip.** The pending authorization session is recorded when the flow starts and asserted against the cookie the browser presents on return. Without it an attacker could open an authorization on their own machine, have a victim complete the directory leg, and hold a token for the victim's workspace. The recorded value is asserted, never restored — re-planting it would reduce the library's own session check to comparing a value with itself. Missing values on either side fail closed.

Unlinking refuses when it would leave an account with no way in at all: no usable password (having a hash is not the same as being allowed to use it) and no other identity.

## Migrations

Four, all additive and ordered after `20260731130000` already in production:
`expand_user_roles_m2m`, `add_identity_providers`, `add_sso_login`, `add_sso_identity_linking`.

## Verification

Verified against a real Entra tenant, through the UI:

- Sign-in with no linked identity is refused (`no_identity_and_jit_disabled`) and the `oid` recorded — the deliberate behaviour, not a failure.
- Linking from Settings, then a password-less sign-in that lands on the dashboard.
- Unlinking: refused with no password, refused when password sign-in is disabled, allowed when a usable password remains.
- Role creation, tool assignment and role assignment through the UI, landing in `user_roles` with `source: manual` and org-scoped, while the legacy column stays written in parallel. A restricted user then sees only their two permitted tools over MCP.
- On the MCP page: with the resource cookie the workspace's provider is offered, without it no buttons render, and pressing it redirects to Entra with an attempt bound to the browser's OAuth session.

Two defects were found *only* by driving the UI, both of which compiled and passed tests: the sign-in code was exchanged twice under React StrictMode, reporting failure for a sign-in that had succeeded; and the resource cookie was read from `req.cookies` when it is signed and lives in `signedCookies`, which would have shipped the MCP buttons permanently invisible.

3806 tests pass; `tsc --noEmit` clean on backend and frontend.