### PR TITLE
fix(mcp): pin the tools/list cache hint to private

### DIFF
--- a/packages/backend/src/mcp-server/mcp-strategy.ts
+++ b/packages/backend/src/mcp-server/mcp-strategy.ts
@@ -34,4 +34,11 @@ export const mcpStrategy = new McpStrategy({
   name: 'anythingmcp',
   version: '0.1.0',
   transports: [mcpHttpTransport],
+  // `tools/list` is filtered per caller — by organization and by MCP role —
+  // so its result must never be cached and reused for a different principal.
+  // 'private' is already the default, but it is pinned here because the
+  // consequence of changing it is invisible: a 'public' hint lets a client or
+  // proxy serve one tenant's tool inventory to another, silently undoing the
+  // scoping in McpEndpointController.attachVisibleTools.
+  cacheHints: { 'tools/list': { cacheScope: 'private', ttlMs: 0 } },
 });


### PR DESCRIPTION
Follow-up to #532, which made `tools/list` on the global `/mcp` endpoint filter by the caller's organization and MCP roles.

A per-caller list must never be cached and reused for a different principal. `server/discover` advertises a `cacheScope` for `tools/list`, and a `public` value invites a client or proxy to do exactly that — serving one tenant's tool inventory to another and silently undoing the scoping.

`private` is already the default, so **this changes no behaviour**. It is pinned because the consequence of changing it is invisible from the code that depends on it: nothing in `McpEndpointController` would fail and no test would break — the leak would simply reappear at whichever cache sits in front.

mcp-nest does warn when the hint is `public` while the list varies by caller, but that warning fires once at startup and only helps if someone reads the logs.

## Verified

```
cacheScope: private | ttlMs: 0
```

`tools/list` still returns the caller's own tools only. 3853 tests pass.

## Also checked while looking for the same class of problem

- `resources/list`, `prompts/list`, `resources/templates/list` → `Method not found`. The server declares neither capability and registers no dynamic resources or prompts, so there is nothing to scope.
- `server/discover` returns capabilities, versions and cache metadata only — no tool list.
- No HTTP `Cache-Control` is set on MCP responses; `Vary: Origin` only.