### PR TITLE
feat(connectors): put a new connector on a server, and refuse a URL that cannot work

### DIFF
--- a/packages/backend/src/connectors/base-url.util.spec.ts
+++ b/packages/backend/src/connectors/base-url.util.spec.ts
@@ -1,0 +1,144 @@
+import { validateBaseUrl } from './base-url.util';
+
+const cloud = { type: 'REST', requirePublicHost: true };
+const selfHosted = { type: 'REST', requirePublicHost: false };
+
+describe('validateBaseUrl', () => {
+  describe('what production actually contained', () => {
+    // Every value below is a real row from the cloud database. Each produced a
+    // connector with no usable tools and no explanation to the user.
+    it('rejects an API key pasted into the URL field', () => {
+      expect(
+        validateBaseUrl(
+          'https://pk_56532023_AZFKELRKU7FWLDAE9W9X0I9M8KYVIC64',
+          cloud,
+        ),
+      ).toMatch(/not a server address.*Authentication/s);
+    });
+
+    it('rejects a secret key pasted into the URL field', () => {
+      expect(
+        validateBaseUrl(
+          'https://sk_b140c13c4b03ab6be9adee5f77899435a773138067e03db8f5d6017902b1be96',
+          cloud,
+        ),
+      ).toBeTruthy();
+    });
+
+    it('rejects a bare single word', () => {
+      expect(validateBaseUrl('https://Ahmad1', cloud)).toBeTruthy();
+    });
+
+    // Whether the UI prefixed https:// or not, the person pasted a credential.
+    // Both paths must point them at the Authentication section.
+    it('points an unprefixed credential at the Authentication section', () => {
+      expect(
+        validateBaseUrl('pk_56532023_AZFKELRKU7FWLDAE9W9X0I9M8KYVIC64', cloud),
+      ).toMatch(/API key or token, put it under Authentication/);
+    });
+
+    it('does not cry credential over an ordinary typo', () => {
+      expect(validateBaseUrl('htp:/oops', cloud)).not.toMatch(/API key/);
+    });
+
+    it('rejects a javascript: payload', () => {
+      expect(
+        validateBaseUrl(
+          "javascript:changeMode('Update','d051917a3bff919971de904263d8e0e5',' ',' ','project')",
+          cloud,
+        ),
+      ).toMatch(/not a supported scheme/);
+    });
+
+    it('rejects "test" as a database connection string', () => {
+      expect(
+        validateBaseUrl('test', { type: 'DATABASE', requirePublicHost: true }),
+      ).toMatch(/not a database connection string/);
+    });
+  });
+
+  describe('what must keep working', () => {
+    it('accepts an ordinary API base URL', () => {
+      expect(
+        validateBaseUrl('https://api.example.com/v1', cloud),
+      ).toBeNull();
+    });
+
+    it('accepts a real tenant host', () => {
+      expect(
+        validateBaseUrl('https://stryve.weclapp.com/webapp/api/v2', cloud),
+      ).toBeNull();
+    });
+
+    // 20 connectors ship a placeholder resolved per call — Amazon SP-API,
+    // Magento, Substack, Bitrix24. They are not literal URLs and must not be
+    // parsed as such.
+    it('leaves a fully templated URL alone', () => {
+      expect(validateBaseUrl('{{SPAPI_ENDPOINT}}', cloud)).toBeNull();
+    });
+
+    it('leaves a partially templated URL alone', () => {
+      expect(
+        validateBaseUrl('{{MAGENTO_BASE_URL}}/rest/default/V1', cloud),
+      ).toBeNull();
+    });
+
+    it('accepts the database connection strings in use', () => {
+      const db = { type: 'DATABASE', requirePublicHost: true };
+      expect(
+        validateBaseUrl(
+          'postgresql://user:pass@aws-0-eu-central-1.pooler.supabase.com:5432/postgres?sslmode=no-verify',
+          db,
+        ),
+      ).toBeNull();
+      expect(
+        validateBaseUrl('mysql://bz-spjk:pw@14.103.194.152:3306/bz-spjk', db),
+      ).toBeNull();
+    });
+
+    it('accepts an IPv4 host', () => {
+      expect(validateBaseUrl('http://78.24.216.122:8080/api', cloud)).toBeNull();
+    });
+
+    it('accepts localhost', () => {
+      expect(validateBaseUrl('http://localhost:3000', cloud)).toBeNull();
+    });
+  });
+
+  // A self-hosted instance reaches services by Docker network name; the cloud
+  // has no internal network, so there a single label is always a mistake.
+  describe('single-label hosts', () => {
+    it('are refused on cloud', () => {
+      expect(validateBaseUrl('http://weclapp:8080', cloud)).toBeTruthy();
+    });
+
+    it('are allowed when self-hosted', () => {
+      expect(validateBaseUrl('http://weclapp:8080', selfHosted)).toBeNull();
+    });
+  });
+
+  describe('basics', () => {
+    it('requires a value', () => {
+      expect(validateBaseUrl('   ', cloud)).toMatch(/required/);
+      expect(validateBaseUrl(undefined as unknown as string, cloud)).toMatch(
+        /required/,
+      );
+    });
+
+    it('rejects something that is not a URL at all', () => {
+      expect(validateBaseUrl('not a url', cloud)).toMatch(/not a valid URL/);
+    });
+
+    it('rejects ftp://', () => {
+      expect(validateBaseUrl('ftp://files.example.com', cloud)).toMatch(
+        /not a supported scheme/,
+      );
+    });
+
+    it('truncates a long offending value instead of echoing all of it', () => {
+      const problem = validateBaseUrl(`https://${'x'.repeat(200)}`, cloud);
+      expect(problem!.length).toBeLessThan(260);
+      expect(problem).toContain('…');
+    });
+  });
+});

