### PR TITLE
feat(sso): role sync from Entra groups, recovery codes, and self-hosted-only gating

### DIFF
--- a/packages/backend/prisma/migrations/20260908124648_add_role_sync_default_roles/migration.sql
+++ b/packages/backend/prisma/migrations/20260908124648_add_role_sync_default_roles/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "users_onboarding_drip_idx";
+
+-- AlterTable
+ALTER TABLE "identity_providers" ADD COLUMN     "role_sync_default_role_ids" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/packages/backend/prisma/migrations/20260908135906_add_recovery_codes/migration.sql
+++ b/packages/backend/prisma/migrations/20260908135906_add_recovery_codes/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "recovery_codes" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "code_hash" TEXT NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "label" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "recovery_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "recovery_codes_user_id_idx" ON "recovery_codes"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "recovery_codes" ADD CONSTRAINT "recovery_codes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -726,6 +726,10 @@ model IdentityProvider {
   roleSyncEnabled  Boolean          @default(false) @map("role_sync_enabled")
   roleSyncSource   RoleSyncSource   @default(GROUPS) @map("role_sync_source")
   roleSyncFallback RoleSyncFallback @default(DENY_ALL) @map("role_sync_fallback")
+  /// MCP roles granted when `roleSyncFallback` is DEFAULT_ROLE and nothing
+  /// matched. Empty makes DEFAULT_ROLE behave like DENY_ALL, which is the safe
+  /// reading of "a default that was never configured".
+  roleSyncDefaultRoleIds String[] @default([]) @map("role_sync_default_role_ids")
 
   /// PLACEHOLDER — column exists, NOTHING reads or writes it yet (PR 6).
   /// Intended to disable password sign-in for members of this organization.

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -159,6 +159,7 @@ model User {
   passwordResetTokens      PasswordResetToken[]
   mcpApiKeys               McpApiKey[]
   emailVerificationTokens  EmailVerificationToken[]
+  recoveryCodes            RecoveryCode[]
 
   @@index([organizationId])
   @@map("users")
@@ -680,6 +681,39 @@ enum RoleSyncFallback {
   DENY_ALL
   KEEP_EXISTING
   DEFAULT_ROLE
+}
+
+/// Single-use break-glass credential for a user.
+///
+/// Exists so that `IdentityProvider.enforceSso` can be switched on at all: an
+/// organization that turns off password sign-in and then loses its directory —
+/// an expired client secret, a tenant migration, a misconfigured claim — has no
+/// remaining way in. Recovery codes are that way in, and the API refuses to
+/// enable enforcement until the acting admin holds some.
+///
+/// Deliberately per-USER and not per-organization: a shared break-glass secret
+/// records that *someone* got in, which is the one thing an audit trail must
+/// never be vague about.
+model RecoveryCode {
+  id     String @id @default(cuid())
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  /// bcrypt. The plaintext is shown once at generation and never recoverable —
+  /// storing it reversibly would make this a password list.
+  codeHash String @map("code_hash")
+
+  /// Single use. Kept rather than deleted so the audit trail can still tie a
+  /// past sign-in to a specific code.
+  usedAt DateTime? @map("used_at")
+  /// Truncated fingerprint of the code, for support conversations ("which one
+  /// did you use?") without storing anything that could be replayed.
+  label  String
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@map("recovery_codes")
 }
 
 model IdentityProvider {

--- a/packages/backend/src/audit/security-event.service.spec.ts
+++ b/packages/backend/src/audit/security-event.service.spec.ts
@@ -153,4 +153,28 @@ describe('SecurityEventService', () => {
       });
     });
   });
+
+  // Regression: the depth cut-off used to emit the same '[REDACTED]' string as
+  // a real key match, so an audit row that had simply nested too far was
+  // indistinguishable from one that had a credential stripped out of it.
+  it('marks a depth cut-off as truncation, not redaction', async () => {
+    await service.log({
+      event: 'IDP_ROLE_MAPPING_CHANGED',
+      actorType: 'USER',
+      metadata: { after: [{ mcpRoleIds: ['role_1'] }] },
+    });
+    const written = (prisma.securityEvent.create as jest.Mock).mock.calls[0][0].data.metadata;
+    expect(written.after[0].mcpRoleIds[0]).toBe('[TRUNCATED:depth]');
+    expect(written.after[0].mcpRoleIds[0]).not.toBe('[REDACTED]');
+  });
+
+  it('still redacts on a key match at any depth', async () => {
+    await service.log({
+      event: 'IDP_UPDATED',
+      actorType: 'USER',
+      metadata: { before: { clientSecret: 'hunter2' } },
+    });
+    const written = (prisma.securityEvent.create as jest.Mock).mock.calls[0][0].data.metadata;
+    expect(written.before.clientSecret).toBe('[REDACTED]');
+  });
 });

--- a/packages/backend/src/audit/security-event.service.ts
+++ b/packages/backend/src/audit/security-event.service.ts
@@ -31,6 +31,11 @@ export const SecurityEvents = {
   ROLE_CHANGED: 'ROLE_CHANGED',
   LAST_ADMIN_PROTECTION_TRIGGERED: 'LAST_ADMIN_PROTECTION_TRIGGERED',
   MEMBERSHIP_REMOVED_BY_SYNC: 'MEMBERSHIP_REMOVED_BY_SYNC',
+  /** A sign-in rewrote the user's roles from the directory's claims. */
+  ROLE_SYNC_APPLIED: 'ROLE_SYNC_APPLIED',
+  /** Claims were incomplete, so roles were deliberately left untouched. */
+  ROLE_SYNC_SKIPPED: 'ROLE_SYNC_SKIPPED',
+  ROLE_SYNC_FAILED: 'ROLE_SYNC_FAILED',
   /** Every token issued before now was invalidated for this user. */
   SESSIONS_REVOKED: 'SESSIONS_REVOKED',
   API_KEY_DEACTIVATED: 'API_KEY_DEACTIVATED',
@@ -70,6 +75,13 @@ const REDACTED_KEY_PATTERN =
   /secret|password|passwd|token|assertion|credential|code_verifier|code_challenge|authorization|cookie|private_key|api[-_]?key/i;
 
 const REDACTED = '[REDACTED]';
+/**
+ * Distinct from REDACTED on purpose. Reusing it for the depth cut-off made
+ * every over-nested value read as "a secret was removed here", which sends an
+ * investigation looking for a credential that was never there — a role id list
+ * one level too deep looked identical to a stripped password.
+ */
+const TRUNCATED_DEPTH = '[TRUNCATED:depth]';
 const MAX_DEPTH = 4;
 const MAX_STRING = 512;
 
@@ -121,7 +133,7 @@ export class SecurityEventService {
   private redact(value: unknown, depth = 0): unknown {
     if (value === null || value === undefined) return null;
 
-    if (depth >= MAX_DEPTH) return REDACTED;
+    if (depth >= MAX_DEPTH) return TRUNCATED_DEPTH;
 
     if (typeof value === 'string') {
       return value.length > MAX_STRING

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -33,7 +33,19 @@ import { OrganizationsService } from '../organizations/organizations.service';
 import { SecurityEventService, SecurityEvents } from '../audit/security-event.service';
 import { LicenseService } from '../license/license.service';
 import { RolesService } from '../roles/roles.service';
+import { RecoveryCodesService } from './recovery-codes.service';
+import { SsoEnforcementService } from './sso-enforcement.service';
 import { Roles, RolesGuard } from './roles.guard';
+
+class RecoveryLoginDto {
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ description: 'One of the codes issued at generation. Case and dashes are ignored.' })
+  @IsString()
+  code: string;
+}
 
 class LoginDto {
   @ApiProperty({ description: 'Email address.', example: 'user@example.com' })
@@ -161,6 +173,8 @@ export class AuthController {
     private readonly licenseService: LicenseService,
     private readonly securityEvents: SecurityEventService,
     private readonly rolesService: RolesService,
+    private readonly recoveryCodes: RecoveryCodesService,
+    private readonly ssoEnforcement: SsoEnforcementService,
   ) {}
 
   private getFrontendUrl(_req?: any): string {
@@ -205,6 +219,57 @@ export class AuthController {
     }
   }
 
+  @Post('login/recovery')
+  @HttpCode(HttpStatus.OK)
+  // Tighter than the password path: a recovery code is 50 bits and single-use,
+  // but it is also the credential that bypasses the workspace's SSO policy, so
+  // an attacker gets fewer attempts at it, not the same number.
+  @Throttle({ default: { limit: 3, ttl: 300_000 } })
+  @ApiOperation({
+    summary: 'Sign in with a recovery code when single sign-on is unreachable',
+  })
+  async loginWithRecoveryCode(@Req() req: any, @Body() dto: RecoveryLoginDto) {
+    const user = await this.usersService.findByEmail(dto.email);
+
+    // One message for every failure below — unknown address, wrong code, code
+    // already spent. Each distinction would confirm something to an attacker
+    // that they cannot otherwise learn.
+    const refuse = () =>
+      new UnauthorizedException('Invalid email or recovery code');
+
+    if (!user) throw refuse();
+
+    const ok = await this.recoveryCodes.consume(user.id, dto.code, {
+      organizationId: user.organizationId,
+      ip: req.ip,
+      userAgent: req.headers?.['user-agent'],
+    });
+    if (!ok) throw refuse();
+
+    const token = this.authService.generateToken({
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+      organizationId: user.organizationId,
+      mcpRoleId: user.mcpRoleId,
+    });
+
+    const { unused } = await this.recoveryCodes.status(user.id);
+
+    return {
+      accessToken: token,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        organizationId: user.organizationId,
+        emailVerified: user.emailVerified,
+      },
+      recoveryCodesRemaining: unused,
+    };
+  }
+
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
@@ -220,6 +285,15 @@ export class AuthController {
     if (user.passwordLoginDisabled) {
       throw new UnauthorizedException(
         'Password sign-in is disabled for this account. Use your organization sign-in.',
+      );
+    }
+
+    // Organization-wide enforcement. Checked BEFORE bcrypt for the same reason
+    // as the per-account flag: comparing first would turn this into an oracle
+    // for whether a password is correct on an account that cannot use one.
+    if (await this.ssoEnforcement.isPasswordLoginBlocked(user.id)) {
+      throw new UnauthorizedException(
+        'This workspace requires single sign-on. Use your organization sign-in, or a recovery code if you cannot reach it.',
       );
     }
 
@@ -794,5 +868,32 @@ export class AuthController {
     });
 
     return { message: 'Password has been reset successfully' };
+  }
+
+  // ── Recovery codes ────────────────────────────────────────────────────────
+
+  @Get('recovery-codes')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'How many recovery codes the caller still holds' })
+  async recoveryCodeStatus(@Req() req: any) {
+    return this.recoveryCodes.status(req.user.sub);
+  }
+
+  @Post('recovery-codes')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Generate a fresh set of recovery codes. Returns them ONCE; any previous set stops working.',
+  })
+  async generateRecoveryCodes(@Req() req: any) {
+    const codes = await this.recoveryCodes.generate(req.user.sub, {
+      organizationId: req.user.organizationId,
+      ip: req.ip,
+      userAgent: req.headers?.['user-agent'],
+    });
+    return { codes };
   }
 }

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -36,6 +36,7 @@ import { RolesService } from '../roles/roles.service';
 import { RecoveryCodesService } from './recovery-codes.service';
 import { SsoEnforcementService } from './sso-enforcement.service';
 import { Roles, RolesGuard } from './roles.guard';
