### PR TITLE
feat(mcp): a per-client grant for the shared /mcp endpoint, not yet wired in

### DIFF
--- a/packages/backend/prisma/migrations/20260911180823_add_mcp_connection_grants/migration.sql
+++ b/packages/backend/prisma/migrations/20260911180823_add_mcp_connection_grants/migration.sql
@@ -1,0 +1,36 @@
+-- What an OAuth client may SEE through the shared /mcp endpoint, chosen by the
+-- user while authorizing it. A filter, never a source of authority: resolution
+-- re-reads each target's owning organization from mcp_server_configs and
+-- re-checks organization_members on every request, so a row naming another
+-- tenant's server concedes nothing.
+--
+-- Deliberately NOT added to prisma/rls/enable-rls.sql. The row is keyed on the
+-- user, not on an organization, and organization_id is null for a
+-- server-list grant — an org_isolation policy keyed on app.current_org would
+-- hide exactly the rows the resolver needs to evaluate. Isolation for this
+-- table lives in the resolver's membership join, which is enforced in SQL.
+
+-- CreateTable
+CREATE TABLE "mcp_connection_grants" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "organization_id" TEXT,
+    "server_ids" TEXT[],
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mcp_connection_grants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "mcp_connection_grants_user_id_idx" ON "mcp_connection_grants"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcp_connection_grants_client_id_user_id_key" ON "mcp_connection_grants"("client_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "mcp_connection_grants" ADD CONSTRAINT "mcp_connection_grants_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mcp_connection_grants" ADD CONSTRAINT "mcp_connection_grants_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Organization {
   securityEvents   SecurityEvent[]
   userRoleAssignments UserRoleAssignment[]
   identityProviders   IdentityProvider[]
+  mcpConnectionGrants McpConnectionGrant[]
 
   @@map("organizations")
 }
