### PR TITLE
fix(mcp): log client-caused MCP rejections as warnings, not errors

### DIFF
--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -429,12 +429,21 @@ export class McpEndpointController {
       // only when a mid-call message appears, which would silently change the
       // framing for clients that get SSE today. 'sse' preserves it exactly.
       responseMode: this.jsonResponseEnabled() ? 'json' : 'sse',
+      // WARN, not ERROR: this callback reports rejected requests as well as
+      // genuine faults, and a rejection is usually the client's doing — a
+      // crawler sending `Mcp-Method` (a 2026-07-28 construct) alongside
+      // `MCP-Protocol-Version: 2025-06-18` is refused with a 400, exactly as
+      // it should be. Logging that at error level lets any malformed client
+      // inflate the error rate and bury real failures underneath it.
       onerror: (error) =>
-        this.logger.error(`MCP handler error (${label}): ${error.message}`),
+        this.logger.warn(`MCP request rejected (${label}): ${error.message}`),
     });
 
     try {
       await toNodeHandler(handler, {
+        // ERROR here is right: the adapter only calls this when it answers a
+        // 500 because request conversion or the handler itself threw, which is
+        // our fault rather than the caller's.
         onerror: (error) =>
           this.logger.error(`MCP adapter error (${label}): ${error.message}`),
       })(req, res, body);


### PR DESCRIPTION
`createMcpHandler`'s `onerror` reports **rejected requests** as well as genuine faults. Wiring it to `logger.error` meant any malformed client inflated our error rate.

Concretely: a crawler (`SentinelOracle/0.1`) sends `Mcp-Method` — a 2026-07-28 construct — alongside `MCP-Protocol-Version: 2025-06-18`. The header routes the request down the modern path, which correctly refuses that version with a 400. Eight of those in two hours were the only "errors" on an otherwise clean deployment.

That matters beyond tidiness: the error rate is what a deploy is judged by, so phantom errors from a noisy client hide the real ones. I found this reading production logs before the next deploy and had to rule out a regression in my own change first.

The adapter-level callback stays at error level — it fires only when the adapter answers a 500 because request conversion or the handler threw, which is our fault rather than the caller's.

No behaviour change: the responses were always correct (400 for the contradictory requests, 200/202 for the well-formed ones from the same client). Only the log level moves.