--- a/packages/backend/src/connectors/base-url.util.spec.ts
+++ b/packages/backend/src/connectors/base-url.util.spec.ts
@@ -135,6 +135,23 @@ describe('validateBaseUrl', () => {
       );
     });
 
+    // The placeholder check used to be /\{\{[^}]+\}\}/, which backtracks
+    // quadratically on a run of '{' (CodeQL js/polynomial-redos) — and this
+    // value arrives straight from a request body.
+    it('handles a pathological run of braces without stalling', () => {
+      const started = Date.now();
+      expect(validateBaseUrl('{'.repeat(50_000), cloud)).toBeTruthy();
+      expect(Date.now() - started).toBeLessThan(500);
+    });
+
+    it('still treats a real placeholder as templated', () => {
+      expect(validateBaseUrl('{{X}}/v1', cloud)).toBeNull();
+    });
+
+    it('does not treat an empty placeholder as one', () => {
+      expect(validateBaseUrl('{{}}', cloud)).toBeTruthy();
+    });
+
     it('truncates a long offending value instead of echoing all of it', () => {
       const problem = validateBaseUrl(`https://${'x'.repeat(200)}`, cloud);
       expect(problem!.length).toBeLessThan(260);

--- a/packages/backend/src/connectors/base-url.util.ts
+++ b/packages/backend/src/connectors/base-url.util.ts
@@ -1,0 +1,119 @@
+/**
+ * Base-URL sanity checks for connector create/update.
+ *
+ * `baseUrl` used to be validated as `@IsString()` and nothing more, so the API
+ * happily stored things that could never work. A fortnight of production rows:
+ * an API key the user pasted into the URL field and the UI prefixed with
+ * `https://` (`https://pk_56532023_AZFKELRKU7FWLDAE9W9X0I9M8KYVIC64`), a bare
+ * `https://Ahmad1`, a `javascript:` payload, and DATABASE connectors reading
+ * `test`, `adada` and `cx`. Each one produced a connector with zero usable
+ * tools and no explanation — and of the people who got that far in the last two
+ * weeks, most never came back.
+ *
+ * The checks are deliberately shallow. They reject what cannot possibly be
+ * right, and say what to do instead; they do not try to prove the host exists.
+ */
+
+/** Schemes a DATABASE connector's connection string may use. */
+const DATABASE_SCHEMES = [
+  'postgres',
+  'postgresql',
+  'mysql',
+  'mariadb',
+  'mssql',
+  'sqlserver',
+];
+
+/**
+ * Hosts that are legitimately single-label. Anything else without a dot is
+ * either an internal Docker/Kubernetes service name — fine when self-hosting,
+ * impossible from the cloud — or, far more often, a pasted secret.
+ */
+const SINGLE_LABEL_ALLOWED = ['localhost'];
+
+const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/**
+ * Connectors may carry `{{ENV_VAR}}` placeholders resolved per call (Amazon
+ * SP-API, Magento, Substack and Bitrix24 all ship this way), so a templated URL
+ * is not a literal one and cannot be parsed here.
+ */
+function isTemplated(baseUrl: string): boolean {
+  return /\{\{[^}]+\}\}/.test(baseUrl);
+}
+
+/**
+ * Returns a human-readable problem, or null when the URL is plausible.
+ *
+ * @param requirePublicHost Reject single-label hostnames. True on cloud, where
+ * every connector necessarily calls a public API; false when self-hosted, where
+ * `http://weclapp:8080` is a perfectly good address on the Docker network.
+ */
+export function validateBaseUrl(
+  baseUrl: string,
+  opts: { type: string; requirePublicHost: boolean },
+): string | null {
+  const raw = (baseUrl ?? '').trim();
+
+  if (!raw) return 'A base URL is required.';
+  if (isTemplated(raw)) return null;
+
+  if (opts.type === 'DATABASE') {
+    const scheme = raw.split('://')[0]?.toLowerCase();
+    if (!raw.includes('://') || !DATABASE_SCHEMES.includes(scheme)) {
+      return `"${truncate(raw)}" is not a database connection string. Use one of ${DATABASE_SCHEMES.join(
+        ', ',
+      )}, for example postgresql://user:password@host:5432/database.`;
+    }
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return `"${truncate(
+      raw,
+    )}" is not a valid URL. It should look like https://api.example.com/v1.${credentialHint(
+      raw,
+    )}`;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return `"${url.protocol}" is not a supported scheme — the base URL must start with https:// (or http:// for a local service).`;
+  }
+
+  if (opts.requirePublicHost && !looksLikeAHost(url.hostname)) {
+    return `"${truncate(
+      url.hostname,
+    )}" is not a server address. The base URL is where your API lives, e.g. https://api.example.com/v1 — if this is an API key or token, put it under Authentication instead.`;
+  }
+
+  return null;
+}
+
+/**
+ * The single most common way this field goes wrong is a pasted credential —
+ * a ClickUp `pk_…`, a Stripe-style `sk_…`. Say so when the value looks like
+ * one, because "that is not a URL" does not tell someone where it belongs.
+ */
+function credentialHint(raw: string): string {
+  const looksLikeSecret =
+    !raw.includes('.') && !raw.includes('/') && raw.length >= 16;
+  return looksLikeSecret
+    ? ' If this is an API key or token, put it under Authentication instead.'
+    : '';
+}
+
+function looksLikeAHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (SINGLE_LABEL_ALLOWED.includes(host)) return true;
+  // Bracketed IPv6 arrives from URL.hostname without the brackets but with colons.
+  if (host.includes(':')) return true;
+  if (IPV4.test(host)) return true;
+  return host.includes('.');
+}
+
+function truncate(value: string, max = 48): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}