+import { SelfHostedOnlyGuard } from '../common/self-hosted-only.guard';
 
 class RecoveryLoginDto {
   @ApiProperty()
@@ -221,6 +222,11 @@ export class AuthController {
 
   @Post('login/recovery')
   @HttpCode(HttpStatus.OK)
+  // Recovery codes exist only to make `enforceSso` safe to enable, and that is
+  // self-hosted only. Leaving this mounted in cloud would keep a password-free
+  // authentication path reachable for a feature no cloud tenant can even turn
+  // on.
+  @UseGuards(SelfHostedOnlyGuard)
   // Tighter than the password path: a recovery code is 50 bits and single-use,
   // but it is also the credential that bypasses the workspace's SSO policy, so
   // an attacker gets fewer attempts at it, not the same number.
@@ -873,7 +879,7 @@ export class AuthController {
   // ── Recovery codes ────────────────────────────────────────────────────────
 
   @Get('recovery-codes')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(SelfHostedOnlyGuard, AuthGuard('jwt'))
   @ApiBearerAuth()
   @ApiOperation({ summary: 'How many recovery codes the caller still holds' })
   async recoveryCodeStatus(@Req() req: any) {
@@ -882,7 +888,7 @@ export class AuthController {
 
   @Post('recovery-codes')
   @HttpCode(HttpStatus.OK)
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(SelfHostedOnlyGuard, AuthGuard('jwt'))
   @ApiBearerAuth()
   @ApiOperation({
     summary:

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -3,6 +3,8 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
+import { RecoveryCodesService } from './recovery-codes.service';
+import { SsoEnforcementService } from './sso-enforcement.service';
 import { AuthController } from './auth.controller';
 import { LoginController } from './login.controller';
 import { JwtStrategy } from './jwt.strategy';
@@ -47,6 +49,8 @@ import { IdentityProvidersModule } from '../identity-providers/identity-provider
   controllers: [AuthController, LoginController],
   providers: [
     AuthService,
+    RecoveryCodesService,
+    SsoEnforcementService,
     JwtStrategy,
     McpAuthGuard,
     McpAuthMiddleware,
@@ -57,6 +61,8 @@ import { IdentityProvidersModule } from '../identity-providers/identity-provider
   ],
   exports: [
     AuthService,
+    RecoveryCodesService,
+    SsoEnforcementService,
     McpAuthGuard,
     McpAuthMiddleware,
     McpRateLimitGuard,

--- a/packages/backend/src/auth/login.controller.spec.ts
+++ b/packages/backend/src/auth/login.controller.spec.ts
@@ -87,6 +87,7 @@ describe('LoginController', () => {
       config as unknown as ConfigService,
       store as unknown as PrismaOAuthStore,
       sso as unknown as SsoService,
+      { mode: 'self-hosted', isCloud: () => false, isSelfHosted: () => true } as any,
     );
   });
 

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -14,6 +14,7 @@ import { Request, Response } from 'express';
 import { randomBytes, timingSafeEqual } from 'crypto';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../common/prisma.service';
+import { DeploymentService } from '../common/deployment.service';
 import { PrismaOAuthStore } from './prisma-oauth.store';
 import { SsoService } from '../identity-providers/sso.service';
 import { MCP_RESOURCE_COOKIE } from './resource-indicator.middleware';
@@ -41,6 +42,7 @@ export class LoginController {
     private readonly configService: ConfigService,
     private readonly oauthStore: PrismaOAuthStore,
     private readonly sso: SsoService,
+    private readonly deployment: DeploymentService,
   ) {}
 
   @Get('login')
@@ -313,6 +315,11 @@ export class LoginController {
   ): Promise<{ id: string; name: string }[]> {
     // SIGNED cookie, so it lives in `signedCookies` — reading `req.cookies`
     // here silently yields undefined and the buttons never render.
+    // Self-hosted only, like the rest of SSO. Cloud has no providers to find,
+    // so this would return an empty list anyway — but saying so here means the
+    // MCP authorization page never queries for them.
+    if (this.deployment.isCloud()) return [];
+
     const serverId = (req as any).signedCookies?.[MCP_RESOURCE_COOKIE];
     if (!serverId) return [];
     try {

--- a/packages/backend/src/auth/recovery-codes.service.spec.ts
+++ b/packages/backend/src/auth/recovery-codes.service.spec.ts
@@ -1,0 +1,120 @@
+import { RecoveryCodesService, CODE_COUNT } from './recovery-codes.service';
+import * as bcrypt from 'bcrypt';
+
+// bcrypt at cost 12, ten codes per generation: a few of these tests do
+// twenty hashes and genuinely need longer than the 5s default.
+jest.setTimeout(60_000);
+
+describe('RecoveryCodesService', () => {
+  let prisma: any;
+  let securityEvents: any;
+  let service: RecoveryCodesService;
+  let store: any[];
+
+  beforeEach(() => {
+    store = [];
+    prisma = {
+      recoveryCode: {
+        deleteMany: jest.fn(async () => {
+          store = [];
+          return { count: 0 };
+        }),
+        createMany: jest.fn(async ({ data }: any) => {
+          store.push(...data.map((d: any, i: number) => ({ id: `c${i}`, usedAt: null, createdAt: new Date(), ...d })));
+          return { count: data.length };
+        }),
+        findMany: jest.fn(async ({ where }: any) =>
+          store.filter((c) => (where.usedAt === null ? c.usedAt === null : true)),
+        ),
+        count: jest.fn(async () => store.filter((c) => c.usedAt === null).length),
+        updateMany: jest.fn(async ({ where }: any) => {
+          const row = store.find((c) => c.id === where.id && c.usedAt === null);
+          if (!row) return { count: 0 };
+          row.usedAt = new Date();
+          return { count: 1 };
+        }),
+      },
+      $transaction: jest.fn((fn: any) => fn(prisma)),
+    };
+    securityEvents = { log: jest.fn() };
+    service = new RecoveryCodesService(prisma, securityEvents);
+  });
+
+  it('issues a full set and stores only hashes', async () => {
+    const codes = await service.generate('u1');
+    expect(codes).toHaveLength(CODE_COUNT);
+    expect(new Set(codes).size).toBe(CODE_COUNT);
+    for (const c of codes) {
+      expect(store.some((row) => row.codeHash === c)).toBe(false);
+    }
+    expect(await bcrypt.compare(codes[0].replace('-', ''), store[0].codeHash)).toBe(true);
+  });
+
+  // The alphabet omits I, L, O and U precisely because these get written on
+  // paper and typed back while SSO is already broken.
+  it('avoids characters that are misread off a printout', async () => {
+    const codes = await service.generate('u1');
+    expect(codes.join('')).not.toMatch(/[ILOU]/);
+    for (const c of codes) expect(c).toMatch(/^[0-9A-Z]{5}-[0-9A-Z]{5}$/);
+  });
+
+  it('accepts a code regardless of case and dashes', async () => {
+    const [code] = await service.generate('u1');
+    const mangled = code.toLowerCase().replace('-', ' ');
+    expect(await service.consume('u1', mangled)).toBe(true);
+  });
+
+  it('accepts each code exactly once', async () => {
+    const [code] = await service.generate('u1');
+    expect(await service.consume('u1', code)).toBe(true);
+    expect(await service.consume('u1', code)).toBe(false);
+  });
+
+  it('rejects an unknown code without consuming anything', async () => {
+    await service.generate('u1');
+    expect(await service.consume('u1', 'ZZZZZ-ZZZZZ')).toBe(false);
+    expect(store.every((c) => c.usedAt === null)).toBe(true);
+  });
+
+  // Two requests arriving with the same code must not both succeed. The
+  // conditional update is what makes that impossible; a read-then-write would
+  // let both pass.
+  it('cannot be consumed twice concurrently', async () => {
+    const [code] = await service.generate('u1');
+    const results = await Promise.all([
+      service.consume('u1', code),
+      service.consume('u1', code),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('regenerating invalidates the previous set', async () => {
+    const first = await service.generate('u1');
+    await service.generate('u1');
+    expect(await service.consume('u1', first[0])).toBe(false);
+  });
+
+  it('reports whether a way back in still exists', async () => {
+    expect(await service.hasUnused('u1')).toBe(false);
+    const codes = await service.generate('u1');
+    expect(await service.hasUnused('u1')).toBe(true);
+    for (const c of codes) await service.consume('u1', c);
+    expect(await service.hasUnused('u1')).toBe(false);
+  });
+
+  it('audits generation and use', async () => {
+    const [code] = await service.generate('u1');
+    await service.consume('u1', code);
+    const events = securityEvents.log.mock.calls.map((c: any[]) => c[0].event);
+    expect(events).toContain('RECOVERY_CODES_GENERATED');
+    expect(events).toContain('RECOVERY_CODE_USED');
+  });
+
+  it('never puts a usable code in the audit trail', async () => {
+    const [code] = await service.generate('u1');
+    await service.consume('u1', code);
+    const serialised = JSON.stringify(securityEvents.log.mock.calls);
+    expect(serialised).not.toContain(code);
+    expect(serialised).not.toContain(code.replace('-', ''));
+  });
+});

--- a/packages/backend/src/auth/recovery-codes.service.ts
+++ b/packages/backend/src/auth/recovery-codes.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomInt } from 'crypto';
+import * as bcrypt from 'bcrypt';
+import { PrismaService } from '../common/prisma.service';
+import {
+  SecurityEventService,
+  SecurityEvents,
+} from '../audit/security-event.service';
+
+/** How many codes a generation produces. */
+export const CODE_COUNT = 10;
+
+/**
+ * Crockford base32 minus the letters that get misread off a printout: I, L, O
+ * and U. These codes are meant to be written down and typed back under
+ * pressure, when SSO is already broken.
+ */
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const GROUP = 5;
+const GROUPS = 2;
+
+/**
+ * Break-glass credentials.
+ *
+ * A workspace that disables password sign-in and then loses its identity
+ * provider has no way back in. These are that way back in — which is why
+ * `enforceSso` cannot be enabled until the acting admin holds unused codes.
+ */
+@Injectable()
+export class RecoveryCodesService {
+  private readonly logger = new Logger(RecoveryCodesService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  /**
+   * Replaces every code the user holds and returns the new ones in plaintext.
+   *
+   * The plaintext is returned exactly once. Regenerating invalidates the old
+   * set on purpose: two live sets means a code someone printed a year ago
+   * still works, which is the opposite of what rotation is for.
+   */
+  async generate(
+    userId: string,
+    ctx: { organizationId?: string | null; ip?: string | null; userAgent?: string | null } = {},
+  ): Promise<string[]> {
+    const codes = Array.from({ length: CODE_COUNT }, () => this.mint());
+
+    // bcrypt at the same cost as passwords: these ARE passwords, and a leaked
+    // table of fast hashes over a 50-bit space is worth brute-forcing.
+    const rows = await Promise.all(
+      codes.map(async (code) => ({
+        userId,
+        // Hash the NORMALISED form. `consume` strips the dash before comparing
+        // — so hashing the display form here means no code would ever verify,
+        // and the break-glass path would be silently dead until the day it was
+        // needed.
+        codeHash: await bcrypt.hash(this.normalise(code), 12),
+        label: this.labelFor(code),
+      })),
+    );
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.recoveryCode.deleteMany({ where: { userId } });
+      await tx.recoveryCode.createMany({ data: rows });
+    });
+
+    await this.securityEvents.log({
+      event: SecurityEvents.RECOVERY_CODES_GENERATED,
+      actorType: 'USER',
+      organizationId: ctx.organizationId ?? null,
+      actorUserId: userId,
+      targetUserId: userId,
+      metadata: { count: codes.length },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+
+    return codes;
+  }
+
+  /** Counts only — the codes themselves are never readable again. */
+  async status(userId: string) {
+    const codes = await this.prisma.recoveryCode.findMany({
+      where: { userId },
+      select: { usedAt: true, createdAt: true },
+    });
+    return {
+      total: codes.length,
+      unused: codes.filter((c) => c.usedAt === null).length,
+      generatedAt: codes[0]?.createdAt ?? null,
+    };
+  }
+
+  /** True when the user could still get in if the directory stopped working. */
+  async hasUnused(userId: string): Promise<boolean> {
+    const count = await this.prisma.recoveryCode.count({
+      where: { userId, usedAt: null },
+    });
+    return count > 0;
+  }
+
+  /**
+   * Consumes one code. Returns false for both "wrong code" and "already used",
+   * which the caller must report identically — distinguishing them tells an
+   * attacker which guesses were once valid.
+   */
+  async consume(
+    userId: string,
+    supplied: string,
+    ctx: { organizationId?: string | null; ip?: string | null; userAgent?: string | null } = {},
+  ): Promise<boolean> {
+    const normalised = this.normalise(supplied);
+    if (normalised.length !== GROUP * GROUPS) return false;
+
+    const candidates = await this.prisma.recoveryCode.findMany({
+      where: { userId, usedAt: null },
+      select: { id: true, codeHash: true },
+    });
+
+    for (const candidate of candidates) {
+      if (!(await bcrypt.compare(normalised, candidate.codeHash))) continue;
+
+      // Conditional update: `usedAt: null` in the WHERE makes the consumption
+      // atomic, so two requests racing with the same code cannot both win.
+      const claimed = await this.prisma.recoveryCode.updateMany({
+        where: { id: candidate.id, usedAt: null },
+        data: { usedAt: new Date() },
+      });
+      if (claimed.count !== 1) return false;
+
+      await this.securityEvents.log({
+        event: SecurityEvents.RECOVERY_CODE_USED,
+        actorType: 'USER',
+        organizationId: ctx.organizationId ?? null,
+        actorUserId: userId,
+        targetUserId: userId,
+        metadata: {
+          remaining: candidates.length - 1,
+        },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  // ── Formatting ────────────────────────────────────────────────────────────
+
+  private mint(): string {
+    // randomInt is rejection-sampled, so the alphabet stays uniform. `% 32`
+    // over a byte would too, since 32 divides 256 — but only by accident, and
+    // the next person to widen the alphabet would inherit a silent bias.
+    const chars = Array.from({ length: GROUP * GROUPS }, () =>
+      ALPHABET[randomInt(ALPHABET.length)],
+    ).join('');
+    return `${chars.slice(0, GROUP)}-${chars.slice(GROUP)}`;
+  }
+
+  /** Uppercase, strip everything that is not in the alphabet. */
+  private normalise(code: string): string {
+    return code.toUpperCase().replace(/[^0-9A-Z]/g, '');
+  }
+
+  /** First group only: enough to identify a code, useless for using one. */
+  private labelFor(code: string): string {
+    return `${code.slice(0, GROUP)}-•••••`;
+  }
+}

--- a/packages/backend/src/auth/sso-enforcement.service.spec.ts
+++ b/packages/backend/src/auth/sso-enforcement.service.spec.ts
@@ -3,13 +3,15 @@ import { SsoEnforcementService } from './sso-enforcement.service';
 describe('SsoEnforcementService', () => {
   let prisma: any;
   let service: SsoEnforcementService;
+  const selfHosted = { mode: 'self-hosted', isCloud: () => false, isSelfHosted: () => true } as any;
+  const cloud = { mode: 'cloud', isCloud: () => true, isSelfHosted: () => false } as any;
 
   beforeEach(() => {
     prisma = {
       organizationMember: { findMany: jest.fn(async () => []) },
       identityProvider: { findMany: jest.fn(async () => []) },
     };
-    service = new SsoEnforcementService(prisma);
+    service = new SsoEnforcementService(prisma, selfHosted);
   });
 
   it('allows password login when no organization enforces SSO', async () => {
@@ -53,6 +55,19 @@ describe('SsoEnforcementService', () => {
 
   it('does not query providers at all for a user with no memberships', async () => {
     expect(await service.isPasswordLoginBlocked('u1')).toBe(false);
+    expect(prisma.identityProvider.findMany).not.toHaveBeenCalled();
+  });
+
+  // Single sign-on is self-hosted only. In cloud this runs on every password
+  // sign-in in the deployment, so it must cost nothing and, more importantly,
+  // must never be able to refuse one.
+  it('never blocks password login in cloud, and queries nothing', async () => {
+    const cloudService = new SsoEnforcementService(prisma, cloud);
+    prisma.organizationMember.findMany.mockResolvedValue([{ organizationId: 'o1' }]);
+    prisma.identityProvider.findMany.mockResolvedValue([{ organizationId: 'o1' }]);
+
+    expect(await cloudService.isPasswordLoginBlocked('u1')).toBe(false);
+    expect(prisma.organizationMember.findMany).not.toHaveBeenCalled();
     expect(prisma.identityProvider.findMany).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/auth/sso-enforcement.service.spec.ts
+++ b/packages/backend/src/auth/sso-enforcement.service.spec.ts
@@ -1,0 +1,58 @@
+import { SsoEnforcementService } from './sso-enforcement.service';
+
+describe('SsoEnforcementService', () => {
+  let prisma: any;
+  let service: SsoEnforcementService;
+
+  beforeEach(() => {
+    prisma = {
+      organizationMember: { findMany: jest.fn(async () => []) },
+      identityProvider: { findMany: jest.fn(async () => []) },
+    };
+    service = new SsoEnforcementService(prisma);
+  });
+
+  it('allows password login when no organization enforces SSO', async () => {
+    prisma.organizationMember.findMany.mockResolvedValue([{ organizationId: 'o1' }]);
+    expect(await service.isPasswordLoginBlocked('u1')).toBe(false);
+  });
+
+  // The whole point of spanning memberships: `POST /organizations/switch` moves
+  // a session between workspaces, so a password accepted in a permissive org
+  // would otherwise be a way into an enforcing one.
+  it('blocks password login when ANY of the user\'s organizations enforces it', async () => {
+    prisma.organizationMember.findMany.mockResolvedValue([
+      { organizationId: 'permissive' },
+      { organizationId: 'strict' },
+    ]);
+    prisma.identityProvider.findMany.mockResolvedValue([{ organizationId: 'strict' }]);
+    expect(await service.isPasswordLoginBlocked('u1')).toBe(true);
+  });
+
+  it('queries only the organizations the user actually belongs to', async () => {
+    prisma.organizationMember.findMany.mockResolvedValue([{ organizationId: 'o1' }]);
+    await service.enforcingOrganizations('u1');
+    expect(prisma.identityProvider.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ organizationId: { in: ['o1'] } }),
+      }),
+    );
+  });
+
+  // An inactive provider cannot be signed in through, so treating it as
+  // enforcing would lock the workspace out with nothing to point at.
+  it('ignores inactive providers', async () => {
+    prisma.organizationMember.findMany.mockResolvedValue([{ organizationId: 'o1' }]);
+    await service.enforcingOrganizations('u1');
+    expect(prisma.identityProvider.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ isActive: true, enforceSso: true }),
+      }),
+    );
+  });
+
+  it('does not query providers at all for a user with no memberships', async () => {
+    expect(await service.isPasswordLoginBlocked('u1')).toBe(false);
+    expect(prisma.identityProvider.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/auth/sso-enforcement.service.ts
+++ b/packages/backend/src/auth/sso-enforcement.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * Answers one question: may this user still sign in with a password?
+ *
+ * The check spans EVERY organization the user belongs to, not just the active
+ * one. `POST /api/organizations/switch` moves a session between workspaces, so
+ * a password that opens a session in a permissive org and is then switched into
+ * an enforcing one would defeat the control entirely. Failing closed across all
+ * memberships is the only version of this that actually enforces anything.
+ */
+@Injectable()
+export class SsoEnforcementService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Organizations of this user that require SSO. Empty means password is fine. */
+  async enforcingOrganizations(userId: string): Promise<string[]> {
+    const memberships = await this.prisma.organizationMember.findMany({
+      where: { userId },
+      select: { organizationId: true },
+    });
+    if (memberships.length === 0) return [];
+
+    const providers = await this.prisma.identityProvider.findMany({
+      where: {
+        organizationId: { in: memberships.map((m) => m.organizationId) },
+        enforceSso: true,
+        // An inactive provider cannot be signed in through, so treating it as
+        // enforcing would lock the workspace out with no way to notice why.
+        isActive: true,
+      },
+      select: { organizationId: true },
+    });
+    return [...new Set(providers.map((p) => p.organizationId))];
+  }
+
+  async isPasswordLoginBlocked(userId: string): Promise<boolean> {
+    return (await this.enforcingOrganizations(userId)).length > 0;
+  }
+}

--- a/packages/backend/src/auth/sso-enforcement.service.ts
+++ b/packages/backend/src/auth/sso-enforcement.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/prisma.service';
+import { DeploymentService } from '../common/deployment.service';
 
 /**
  * Answers one question: may this user still sign in with a password?
@@ -12,10 +13,18 @@ import { PrismaService } from '../common/prisma.service';
  */
 @Injectable()
 export class SsoEnforcementService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly deployment: DeploymentService,
+  ) {}
 
   /** Organizations of this user that require SSO. Empty means password is fine. */
   async enforcingOrganizations(userId: string): Promise<string[]> {
+    // Single sign-on is self-hosted only, so in cloud there is nothing to
+    // enforce and no reason to pay for two queries on the hot path of every
+    // password sign-in in the deployment.
+    if (this.deployment.isCloud()) return [];
+
     const memberships = await this.prisma.organizationMember.findMany({
       where: { userId },
       select: { organizationId: true },

--- a/packages/backend/src/common/self-hosted-only.guard.spec.ts
+++ b/packages/backend/src/common/self-hosted-only.guard.spec.ts
@@ -1,0 +1,40 @@
+import { NotFoundException } from '@nestjs/common';
+import { SelfHostedOnlyGuard } from './self-hosted-only.guard';
+
+describe('SelfHostedOnlyGuard', () => {
+  const ctx = {} as any;
+
+  it('lets requests through on a self-hosted deployment', () => {
+    const guard = new SelfHostedOnlyGuard({
+      mode: 'self-hosted',
+      isCloud: () => false,
+      isSelfHosted: () => true,
+    } as any);
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  // 404 and not 403: a 403 confirms the endpoint exists and is merely switched
+  // off here, which tells a prober exactly where to come back to.
+  it('answers 404 in cloud, not 403', () => {
+    const guard = new SelfHostedOnlyGuard({
+      mode: 'cloud',
+      isCloud: () => true,
+      isSelfHosted: () => false,
+    } as any);
+    expect(() => guard.canActivate(ctx)).toThrow(NotFoundException);
+  });
+
+  // DEPLOYMENT_MODE unset must mean self-hosted: a community operator who never
+  // sets the variable has to get the feature, not lose it.
+  it('treats an unset deployment mode as self-hosted', () => {
+    const previous = process.env.DEPLOYMENT_MODE;
+    delete process.env.DEPLOYMENT_MODE;
+    try {
+      const { DeploymentService } = require('./deployment.service');
+      expect(new SelfHostedOnlyGuard(new DeploymentService()).canActivate(ctx)).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.DEPLOYMENT_MODE;
+      else process.env.DEPLOYMENT_MODE = previous;
+    }
+  });
+});

--- a/packages/backend/src/common/self-hosted-only.guard.ts
+++ b/packages/backend/src/common/self-hosted-only.guard.ts
@@ -1,0 +1,31 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { DeploymentService } from './deployment.service';
+
+/**
+ * Restricts a route to self-hosted deployments.
+ *
+ * Single sign-on is an enterprise, self-hosted capability: the workspace owns
+ * its own directory, its own tenant and its own operator. In cloud the same
+ * feature would let any customer point a workspace at an arbitrary directory
+ * and start provisioning accounts inside a shared, multi-tenant deployment —
+ * a materially different trust model from the one the SSO code was written
+ * against.
+ *
+ * Answers 404 rather than 403 on purpose. A 403 confirms the endpoint exists
+ * and is merely switched off here, which is an invitation; 404 says the same
+ * thing the router would say about any URL this deployment does not serve.
+ */
+@Injectable()
+export class SelfHostedOnlyGuard implements CanActivate {
+  constructor(private readonly deployment: DeploymentService) {}
+
+  canActivate(_context: ExecutionContext): boolean {
+    if (this.deployment.isSelfHosted()) return true;
+    throw new NotFoundException('Not found');
+  }
+}

--- a/packages/backend/src/identity-providers/enforce-sso.service.spec.ts
+++ b/packages/backend/src/identity-providers/enforce-sso.service.spec.ts
@@ -1,0 +1,90 @@
+import { IdentityProvidersService, IdentityProviderError } from './identity-providers.service';
+
+/**
+ * `setEnforceSso` is the one setting in the product that can lock every human
+ * out of a workspace, so each precondition gets its own test.
+ */
+describe('IdentityProvidersService.setEnforceSso', () => {
+  let prisma: any;
+  let service: IdentityProvidersService;
+
+  const provider = (over: Record<string, unknown> = {}) => ({
+    id: 'idp1',
+    isActive: true,
+    enforceSso: false,
+    lastSuccessfulLoginAt: new Date(),
+    ...over,
+  });
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = 'a-test-encryption-key-of-32-chars!!';
+    prisma = {
+      identityProvider: {
+        findFirst: jest.fn(async () => provider()),
+        update: jest.fn(async () => ({ id: 'idp1', enforceSso: true })),
+      },
+    };
+    service = new IdentityProvidersService(prisma, {
+      mode: 'self-hosted',
+      isCloud: () => false,
+      isSelfHosted: () => true,
+    } as any);
+  });
+
+  const actor = { userId: 'u1', hasRecoveryCodes: true };
+
+  it('enables enforcement when every precondition holds', async () => {
+    await service.setEnforceSso('idp1', 'org1', true, actor);
+    expect(prisma.identityProvider.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { enforceSso: true } }),
+    );
+  });
+
+  // Without this the admin is trusting a configuration nobody has ever used.
+  it('refuses when nobody has completed a sign-in through the provider', async () => {
+    prisma.identityProvider.findFirst.mockResolvedValue(
+      provider({ lastSuccessfulLoginAt: null }),
+    );
+    await expect(service.setEnforceSso('idp1', 'org1', true, actor)).rejects.toThrow(
+      IdentityProviderError,
+    );
+    expect(prisma.identityProvider.update).not.toHaveBeenCalled();
+  });
+
+  // The whole reason recovery codes exist.
+  it('refuses when the admin holds no recovery codes', async () => {
+    await expect(
+      service.setEnforceSso('idp1', 'org1', true, { userId: 'u1', hasRecoveryCodes: false }),
+    ).rejects.toThrow(IdentityProviderError);
+    expect(prisma.identityProvider.update).not.toHaveBeenCalled();
+  });
+
+  // An inactive provider cannot be signed in through, so requiring it would
+  // mean requiring something impossible.
+  it('refuses when the provider is inactive', async () => {
+    prisma.identityProvider.findFirst.mockResolvedValue(provider({ isActive: false }));
+    await expect(service.setEnforceSso('idp1', 'org1', true, actor)).rejects.toThrow(
+      IdentityProviderError,
+    );
+  });
+
+  // Undoing a lockout risk must never be gated — including when the very
+  // conditions that would allow enabling it no longer hold.
+  it('always allows disabling, even with no recovery codes and no prior sign-in', async () => {
+    prisma.identityProvider.findFirst.mockResolvedValue(
+      provider({ enforceSso: true, isActive: false, lastSuccessfulLoginAt: null }),
+    );
+    await service.setEnforceSso('idp1', 'org1', false, {
+      userId: 'u1',
+      hasRecoveryCodes: false,
+    });
+    expect(prisma.identityProvider.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { enforceSso: false } }),
+    );
+  });
+
+  it('returns null for a provider belonging to another workspace', async () => {
+    prisma.identityProvider.findFirst.mockResolvedValue(null);
+    expect(await service.setEnforceSso('idp1', 'other', true, actor)).toBeNull();
+  });
+});

--- a/packages/backend/src/identity-providers/identity-providers.controller.spec.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.spec.ts
@@ -52,6 +52,7 @@ describe('IdentityProvidersController audit trail', () => {
     controller = new IdentityProvidersController(
       service,
       new SecurityEventService(prisma as unknown as PrismaService),
+      { hasUnused: jest.fn(async () => true) } as any,
     );
   });
 

--- a/packages/backend/src/identity-providers/identity-providers.controller.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.ts
@@ -33,6 +33,7 @@ import {
 import { Type } from 'class-transformer';
 import { IdentityProviderType } from '../generated/prisma/client';
 import { Roles, RolesGuard } from '../auth/roles.guard';
+import { SelfHostedOnlyGuard } from '../common/self-hosted-only.guard';
 import {
   IdentityProvidersService,
   IdentityProviderError,
@@ -192,7 +193,7 @@ class ReplaceRoleMappingsDto {
  */
 @ApiTags('Identity Providers')
 @ApiBearerAuth()
-@UseGuards(AuthGuard('jwt'), RolesGuard)
+@UseGuards(SelfHostedOnlyGuard, AuthGuard('jwt'), RolesGuard)
 @Roles('ADMIN')
 @Controller('api/identity-providers')
 export class IdentityProvidersController {

--- a/packages/backend/src/identity-providers/identity-providers.controller.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.ts
@@ -41,6 +41,7 @@ import {
   SecurityEventService,
   SecurityEvents,
 } from '../audit/security-event.service';
+import { RecoveryCodesService } from '../auth/recovery-codes.service';
 
 // Derived from the Prisma enum rather than hand-kept: a new provider type is
 // then accepted automatically and cannot drift out of sync with the database.
@@ -163,6 +164,15 @@ class RoleMappingDto {
   mcpRoleIds?: string[];
 }
 
+class EnforceSsoDto {
+  @ApiProperty({
+    description:
+      'Turn password sign-in off for this workspace. Enabling requires a completed sign-in through this provider and unused recovery codes on the calling account.',
+  })
+  @IsBoolean()
+  enforce: boolean;
+}
+
 class ReplaceRoleMappingsDto {
   @ApiProperty({ type: [RoleMappingDto] })
   @IsArray()
@@ -189,6 +199,7 @@ export class IdentityProvidersController {
   constructor(
     private readonly service: IdentityProvidersService,
     private readonly securityEvents: SecurityEventService,
+    private readonly recoveryCodes: RecoveryCodesService,
   ) {}
 
   @Get()
@@ -338,6 +349,30 @@ export class IdentityProvidersController {
       after: (after ?? []).map(summariseMapping),
     });
     return after;
+  }
+
+  @Put(':id/enforce-sso')
+  @ApiOperation({
+    summary: 'Require single sign-on for this workspace (ADMIN)',
+  })
+  async setEnforceSso(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: EnforceSsoDto,
+  ) {
+    const hasRecoveryCodes = await this.recoveryCodes.hasUnused(req.user.sub);
+    const updated = await this.run(() =>
+      this.service.setEnforceSso(id, req.user.organizationId, dto.enforce, {
+        userId: req.user.sub,
+        hasRecoveryCodes,
+      }),
+    );
+    if (!updated) throw new NotFoundException('Identity provider not found');
+
+    await this.audit(req, SecurityEvents.SSO_ENFORCEMENT_CHANGED, id, {
+      enforce: dto.enforce,
+    });
+    return updated;
   }
 
   @Post(':id/test')

--- a/packages/backend/src/identity-providers/identity-providers.controller.ts
+++ b/packages/backend/src/identity-providers/identity-providers.controller.ts
@@ -27,7 +27,10 @@ import {
   IsIn,
   IsObject,
   IsISO8601,
+  IsArray,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { IdentityProviderType } from '../generated/prisma/client';
 import { Roles, RolesGuard } from '../auth/roles.guard';
 import {
@@ -118,6 +121,54 @@ class UpsertProviderDto {
   @IsOptional()
   @IsIn(['DENY_ALL', 'KEEP_EXISTING', 'DEFAULT_ROLE'])
   roleSyncFallback?: 'DENY_ALL' | 'KEEP_EXISTING' | 'DEFAULT_ROLE';
+
+  @ApiPropertyOptional({
+    type: [String],
+    description:
+      'MCP roles granted when the fallback is DEFAULT_ROLE and nothing matched. Empty makes DEFAULT_ROLE behave like DENY_ALL.',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  roleSyncDefaultRoleIds?: string[];
+}
+
+class RoleMappingDto {
+  @ApiProperty({
+    description:
+      "The Entra group's OBJECT ID or the app role's `value` — never its display name. Microsoft does not make group names unique, so matching on one would let anyone able to create a group mint one named like a privileged mapping.",
+  })
+  @IsString()
+  externalId: string;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable name, shown in the admin table. Carries no authorization meaning.',
+  })
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @ApiPropertyOptional({
+    enum: ['VIEWER', 'EDITOR', 'ADMIN'],
+    description: 'Workspace role granted. Omit to leave it untouched. Across several matching groups the MOST privileged wins.',
+  })
+  @IsOptional()
+  @IsIn(['VIEWER', 'EDITOR', 'ADMIN'])
+  userRole?: 'VIEWER' | 'EDITOR' | 'ADMIN';
+
+  @ApiPropertyOptional({ type: [String], description: 'MCP roles granted. A user in several mapped groups receives the UNION.' })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mcpRoleIds?: string[];
+}
+
+class ReplaceRoleMappingsDto {
+  @ApiProperty({ type: [RoleMappingDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RoleMappingDto)
+  mappings: RoleMappingDto[];
 }
 
 /**
@@ -250,6 +301,45 @@ export class IdentityProvidersController {
     return { message: 'Identity provider deleted' };
   }
 
+  @Get(':id/role-mappings')
+  @ApiOperation({ summary: 'List this provider\'s group/app-role mappings (ADMIN)' })
+  async listRoleMappings(@Req() req: any, @Param('id') id: string) {
+    const mappings = await this.service.listRoleMappings(
+      id,
+      req.user.organizationId,
+    );
+    if (mappings === null) throw new NotFoundException('Identity provider not found');
+    return mappings;
+  }
+
+  @Put(':id/role-mappings')
+  @ApiOperation({
+    summary: 'Replace this provider\'s group/app-role mappings (ADMIN)',
+  })
+  async replaceRoleMappings(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: ReplaceRoleMappingsDto,
+  ) {
+    const before = await this.service.listRoleMappings(
+      id,
+      req.user.organizationId,
+    );
+    if (before === null) throw new NotFoundException('Identity provider not found');
+
+    const after = await this.run(() =>
+      this.service.replaceRoleMappings(id, req.user.organizationId, dto.mappings),
+    );
+
+    // Before AND after: this table decides who gets which tools, so an event
+    // saying only what the rules became cannot answer "what did this change?"
+    await this.audit(req, SecurityEvents.IDP_ROLE_MAPPING_CHANGED, id, {
+      before: before.map(summariseMapping),
+      after: (after ?? []).map(summariseMapping),
+    });
+    return after;
+  }
+
   @Post(':id/test')
   @ApiOperation({
     summary:
@@ -296,4 +386,23 @@ export class IdentityProvidersController {
       userAgent: req.headers?.['user-agent'],
     });
   }
+}
+
+/** Audit projection: the fields that decide access, without the row id. */
+function summariseMapping(m: {
+  externalId: string;
+  label: string | null;
+  userRole: string | null;
+  mcpRoleIds: string[];
+}) {
+  return {
+    externalId: m.externalId,
+    label: m.label,
+    userRole: m.userRole,
+    // Joined, not an array: `metadata → after[] → {} → mcpRoleIds[] → string`
+    // is five levels, one past the redactor's depth bound, and the ids came
+    // out as a truncation marker — the audit recorded that mappings changed
+    // but not what they changed to, which is the only part worth having.
+    mcpRoleIds: [...m.mcpRoleIds].sort().join(','),
+  };
 }

--- a/packages/backend/src/identity-providers/identity-providers.module.ts
+++ b/packages/backend/src/identity-providers/identity-providers.module.ts
@@ -3,13 +3,14 @@ import { IdentityProvidersService } from './identity-providers.service';
 import { IdentityProvidersController } from './identity-providers.controller';
 import { SsoController } from './sso.controller';
 import { SsoService } from './sso.service';
+import { RoleSyncService } from './role-sync.service';
 
 // `DeploymentService` and `PrismaService` come from the @Global() PrismaModule,
 // and `SecurityEventService` from the @Global() AuditModule — providing any of
 // them here would shadow the shared instance for no reason.
 @Module({
   controllers: [IdentityProvidersController, SsoController],
-  providers: [IdentityProvidersService, SsoService],
-  exports: [IdentityProvidersService, SsoService],
+  providers: [IdentityProvidersService, SsoService, RoleSyncService],
+  exports: [IdentityProvidersService, SsoService, RoleSyncService],
 })
 export class IdentityProvidersModule {}

--- a/packages/backend/src/identity-providers/identity-providers.service.ts
+++ b/packages/backend/src/identity-providers/identity-providers.service.ts
@@ -40,6 +40,7 @@ export interface UpsertProviderInput {
   roleSyncEnabled?: boolean;
   roleSyncSource?: RoleSyncSource;
   roleSyncFallback?: RoleSyncFallback;
+  roleSyncDefaultRoleIds?: string[];
 }
 
 /** Shape returned to the API. Never carries the client secret. */
@@ -57,6 +58,7 @@ const PUBLIC_SELECT = {
   roleSyncEnabled: true,
   roleSyncSource: true,
   roleSyncFallback: true,
+  roleSyncDefaultRoleIds: true,
   enforceSso: true,
   lastSuccessfulLoginAt: true,
   config: true,
@@ -150,6 +152,7 @@ export class IdentityProvidersService {
           roleSyncEnabled: input.roleSyncEnabled ?? false,
           roleSyncSource: input.roleSyncSource ?? 'GROUPS',
           roleSyncFallback: input.roleSyncFallback ?? 'DENY_ALL',
+          roleSyncDefaultRoleIds: input.roleSyncDefaultRoleIds ?? [],
           clientSecretExpiresAt: input.clientSecretExpiresAt
             ? this.parseExpiry(input.clientSecretExpiresAt)
             : null,
@@ -218,6 +221,7 @@ export class IdentityProvidersService {
         roleSyncEnabled: input.roleSyncEnabled,
         roleSyncSource: input.roleSyncSource,
         roleSyncFallback: input.roleSyncFallback,
+        roleSyncDefaultRoleIds: input.roleSyncDefaultRoleIds,
         // `null` clears it; omitting the key keeps the stored value. Without
         // the null branch a stale expiry could never be removed and the
         // renewal reminder would keep reporting a date that no longer applies
@@ -428,5 +432,104 @@ export class IdentityProvidersService {
     }
 
     return { issuer, config };
+  }
+
+  // ── Role mappings ─────────────────────────────────────────────────────────
+
+  /**
+   * The provider's group/app-role mappings, ordered by label so the admin
+   * table is stable across reloads.
+   */
+  async listRoleMappings(providerId: string, organizationId: string) {
+    const provider = await this.prisma.identityProvider.findFirst({
+      where: { id: providerId, organizationId },
+      select: { id: true },
+    });
+    if (!provider) return null;
+    return this.prisma.identityProviderRoleMapping.findMany({
+      where: { providerId },
+      select: {
+        id: true,
+        externalId: true,
+        label: true,
+        userRole: true,
+        mcpRoleIds: true,
+      },
+      orderBy: [{ label: 'asc' }, { externalId: 'asc' }],
+    });
+  }
+
+  /**
+   * Replaces the whole mapping set in one transaction.
+   *
+   * Whole-set rather than per-row CRUD on purpose: a half-applied edit to an
+   * authorization table is a state nobody can reason about, and the audit
+   * event for "these are now the rules" is far easier to read during an
+   * investigation than a stream of individual adds and removes.
+   */
+  async replaceRoleMappings(
+    providerId: string,
+    organizationId: string,
+    mappings: {
+      externalId: string;
+      label?: string | null;
+      userRole?: UserRole | null;
+      mcpRoleIds?: string[];
+    }[],
+  ) {
+    const provider = await this.prisma.identityProvider.findFirst({
+      where: { id: providerId, organizationId },
+      select: { id: true },
+    });
+    if (!provider) return null;
+
+    const seen = new Set<string>();
+    for (const m of mappings) {
+      const id = m.externalId?.trim();
+      if (!id) {
+        throw new IdentityProviderError('Every mapping needs a group or app role id');
+      }
+      // @@unique([providerId, externalId]) would reject this anyway, but as a
+      // P2002 mid-transaction rather than a message naming the duplicate.
+      if (seen.has(id)) {
+        throw new IdentityProviderError(`Duplicate mapping for "${id}"`);
+      }
+      seen.add(id);
+    }
+
+    // Roles are re-checked against the workspace here rather than only at
+    // sync time, so an admin gets a 400 while editing instead of a mapping
+    // that silently grants nothing months later.
+    const referenced = [...new Set(mappings.flatMap((m) => m.mcpRoleIds ?? []))];
+    if (referenced.length > 0) {
+      const visible = await this.prisma.role.count({
+        where: {
+          id: { in: referenced },
+          OR: [{ organizationId }, { isSystem: true }],
+        },
+      });
+      if (visible !== referenced.length) {
+        throw new IdentityProviderError(
+          'One or more MCP roles do not exist in this workspace',
+        );
+      }
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.identityProviderRoleMapping.deleteMany({ where: { providerId } });
+      if (mappings.length > 0) {
+        await tx.identityProviderRoleMapping.createMany({
+          data: mappings.map((m) => ({
+            providerId,
+            externalId: m.externalId.trim(),
+            label: m.label?.trim() || null,
+            userRole: m.userRole ?? null,
+            mcpRoleIds: m.mcpRoleIds ?? [],
+          })),
+        });
+      }
+    });
+
+    return this.listRoleMappings(providerId, organizationId);
   }
 }

--- a/packages/backend/src/identity-providers/identity-providers.service.ts
+++ b/packages/backend/src/identity-providers/identity-providers.service.ts
@@ -41,6 +41,7 @@ export interface UpsertProviderInput {
   roleSyncSource?: RoleSyncSource;
   roleSyncFallback?: RoleSyncFallback;
   roleSyncDefaultRoleIds?: string[];
+  enforceSso?: boolean;
 }
 
 /** Shape returned to the API. Never carries the client secret. */
@@ -531,5 +532,66 @@ export class IdentityProvidersService {
     });
 
     return this.listRoleMappings(providerId, organizationId);
+  }
+
+  // ── SSO enforcement ───────────────────────────────────────────────────────
+
+  /**
+   * Turns password sign-in off (or back on) for a workspace.
+   *
+   * Separate from `update()` on purpose. This is the one setting that can lock
+   * every human out of a workspace, so it does not travel in the same payload
+   * as a display-name change — and enabling it has preconditions that a general
+   * update path would have to special-case anyway.
+   *
+   * Two preconditions, both about having a way back in:
+   *
+   *  - the provider must have completed a real dashboard sign-in, so the
+   *    configuration is known to work rather than merely believed to;
+   *  - the admin flipping the switch must hold unused recovery codes, so a
+   *    directory that breaks tomorrow is an inconvenience and not an outage.
+   *
+   * Disabling is ungated: removing a lockout risk never needs permission.
+   */
+  async setEnforceSso(
+    providerId: string,
+    organizationId: string,
+    enforce: boolean,
+    actor: { userId: string; hasRecoveryCodes: boolean },
+  ) {
+    const provider = await this.prisma.identityProvider.findFirst({
+      where: { id: providerId, organizationId },
+      select: {
+        id: true,
+        isActive: true,
+        enforceSso: true,
+        lastSuccessfulLoginAt: true,
+      },
+    });
+    if (!provider) return null;
+
+    if (enforce) {
+      if (!provider.isActive) {
+        throw new IdentityProviderError(
+          'Activate this provider before requiring single sign-on — an inactive provider cannot be signed in through.',
+        );
+      }
+      if (!provider.lastSuccessfulLoginAt) {
+        throw new IdentityProviderError(
+          'Sign in through this provider at least once before requiring it. Until that succeeds there is no evidence the configuration works.',
+        );
+      }
+      if (!actor.hasRecoveryCodes) {
+        throw new IdentityProviderError(
+          'Generate recovery codes for your account first. Without them, a directory outage would leave this workspace with no way in.',
+        );
+      }
+    }
+
+    return this.prisma.identityProvider.update({
+      where: { id: providerId },
+      data: { enforceSso: enforce },
+      select: PUBLIC_SELECT,
+    });
   }
 }

--- a/packages/backend/src/identity-providers/role-sync.service.spec.ts
+++ b/packages/backend/src/identity-providers/role-sync.service.spec.ts
@@ -1,0 +1,238 @@
+import { RoleSyncService, DENY_ALL_ROLE_NAME, SYNC_SOURCE } from './role-sync.service';
+
+const ORG = 'org_1';
+const USER = 'user_1';
+
+function makeProvider(over: Partial<any> = {}) {
+  return {
+    id: 'idp_1',
+    organizationId: ORG,
+    roleSyncEnabled: true,
+    roleSyncSource: 'GROUPS',
+    roleSyncFallback: 'DENY_ALL',
+    roleSyncDefaultRoleIds: [],
+    ...over,
+  } as any;
+}
+
+describe('RoleSyncService', () => {
+  let prisma: any;
+  let securityEvents: any;
+  let service: RoleSyncService;
+
+  beforeEach(() => {
+    prisma = {
+      identityProviderRoleMapping: { findMany: jest.fn(async () => []) },
+      role: {
+        findMany: jest.fn(async ({ where }: any) =>
+          (where.id.in as string[]).map((id) => ({ id })),
+        ),
+        upsert: jest.fn(async () => ({ id: 'role_deny' })),
+      },
+      userRoleAssignment: {
+        deleteMany: jest.fn(async () => ({ count: 0 })),
+        createMany: jest.fn(async () => ({ count: 0 })),
+      },
+      organizationMember: {
+        findUnique: jest.fn(async () => ({ role: 'VIEWER' })),
+        update: jest.fn(async () => ({})),
+        count: jest.fn(async () => 2),
+      },
+      $transaction: jest.fn((fn: any) => fn(prisma)),
+    };
+    securityEvents = { log: jest.fn() };
+    service = new RoleSyncService(prisma, securityEvents);
+  });
+
+  it('does nothing when role sync is off', async () => {
+    const out = await service.syncOnLogin(
+      makeProvider({ roleSyncEnabled: false }),
+      USER,
+      { groups: ['g1'] },
+    );
+    expect(out).toMatchObject({ applied: false, reason: 'disabled' });
+    expect(prisma.userRoleAssignment.deleteMany).not.toHaveBeenCalled();
+  });
+
+  // The failure this guards against is not theoretical: past ~150 groups Entra
+  // replaces the claim with a Graph pointer, so every mapping misses and a
+  // naive sync revokes the roles of the most heavily-grouped people in the
+  // directory.
+  it('refuses to act on a token that signalled a groups overage', async () => {
+    const out = await service.syncOnLogin(makeProvider(), USER, {
+      _claim_names: { groups: 'src1' },
+      _claim_sources: { src1: { endpoint: 'https://graph.microsoft.com/...' } },
+    });
+    expect(out).toMatchObject({ applied: false, reason: 'overage' });
+    expect(prisma.userRoleAssignment.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.userRoleAssignment.createMany).not.toHaveBeenCalled();
+    expect(securityEvents.log).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'ROLE_SYNC_SKIPPED' }),
+    );
+  });
+
+  it('matches on group object ids and grants the union of their roles', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: null, mcpRoleIds: ['r1', 'r2'] },
+      { externalId: 'g2', userRole: null, mcpRoleIds: ['r2', 'r3'] },
+      { externalId: 'g9', userRole: null, mcpRoleIds: ['r9'] },
+    ]);
+    const out = await service.syncOnLogin(makeProvider(), USER, {
+      groups: ['g1', 'g2', 'unmapped'],
+    });
+    expect(out.reason).toBe('matched');
+    expect(out.matched).toBe(2);
+    expect(out.presented).toBe(3);
+    expect([...out.grantedRoleIds].sort()).toEqual(['r1', 'r2', 'r3']);
+    // r9 is never granted: the user is not in g9.
+    expect(out.grantedRoleIds).not.toContain('r9');
+  });
+
+  it('never matches on a group display name', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'GB_Fuehrungskreis', userRole: 'ADMIN', mcpRoleIds: ['r1'] },
+    ]);
+    const out = await service.syncOnLogin(makeProvider(), USER, {
+      // A real Entra token carries object ids here, not names. A directory
+      // that sent names must not be able to hit a privileged mapping.
+      groups: ['4be78614-f22d-472f-a2cb-5eb81b6e3f6f'],
+    });
+    expect(out.matched).toBe(0);
+  });
+
+  it('takes the most privileged organization role across matches', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: 'VIEWER', mcpRoleIds: [] },
+      { externalId: 'g2', userRole: 'ADMIN', mcpRoleIds: [] },
+      { externalId: 'g3', userRole: 'EDITOR', mcpRoleIds: [] },
+    ]);
+    await service.syncOnLogin(makeProvider(), USER, { groups: ['g1', 'g2', 'g3'] });
+    expect(prisma.organizationMember.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { role: 'ADMIN' } }),
+    );
+  });
+
+  it('refuses a demotion that would leave the workspace with no admin', async () => {
+    prisma.organizationMember.findUnique.mockResolvedValue({ role: 'ADMIN' });
+    prisma.organizationMember.count.mockResolvedValue(1);
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: 'VIEWER', mcpRoleIds: [] },
+    ]);
+    const out = await service.syncOnLogin(makeProvider(), USER, { groups: ['g1'] });
+    expect(out.lastAdminProtected).toBe(true);
+    expect(prisma.organizationMember.update).not.toHaveBeenCalled();
+    expect(securityEvents.log).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'LAST_ADMIN_PROTECTION_TRIGGERED' }),
+    );
+  });
+
+  it('still demotes when another admin remains', async () => {
+    prisma.organizationMember.findUnique.mockResolvedValue({ role: 'ADMIN' });
+    prisma.organizationMember.count.mockResolvedValue(2);
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: 'VIEWER', mcpRoleIds: [] },
+    ]);
+    await service.syncOnLogin(makeProvider(), USER, { groups: ['g1'] });
+    expect(prisma.organizationMember.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { role: 'VIEWER' } }),
+    );
+  });
+
+  // The whole point of DENY_ALL. Deleting the user's grants would leave them
+  // with none, and `getUserToolAccess` reads "no role" as UNRESTRICTED — so
+  // the obvious implementation grants full access.
+  it('DENY_ALL assigns an empty role instead of leaving the user role-less', async () => {
+    const out = await service.syncOnLogin(makeProvider(), USER, { groups: ['nope'] });
+    expect(out.reason).toBe('fallback_deny_all');
+    expect(prisma.role.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId_name: { organizationId: ORG, name: DENY_ALL_ROLE_NAME } },
+      }),
+    );
+    expect(out.grantedRoleIds).toEqual(['role_deny']);
+    expect(prisma.userRoleAssignment.createMany).toHaveBeenCalled();
+  });
+
+  it('KEEP_EXISTING writes nothing at all', async () => {
+    const out = await service.syncOnLogin(
+      makeProvider({ roleSyncFallback: 'KEEP_EXISTING' }),
+      USER,
+      { groups: ['nope'] },
+    );
+    expect(out).toMatchObject({ applied: false, reason: 'fallback_keep_existing' });
+    expect(prisma.userRoleAssignment.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.role.upsert).not.toHaveBeenCalled();
+  });
+
+  it('DEFAULT_ROLE grants the configured roles', async () => {
+    const out = await service.syncOnLogin(
+      makeProvider({ roleSyncFallback: 'DEFAULT_ROLE', roleSyncDefaultRoleIds: ['r_default'] }),
+      USER,
+      { groups: ['nope'] },
+    );
+    expect(out.grantedRoleIds).toEqual(['r_default']);
+  });
+
+  it('only ever deletes assignments it owns', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: null, mcpRoleIds: ['r1'] },
+    ]);
+    await service.syncOnLogin(makeProvider(), USER, { groups: ['g1'] });
+    expect(prisma.userRoleAssignment.deleteMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({ source: SYNC_SOURCE, userId: USER, organizationId: ORG }),
+    });
+  });
+
+  it('drops mapped roles that do not belong to the workspace', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: null, mcpRoleIds: ['r_mine', 'r_other_org'] },
+    ]);
+    prisma.role.findMany.mockResolvedValue([{ id: 'r_mine' }]);
+    const out = await service.syncOnLogin(makeProvider(), USER, { groups: ['g1'] });
+    expect(out.grantedRoleIds).toEqual(['r_mine']);
+  });
+
+  it('treats a non-array claim as absent rather than coercing it', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'g1', userRole: 'ADMIN', mcpRoleIds: ['r1'] },
+    ]);
+    const out = await service.syncOnLogin(makeProvider(), USER, { groups: 'g1' });
+    expect(out.matched).toBe(0);
+    expect(prisma.organizationMember.update).not.toHaveBeenCalled();
+  });
+
+  it('reads app roles from `roles` when the source is APP_ROLES', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'amcp.einkauf', userRole: null, mcpRoleIds: ['r1'] },
+    ]);
+    const out = await service.syncOnLogin(
+      makeProvider({ roleSyncSource: 'APP_ROLES' }),
+      USER,
+      { roles: ['amcp.einkauf'], groups: ['ignored'] },
+    );
+    expect(out.matched).toBe(1);
+  });
+
+  // An overage pointer is a GROUPS concept; app roles are never paged, so the
+  // same token must not be treated as incomplete when reading `roles`.
+  it('ignores a groups overage when syncing app roles', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockResolvedValue([
+      { externalId: 'amcp.leitung', userRole: null, mcpRoleIds: ['r1'] },
+    ]);
+    const out = await service.syncOnLogin(
+      makeProvider({ roleSyncSource: 'APP_ROLES' }),
+      USER,
+      { roles: ['amcp.leitung'], _claim_names: { groups: 'src1' } },
+    );
+    expect(out.reason).toBe('matched');
+  });
+
+  it('never turns a database failure into a failed login', async () => {
+    prisma.identityProviderRoleMapping.findMany.mockRejectedValue(new Error('db down'));
+    const out = await service.syncOnLogin(makeProvider(), USER, { groups: ['g1'] });
+    expect(out.applied).toBe(false);
+    expect(securityEvents.log).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'ROLE_SYNC_FAILED' }),
+    );
+  });
+});

