### PR TITLE
fix(rest): make a flaky upstream look like one, and stop giving up early

### DIFF
--- a/packages/backend/src/connectors/engines/rest.engine.spec.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.spec.ts
@@ -492,8 +492,97 @@ describe('RestEngine', () => {
           {},
         ),
       ).rejects.toBeInstanceOf(AxiosError);
-      // 1 initial + 2 retries
-      expect(mockedAxios).toHaveBeenCalledTimes(3);
+      // 1 initial + 3 retries
+      expect(mockedAxios).toHaveBeenCalledTimes(4);
+    });
+
+    // Origins that reject a handshake keep rejecting for a few seconds. The
+    // old two-delay budget (1.2 s) regularly gave up just short of recovery.
+    it('still succeeds when the origin only recovers on the last retry', async () => {
+      mockedAxios
+        .mockRejectedValueOnce(err(undefined, 'EPROTO'))
+        .mockRejectedValueOnce(err(undefined, 'EPROTO'))
+        .mockRejectedValueOnce(err(undefined, 'EPROTO'))
+        .mockResolvedValueOnce({ data: { ok: true } });
+
+      const result = await engine.execute(
+        { baseUrl: 'https://api.example.com', authType: 'NONE' },
+        { method: 'GET', path: '/' },
+        {},
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(mockedAxios).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  /**
+   * A connection-level failure used to surface to the model as the raw OpenSSL
+   * dump, which reads like a credentials problem and tells nobody that trying
+   * again is the right move.
+   */
+  describe('connection-error messages', () => {
+    const err = (status?: number, code?: string) =>
+      new AxiosError(
+        'boom',
+        code,
+        undefined,
+        {},
+        status ? ({ status, data: {} } as any) : undefined,
+      );
+
+    it('restates a TLS handshake rejection in plain language', async () => {
+      mockedAxios.mockRejectedValue(err(undefined, 'EPROTO'));
+
+      await expect(
+        engine.execute(
+          { baseUrl: 'https://api.example.com', authType: 'NONE' },
+          { method: 'GET', path: '/' },
+          {},
+        ),
+      ).rejects.toThrow(
+        /Could not reach the API after 4 attempts: the TLS handshake was rejected .* \(EPROTO\)/,
+      );
+    });
+
+    it('keeps the original error as `cause` and carries the code', async () => {
+      const original = err(undefined, 'ECONNRESET');
+      mockedAxios.mockRejectedValue(original);
+
+      const thrown = (await engine
+        .execute(
+          { baseUrl: 'https://api.example.com', authType: 'NONE' },
+          { method: 'GET', path: '/' },
+          {},
+        )
+        .catch((e: unknown) => e)) as Error & { code?: string };
+
+      expect(thrown.cause).toBe(original);
+      expect(thrown.code).toBe('ECONNRESET');
+    });
+
+    it('leaves an error that carries an HTTP status untouched', async () => {
+      mockedAxios.mockRejectedValue(err(503));
+
+      await expect(
+        engine.execute(
+          { baseUrl: 'https://api.example.com', authType: 'NONE' },
+          { method: 'GET', path: '/' },
+          {},
+        ),
+      ).rejects.toBeInstanceOf(AxiosError);
+    });
+
+    it('leaves an unrecognised connection code untouched', async () => {
+      mockedAxios.mockRejectedValue(err(undefined, 'ESOMETHINGELSE'));
+
+      await expect(
+        engine.execute(
+          { baseUrl: 'https://api.example.com', authType: 'NONE' },
+          { method: 'GET', path: '/' },
+          {},
+        ),
+      ).rejects.toBeInstanceOf(AxiosError);
     });
   });
 

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -281,17 +281,72 @@ export class RestEngine {
     ].includes(error.code ?? '');
   }
 
+  /**
+   * Human-readable replacements for connection-level failures. Without these
+   * the caller — and the model reading the tool result — gets the raw OpenSSL
+   * dump, e.g.
+   *   write EPROTO 40032A705A780000:error:0A000438:SSL routines:
+   *   ssl3_read_bytes:tlsv1 alert internal error:../deps/openssl/...
+   * which says nothing about whose fault it is or whether trying again helps.
+   */
+  private static readonly CONNECTION_ERROR_HINTS: Record<string, string> = {
+    EPROTO:
+      'the TLS handshake was rejected by the API (or something in front of it). This is usually temporary and not a credentials problem',
+    ECONNRESET: 'the API closed the connection before responding',
+    ETIMEDOUT: 'the API did not respond in time',
+    ECONNABORTED: 'the request was aborted before the API responded',
+    EAI_AGAIN: 'the API hostname could not be resolved (temporary DNS failure)',
+    ECONNREFUSED: 'the API refused the connection',
+    ENOTFOUND: 'the API hostname does not resolve — check the base URL',
+  };
+
+  /**
+   * Restate a connection-level failure in terms the caller can act on, keeping
+   * the original as `cause` and the code in the text for support. Only touches
+   * errors that never reached the application (no HTTP response), so nothing
+   * that carries a status — and therefore an API-level meaning — is reworded.
+   */
+  private describeConnectionError(error: unknown, attempts: number): unknown {
+    if (!(error instanceof AxiosError) || error.response) return error;
+    const hint = RestEngine.CONNECTION_ERROR_HINTS[error.code ?? ''];
+    if (!hint) return error;
+
+    const tried =
+      attempts > 1 ? ` after ${attempts} attempts` : '';
+    const wrapped = new Error(
+      `Could not reach the API${tried}: ${hint} (${error.code}).`,
+      { cause: error },
+    );
+    (wrapped as { code?: string }).code = error.code;
+    return wrapped;
+  }
+
   /** Execute the request with a small bounded backoff on transient errors. */
   private async requestWithRetry(
     axiosConfig: AxiosRequestConfig,
   ): Promise<AxiosResponse> {
-    const delaysMs = [300, 900];
+    // Three delays rather than two: origins that reject a handshake tend to do
+    // so for a few seconds, and the old 1.2 s total often gave up just short of
+    // recovery. 3.7 s worst case still sits well inside any MCP client timeout.
+    const delaysMs = [300, 900, 2500];
     for (let attempt = 0; ; attempt++) {
       try {
         return await axios(axiosConfig);
       } catch (error) {
-        if (attempt >= delaysMs.length || !this.isTransientError(error)) {
-          throw error;
+        const transient = this.isTransientError(error);
+        if (attempt >= delaysMs.length || !transient) {
+          // Warn, not debug: production runs at info, so a call that burned
+          // every retry used to look identical to one that failed outright —
+          // there was no way to tell a flaky upstream from a broken connector.
+          if (transient) {
+            this.logger.warn(
+              `Gave up after ${attempt + 1} attempts on a transient upstream failure: ${
+                (error as AxiosError).code ??
+                (error as AxiosError).response?.status
+              } ${axiosConfig.method?.toUpperCase()} ${axiosConfig.url}`,
+            );
+          }
+          throw this.describeConnectionError(error, attempt + 1);
         }
         this.logger.debug(
           `Transient error (attempt ${attempt + 1}), retrying in ${delaysMs[attempt]}ms`,


### PR DESCRIPTION
## What customers actually saw

Two paying workspaces hit the same thing this week — `stryve.weclapp.com` and `api.billbee.io` intermittently reject the TLS handshake:

| workspace | connector | calls (14d) | ok | TLS rejects |
|---|---|---|---|---|
| Chris Engel | Billbee REST API | 36 | 30 | 6 |
| Lennart Rieper | Weclapp Matze | 5 | 1 | 4 |

Roughly **one call in six**, and what reached them was the raw OpenSSL dump:

```
write EPROTO 40032A705A780000:error:0A000438:SSL routines:ssl3_read_bytes:
tlsv1 alert internal error:../deps/openssl/openssl/ssl/record/rec_layer_s3.c
```

That reads like a credentials problem, names no culprit, and gives the model reading the tool result nothing to act on. A trial user seeing it concludes the product is broken.

## Three changes

**Plain-language connection errors.** Failures that never reached the application (no HTTP response, a recognised network code) are restated — `Could not reach the API after 4 attempts: the TLS handshake was rejected by the API (or something in front of it). This is usually temporary and not a credentials problem (EPROTO).` The original is kept as `cause` and the code stays in the text for support. Anything carrying an HTTP status is left alone, so nothing with an API-level meaning gets reworded.

**A third retry delay.** The retry was already firing and already covered `EPROTO` — it just lost. Two delays spend 1.2 s total, and an origin that rejects a handshake tends to keep rejecting for longer. Lennart's failed invocations each took ~1240 ms, i.e. the full budget, against 362 ms for a successful one. Added a 2.5 s third delay: worst case 1.2 s → 3.7 s, still well inside any MCP client timeout.

**Visibility.** The retry notice is `logger.debug` and the cloud runs at info — verified on the droplet, only levels 30 and 40 are emitted. So a call that burned every attempt was indistinguishable from one that failed on the first try, and nobody could tell a flaky upstream from a broken connector. Giving up on a transient failure now logs a warning with the code, method and URL.

## What this deliberately does not do

**It does not route these connectors through the unblocker proxy.** That was the obvious per-customer fix — Lennart's older weclapp connector has all 11 tools on `use_proxy` and never fails, the new one has none and does. But over 30 days direct calls to weclapp succeed 688/894 and proxied ones 121/133, with only 4 TLS errors in the whole direct sample. The failure is transient, not a block, and proxy capacity is metered per workspace. Retrying is the cheaper and more honest answer; flipping a paying customer onto metered egress to paper over a 2-minute blip is not.

Worth noting separately: `use_proxy` is per-tool and defaults to false on import, so re-importing a connector that had been switched to the proxy silently loses it. That is a real trap, but a different fix.

Full suite green: 3994 passed, 236 suites.