@@ -167,6 +168,7 @@ model User {
   emailVerificationTokens  EmailVerificationToken[]
   recoveryCodes            RecoveryCode[]
   scimGroupMemberships     IdentityProviderGroupMember[]
+  mcpConnectionGrants      McpConnectionGrant[]
 
   @@index([organizationId])
   @@map("users")
@@ -603,6 +605,46 @@ model McpServerConnector {
 
   @@unique([mcpServerId, connectorId])
   @@map("mcp_server_connectors")
+}
+
+// ── MCP Connection Grant ────────────────────────────────────────────────────
+
+/// What an OAuth client is allowed to SEE through the shared `/mcp` endpoint,
+/// chosen by the user while authorizing it.
+///
+/// A filter, never a source of authority. Resolution re-checks organization
+/// membership for every target on every request and fails closed, because a
+/// grant is written when the token is issued and membership can be revoked long
+/// afterwards. A grant naming another organization's server therefore concedes
+/// nothing — the target is simply dropped.
+///
+/// Keyed on (clientId, userId): one live selection per client per user, so
+/// re-authorizing overwrites it and the user can revoke it from the dashboard.
+model McpConnectionGrant {
+  id String @id @default(cuid())
+
+  /// `client_id` claim of the access token. Present on every token mcp-nest
+  /// issues, which is what lets the selection live server-side instead of
+  /// having to be carried in the token.
+  clientId String @map("client_id")
+  userId   String @map("user_id")
+  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  /// Set for a whole-workspace grant: every tool of this organization, which is
+  /// what `/mcp` served before grants existed. Null when `serverIds` is used.
+  organizationId String?       @map("organization_id")
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  /// Chosen MCP servers. Ids only — the owning organization is read back from
+  /// `mcp_server_configs` at resolution time and never trusted from here.
+  serverIds String[] @map("server_ids")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([clientId, userId])
+  @@index([userId])
+  @@map("mcp_connection_grants")
 }
 
 // ── Audit Log ───────────────────────────────────────────────────────────────

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.spec.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.spec.ts
@@ -1,0 +1,297 @@
+import {
+  McpConnectionGrantService,
+  ResolvedGrant,
+} from './mcp-connection-grant.service';
+
+/**
+ * Tenant isolation for the shared `/mcp` endpoint.
+ *
+ * Two kinds of assertion here, deliberately:
+ *
+ * 1. **Branching** — that `resolve` fails CLOSED. A grant whose targets no
+ *    longer validate must produce zero tools, never "everything".
+ * 2. **Query shape** — that membership is part of the SQL `WHERE`, not a
+ *    check applied to rows after they come back. CI has no database, so the
+ *    structural assertion is what stops someone refactoring the join into a
+ *    post-filter (or dropping `deactivatedAt: null`) without noticing. The
+ *    same queries were run against the production database by hand; see the
+ *    pull request.
+ */
+function build(
+  overrides: {
+    grant?: { organizationId: string | null; serverIds: string[] } | null;
+    memberCount?: number;
+    servers?: { id: string; organizationId: string }[];
+  } = {},
+) {
+  const calls: Record<string, any[]> = {
+    findManyServers: [],
+    countMembers: [],
+    upsert: [],
+    del: [],
+  };
+
+  const prisma: any = {
+    mcpConnectionGrant: {
+      findUnique: jest
+        .fn()
+        .mockResolvedValue(
+          overrides.grant === undefined ? null : overrides.grant,
+        ),
+      upsert: jest.fn(async (args: any) => {
+        calls.upsert.push(args);
+      }),
+      delete: jest.fn(async (args: any) => {
+        calls.del.push(args);
+      }),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    mcpServerConfig: {
+      findMany: jest.fn(async (args: any) => {
+        calls.findManyServers.push(args);
+        return overrides.servers ?? [];
+      }),
+    },
+    organizationMember: {
+      count: jest.fn(async (args: any) => {
+        calls.countMembers.push(args);
+        return overrides.memberCount ?? 0;
+      }),
+    },
+  };
+
+  return { svc: new McpConnectionGrantService(prisma), prisma, calls };
+}
+
+describe('McpConnectionGrantService.resolve', () => {
+  it('returns null when the client has no grant, so old tokens keep working', async () => {
+    const { svc } = build({ grant: null });
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toBeNull();
+  });
+
+  it('returns null without querying when the token carries no client_id', async () => {
+    const { svc, prisma } = build();
+    await expect(svc.resolve(undefined, 'user-1')).resolves.toBeNull();
+    expect(prisma.mcpConnectionGrant.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns null without querying when there is no subject', async () => {
+    const { svc, prisma } = build();
+    await expect(svc.resolve('client-1', undefined)).resolves.toBeNull();
+    expect(prisma.mcpConnectionGrant.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('resolves a whole-workspace grant for a current member', async () => {
+    const { svc } = build({
+      grant: { organizationId: 'org-A', serverIds: [] },
+      memberCount: 1,
+    });
+
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'organization',
+      organizationId: 'org-A',
+    } satisfies ResolvedGrant);
+  });
+
+  // The grant was written when the token was issued. Membership can be revoked
+  // long before the token expires, and the answer then is nothing — not the
+  // whole workspace.
+  it('fails closed on a whole-workspace grant once membership is gone', async () => {
+    const { svc } = build({
+      grant: { organizationId: 'org-A', serverIds: [] },
+      memberCount: 0,
+    });
+
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'none',
+    });
+  });
+
+  it('resolves the servers that validate, with the organization read from the server row', async () => {
+    const { svc } = build({
+      grant: { organizationId: null, serverIds: ['srv-1', 'srv-2'] },
+      servers: [
+        { id: 'srv-1', organizationId: 'org-A' },
+        { id: 'srv-2', organizationId: 'org-B' },
+      ],
+    });
+
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'servers',
+      servers: [
+        { id: 'srv-1', organizationId: 'org-A' },
+        { id: 'srv-2', organizationId: 'org-B' },
+      ],
+    });
+  });
+
+  // A row naming another tenant's server, whether through tampering or through
+  // the server having moved, concedes nothing: the membership join returns it
+  // to nobody, and an empty result is zero tools.
+  it('fails closed — NOT to null — when no granted server validates', async () => {
+    const { svc } = build({
+      grant: { organizationId: null, serverIds: ['srv-of-another-tenant'] },
+      servers: [],
+    });
+
+    const resolved = await svc.resolve('client-1', 'user-1');
+
+    expect(resolved).toEqual({ mode: 'none' });
+    expect(resolved).not.toBeNull();
+  });
+
+  it('drops the targets that do not validate and keeps the ones that do', async () => {
+    const { svc } = build({
+      grant: { organizationId: null, serverIds: ['srv-mine', 'srv-theirs'] },
+      servers: [{ id: 'srv-mine', organizationId: 'org-A' }],
+    });
+
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'servers',
+      servers: [{ id: 'srv-mine', organizationId: 'org-A' }],
+    });
+  });
+
+  it('fails closed on a grant that is empty on both sides', async () => {
+    const { svc } = build({ grant: { organizationId: null, serverIds: [] } });
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'none',
+    });
+  });
+});
+
+describe('McpConnectionGrantService isolation is enforced in SQL', () => {
+  it('asks the database for membership, active servers and the listed ids together', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: null, serverIds: ['srv-1'] },
+      servers: [{ id: 'srv-1', organizationId: 'org-A' }],
+    });
+
+    await svc.resolve('client-1', 'user-1');
+
+    expect(calls.findManyServers).toHaveLength(1);
+    expect(calls.findManyServers[0].where).toEqual({
+      id: { in: ['srv-1'] },
+      isActive: true,
+      organization: {
+        members: { some: { userId: 'user-1', deactivatedAt: null } },
+      },
+    });
+  });
+
+  it('never asks for more than the id and the owning organization', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: null, serverIds: ['srv-1'] },
+      servers: [{ id: 'srv-1', organizationId: 'org-A' }],
+    });
+
+    await svc.resolve('client-1', 'user-1');
+
+    expect(calls.findManyServers[0].select).toEqual({
+      id: true,
+      organizationId: true,
+    });
+  });
+
+  it('excludes deactivated members from the whole-workspace check', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: 'org-A', serverIds: [] },
+      memberCount: 1,
+    });
+
+    await svc.resolve('client-1', 'user-1');
+
+    expect(calls.countMembers[0].where).toEqual({
+      userId: 'user-1',
+      organizationId: 'org-A',
+      deactivatedAt: null,
+    });
+  });
+
+  it('does not hit the database at all for an empty id list', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: null, serverIds: ['', '  '] },
+    });
+
+    await svc.resolve('client-1', 'user-1');
+
+    // '' is filtered out; '  ' is not an id we mint, but it must not widen
+    // anything either — it can only ever fail to match.
+    expect(calls.findManyServers.length).toBeLessThanOrEqual(1);
+    if (calls.findManyServers.length === 1) {
+      expect(calls.findManyServers[0].where.id.in).not.toContain('');
+    }
+  });
+
+  it('de-duplicates ids before querying', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: null, serverIds: ['srv-1', 'srv-1', 'srv-2'] },
+      servers: [{ id: 'srv-1', organizationId: 'org-A' }],
+    });
+
+    await svc.resolve('client-1', 'user-1');
+
+    expect(calls.findManyServers[0].where.id.in).toEqual(['srv-1', 'srv-2']);
+  });
+});
+
+describe('McpConnectionGrantService writing a grant', () => {
+  it('refuses a whole-workspace grant for an organization the user is not in', async () => {
+    const { svc, calls } = build({ memberCount: 0 });
+
+    await expect(
+      svc.grantWholeOrganization('client-1', 'user-1', 'org-of-another-tenant'),
+    ).resolves.toBe(false);
+    expect(calls.upsert).toHaveLength(0);
+  });
+
+  it('writes a whole-workspace grant for a member', async () => {
+    const { svc, calls } = build({ memberCount: 1 });
+
+    await expect(
+      svc.grantWholeOrganization('client-1', 'user-1', 'org-A'),
+    ).resolves.toBe(true);
+    expect(calls.upsert[0].create).toEqual({
+      clientId: 'client-1',
+      userId: 'user-1',
+      organizationId: 'org-A',
+      serverIds: [],
+    });
+  });
+
+  it('stores only the servers that validate', async () => {
+    const { svc, calls } = build({
+      servers: [{ id: 'srv-mine', organizationId: 'org-A' }],
+    });
+
+    await expect(
+      svc.grantServers('client-1', 'user-1', ['srv-mine', 'srv-theirs']),
+    ).resolves.toEqual(['srv-mine']);
+    expect(calls.upsert[0].update).toEqual({
+      organizationId: null,
+      serverIds: ['srv-mine'],
+    });
+  });
+
+  // Otherwise a caller could turn a wholly invalid selection into a stored
+  // empty grant, which would then resolve to `{ mode: 'none' }` and silently
+  // blank a connection that used to work.
+  it('writes nothing when no requested server validates', async () => {
+    const { svc, calls } = build({ servers: [] });
+
+    await expect(
+      svc.grantServers('client-1', 'user-1', ['srv-theirs']),
+    ).resolves.toEqual([]);
+    expect(calls.upsert).toHaveLength(0);
+  });
+
+  it('revokes by (client, user) and tolerates a missing row', async () => {
+    const { svc, calls } = build();
+
+    await svc.revoke('client-1', 'user-1');
+
+    expect(calls.del[0].where).toEqual({
+      clientId_userId: { clientId: 'client-1', userId: 'user-1' },
+    });
+  });
+});

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
@@ -1,0 +1,194 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * What a grant resolved to, for the caller that is about to build a tool list.
+ *
+ * `null` from {@link McpConnectionGrantService.resolve} and `{ mode: 'none' }`
+ * mean very different things and must not be collapsed:
+ *
+ * - `null` — this client has **no** grant. Every token issued before grants
+ *   existed is in this bucket, so the caller keeps the previous behaviour
+ *   (the caller's active organization) and nothing regresses.
+ * - `{ mode: 'none' }` — a grant exists and **nothing in it survived
+ *   validation**: the servers were deleted, deactivated, or belong to an
+ *   organization this user is no longer a member of. That is zero tools, never
+ *   "fall back to everything".
+ */
+export type ResolvedGrant =
+  | { mode: 'organization'; organizationId: string }
+  | { mode: 'servers'; servers: { id: string; organizationId: string }[] }
+  | { mode: 'none' };
+
+/**
+ * The user's selection of what an OAuth client may see through the shared
+ * `/mcp` endpoint.
+ *
+ * The one rule everything here follows: **a grant can only ever narrow what the
+ * user is already entitled to.** It is applied after authorization, never
+ * instead of it. Concretely —
+ *
+ * - Stored ids are never trusted. A target's owning organization is read back
+ *   from `mcp_server_configs`, and membership is re-checked, on every
+ *   resolution. A grant is written when a token is issued; membership can be
+ *   revoked hours later, and the token stays valid until it expires.
+ * - Validation is expressed as a SQL join rather than a loop with an `if`, so
+ *   a target the user cannot reach cannot be returned by construction.
+ * - Anything unresolvable is dropped silently. The caller must not be able to
+ *   tell "no such server" from "not your server" — that difference would
+ *   confirm the existence of another tenant's server.
+ */
+@Injectable()
+export class McpConnectionGrantService {
+  private readonly logger = new Logger(McpConnectionGrantService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Resolve what `clientId` may see on behalf of `userId`, re-validating every
+   * target. See {@link ResolvedGrant} for why `null` and `{ mode: 'none' }` are
+   * distinct.
+   */
+  async resolve(
+    clientId: string | undefined,
+    userId: string | undefined,
+  ): Promise<ResolvedGrant | null> {
+    if (!clientId || !userId) return null;
+
+    const grant = await this.prisma.mcpConnectionGrant.findUnique({
+      where: { clientId_userId: { clientId, userId } },
+      select: { organizationId: true, serverIds: true },
+    });
+    if (!grant) return null;
+
+    if (grant.organizationId) {
+      const stillAMember = await this.isMember(userId, grant.organizationId);
+      return stillAMember
+        ? { mode: 'organization', organizationId: grant.organizationId }
+        : { mode: 'none' };
+    }
+
+    const servers = await this.validateServers(userId, grant.serverIds);
+    return servers.length > 0 ? { mode: 'servers', servers } : { mode: 'none' };
+  }
+
+  /**
+   * Grant the whole of one workspace — every tool of that organization, which
+   * is what `/mcp` served before grants existed. Refuses when the user is not a
+   * member, so a forged form value cannot mint access to another tenant.
+   */
+  async grantWholeOrganization(
+    clientId: string,
+    userId: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    if (!(await this.isMember(userId, organizationId))) {
+      this.logger.warn(
+        `Refused whole-workspace grant: user ${userId} is not a member of ${organizationId}`,
+      );
+      return false;
+    }
+    await this.upsert(clientId, userId, { organizationId, serverIds: [] });
+    return true;
+  }
+
+  /**
+   * Grant a specific set of MCP servers. Ids the user cannot reach are dropped;
+   * if nothing is left the grant is not written at all, so a caller cannot turn
+   * an entirely invalid selection into a stored empty grant.
+   *
+   * Returns the ids actually granted.
+   */
+  async grantServers(
+    clientId: string,
+    userId: string,
+    serverIds: string[],
+  ): Promise<string[]> {
+    const valid = await this.validateServers(userId, serverIds);
+    const dropped = serverIds.length - valid.length;
+    if (dropped > 0) {
+      this.logger.warn(
+        `Dropped ${dropped} unreachable server id(s) from a grant for user ${userId}`,
+      );
+    }
+    if (valid.length === 0) return [];
+
+    await this.upsert(clientId, userId, {
+      organizationId: null,
+      serverIds: valid.map((s) => s.id),
+    });
+    return valid.map((s) => s.id);
+  }
+
+  /** Drop a client's grant. Idempotent. */
+  async revoke(clientId: string, userId: string): Promise<void> {
+    await this.prisma.mcpConnectionGrant
+      .delete({ where: { clientId_userId: { clientId, userId } } })
+      .catch(() => undefined);
+  }
+
+  /** Everything this user has granted, for the dashboard's revoke list. */
+  async listForUser(userId: string) {
+    return this.prisma.mcpConnectionGrant.findMany({
+      where: { userId },
+      orderBy: { updatedAt: 'desc' },
+      select: {
+        clientId: true,
+        organizationId: true,
+        serverIds: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  /**
+   * The servers out of `serverIds` that this user can actually reach, with the
+   * organization each one really belongs to.
+   *
+   * Membership is part of the WHERE clause on purpose: there is no code path
+   * where a row comes back and a separate check is then expected to reject it.
+   * Deactivated members (`deactivatedAt`) and inactive servers are excluded on
+   * the same terms as the per-server endpoint.
+   */
+  private async validateServers(
+    userId: string,
+    serverIds: string[],
+  ): Promise<{ id: string; organizationId: string }[]> {
+    const ids = [...new Set(serverIds.filter((id) => !!id))];
+    if (ids.length === 0) return [];
+
+    return this.prisma.mcpServerConfig.findMany({
+      where: {
+        id: { in: ids },
+        isActive: true,
+        organization: {
+          members: { some: { userId, deactivatedAt: null } },
+        },
+      },
+      select: { id: true, organizationId: true },
+    });
+  }
+
+  private async isMember(
+    userId: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    const count = await this.prisma.organizationMember.count({
+      where: { userId, organizationId, deactivatedAt: null },
+    });
+    return count > 0;
+  }
+
+  private async upsert(
+    clientId: string,
+    userId: string,
+    data: { organizationId: string | null; serverIds: string[] },
+  ): Promise<void> {
+    await this.prisma.mcpConnectionGrant.upsert({
+      where: { clientId_userId: { clientId, userId } },
+      create: { clientId, userId, ...data },
+      update: data,
+    });
+  }
+}

--- a/packages/backend/src/mcp-servers/mcp-servers.module.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { McpServersService } from './mcp-servers.service';
+import { McpConnectionGrantService } from './mcp-connection-grant.service';
 import { McpServersController } from './mcp-servers.controller';
 import { McpSessionManager } from './mcp-session.manager';
 import { LicenseModule } from '../license/license.module';
 
 @Module({
   imports: [LicenseModule],
-  providers: [McpServersService, McpSessionManager],
+  providers: [McpServersService, McpSessionManager, McpConnectionGrantService],
   controllers: [McpServersController],
-  exports: [McpServersService, McpSessionManager],
+  exports: [McpServersService, McpSessionManager, McpConnectionGrantService],
 })
 export class McpServersModule {}


### PR DESCRIPTION
First of five changes towards serving every tenant from one URL — `https://cloud.anythingmcp.com/mcp` — instead of a per-server one.

**Nothing consumes this yet.** The request path is untouched, so this cannot change what any existing connection sees. Wiring it into `attachVisibleTools` and `tools/call` is the next PR, kept separate because that is the part that needs the closer read.

## Why one URL

The directory cannot list us as we are: *"If your server URL varies per tenant … The directory does not currently template a single entry across tenant subdomains."* And separately, finding and pasting the right per-server URL is where **21 of the 35** workspaces that attached a connector in the fortnight to 11 Sep stopped.

The access token mcp-nest issues already carries `client_id` (`jwt-token.service.js:99`). That is what lets the selection live server-side, keyed on `(clientId, userId)`, with no new token claims and no fork of the library.

## The isolation rules

A grant **only ever narrows what the user already has**. It is applied after authorization, never instead of it.

| rule | how |
|---|---|
| stored ids are not trusted | the owning organization is read back from `mcp_server_configs` on every resolution |
| membership is re-checked every request | a grant is written when the token is issued; membership can be revoked hours before that token expires |
| a target the user cannot reach cannot be returned | validation is a SQL join, not a loop with an `if`; `deactivatedAt: null` and `isActive` on the same terms as the per-server endpoint |
| no enumeration | an unresolvable target is dropped silently — the caller cannot tell "no such server" from "not your server" |

`resolve()` returning `null` and `{ mode: 'none' }` are **deliberately distinct** and separately tested:

- `null` — no grant at all. Every token issued before today. Caller keeps the previous behaviour, nothing regresses.
- `{ mode: 'none' }` — a grant exists and nothing in it validated. **Zero tools.** Collapsing these two would turn a revoked membership into full workspace access.

Writing refuses an organization the user is not in, and drops ids it cannot validate. A wholly invalid selection is not stored at all, so it cannot later resolve to `{ mode: 'none' }` and silently blank a connection that used to work.

## How it is verified

CI has no database, so the SQL guarantee is pinned **structurally** — tests assert the membership predicate, `deactivatedAt: null` and `isActive` are in the `WHERE`. That is what stops a future refactor turning the join into a post-filter.

The same predicate was then run **by hand against production**:

```
-- Matteo asking for 4 servers: 2 his, 2 belonging to other tenants
→ 2 rows, both his. The foreign ids silently dropped.

-- Lenin asking for Matteo's 2 servers
→ 0 rows.
```

## Numbers that shaped the design

Measured on the cloud DB, 11 Sep:

| | |
|---|---|
| users in exactly one organization | 1413 |
| users in two | **4** |
| orgs with exactly one MCP server | 1318 |
| orgs with 2 / 5 / 7 | 73 / 1 / 1 |
| active connectors on **no** server | **211 (36%), across 182 orgs** |

So for ~95% of users there is exactly one thing to pick, and the picker must not add a step for them — it auto-selects and shows nothing. And because `/mcp` currently scopes by *organization*, those 211 unattached connectors are reachable through it today; a whole-workspace grant mode exists precisely so PR 2 does not take them away from 182 workspaces.

## Remaining PRs

2. `attachVisibleTools` + `tools/call` consume the grant; absent grant = today's behaviour.
3. The `select-servers` page, auto-selection when there is one target, grant written.
4. Revoke from the dashboard, audit events, docs.
5. Directory prerequisites: census of tools with no annotation hint, privacy policy, icon, reviewer test account.

Full plan in `.context/plans/mcp-single-url-server-picker.md` (gitignored).

Suite green: 4043 passed, 238 suites.