--- a/packages/backend/src/identity-providers/role-sync.service.ts
+++ b/packages/backend/src/identity-providers/role-sync.service.ts
@@ -1,0 +1,478 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import {
+  SecurityEventService,
+  SecurityEvents,
+} from '../audit/security-event.service';
+import type { RoleSyncFallback, RoleSyncSource, UserRole } from '../generated/prisma/client';
+
+/**
+ * `source` written on every assignment this service owns. It is part of the
+ * unique key on `user_roles`, which is what keeps a sync from ever deleting a
+ * grant an admin made by hand — and vice versa.
+ */
+export const SYNC_SOURCE = 'entra';
+
+/**
+ * Name of the per-organization role that expresses "role sync ran and matched
+ * nothing". See `applyDenyAll` for why this exists instead of simply deleting
+ * the user's grants.
+ */
+export const DENY_ALL_ROLE_NAME = 'No access (SSO)';
+
+/** Ordered least- to most-privileged. Index is the comparison key. */
+const ORG_ROLE_RANK: UserRole[] = ['VIEWER', 'EDITOR', 'ADMIN'];
+
+export interface RoleSyncProvider {
+  id: string;
+  organizationId: string;
+  roleSyncEnabled: boolean;
+  roleSyncSource: RoleSyncSource;
+  roleSyncFallback: RoleSyncFallback;
+  roleSyncDefaultRoleIds: string[];
+}
+
+export type RoleSyncReason =
+  | 'disabled'
+  | 'overage'
+  | 'no_claim'
+  | 'matched'
+  | 'fallback_deny_all'
+  | 'fallback_keep_existing'
+  | 'fallback_default_role';
+
+export interface RoleSyncOutcome {
+  /** False means nothing was written. */
+  applied: boolean;
+  reason: RoleSyncReason;
+  /** How many ids the token presented. */
+  presented: number;
+  /** How many mappings those ids hit. */
+  matched: number;
+  grantedRoleIds: string[];
+  orgRoleBefore?: UserRole;
+  orgRoleAfter?: UserRole;
+  /** True when a demotion was refused because it would empty the org of admins. */
+  lastAdminProtected?: boolean;
+}
+
+/**
+ * Projects an external directory's groups (or application roles) onto
+ * AnythingMCP roles, on every sign-in.
+ *
+ * Three properties this service is built around:
+ *
+ * 1. It matches on OBJECT IDS, never display names. Entra group names are not
+ *    unique and anyone able to create a group could otherwise mint one whose
+ *    name matches a privileged mapping.
+ *
+ * 2. It refuses to act on incomplete claims. A token that overflowed the group
+ *    limit carries a `_claim_names` pointer instead of the list; treating that
+ *    as "member of nothing" would revoke access from exactly the people who
+ *    belong to the most groups.
+ *
+ * 3. It never touches assignments a human made. Only rows with
+ *    `source = 'entra'` are its to rewrite.
+ */
+@Injectable()
+export class RoleSyncService {
+  private readonly logger = new Logger(RoleSyncService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  /**
+   * Runs a sync for one sign-in. Never throws: a directory that returns
+   * something unexpected must not turn a valid authentication into a failed
+   * login, so problems are logged and audited and the user keeps whatever
+   * they already had.
+   */
+  async syncOnLogin(
+    provider: RoleSyncProvider,
+    userId: string,
+    claims: Record<string, any>,
+    ctx: { ip?: string | null; userAgent?: string | null } = {},
+  ): Promise<RoleSyncOutcome> {
+    try {
+      return await this.run(provider, userId, claims, ctx);
+    } catch (e: any) {
+      this.logger.error(
+        `Role sync failed for provider ${provider.id}: ${e?.message}`,
+      );
+      await this.securityEvents.log({
+        event: SecurityEvents.ROLE_SYNC_FAILED,
+        actorType: 'SYSTEM',
+        organizationId: provider.organizationId,
+        targetUserId: userId,
+        metadata: { providerId: provider.id, error: String(e?.message ?? e) },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+      return { applied: false, reason: 'disabled', presented: 0, matched: 0, grantedRoleIds: [] };
+    }
+  }
+
+  private async run(
+    provider: RoleSyncProvider,
+    userId: string,
+    claims: Record<string, any>,
+    ctx: { ip?: string | null; userAgent?: string | null },
+  ): Promise<RoleSyncOutcome> {
+    if (!provider.roleSyncEnabled) {
+      return { applied: false, reason: 'disabled', presented: 0, matched: 0, grantedRoleIds: [] };
+    }
+
+    // Entra replaces the claim with a Graph URL past ~150 groups (~200 for
+    // SAML). The list we would read is then simply absent, and every mapping
+    // would miss. Acting on that would silently strip the roles of the most
+    // heavily-grouped users in the directory — so we do nothing at all and say
+    // so loudly. Resolving the overage needs Graph `GroupMember.Read.All`,
+    // which this product deliberately does not ask for.
+    if (this.hasOverage(provider.roleSyncSource, claims)) {
+      this.logger.warn(
+        `Role sync skipped: token from provider ${provider.id} signalled a groups overage`,
+      );
+      await this.securityEvents.log({
+        event: SecurityEvents.ROLE_SYNC_SKIPPED,
+        actorType: 'SYSTEM',
+        organizationId: provider.organizationId,
+        targetUserId: userId,
+        metadata: { providerId: provider.id, reason: 'overage' },
+        ip: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+      return { applied: false, reason: 'overage', presented: 0, matched: 0, grantedRoleIds: [] };
+    }
+
+    const presented = this.extractIds(provider.roleSyncSource, claims);
+
+    const mappings = await this.prisma.identityProviderRoleMapping.findMany({
+      where: { providerId: provider.id },
+      select: { externalId: true, userRole: true, mcpRoleIds: true },
+    });
+
+    // Set membership rather than a nested loop: a Führungskreis member can
+    // easily present a hundred groups against a few dozen mappings.
+    const presentedSet = new Set(presented);
+    const matches = mappings.filter((m) => presentedSet.has(m.externalId));
+
+    if (matches.length === 0) {
+      return this.applyFallback(provider, userId, presented.length, ctx);
+    }
+
+    const desiredMcpRoleIds = [
+      ...new Set(matches.flatMap((m) => m.mcpRoleIds)),
+    ];
+    // Being in more groups can only ever widen access, so the org role is the
+    // most privileged of the matches — not the last one read.
+    const desiredOrgRole = this.highestOrgRole(
+      matches.map((m) => m.userRole).filter((r): r is UserRole => r != null),
+    );
+
+    const granted = await this.writeAssignments(
+      provider,
+      userId,
+      desiredMcpRoleIds,
+    );
+    const org = await this.writeOrgRole(provider, userId, desiredOrgRole, ctx);
+
+    await this.securityEvents.log({
+      event: SecurityEvents.ROLE_SYNC_APPLIED,
+      actorType: 'SYSTEM',
+      organizationId: provider.organizationId,
+      targetUserId: userId,
+      metadata: {
+        providerId: provider.id,
+        source: provider.roleSyncSource,
+        presented: presented.length,
+        matched: matches.length,
+        grantedRoleIds: granted,
+        orgRoleBefore: org.before,
+        orgRoleAfter: org.after,
+        lastAdminProtected: org.lastAdminProtected,
+      },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+
+    return {
+      applied: true,
+      reason: 'matched',
+      presented: presented.length,
+      matched: matches.length,
+      grantedRoleIds: granted,
+      orgRoleBefore: org.before,
+      orgRoleAfter: org.after,
+      lastAdminProtected: org.lastAdminProtected,
+    };
+  }
+
+  // ── Claim reading ─────────────────────────────────────────────────────────
+
+  private hasOverage(source: RoleSyncSource, claims: Record<string, any>) {
+    if (source !== 'GROUPS') return false;
+    const names = claims._claim_names;
+    return Boolean(names && typeof names === 'object' && 'groups' in names);
+  }
+
+  /**
+   * Entra puts group object ids in `groups` and application role `value`s in
+   * `roles`. Both are arrays of strings; anything else is treated as absent
+   * rather than coerced, because a directory that suddenly sends a different
+   * shape is a reason to grant nothing, not to guess.
+   */
+  private extractIds(
+    source: RoleSyncSource,
+    claims: Record<string, any>,
+  ): string[] {
+    const raw = source === 'APP_ROLES' ? claims.roles : claims.groups;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((v): v is string => typeof v === 'string' && v.length > 0);
+  }
+
+  private highestOrgRole(roles: UserRole[]): UserRole | null {
+    let best: UserRole | null = null;
+    for (const r of roles) {
+      if (best === null || ORG_ROLE_RANK.indexOf(r) > ORG_ROLE_RANK.indexOf(best)) {
+        best = r;
+      }
+    }
+    return best;
+  }
+
+  // ── Writing ───────────────────────────────────────────────────────────────
+
+  /**
+   * Rewrites this user's SYNCED role grants in the provider's organization to
+   * exactly `roleIds`, leaving manual grants untouched.
+   *
+   * Ids are re-validated against the organization before use: a mapping row
+   * can outlive the role it points at, or name a role belonging to another
+   * workspace if one was ever moved.
+   */
+  private async writeAssignments(
+    provider: RoleSyncProvider,
+    userId: string,
+    roleIds: string[],
+  ): Promise<string[]> {
+    const valid =
+      roleIds.length === 0
+        ? []
+        : (
+            await this.prisma.role.findMany({
+              where: {
+                id: { in: roleIds },
+                OR: [{ organizationId: provider.organizationId }, { isSystem: true }],
+              },
+              select: { id: true },
+            })
+          ).map((r) => r.id);
+
+    if (valid.length !== roleIds.length) {
+      this.logger.warn(
+        `Role sync for provider ${provider.id} dropped ${roleIds.length - valid.length} mapped role id(s) not visible to org ${provider.organizationId}`,
+      );
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.userRoleAssignment.deleteMany({
+        where: {
+          userId,
+          source: SYNC_SOURCE,
+          organizationId: provider.organizationId,
+          ...(valid.length > 0 ? { roleId: { notIn: valid } } : {}),
+        },
+      });
+      if (valid.length > 0) {
+        await tx.userRoleAssignment.createMany({
+          data: valid.map((roleId) => ({
+            userId,
+            roleId,
+            organizationId: provider.organizationId,
+            source: SYNC_SOURCE,
+            externalRef: provider.id,
+          })),
+          skipDuplicates: true,
+        });
+      }
+    });
+
+    // `users.mcp_role_id` is deliberately NOT written here. It holds one role
+    // where a sync produces N, and it is dropped in the contract migration; a
+    // release rolled back to before role sync existed should see no synced
+    // roles, which is exactly what leaving it alone produces.
+    return valid;
+  }
+
+  /**
+   * Moves the user's organization role, refusing any change that would leave
+   * the workspace with no administrator.
+   */
+  private async writeOrgRole(
+    provider: RoleSyncProvider,
+    userId: string,
+    desired: UserRole | null,
+    ctx: { ip?: string | null; userAgent?: string | null },
+  ): Promise<{ before?: UserRole; after?: UserRole; lastAdminProtected?: boolean }> {
+    if (desired === null) return {};
+
+    const membership = await this.prisma.organizationMember.findUnique({
+      where: {
+        userId_organizationId: { userId, organizationId: provider.organizationId },
+      },
+      select: { role: true },
+    });
+    if (!membership) return {};
+    if (membership.role === desired) return { before: membership.role, after: desired };
+
+    // A directory edit must not be able to lock every human out of a
+    // workspace. Only the demotion direction can do that, so only it is
+    // guarded — promotion is always allowed.
+    if (membership.role === 'ADMIN' && desired !== 'ADMIN') {
+      const admins = await this.prisma.organizationMember.count({
+        where: { organizationId: provider.organizationId, role: 'ADMIN' },
+      });
+      if (admins <= 1) {
+        this.logger.warn(
+          `Role sync refused to demote the last admin of org ${provider.organizationId}`,
+        );
+        await this.securityEvents.log({
+          event: SecurityEvents.LAST_ADMIN_PROTECTION_TRIGGERED,
+          actorType: 'SYSTEM',
+          organizationId: provider.organizationId,
+          targetUserId: userId,
+          metadata: { providerId: provider.id, attemptedRole: desired },
+          ip: ctx.ip,
+          userAgent: ctx.userAgent,
+        });
+        return { before: membership.role, after: membership.role, lastAdminProtected: true };
+      }
+    }
+
+    await this.prisma.organizationMember.update({
+      where: {
+        userId_organizationId: { userId, organizationId: provider.organizationId },
+      },
+      data: { role: desired },
+    });
+    await this.securityEvents.log({
+      event: SecurityEvents.ROLE_CHANGED,
+      actorType: 'SYSTEM',
+      organizationId: provider.organizationId,
+      targetUserId: userId,
+      metadata: { providerId: provider.id, from: membership.role, to: desired, via: 'role_sync' },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+    return { before: membership.role, after: desired };
+  }
+
+  // ── Fallbacks ─────────────────────────────────────────────────────────────
+
+  private async applyFallback(
+    provider: RoleSyncProvider,
+    userId: string,
+    presented: number,
+    ctx: { ip?: string | null; userAgent?: string | null },
+  ): Promise<RoleSyncOutcome> {
+    if (provider.roleSyncFallback === 'KEEP_EXISTING') {
+      return {
+        applied: false,
+        reason: 'fallback_keep_existing',
+        presented,
+        matched: 0,
+        grantedRoleIds: [],
+      };
+    }
+
+    if (provider.roleSyncFallback === 'DEFAULT_ROLE') {
+      const granted = await this.writeAssignments(
+        provider,
+        userId,
+        provider.roleSyncDefaultRoleIds,
+      );
+      await this.audit(provider, userId, 'fallback_default_role', presented, granted, ctx);
+      return {
+        applied: true,
+        reason: 'fallback_default_role',
+        presented,
+        matched: 0,
+        grantedRoleIds: granted,
+      };
+    }
+
+    const granted = await this.applyDenyAll(provider, userId);
+    await this.audit(provider, userId, 'fallback_deny_all', presented, granted, ctx);
+    return {
+      applied: true,
+      reason: 'fallback_deny_all',
+      presented,
+      matched: 0,
+      grantedRoleIds: granted,
+    };
+  }
+
+  /**
+   * DENY_ALL cannot be implemented by deleting the user's grants.
+   *
+   * `RolesService.getUserToolAccess` returns `null` — meaning UNRESTRICTED —
+   * for a user with no role at all, which is the behaviour inherited from the
+   * single-FK era. So "revoke everything" written the obvious way produces
+   * full access: the precise failure this fallback exists to prevent.
+   *
+   * Instead the user is given a real role that whitelists nothing. The union
+   * of an empty whitelist is empty, so every existing access check already
+   * does the right thing with it, and an admin can see in the roles UI why
+   * someone has no tools rather than having to infer it from an absence.
+   */
+  private async applyDenyAll(
+    provider: RoleSyncProvider,
+    userId: string,
+  ): Promise<string[]> {
+    const role = await this.prisma.role.upsert({
+      where: {
+        organizationId_name: {
+          organizationId: provider.organizationId,
+          name: DENY_ALL_ROLE_NAME,
+        },
+      },
+      create: {
+        organizationId: provider.organizationId,
+        name: DENY_ALL_ROLE_NAME,
+        description:
+          'Assigned automatically when SSO role sync finds no matching group mapping. Grants no tools. Do not add tool access to this role.',
+      },
+      update: {},
+      select: { id: true },
+    });
+    return this.writeAssignments(provider, userId, [role.id]);
+  }
+
+  private async audit(
+    provider: RoleSyncProvider,
+    userId: string,
+    reason: RoleSyncReason,
+    presented: number,
+    grantedRoleIds: string[],
+    ctx: { ip?: string | null; userAgent?: string | null },
+  ) {
+    await this.securityEvents.log({
+      event: SecurityEvents.ROLE_SYNC_APPLIED,
+      actorType: 'SYSTEM',
+      organizationId: provider.organizationId,
+      targetUserId: userId,
+      metadata: {
+        providerId: provider.id,
+        source: provider.roleSyncSource,
+        reason,
+        presented,
+        matched: 0,
+        grantedRoleIds,
+      },
+      ip: ctx.ip,
+      userAgent: ctx.userAgent,
+    });
+  }
+}

--- a/packages/backend/src/identity-providers/sso.controller.ts
+++ b/packages/backend/src/identity-providers/sso.controller.ts
@@ -15,6 +15,7 @@ import {
   BadRequestException,
   NotFoundException,
 } from '@nestjs/common';
+import { SelfHostedOnlyGuard } from '../common/self-hosted-only.guard';
 import {
   ApiTags,
   ApiOperation,
@@ -74,6 +75,11 @@ const LINK_FAILURE_REASONS = new Map<string, string>([
  * these endpoints into an enumeration oracle for workspaces and accounts.
  */
 @ApiTags('SSO')
+// Whole surface, not only the admin API: the sign-in entry point, the callback
+// and the identity-linking routes are all part of the same self-hosted-only
+// feature, and leaving them mounted in cloud would keep a directory-driven
+// account-provisioning path reachable in a shared deployment.
+@UseGuards(SelfHostedOnlyGuard)
 @Controller()
 export class SsoController {
   private readonly logger = new Logger(SsoController.name);

--- a/packages/backend/src/identity-providers/sso.service.spec.ts
+++ b/packages/backend/src/identity-providers/sso.service.spec.ts
@@ -51,6 +51,7 @@ describe('SsoService', () => {
       { getClientSecret: jest.fn() } as any,
       { generateToken: jest.fn(() => 'jwt') } as any,
       securityEvents as any,
+      { syncOnLogin: jest.fn(async () => ({ applied: false, reason: 'disabled' })) } as any,
     );
   });
 

--- a/packages/backend/src/identity-providers/sso.service.ts
+++ b/packages/backend/src/identity-providers/sso.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { randomBytes } from 'crypto';
 import * as client from 'openid-client';
 import { PrismaService } from '../common/prisma.service';
+import { RoleSyncService } from './role-sync.service';
 import { DeploymentService } from '../common/deployment.service';
 import { AuthService } from '../auth/auth.service';
 import { assertSafeOutboundUrl } from '../common/ssrf.util';
@@ -68,6 +69,7 @@ export class SsoService {
     private readonly providers: IdentityProvidersService,
     private readonly authService: AuthService,
     private readonly securityEvents: SecurityEventService,
+    private readonly roleSync: RoleSyncService,
   ) {}
 
   /**
@@ -330,6 +332,10 @@ export class SsoService {
             jitProvisioning: true,
             jitDefaultRole: true,
             config: true,
+            roleSyncEnabled: true,
+            roleSyncSource: true,
+            roleSyncFallback: true,
+            roleSyncDefaultRoleIds: true,
           },
         },
       },
@@ -397,12 +403,24 @@ export class SsoService {
       });
       if (!user) throw new SsoError('user_vanished');
 
+      // Synced BEFORE the profile is returned: the MCP surface is where the
+      // roles are actually spent, so a session must never be handed out with
+      // yesterday's group membership still in force.
+      const sync = await this.roleSync.syncOnLogin(provider, user.id, claims, ctx);
+
       await this.securityEvents.log({
         event: SecurityEvents.SSO_LOGIN_SUCCESS,
         actorType: 'USER',
         organizationId: provider.organizationId,
         actorUserId: user.id,
-        metadata: { providerId: provider.id, oid: subject, tid, surface: 'MCP' },
+        metadata: {
+          providerId: provider.id,
+          oid: subject,
+          tid,
+          surface: 'MCP',
+          ...this.claimShape(claims),
+          roleSync: sync.reason,
+        },
         ip: ctx.ip,
         userAgent: ctx.userAgent,
       });
@@ -420,6 +438,8 @@ export class SsoService {
 
     const userId = await this.resolveUser(provider, subject, tid, claims, ctx);
 
+    const sync = await this.roleSync.syncOnLogin(provider, userId, claims, ctx);
+
     const handoffCode = randomBytes(32).toString('base64url');
     await this.prisma.ssoLoginAttempt.update({
       where: { id: attempt.id },
@@ -435,12 +455,36 @@ export class SsoService {
       actorType: 'USER',
       organizationId: provider.organizationId,
       actorUserId: userId,
-      metadata: { providerId: provider.id, oid: subject, tid, surface: 'DASHBOARD' },
+      metadata: {
+        providerId: provider.id,
+        oid: subject,
+        tid,
+        surface: 'DASHBOARD',
+        ...this.claimShape(claims),
+        roleSync: sync.reason,
+      },
       ip: ctx.ip,
       userAgent: ctx.userAgent,
     });
 
     return { kind: 'LOGIN', handoffCode, returnTo: attempt.returnTo ?? '/' };
+  }
+
+  /**
+   * What the token carried, as SHAPE only.
+   *
+   * The counts answer the first question asked when role sync misbehaves —
+   * did the directory send any groups at all? — which an absent claim and a
+   * claim matching no mapping otherwise look identical for. The ids
+   * themselves are directory structure and are deliberately not persisted in
+   * a long-lived audit row.
+   */
+  private claimShape(claims: Record<string, any>) {
+    return {
+      groupCount: Array.isArray(claims.groups) ? claims.groups.length : 0,
+      appRoleCount: Array.isArray(claims.roles) ? claims.roles.length : 0,
+      groupsOverage: Boolean(claims._claim_names?.groups),
+    };
   }
 
   // ── Linking ───────────────────────────────────────────────────────────────

--- a/packages/backend/src/identity-providers/sso.service.ts
+++ b/packages/backend/src/identity-providers/sso.service.ts
@@ -440,6 +440,14 @@ export class SsoService {
 
     const sync = await this.roleSync.syncOnLogin(provider, userId, claims, ctx);
 
+    // Recorded here rather than in the MCP branch as well, because this is the
+    // signal `enforceSso` is gated on: it must mean "a human completed this
+    // provider's flow in a browser", which is exactly the dashboard surface.
+    await this.prisma.identityProvider.update({
+      where: { id: provider.id },
+      data: { lastSuccessfulLoginAt: new Date() },
+    });
+
     const handoffCode = randomBytes(32).toString('base64url');
     await this.prisma.ssoLoginAttempt.update({
       where: { id: attempt.id },

--- a/packages/frontend/src/app/login/page.tsx
+++ b/packages/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { auth, license, server, sso, type SsoProviderButton } from '@/lib/api';
+import { auth, license, server, sso, type SsoProviderButton, recoveryCodes as recoveryApi } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { buildPricingUrl } from '@/lib/marketing';
 import { LogoIcon } from '@/components/logo-icon';
@@ -40,6 +40,8 @@ const alertSuccess =
 function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [recoveryMode, setRecoveryMode] = useState(false);
+  const [recoveryCode, setRecoveryCode] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [error, setError] = useState('');
@@ -153,6 +155,8 @@ function LoginForm() {
         const regResult = await auth.register(email, password, name, acceptTerms);
         result = regResult;
         needsLicenseSetup = !!regResult.isFirstUser;
+      } else if (recoveryMode) {
+        result = await recoveryApi.login(email, recoveryCode);
       } else {
         const loginResult = await auth.login(email, password);
         result = loginResult;
@@ -687,7 +691,7 @@ function LoginForm() {
             />
           </div>
 
-          <div>
+          <div className={recoveryMode ? 'hidden' : undefined}>
             <label htmlFor="auth-password" className="block text-sm font-medium mb-1 text-[var(--text)]">Password</label>
             <input
               id="auth-password"
@@ -698,7 +702,9 @@ function LoginForm() {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Min. 8 characters"
               className={inputClass}
-              required
+              // A hidden field that is still `required` blocks submission with
+              // a validation bubble the user cannot see or reach.
+              required={!recoveryMode}
               minLength={8}
             />
             {isRegister && password.length > 0 && (
@@ -758,16 +764,60 @@ function LoginForm() {
             </>
           )}
 
+          {recoveryMode && (
+            <div>
+              <label htmlFor="auth-recovery-code" className="block text-sm font-medium mb-1 text-[var(--text)]">
+                Recovery code
+              </label>
+              <input
+                id="auth-recovery-code"
+                name="recovery-code"
+                type="text"
+                autoComplete="one-time-code"
+                spellCheck={false}
+                value={recoveryCode}
+                onChange={(e) => setRecoveryCode(e.target.value)}
+                placeholder="XXXXX-XXXXX"
+                className={`${inputClass} tracking-widest uppercase`}
+                required
+              />
+              <p className="text-xs text-[var(--text-2)] mt-1.5">
+                One of the codes you saved when setting up single sign-on. Each works once.
+              </p>
+            </div>
+          )}
+
           <Button type="submit" disabled={loading} className="w-full" size="lg">
-            {loading ? 'Loading...' : isRegister ? 'Create Account' : 'Sign In'}
+            {loading
+              ? 'Loading...'
+              : isRegister
+                ? 'Create Account'
+                : recoveryMode
+                  ? 'Sign in with recovery code'
+                  : 'Sign In'}
           </Button>
         </form>
 
         {!isRegister && (
-          <p className="text-center text-sm mt-3">
-            <Link href="/forgot-password" className="text-[var(--text-2)] hover:text-[var(--brand)] hover:underline">
-              Forgot password?
-            </Link>
+          <p className="text-center text-sm mt-3 flex items-center justify-center gap-3">
+            {!recoveryMode && (
+              <Link href="/forgot-password" className="text-[var(--text-2)] hover:text-[var(--brand)] hover:underline">
+                Forgot password?
+              </Link>
+            )}
+            {/*
+              Always reachable, not just once a password has been refused: the
+              situation this exists for is one where the identity provider is
+              down, and an admin should not have to guess a wrong password
+              first to be offered the way in.
+            */}
+            <button
+              type="button"
+              onClick={() => { setRecoveryMode(!recoveryMode); setError(''); }}
+              className="text-[var(--text-2)] hover:text-[var(--brand)] hover:underline"
+            >
+              {recoveryMode ? 'Back to password sign-in' : 'Use a recovery code'}
+            </button>
           </p>
         )}
 

--- a/packages/frontend/src/app/settings/identity-providers/page.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/page.tsx
@@ -14,6 +14,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/toast';
 import { RoleMappingsPanel } from './role-mappings';
+import { RecoveryCodesCard } from './recovery-codes';
 
 /**
  * Per-type configuration fields.
@@ -131,6 +132,7 @@ export default function IdentityProvidersPage() {
   const [testing, setTesting] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [mappingsFor, setMappingsFor] = useState<string | null>(null);
+  const [enforcing, setEnforcing] = useState<string | null>(null);
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -178,6 +180,34 @@ export default function IdentityProvidersPage() {
     });
     setEditingId(p.id);
     setShowForm(true);
+  };
+
+  const handleEnforceSso = async (p: IdentityProvider, enforce: boolean) => {
+    if (!token) return;
+    // Confirm only on the way IN. Turning enforcement off removes a lockout
+    // risk, and putting a dialog in front of that would be an obstacle in
+    // exactly the moment someone is trying to undo a mistake.
+    if (
+      enforce &&
+      !confirm(
+        'Require single sign-on for this workspace?\n\nPassword sign-in stops working for every member. Your recovery codes become the only way in if the identity provider becomes unreachable.',
+      )
+    ) {
+      return;
+    }
+    setEnforcing(p.id);
+    try {
+      await identityProviders.setEnforceSso(p.id, enforce, token);
+      toast.show({
+        tone: 'success',
+        title: enforce ? 'Single sign-on required' : 'Password sign-in re-enabled',
+      });
+      await loadData();
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not change enforcement', description: err.message });
+    } finally {
+      setEnforcing(null);
+    }
   };
 
   const handleSave = async () => {
@@ -547,6 +577,7 @@ export default function IdentityProvidersPage() {
                       <span className="text-sm font-medium text-[var(--text)]">{p.name}</span>
                       <Badge tone="neutral">{PROVIDER_TYPES[p.type]?.label ?? p.type}</Badge>
                       {!p.isActive && <Badge tone="warn">Inactive</Badge>}
+                      {p.enforceSso && <Badge tone="danger">SSO required</Badge>}
                       {expiringSoon(p) && <Badge tone="danger">Secret expiring</Badge>}
                     </div>
                     <p className="text-[12px] text-[var(--text-3)] mt-1 truncate">{p.issuer}</p>
@@ -597,13 +628,25 @@ export default function IdentityProvidersPage() {
                    role sync, and an always-open editor for a table they do not
                    use is the loudest thing on the page.
                  */}
-                 <button
-                   type="button"
-                   className="mt-2 text-[11.5px] text-[var(--brand)] hover:underline"
-                   onClick={() => setMappingsFor(mappingsFor === p.id ? null : p.id)}
-                 >
-                   {mappingsFor === p.id ? 'Hide role mappings' : 'Role mappings'}
-                 </button>
+                 <div className="mt-2 flex items-center gap-4 flex-wrap">
+                   <button
+                     type="button"
+                     className="text-[11.5px] text-[var(--brand)] hover:underline"
+                     onClick={() => setMappingsFor(mappingsFor === p.id ? null : p.id)}
+                   >
+                     {mappingsFor === p.id ? 'Hide role mappings' : 'Role mappings'}
+                   </button>
+                   <label className="flex items-center gap-2 text-[11.5px] text-[var(--text-2)]">
+                     <input
+                       type="checkbox"
+                       className="accent-[var(--brand)]"
+                       checked={p.enforceSso}
+                       disabled={enforcing === p.id}
+                       onChange={(e) => handleEnforceSso(p, e.target.checked)}
+                     />
+                     Require single sign-on
+                   </label>
+                 </div>
                  {mappingsFor === p.id && token && (
                    <RoleMappingsPanel provider={p} token={token} />
                  )}
@@ -611,6 +654,8 @@ export default function IdentityProvidersPage() {
               ))}
             </div>
           )}
+
+          {token && <RecoveryCodesCard token={token} />}
         </Card>
       )}
     </div>

--- a/packages/frontend/src/app/settings/identity-providers/page.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/page.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/toast';
+import { RoleMappingsPanel } from './role-mappings';
 
 /**
  * Per-type configuration fields.
@@ -129,6 +130,7 @@ export default function IdentityProvidersPage() {
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [mappingsFor, setMappingsFor] = useState<string | null>(null);
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -172,6 +174,7 @@ export default function IdentityProvidersPage() {
       roleSyncEnabled: p.roleSyncEnabled,
       roleSyncSource: p.roleSyncSource,
       roleSyncFallback: p.roleSyncFallback,
+      roleSyncDefaultRoleIds: p.roleSyncDefaultRoleIds ?? [],
     });
     setEditingId(p.id);
     setShowForm(true);
@@ -446,6 +449,62 @@ export default function IdentityProvidersPage() {
                 </span>
               </label>
 
+              <div className="pt-1 space-y-2 border-t border-[var(--border)]">
+                <label className="flex items-start gap-2 text-[13px] text-[var(--text)] pt-2">
+                  <input
+                    type="checkbox"
+                    className="accent-[var(--brand)] mt-0.5"
+                    checked={form.roleSyncEnabled ?? false}
+                    onChange={(e) => setForm({ ...form, roleSyncEnabled: e.target.checked })}
+                  />
+                  <span>
+                    Sync roles from the directory on every sign-in
+                    <span className="block text-[11.5px] text-[var(--text-3)]">
+                      Rights are then maintained where joiners and leavers are already
+                      handled. Roles an admin assigned by hand are never removed by a sync.
+                    </span>
+                  </span>
+                </label>
+
+                {form.roleSyncEnabled && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pl-6">
+                    <div>
+                      <label className={labelClass}>Read roles from</label>
+                      <AppSelect
+                        value={form.roleSyncSource ?? 'GROUPS'}
+                        onValueChange={(v) => setForm({ ...form, roleSyncSource: v })}
+                        options={[
+                          { value: 'GROUPS', label: 'Security / Microsoft 365 groups' },
+                          { value: 'APP_ROLES', label: 'Application roles' },
+                        ]}
+                      />
+                      <p className={helpClass}>
+                        Groups reuse what the directory already maintains, at the cost of
+                        matching on object IDs rather than readable names. Application roles
+                        read better but have to be declared in the app manifest first.
+                      </p>
+                    </div>
+                    <div>
+                      <label className={labelClass}>When nothing matches</label>
+                      <AppSelect
+                        value={form.roleSyncFallback ?? 'DENY_ALL'}
+                        onValueChange={(v) => setForm({ ...form, roleSyncFallback: v })}
+                        options={[
+                          { value: 'DENY_ALL', label: 'Grant no tools' },
+                          { value: 'KEEP_EXISTING', label: 'Leave existing roles alone' },
+                          { value: 'DEFAULT_ROLE', label: 'Grant a default role' },
+                        ]}
+                      />
+                      <p className={helpClass}>
+                        &ldquo;Grant no tools&rdquo; is the default deliberately: a user
+                        holding no MCP role at all is treated as unrestricted, so the
+                        alternative to denying is granting everything.
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
               <label className="flex items-center gap-2 text-[13px] text-[var(--text)]">
                 <input
                   type="checkbox"
@@ -480,8 +539,9 @@ export default function IdentityProvidersPage() {
               {providers.map((p) => (
                 <div
                   key={p.id}
-                  className="rounded-[9px] border border-[var(--border)] p-3 flex items-start justify-between gap-3"
+                  className="rounded-[9px] border border-[var(--border)] p-3"
                 >
+                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
                       <span className="text-sm font-medium text-[var(--text)]">{p.name}</span>
@@ -531,6 +591,22 @@ export default function IdentityProvidersPage() {
                       Delete
                     </Button>
                   </div>
+                 </div>
+                 {/*
+                   Kept collapsed by default: most workspaces run SSO without
+                   role sync, and an always-open editor for a table they do not
+                   use is the loudest thing on the page.
+                 */}
+                 <button
+                   type="button"
+                   className="mt-2 text-[11.5px] text-[var(--brand)] hover:underline"
+                   onClick={() => setMappingsFor(mappingsFor === p.id ? null : p.id)}
+                 >
+                   {mappingsFor === p.id ? 'Hide role mappings' : 'Role mappings'}
+                 </button>
+                 {mappingsFor === p.id && token && (
+                   <RoleMappingsPanel provider={p} token={token} />
+                 )}
                 </div>
               ))}
             </div>

--- a/packages/frontend/src/app/settings/identity-providers/recovery-codes.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/recovery-codes.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { recoveryCodes as api, type RecoveryCodeStatus } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/toast';
+
+/**
+ * Break-glass credentials for the signed-in admin.
+ *
+ * Lives beside the SSO settings rather than under Profile because it exists
+ * for one reason: `enforceSso` cannot be switched on without it, and an admin
+ * reading about enforcement should find the prerequisite in the same place.
+ */
+export function RecoveryCodesCard({
+  token,
+  onChanged,
+}: {
+  token: string;
+  onChanged?: () => void;
+}) {
+  const toast = useToast();
+  const [status, setStatus] = useState<RecoveryCodeStatus | null>(null);
+  const [issued, setIssued] = useState<string[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const load = async () => {
+    try {
+      setStatus(await api.status(token));
+    } catch {
+      // Non-fatal: the card degrades to "generate" rather than blocking the
+      // whole SSO page on a count.
+      setStatus(null);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const handleGenerate = async () => {
+    setBusy(true);
+    try {
+      const { codes } = await api.generate(token);
+      setIssued(codes);
+      setCopied(false);
+      await load();
+      onChanged?.();
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not generate codes', description: err.message });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!issued) return;
+    await navigator.clipboard.writeText(issued.join('\n'));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownload = () => {
+    if (!issued) return;
+    const body = [
+      'AnythingMCP recovery codes',
+      `Generated ${new Date().toISOString()}`,
+      '',
+      'Each code works once. Keep them somewhere you can reach WITHOUT',
+      'single sign-on — that is the situation they exist for.',
+      '',
+      ...issued,
+      '',
+    ].join('\n');
+    const url = URL.createObjectURL(new Blob([body], { type: 'text/plain' }));
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'anythingmcp-recovery-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const none = !status || status.unused === 0;
+
+  return (
+    <div className="mt-5 pt-4 border-t border-[var(--border)]">
+      <h4 className="text-[13px] font-semibold text-[var(--text)]">Recovery codes</h4>
+      <p className="text-[11.5px] text-[var(--text-3)] mt-1 max-w-2xl">
+        Single-use codes that sign you in when the identity provider cannot be reached — an
+        expired client secret, a tenant migration, a claim that stopped arriving. Requiring
+        single sign-on is only possible once you hold some.
+      </p>
+
+      {issued ? (
+        <div className="mt-3 p-3 rounded-[9px] bg-[var(--surface-2)] space-y-3">
+          {/*
+            Shown once and never again: the server stores bcrypt hashes, so
+            there is nothing to display on a later visit. Saying so here is the
+            difference between an admin saving them and an admin closing the
+            page.
+          */}
+          <p className="text-[12px] text-[var(--text)] font-medium">
+            Save these now — they cannot be shown again.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-1.5">
+            {issued.map((c) => (
+              <code
+                key={c}
+                className="text-[12px] tracking-wide text-[var(--text)] bg-[var(--surface)] border border-[var(--border)] rounded px-2 py-1 text-center"
+              >
+                {c}
+              </code>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="secondary" onClick={handleCopy}>
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+            <Button size="sm" variant="secondary" onClick={handleDownload}>
+              Download
+            </Button>
+            <Button size="sm" onClick={() => setIssued(null)}>
+              I have saved them
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 flex items-center gap-3 flex-wrap">
+          <Button size="sm" variant={none ? undefined : 'secondary'} onClick={handleGenerate} disabled={busy}>
+            {busy ? 'Generating...' : none ? 'Generate recovery codes' : 'Regenerate'}
+          </Button>
+          <span className="text-[12px] text-[var(--text-3)]">
+            {status === null
+              ? ''
+              : status.total === 0
+                ? 'None yet.'
+                : `${status.unused} of ${status.total} unused.`}
+            {status && status.total > 0 && ' Regenerating invalidates the current set.'}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/settings/identity-providers/role-mappings.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/role-mappings.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  identityProviders,
+  roles as rolesApi,
+  type IdentityProvider,
+  type RoleMapping,
+} from '@/lib/api';
+import { AppSelect } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/toast';
+
+const ORG_ROLE_OPTIONS = [
+  { value: '', label: 'Leave unchanged' },
+  { value: 'VIEWER', label: 'Viewer' },
+  { value: 'EDITOR', label: 'Editor' },
+  { value: 'ADMIN', label: 'Admin' },
+];
+
+const blankRow = (): RoleMapping => ({
+  externalId: '',
+  label: '',
+  userRole: null,
+  mcpRoleIds: [],
+});
+
+/**
+ * Editor for one provider's group → role mappings.
+ *
+ * Saves the whole set at once, because that is the only shape the API offers:
+ * a half-applied edit to the table that decides who can call which tools is a
+ * state nobody can reason about.
+ */
+export function RoleMappingsPanel({
+  provider,
+  token,
+}: {
+  provider: IdentityProvider;
+  token: string;
+}) {
+  const toast = useToast();
+  const [rows, setRows] = useState<RoleMapping[]>([]);
+  const [available, setAvailable] = useState<{ id: string; name: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [mappings, allRoles] = await Promise.all([
+          identityProviders.roleMappings(provider.id, token),
+          rolesApi.list(token),
+        ]);
+        if (cancelled) return;
+        setRows(mappings.length > 0 ? mappings : [blankRow()]);
+        setAvailable(allRoles.map((r: any) => ({ id: r.id, name: r.name })));
+      } catch (err: any) {
+        if (!cancelled) {
+          toast.show({
+            tone: 'error',
+            title: 'Could not load mappings',
+            description: err.message,
+          });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider.id, token]);
+
+  const patch = (i: number, next: Partial<RoleMapping>) =>
+    setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...next } : r)));
+
+  const toggleRole = (i: number, roleId: string) =>
+    setRows((rs) =>
+      rs.map((r, j) =>
+        j === i
+          ? {
+              ...r,
+              mcpRoleIds: r.mcpRoleIds.includes(roleId)
+                ? r.mcpRoleIds.filter((x) => x !== roleId)
+                : [...r.mcpRoleIds, roleId],
+            }
+          : r,
+      ),
+    );
+
+  const handleSave = async () => {
+    // Blank rows are the natural end state of "add row then change your mind";
+    // dropping them here is friendlier than a validation error on a row the
+    // admin never filled in.
+    //
+    // Projected field by field rather than sent as-is: the API validates with
+    // `forbidNonWhitelisted`, so echoing back the `id` that GET returned — the
+    // obvious thing for a client to do — is a 400. Only the first save worked,
+    // because those rows had never been round-tripped.
+    const payload = rows
+      .filter((r) => r.externalId.trim() !== '')
+      .map((r) => ({
+        externalId: r.externalId.trim(),
+        label: r.label ?? '',
+        userRole: r.userRole,
+        mcpRoleIds: r.mcpRoleIds,
+      }));
+    setSaving(true);
+    try {
+      const saved = await identityProviders.saveRoleMappings(
+        provider.id,
+        payload,
+        token,
+      );
+      setRows(saved.length > 0 ? saved : [blankRow()]);
+      toast.show({ tone: 'success', title: 'Mappings saved' });
+    } catch (err: any) {
+      toast.show({ tone: 'error', title: 'Could not save', description: err.message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass =
+    'w-full h-9 rounded-[9px] border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--text)] outline-none focus:border-[var(--brand)]';
+  const labelClass = 'block text-[11.5px] font-medium text-[var(--text-3)] mb-1';
+
+  if (loading) {
+    return <p className="text-[13px] text-[var(--text-3)] py-4">Loading mappings...</p>;
+  }
+
+  const isGroups = provider.roleSyncSource === 'GROUPS';
+
+  return (
+    <div className="mt-3 pt-3 border-t border-[var(--border)] space-y-3">
+      <div>
+        <h4 className="text-[13px] font-semibold text-[var(--text)]">
+          {isGroups ? 'Group mappings' : 'App role mappings'}
+        </h4>
+        <p className="text-[11.5px] text-[var(--text-3)] mt-1 max-w-2xl">
+          {isGroups ? (
+            <>
+              Enter the group&apos;s <strong>object ID</strong>, not its name — Microsoft does
+              not make group names unique, so matching on one would let anyone able to create
+              a group grant themselves a role. Find it in Entra under Groups → the group →
+              Overview → Object Id. Only groups <em>assigned to the application</em> appear in
+              the token.
+            </>
+          ) : (
+            <>
+              Enter the app role&apos;s <strong>value</strong> from the application manifest
+              (for example <code>amcp.einkauf</code>), not its display name.
+            </>
+          )}
+        </p>
+      </div>
+
+      {!provider.roleSyncEnabled && (
+        <p className="text-[12px] text-[var(--warn,#b45309)] bg-[var(--surface-2)] rounded-[9px] px-3 py-2">
+          Role sync is turned off for this provider, so these mappings are stored but never
+          applied. Turn it on under Edit.
+        </p>
+      )}
+
+      <div className="space-y-2">
+        {rows.map((row, i) => (
+          <div
+            key={i}
+            className="rounded-[9px] border border-[var(--border)] p-3 space-y-2"
+          >
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+              <div className="md:col-span-2">
+                <label className={labelClass}>
+                  {isGroups ? 'Group object ID' : 'App role value'}
+                </label>
+                <input
+                  className={inputClass}
+                  value={row.externalId}
+                  onChange={(e) => patch(i, { externalId: e.target.value })}
+                  placeholder={
+                    isGroups ? '4be78614-f22d-472f-a2cb-5eb81b6e3f6f' : 'amcp.einkauf'
+                  }
+                  data-testid={`mapping-external-id-${i}`}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Name (for humans)</label>
+                <input
+                  className={inputClass}
+                  value={row.label ?? ''}
+                  onChange={(e) => patch(i, { label: e.target.value })}
+                  placeholder="GB_Grosshandel_Innendienst"
+                  data-testid={`mapping-label-${i}`}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+              <div>
+                <label className={labelClass}>Workspace role</label>
+                <AppSelect
+                  value={row.userRole ?? ''}
+                  onValueChange={(v) =>
+                    patch(i, { userRole: (v || null) as RoleMapping['userRole'] })
+                  }
+                  options={ORG_ROLE_OPTIONS}
+                />
+              </div>
+              <div className="md:col-span-2">
+                <label className={labelClass}>
+                  MCP roles ({row.mcpRoleIds.length} selected)
+                </label>
+                {available.length === 0 ? (
+                  <p className="text-[11.5px] text-[var(--text-3)]">
+                    No MCP roles exist yet. Create one under Roles first.
+                  </p>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">
+                    {available.map((r) => {
+                      const on = row.mcpRoleIds.includes(r.id);
+                      return (
+                        <button
+                          key={r.id}
+                          type="button"
+                          onClick={() => toggleRole(i, r.id)}
+                          aria-pressed={on}
+                          className={`text-[11.5px] rounded-full px-2.5 py-1 border transition-colors ${
+                            on
+                              ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
+                              : 'bg-[var(--surface)] text-[var(--text-2)] border-[var(--border)] hover:border-[var(--brand)]'
+                          }`}
+                        >
+                          {r.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className="text-[11.5px] text-[var(--danger,#dc2626)] hover:underline"
+                onClick={() => setRows((rs) => rs.filter((_, j) => j !== i))}
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="secondary" onClick={() => setRows((rs) => [...rs, blankRow()])}>
+          Add mapping
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save mappings'}
+        </Button>
+      </div>
+
+      <p className="text-[11.5px] text-[var(--text-3)] max-w-2xl">
+        A user in several mapped groups receives the <strong>union</strong> of their MCP roles
+        and the <strong>most privileged</strong> workspace role. Roles an admin assigned by
+        hand are never removed by a sync.
+        {provider.roleSyncFallback === 'DENY_ALL' && (
+          <> Someone who matches nothing is given a &ldquo;No access (SSO)&rdquo; role, which
+          grants no tools.</>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/settings/identity-providers/role-mappings.tsx
+++ b/packages/frontend/src/app/settings/identity-providers/role-mappings.tsx
@@ -8,6 +8,7 @@ import {
   type RoleMapping,
 } from '@/lib/api';
 import { AppSelect } from '@/components/ui/select';
+import { MultiSelect } from '@/components/ui/multi-select';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/toast';
 
@@ -76,20 +77,6 @@ export function RoleMappingsPanel({
 
   const patch = (i: number, next: Partial<RoleMapping>) =>
     setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...next } : r)));
-
-  const toggleRole = (i: number, roleId: string) =>
-    setRows((rs) =>
-      rs.map((r, j) =>
-        j === i
-          ? {
-              ...r,
-              mcpRoleIds: r.mcpRoleIds.includes(roleId)
-                ? r.mcpRoleIds.filter((x) => x !== roleId)
-                : [...r.mcpRoleIds, roleId],
-            }
-          : r,
-      ),
-    );
 
   const handleSave = async () => {
     // Blank rows are the natural end state of "add row then change your mind";
@@ -210,35 +197,14 @@ export function RoleMappingsPanel({
                 />
               </div>
               <div className="md:col-span-2">
-                <label className={labelClass}>
-                  MCP roles ({row.mcpRoleIds.length} selected)
-                </label>
-                {available.length === 0 ? (
-                  <p className="text-[11.5px] text-[var(--text-3)]">
-                    No MCP roles exist yet. Create one under Roles first.
-                  </p>
-                ) : (
-                  <div className="flex flex-wrap gap-1.5">
-                    {available.map((r) => {
-                      const on = row.mcpRoleIds.includes(r.id);
-                      return (
-                        <button
-                          key={r.id}
-                          type="button"
-                          onClick={() => toggleRole(i, r.id)}
-                          aria-pressed={on}
-                          className={`text-[11.5px] rounded-full px-2.5 py-1 border transition-colors ${
-                            on
-                              ? 'bg-[var(--brand)] text-white border-[var(--brand)]'
-                              : 'bg-[var(--surface)] text-[var(--text-2)] border-[var(--border)] hover:border-[var(--brand)]'
-                          }`}
-                        >
-                          {r.name}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
+                <label className={labelClass}>MCP roles</label>
+                <MultiSelect
+                  value={row.mcpRoleIds}
+                  onValueChange={(ids) => patch(i, { mcpRoleIds: ids })}
+                  options={available.map((r) => ({ value: r.id, label: r.name }))}
+                  placeholder="No roles — grants nothing"
+                  emptyMessage="No MCP roles exist yet — create one under Roles"
+                />
               </div>
             </div>
 

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -13,6 +13,8 @@ interface SidebarItem {
   icon: React.ComponentType<{ size?: number }>;
   exact?: boolean;
   adminOnly?: boolean;
+  /** Hidden in cloud. The backend answers 404 there regardless. */
+  selfHostedOnly?: boolean;
 }
 
 interface SidebarSection {
@@ -35,7 +37,10 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
       { href: '/settings/organization', label: 'General', description: 'Workspace and new orgs', icon: BuildingIcon },
       { href: '/settings/users', label: 'Users', description: 'Members and invitations', icon: UsersIcon, adminOnly: true },
       { href: '/settings/roles', label: 'Roles', description: 'MCP tool access control', icon: ShieldIcon, adminOnly: true },
-      { href: '/settings/identity-providers', label: 'Single sign-on', description: 'Microsoft, Google, Okta', icon: FingerprintIcon, adminOnly: true },
+      // Self-hosted only: SSO assumes the workspace owns its own directory,
+      // tenant and operator. The backend refuses these routes in cloud, so
+      // showing the entry there would lead an admin to a page that 404s.
+      { href: '/settings/identity-providers', label: 'Single sign-on', description: 'Microsoft, Google, Okta', icon: FingerprintIcon, adminOnly: true, selfHostedOnly: true },
       { href: '/settings/license', label: 'License', description: 'Plan, features', icon: KeyIcon, adminOnly: true },
       { href: '/settings/admin', label: 'Administration', description: 'SMTP, footer links', icon: WrenchIcon, adminOnly: true },
     ],
@@ -44,8 +49,9 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const { user } = useAuth();
+  const { user, deploymentMode } = useAuth();
   const isAdmin = user?.role === 'ADMIN';
+  const isCloud = deploymentMode === 'cloud';
 
   return (
     <AppShell title="Settings">
@@ -64,6 +70,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
                 )}
                 {section.items.map((item) => {
                   if (item.adminOnly && !isAdmin) return null;
+                  if (item.selfHostedOnly && isCloud) return null;
                   const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href);
                   return (
                     <Link

--- a/packages/frontend/src/components/ui/multi-select.tsx
+++ b/packages/frontend/src/components/ui/multi-select.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+
+interface MultiSelectProps {
+  value: string[];
+  onValueChange: (value: string[]) => void;
+  options: { value: string; label: string }[];
+  /** Shown when nothing is selected. */
+  placeholder?: string;
+  /** Shown in place of the list when there is nothing to choose from. */
+  emptyMessage?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Checkbox dropdown for picking several options.
+ *
+ * Deliberately not built on `AppSelect`: Radix's Select is single-value by
+ * design, and a listbox that reports one value while the caller needs a set is
+ * the kind of mismatch that shows up later as a silently dropped selection.
+ * DropdownMenu.CheckboxItem is the primitive meant for this, and it keeps the
+ * menu open across clicks so several can be ticked in one go.
+ */
+export function MultiSelect({
+  value,
+  onValueChange,
+  options,
+  placeholder = 'None selected',
+  emptyMessage,
+  className,
+  disabled,
+}: MultiSelectProps) {
+  const toggle = (v: string) =>
+    onValueChange(
+      value.includes(v) ? value.filter((x) => x !== v) : [...value, v],
+    );
+
+  // Names, not a bare count: "Leitung / Controlling" tells an admin what a
+  // mapping grants without opening it, which "2 selected" does not.
+  const selected = options.filter((o) => value.includes(o.value));
+  const summary =
+    selected.length === 0
+      ? placeholder
+      : selected.map((o) => o.label).join(', ');
+
+  const isEmpty = options.length === 0;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        disabled={disabled || isEmpty}
+        className={`flex items-center justify-between gap-2 w-full h-9 rounded-[9px] border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-left outline-none focus:border-[var(--brand)] disabled:opacity-60 disabled:cursor-not-allowed ${
+          selected.length === 0 ? 'text-[var(--text-3)]' : 'text-[var(--text)]'
+        } ${className ?? ''}`}
+      >
+        <span className="truncate">{isEmpty ? (emptyMessage ?? placeholder) : summary}</span>
+        <svg
+          className="w-4 h-4 text-[var(--text-3)] shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="m19 9-7 7-7-7" />
+        </svg>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={4}
+          collisionPadding={8}
+          className="bg-[var(--background)] border border-[var(--border)] rounded-md shadow-md min-w-[var(--radix-dropdown-menu-trigger-width)] max-h-60 overflow-auto z-50 p-1"
+        >
+          {options.map((opt) => (
+            <DropdownMenu.CheckboxItem
+              key={opt.value}
+              checked={value.includes(opt.value)}
+              // Without this the menu closes on the first tick, so picking
+              // three roles would mean reopening it three times.
+              onSelect={(e) => e.preventDefault()}
+              onCheckedChange={() => toggle(opt.value)}
+              className="flex items-center gap-2 px-2 py-1.5 text-sm rounded-[6px] cursor-pointer outline-none select-none text-[var(--text)] hover:bg-[var(--surface-2)] focus:bg-[var(--surface-2)]"
+            >
+              <span className="w-4 h-4 shrink-0 rounded-[4px] border border-[var(--border)] flex items-center justify-center">
+                <DropdownMenu.ItemIndicator>
+                  <svg
+                    className="w-3 h-3 text-[var(--brand)]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="m5 13 4 4L19 7" />
+                  </svg>
+                </DropdownMenu.ItemIndicator>
+              </span>
+              <span className="truncate">{opt.label}</span>
+            </DropdownMenu.CheckboxItem>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -789,6 +789,31 @@ export const sso = {
     }),
 };
 
+export interface RecoveryCodeStatus {
+  total: number;
+  unused: number;
+  generatedAt: string | null;
+}
+
+export const recoveryCodes = {
+  status: (token: string) =>
+    request<RecoveryCodeStatus>('/api/auth/recovery-codes', { token }),
+
+  /** Returns the codes in plaintext ONCE. Any previous set stops working. */
+  generate: (token: string) =>
+    request<{ codes: string[] }>('/api/auth/recovery-codes', {
+      method: 'POST',
+      token,
+    }),
+
+  /** Break-glass sign-in for when the identity provider is unreachable. */
+  login: (email: string, code: string) =>
+    request<{ accessToken: string; user: any; recoveryCodesRemaining: number }>(
+      '/api/auth/login/recovery',
+      { method: 'POST', body: { email, code } },
+    ),
+};
+
 export const identityProviders = {
   list: (token: string) =>
     request<IdentityProvider[]>('/api/identity-providers', { token }),
@@ -803,6 +828,17 @@ export const identityProviders = {
       `/api/identity-providers/${id}/test`,
       { method: 'POST', token },
     ),
+
+  /**
+   * Enabling requires a completed sign-in through this provider and unused
+   * recovery codes on the calling account; the API rejects it otherwise.
+   */
+  setEnforceSso: (id: string, enforce: boolean, token: string) =>
+    request<IdentityProvider>(`/api/identity-providers/${id}/enforce-sso`, {
+      method: 'PUT',
+      body: { enforce },
+      token,
+    }),
 
   roleMappings: (id: string, token: string) =>
     request<RoleMapping[]>(`/api/identity-providers/${id}/role-mappings`, { token }),

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -702,6 +702,7 @@ export interface IdentityProvider {
   roleSyncEnabled: boolean;
   roleSyncSource: 'APP_ROLES' | 'GROUPS';
   roleSyncFallback: 'DENY_ALL' | 'KEEP_EXISTING' | 'DEFAULT_ROLE';
+  roleSyncDefaultRoleIds: string[];
   enforceSso: boolean;
   lastSuccessfulLoginAt: string | null;
   config: Record<string, string>;
@@ -726,6 +727,21 @@ export interface IdentityProviderInput {
   roleSyncEnabled?: boolean;
   roleSyncSource?: string;
   roleSyncFallback?: string;
+  roleSyncDefaultRoleIds?: string[];
+}
+
+/**
+ * One directory group (or application role) projected onto AnythingMCP roles.
+ *
+ * `externalId` is the group's OBJECT ID, not its name — Entra does not make
+ * group names unique. `label` exists only so the admin table is readable.
+ */
+export interface RoleMapping {
+  id?: string;
+  externalId: string;
+  label: string | null;
+  userRole: 'VIEWER' | 'EDITOR' | 'ADMIN' | null;
+  mcpRoleIds: string[];
 }
 
 export interface SsoProviderButton {
@@ -787,6 +803,17 @@ export const identityProviders = {
       `/api/identity-providers/${id}/test`,
       { method: 'POST', token },
     ),
+
+  roleMappings: (id: string, token: string) =>
+    request<RoleMapping[]>(`/api/identity-providers/${id}/role-mappings`, { token }),
+
+  /** Replaces the whole set — the API has no per-row endpoint on purpose. */
+  saveRoleMappings: (id: string, mappings: RoleMapping[], token: string) =>
+    request<RoleMapping[]>(`/api/identity-providers/${id}/role-mappings`, {
+      method: 'PUT',
+      body: { mappings },
+      token,
+    }),
 };
 
 export const roles = {


### PR DESCRIPTION
Completes the single sign-on work: rights maintained from the directory, a safe way to require SSO, and the whole feature restricted to self-hosted deployments.

## Role sync from directory groups

Projects Entra groups (or application roles) onto AnythingMCP roles at each sign-in. PR 2 shipped the schema; nothing read or wrote it until now.

Three properties it is built around:

- **Matches on object IDs, never display names.** Microsoft does not make group names unique, so matching on one would let anyone able to create a group grant themselves a role.
- **Refuses to act on incomplete claims.** Past ~150 groups Entra replaces the claim with a Graph pointer; treating that as "member of nothing" would revoke the roles of exactly the people who belong to the most groups. Such a token is audited and otherwise ignored.
- **Never touches assignments a human made.** Only rows with `source='entra'` are its to rewrite.

`DENY_ALL` cannot be implemented by deleting the user's grants: `getUserToolAccess` reads "no role" as UNRESTRICTED, so the obvious implementation grants full access — the precise failure the fallback exists to prevent. Unmatched users are instead given a real role that whitelists nothing.

## Recovery codes and "Require SSO"

`enforceSso` has been a column since PR 2 with nothing able to write it, deliberately: turning off password sign-in without a way back in is how a workspace loses every one of its administrators.

Enabling now requires a completed dashboard sign-in through the provider **and** unused recovery codes on the account flipping the switch. Disabling is ungated — undoing a lockout risk never needs permission.

Enforcement spans every organization the user belongs to, not just the active one: `POST /api/organizations/switch` moves a session between workspaces, so a password accepted in a permissive org would otherwise be a way into an enforcing one.

## Self-hosted only

SSO assumes the workspace owns its own directory, tenant and operator. In cloud the same feature would let any customer point a workspace at an arbitrary directory and provision accounts from it inside a shared deployment.

Only `allowArbitraryIssuer` was gated before, which restricted Okta, Auth0 and OIDC. **Entra and Google SSO were fully configurable in cloud** — verified live against production, where `GET /api/identity-providers` answers 401 rather than 404.

Now gated: the configuration API, the sign-in entry point, the callback, identity linking, the SSO buttons on the MCP authorization page, and the recovery-code routes. The guard answers 404 rather than 403, because a 403 confirms the endpoint exists and is merely switched off here.

`SsoEnforcementService` returns early in cloud before touching the database. It runs on every password sign-in in the deployment, so it is both the hot path and the one place where a mistake locks everybody out.

## Bugs found while testing through the UI

- The audit redactor reused `[REDACTED]` for its depth cut-off, so a role id list one level too deep was indistinguishable from a stripped credential. The mapping-change event recorded that the rules changed but not what they changed to.
- The mappings editor echoed back the `id` that GET returned, which the API rejects under `forbidNonWhitelisted`. Only the first save worked.
- Recovery codes were hashed in their display form but compared after normalisation, so **no code would ever have verified** — the break-glass path would have been silently dead until the day it was needed.
- `lastSuccessfulLoginAt` was documented as written by PR 3 and never was, so the precondition it exists for could not have been evaluated.

## Verification

Production audited before changing behaviour: the cloud database holds zero identity providers and zero linked identities, so nothing depends on what is being closed off.

Against the real Entra tenant, through the UI:

| Scenario | Result |
|---|---|
| Token with no groups | `fallback_deny_all`, "No access (SSO)" role assigned |
| Token with a mapped group | role granted, previous assignment replaced |
| Last-admin demotion | refused, `LAST_ADMIN_PROTECTION_TRIGGERED` audited |
| Password sign-in under enforcement | refused with the enforcement message |
| Recovery code through the login page | accepted in lower case, refused on reuse |

Running the server in each mode: in cloud every SSO route answers 404, password sign-in returns its ordinary "invalid email or password" even with an enforcing provider row present, and the settings navigation drops the entry; self-hosted keeps all of it.

3849 tests pass.