--- a/packages/backend/src/connectors/base-url.util.ts
+++ b/packages/backend/src/connectors/base-url.util.ts
@@ -39,7 +39,13 @@ const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
  * is not a literal one and cannot be parsed here.
  */
 function isTemplated(baseUrl: string): boolean {
-  return /\{\{[^}]+\}\}/.test(baseUrl);
+  // Two indexOf scans rather than /\{\{[^}]+\}\}/. The regex backtracks
+  // quadratically on an input of many '{' — CodeQL js/polynomial-redos — and
+  // this value comes straight from a request body. Same question either way:
+  // is there an opening '{{' with a non-empty run before a closing '}}'.
+  const open = baseUrl.indexOf('{{');
+  if (open === -1) return false;
+  return baseUrl.indexOf('}}', open + 2) > open + 2;
 }
 
 /**

--- a/packages/backend/src/connectors/connectors.controller.spec.ts
+++ b/packages/backend/src/connectors/connectors.controller.spec.ts
@@ -8,6 +8,8 @@ function buildController(overrides: {
   prisma?: any;
   mcpServer?: any;
   licenseGuard?: any;
+  mcpServers?: any;
+  deployment?: any;
 } = {}) {
   const connectorsService = overrides.connectorsService ?? {
     create: jest.fn().mockResolvedValue({ id: 'c1', type: 'REST' }),
@@ -23,6 +25,12 @@ function buildController(overrides: {
     checkCanCreateConnector: jest.fn().mockResolvedValue(undefined),
   };
   const configService = { get: jest.fn().mockReturnValue(VALID_ENCRYPTION_KEY) };
+  const mcpServers = overrides.mcpServers ?? {
+    attachToDefaultServer: jest
+      .fn()
+      .mockResolvedValue({ id: 's1', name: 'Default' }),
+  };
+  const deployment = overrides.deployment ?? { isCloud: () => true };
 
   const controller = new ConnectorsController(
     connectorsService as any,
@@ -38,9 +46,19 @@ function buildController(overrides: {
     mcpServer as any,
     configService as any,
     licenseGuard as any,
+    mcpServers as any,
+    deployment as any,
   );
 
-  return { controller, connectorsService, prisma, mcpServer, licenseGuard };
+  return {
+    controller,
+    connectorsService,
+    prisma,
+    mcpServer,
+    licenseGuard,
+    mcpServers,
+    deployment,
+  };
 }
 
 const req = (role: string) => ({
@@ -259,5 +277,115 @@ describe('OAuth2 config endpoints', () => {
       expect(result.clientId).toBe('');
       expect(result.tokenAuthMethod).toBe('client_secret_post');
     });
+  });
+});
+
+/**
+ * A connector that is not on any MCP server is reachable by nobody. Assigning
+ * it used to be a separate page, and in the fortnight to 11 Sep 2026, 49 of the
+ * 84 workspaces that imported a working connector never found it.
+ */
+describe('ConnectorsController attaches new connectors to a server', () => {
+  const dto = {
+    name: 'Acme',
+    type: 'REST',
+    baseUrl: 'https://api.acme.example/v1',
+  } as any;
+
+  it('attaches to the default server and reports which one', async () => {
+    const { controller, mcpServers } = buildController();
+
+    const result: any = await controller.create(req('ADMIN'), dto);
+
+    expect(mcpServers.attachToDefaultServer).toHaveBeenCalledWith(
+      'u1',
+      'org1',
+      'c1',
+    );
+    expect(result.attachedToServer).toEqual({ id: 's1', name: 'Default' });
+  });
+
+  it('still returns the connector when there is no server to attach to', async () => {
+    const { controller } = buildController({
+      mcpServers: { attachToDefaultServer: jest.fn().mockResolvedValue(null) },
+    });
+
+    const result: any = await controller.create(req('ADMIN'), dto);
+
+    expect(result.id).toBe('c1');
+    expect(result.attachedToServer).toBeNull();
+  });
+});
+
+describe('ConnectorsController base-URL validation', () => {
+  // The real row that started this: a ClickUp API key typed into the URL field,
+  // which the UI prefixed with https:// and the API stored without complaint.
+  const pastedApiKey = {
+    name: 'Click Up',
+    type: 'MCP',
+    baseUrl: 'https://pk_56532023_AZFKELRKU7FWLDAE9W9X0I9M8KYVIC64',
+  } as any;
+
+  it('refuses to create a connector whose URL is not a server address', async () => {
+    const { controller, connectorsService } = buildController();
+
+    await expect(controller.create(req('ADMIN'), pastedApiKey)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(connectorsService.create).not.toHaveBeenCalled();
+  });
+
+  it('refuses before consuming the licence check', async () => {
+    const { controller, licenseGuard } = buildController();
+
+    await expect(
+      controller.create(req('ADMIN'), pastedApiKey),
+    ).rejects.toThrow(BadRequestException);
+    expect(licenseGuard.checkCanCreateConnector).not.toHaveBeenCalled();
+  });
+
+  it('allows a Docker service name when self-hosted', async () => {
+    const { controller, connectorsService } = buildController({
+      deployment: { isCloud: () => false },
+    });
+
+    await controller.create(req('ADMIN'), {
+      name: 'weclapp',
+      type: 'REST',
+      baseUrl: 'http://weclapp:8080',
+    } as any);
+
+    expect(connectorsService.create).toHaveBeenCalled();
+  });
+
+  it('validates the URL on update too', async () => {
+    const { controller, connectorsService } = buildController({
+      connectorsService: {
+        findById: jest
+          .fn()
+          .mockResolvedValue({ id: 'c1', type: 'REST', organizationId: 'org1' }),
+        update: jest.fn(),
+      },
+    });
+
+    await expect(
+      controller.update(req('ADMIN'), 'c1', { baseUrl: 'https://Ahmad1' } as any),
+    ).rejects.toThrow(BadRequestException);
+    expect(connectorsService.update).not.toHaveBeenCalled();
+  });
+
+  it('leaves an update that does not touch the URL alone', async () => {
+    const { controller, connectorsService } = buildController({
+      connectorsService: {
+        findById: jest
+          .fn()
+          .mockResolvedValue({ id: 'c1', type: 'REST', organizationId: 'org1' }),
+        update: jest.fn().mockResolvedValue({ id: 'c1' }),
+      },
+    });
+
+    await controller.update(req('ADMIN'), 'c1', { name: 'Renamed' } as any);
+
+    expect(connectorsService.update).toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -41,6 +41,9 @@ import { CurlParser } from './parsers/curl.parser';
 import { McpClientEngine } from './engines/mcp-client.engine';
 import { McpOAuthService } from './mcp-oauth.service';
 import { CatalogResyncService } from './catalog-resync.service';
+import { McpServersService } from '../mcp-servers/mcp-servers.service';
+import { DeploymentService } from '../common/deployment.service';
+import { validateBaseUrl } from './base-url.util';
 import { PrismaService } from '../common/prisma.service';
 import { McpServerService } from '../mcp-server/mcp-server.service';
 import { LicenseGuardService } from '../license/license-guard.service';
@@ -441,6 +444,8 @@ export class ConnectorsController {
     private readonly mcpServer: McpServerService,
     private readonly configService: ConfigService,
     private readonly licenseGuard: LicenseGuardService,
+    private readonly mcpServers: McpServersService,
+    private readonly deployment: DeploymentService,
   ) {
     this.encryptionKey = getRequiredSecret(
       'ENCRYPTION_KEY',
@@ -487,6 +492,7 @@ export class ConnectorsController {
   @ApiOperation({ summary: 'Create a new connector' })
   async create(@Req() req: any, @Body() dto: CreateConnectorDto) {
     this.assertCanCreate(req);
+    this.assertUsableBaseUrl(dto.baseUrl, dto.type);
     await this.licenseGuard.checkCanCreateConnector(req.user.sub, req.user.organizationId);
     const connector = await this.connectorsService.create(req.user.sub, req.user.organizationId, dto);
 
@@ -546,7 +552,36 @@ export class ConnectorsController {
       );
     }
 
-    return connector;
+    // Put the connector on a server straight away. Assigning it was a separate
+    // page most people never found: of the 84 workspaces that imported a
+    // working connector in the last fortnight, 49 never attached it to
+    // anything, so their tools were reachable by nobody. Additive, so an
+    // existing server keeps what it already had, and detaching is one click.
+    const attachedTo = await this.mcpServers.attachToDefaultServer(
+      req.user.sub,
+      req.user.organizationId,
+      connector.id,
+    );
+    if (attachedTo) {
+      this.logger.log(
+        `Attached connector ${connector.id} to MCP server ${attachedTo.id}`,
+      );
+    }
+
+    return { ...connector, attachedToServer: attachedTo };
+  }
+
+  /**
+   * Reject a base URL that cannot work, with a message that says what to do.
+   * Single-label hostnames are only refused on cloud — self-hosted instances
+   * legitimately reach services by Docker network name.
+   */
+  private assertUsableBaseUrl(baseUrl: string, type: string): void {
+    const problem = validateBaseUrl(baseUrl, {
+      type,
+      requirePublicHost: this.deployment.isCloud(),
+    });
+    if (problem) throw new BadRequestException(problem);
   }
 
   @Get('proxy-availability')
@@ -668,6 +703,9 @@ export class ConnectorsController {
   ) {
     const connector = await this.connectorsService.findById(id);
     this.assertCanWrite(connector, req);
+    if (dto.baseUrl !== undefined) {
+      this.assertUsableBaseUrl(dto.baseUrl, connector.type);
+    }
     return this.connectorsService.update(id, dto);
   }
 

--- a/packages/backend/src/connectors/connectors.module.ts
+++ b/packages/backend/src/connectors/connectors.module.ts
@@ -21,6 +21,7 @@ import { McpOAuthCallbackController } from './mcp-oauth-callback.controller';
 import { CatalogResyncService } from './catalog-resync.service';
 import { CatalogReconciler } from './catalog-reconciler.service';
 import { LicenseModule } from '../license/license.module';
+import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 
 const ENGINES = [
   RestEngine,
@@ -33,7 +34,7 @@ const ENGINES = [
 const PARSERS = [OpenApiParser, WsdlParser, GraphqlParser, PostmanParser, CurlParser];
 
 @Module({
-  imports: [McpServerModule, LicenseModule],
+  imports: [McpServerModule, McpServersModule, LicenseModule],
   controllers: [ConnectorsController, McpOAuthCallbackController, ToolsController],
   providers: [
     ConnectorsService,

--- a/packages/backend/src/mcp-servers/mcp-servers.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.service.ts
@@ -138,6 +138,53 @@ export class McpServersService {
       );
   }
 
+  /**
+   * Attach one connector to the user's default server, additively.
+   *
+   * Distinct from {@link assignConnectors}, which replaces the whole set — the
+   * caller here is connector creation, and a new connector must never silently
+   * detach the ones already on the server.
+   *
+   * Returns the server it attached to, or null when there is nothing sensible
+   * to attach to. Never throws: a connector that exists but is not wired up is
+   * recoverable in the UI, a failed creation is not.
+   */
+  async attachToDefaultServer(
+    userId: string,
+    organizationId: string,
+    connectorId: string,
+  ): Promise<{ id: string; name: string } | null> {
+    try {
+      const server = await this.prisma.mcpServerConfig.findFirst({
+        where: { userId, organizationId, isActive: true },
+        orderBy: { createdAt: 'asc' },
+        select: { id: true, name: true },
+      });
+      if (!server) return null;
+
+      await this.prisma.mcpServerConnector.create({
+        data: { mcpServerId: server.id, connectorId },
+      });
+
+      this.sessionManager
+        .notifyToolsChanged()
+        .catch((e) =>
+          this.logger.warn(`MCP session notify failed: ${e.message}`),
+        );
+
+      return server;
+    } catch (e: any) {
+      // P2002 = already attached. Creation is retried often enough (import,
+      // re-import, catalog resync) that this is expected, not a fault.
+      if (e?.code !== 'P2002') {
+        this.logger.warn(
+          `Could not attach connector ${connectorId} to a default server: ${e?.message}`,
+        );
+      }
+      return null;
+    }
+  }
+
   async getConnectorIds(serverId: string): Promise<string[]> {
     const rows = await this.prisma.mcpServerConnector.findMany({
       where: { mcpServerId: serverId },

--- a/packages/frontend/src/app/connectors/new/page.tsx
+++ b/packages/frontend/src/app/connectors/new/page.tsx
@@ -156,10 +156,19 @@ export default function NewConnectorPage() {
       const full = await connectors.get(created.id, token);
       const hasTools = (full.tools?.length || 0) > 0;
 
-      if (hasTools) {
-        setCreatedConnector({ id: created.id, name: name || created.name });
-      } else {
+      if (!hasTools) {
         router.push(`/connectors/${created.id}`);
+      } else if (created.attachedToServer) {
+        // Already on a server, so there is no choice left to make here. Go
+        // straight to that server: its page carries the URL to paste into
+        // Claude, which is the next thing anyone needs. The modal this
+        // replaces offered "Skip for now", and most people took it — 49 of the
+        // 84 workspaces that imported a working connector in the fortnight to
+        // 11 Sep 2026 left it attached to nothing, reachable by no agent.
+        // Reassigning is still one click from the connector page.
+        router.push(`/mcp-server/${created.attachedToServer.id}`);
+      } else {
+        setCreatedConnector({ id: created.id, name: name || created.name });
       }
     } catch (err: any) {
       setError(err.message);

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -187,8 +187,16 @@ export const connectors = {
     request<any[]>('/api/connectors', { token }),
   proxyAvailability: (token: string) =>
     request<{ available: boolean }>('/api/connectors/proxy-availability', { token }),
+  /**
+   * `attachedToServer` is the MCP server the backend put the connector on, or
+   * null when the workspace has none yet. Attaching used to be a separate step
+   * the caller had to remember.
+   */
   create: (data: unknown, token: string) =>
-    request<any>('/api/connectors', { method: 'POST', body: data, token }),
+    request<any & { attachedToServer: { id: string; name: string } | null }>(
+      '/api/connectors',
+      { method: 'POST', body: data, token },
+    ),
   get: (id: string, token: string) =>
     request<any>(`/api/connectors/${id}`, { token }),
   update: (id: string, data: unknown, token: string) =>


### PR DESCRIPTION
## The funnel this targets

Fortnight to 11 Sep 2026, cloud:

| | workspaces |
|---|---|
| signed up | 430 |
| imported a connector | 92 |
| **connector whose tools generated correctly** | **84** |
| → never attached it to an MCP server | **49** |
| attached it | 35 |
| → never made a call | 21 |
| made a successful call | **9** |

The import works — 84 workspaces got a working connector. Then 70 of them fell off two purely mechanical steps. This PR is the first of those two.

## 49 connectors that no agent could reach

Assigning a connector to an MCP server was a modal with a **"Skip for now"** button, and most people took it (or clicked the backdrop). Their tools existed and were exposed to nobody.

A new connector now goes onto the user's server as it is created. Additive, not `assignConnectors`'s replace-all — a new connector must never silently detach what is already there. Creation returns `attachedToServer`, and with the choice already made the frontend skips the modal and lands the user on the **server page**, which carries the MCP endpoint URL to paste into Claude. That is the next thing anyone needs, and it is also step two of the funnel above.

Reassigning stays one click from the connector page. The modal still appears for a workspace with no server yet, where it also offers to create one.

## URLs that could never work

`baseUrl` was `@IsString()` and nothing more. Real production rows:

```
https://pk_56532023_AZFKELRKU7FWLDAE9W9X0I9M8KYVIC64   ← a ClickUp API key
https://Ahmad1
javascript:changeMode('Update','d051917a3bff919971de904263d8e0e5',…)
test / adada / cx                                       ← DATABASE connectors
```

Every one was accepted, produced a connector with zero tools, and explained nothing. Create and update now refuse them with a message that says what to do — including naming the Authentication section when the value looks like a pasted credential, which is how this fails most often.

The checks are deliberately shallow and know what production actually holds:

- **`{{ENV_VAR}}` placeholders are left alone** — 20 connectors ship one (Amazon SP-API, Magento, Substack, Bitrix24) and are not literal URLs.
- **DATABASE keeps its connection strings** — `postgresql://`, `mysql://` and friends, 27 rows.
- **Single-label hosts are refused only on cloud.** Self-hosted instances legitimately reach services by Docker network name (`http://weclapp:8080`); the cloud has no internal network, so there it is always a mistake.

## Verified in a browser, not just in tests

Against a local stack (own Postgres, `DEPLOYMENT_MODE=cloud`):

1. Reproduced Laura's row — pasted the ClickUp key into the URL field of an MCP connector. Refused, with *"…is not a valid URL. It should look like https://api.example.com/v1. If this is an API key or token, put it under Authentication instead."* Nothing was written.
2. Created a Petstore REST connector from its OpenAPI spec → 19 tools imported, `mcp_server_connectors` row present, landed on the server page with the endpoint and the Quick Connect buttons for Claude Web/Desktop, Cursor, ChatGPT.

Backend suite green: 4021 passed, 237 suites. Frontend lint and typecheck clean.