### PR TITLE
fix(mcp): resolve a tool in the caller's scope, never the first one registered

### DIFF
--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.spec.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.spec.ts
@@ -184,3 +184,141 @@ describe('DynamicMcpTools — response cache', () => {
     expect(redis.set).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Which tool a name resolves to, when two tenants have registered the same one.
+ *
+ * This is the multi-tenant boundary of the shared `/mcp` endpoint. Until
+ * 12 Sep 2026 resolution ran `getTool(name, context.connectorIds)` first and
+ * only fell back to the organization `if (!tool)`. On `/mcp` there are no
+ * `connectorIds`, and an unfiltered `getTool` returns whichever connector
+ * registered the name FIRST across the whole deployment — so the fallback never
+ * ran and the caller executed somebody else's connector, with that tenant's
+ * credentials. Verified on production: two fresh tenants both invoked a third,
+ * unrelated workspace's connector. 610 tool names were shared across more than
+ * one organization at the time; one was shared by 76.
+ */
+describe('DynamicMcpTools — tool resolution is scoped to the caller', () => {
+  // Distinct base URLs, so "which connector ran" is something the test can
+  // actually see — the same way the production reproduction identified it.
+  const mine: RegisteredTool = {
+    ...makeTool(),
+    id: 'tool-mine',
+    connectorId: 'conn-mine',
+    organizationId: 'org-mine',
+    connectorConfig: { baseUrl: 'https://mine.example.com', authType: 'NONE' },
+  };
+  const theirs: RegisteredTool = {
+    ...makeTool(),
+    id: 'tool-theirs',
+    connectorId: 'conn-theirs',
+    organizationId: 'org-theirs',
+    connectorConfig: { baseUrl: 'https://theirs.example.com', authType: 'NONE' },
+  };
+
+  /** A registry that behaves like the real one: same name, two owners. */
+  function registry() {
+    const calls: string[] = [];
+    return {
+      calls,
+      // Unfiltered → first registered wins, exactly as ToolRegistry does.
+      getTool: (name: string, connectorIds?: string[]) => {
+        calls.push(connectorIds ? `getTool(${connectorIds.join()})` : 'getTool(unscoped)');
+        const candidates = [theirs, mine].filter((t) => t.name === name);
+        if (!connectorIds) return candidates[0];
+        return candidates.find((t) => connectorIds.includes(t.connectorId));
+      },
+      getToolForOrg: (name: string, organizationId: string) => {
+        calls.push(`getToolForOrg(${organizationId})`);
+        return [theirs, mine].find(
+          (t) => t.name === name && t.organizationId === organizationId,
+        );
+      },
+    };
+  }
+
+  function executorWith(reg: ReturnType<typeof registry>) {
+    const restEngine = { execute: jest.fn().mockResolvedValue(RAW) };
+    const executor = new DynamicMcpTools(
+      reg as any,
+      { logInvocation: jest.fn().mockResolvedValue(undefined) } as any,
+      { get: jest.fn().mockResolvedValue(null), set: jest.fn(), incr: jest.fn(), expire: jest.fn(), ttl: jest.fn() } as any,
+      { checkLicenseActive: jest.fn().mockResolvedValue(undefined) } as any,
+      { isCloud: () => true } as any,
+      {} as any,
+      restEngine as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      { scheduleObservationalIngest: jest.fn() } as any,
+    );
+    return { executor, restEngine };
+  }
+
+  it('runs MY connector, not the one that registered the name first', async () => {
+    const reg = registry();
+    const { executor, restEngine } = executorWith(reg);
+
+    await executor.executeTool('list_devices', {}, { organizationId: 'org-mine' });
+
+    expect(restEngine.execute).toHaveBeenCalledTimes(1);
+    const [config] = restEngine.execute.mock.calls[0];
+    expect(config.baseUrl).toBe('https://mine.example.com');
+    // The scoped lookup is the one that must have been consulted.
+    expect(reg.calls).toContain('getToolForOrg(org-mine)');
+    expect(reg.calls).not.toContain('getTool(unscoped)');
+  });
+
+  it('refuses rather than widening when my organization has no such tool', async () => {
+    const reg = registry();
+    const { executor, restEngine } = executorWith(reg);
+
+    const res = await executor.executeTool('list_devices', {}, {
+      organizationId: 'org-with-nothing',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('not found');
+    expect(restEngine.execute).not.toHaveBeenCalled();
+    expect(reg.calls).not.toContain('getTool(unscoped)');
+  });
+
+  it('uses the server scope when the call came through /mcp/:serverId', async () => {
+    const reg = registry();
+    const { executor } = executorWith(reg);
+
+    await executor.executeTool('list_devices', {}, {
+      organizationId: 'org-mine',
+      connectorIds: ['conn-mine'],
+    });
+
+    expect(reg.calls).toContain('getTool(conn-mine)');
+    expect(reg.calls).not.toContain('getToolForOrg(org-mine)');
+  });
+
+  it('does not fall back to the organization when the server has no such tool', async () => {
+    const reg = registry();
+    const { executor, restEngine } = executorWith(reg);
+
+    const res = await executor.executeTool('list_devices', {}, {
+      organizationId: 'org-mine',
+      connectorIds: ['conn-unrelated'],
+    });
+
+    expect(res.isError).toBe(true);
+    expect(restEngine.execute).not.toHaveBeenCalled();
+  });
+
+  // A self-hosted box with an instance-level MCP_API_KEY has no tenant to scope
+  // to, and "any tool" is the right answer there.
+  it('still resolves unscoped for an instance credential with no organization', async () => {
+    const reg = registry();
+    const { executor, restEngine } = executorWith(reg);
+
+    await executor.executeTool('list_devices', {}, {});
+
+    expect(reg.calls).toContain('getTool(unscoped)');
+    expect(restEngine.execute).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -165,13 +165,32 @@ export class DynamicMcpTools {
       };
     }
 
-    // Resolve the tool with the most specific scope available so cross-org
-    // collisions on the global /mcp endpoint don't leak. connectorIds is set
-    // when invoked through /mcp/:serverId; organizationId is set whenever
-    // we have a JWT.
-    let tool = this.toolRegistry.getTool(toolName, context?.connectorIds);
-    if (!tool && context?.organizationId) {
+    // Resolve the tool in the ONE scope this caller is entitled to, and never
+    // widen when that scope has no match.
+    //
+    // This used to try `getTool(toolName, context?.connectorIds)` first and
+    // fall back to the organization only `if (!tool)`. On the global /mcp
+    // endpoint `connectorIds` is undefined, and `getTool` with no connector
+    // filter returns `candidates[0]` — whichever connector registered that
+    // name FIRST, in ANY organization. The fallback then never ran, because a
+    // tool had already been found. So a caller whose own workspace had a tool
+    // of the same name executed somebody else's connector, with that tenant's
+    // stored credentials and base URL. 610 tool names are shared across more
+    // than one organization on the cloud instance today; one is shared by 76.
+    //
+    // The scopes are mutually exclusive, in decreasing specificity:
+    //   - connectorIds — invoked through /mcp/:serverId, or by an API key
+    //     pinned to a server. Only that server's connectors, never wider.
+    //   - organizationId — any JWT on the global /mcp. Only the caller's org.
+    //   - neither — an instance-level static credential on a single-tenant
+    //     self-hosted box, where "any tool" is the correct answer.
+    let tool: RegisteredTool | undefined;
+    if (context?.connectorIds) {
+      tool = this.toolRegistry.getTool(toolName, context.connectorIds);
+    } else if (context?.organizationId) {
       tool = this.toolRegistry.getToolForOrg(toolName, context.organizationId);
+    } else {
+      tool = this.toolRegistry.getTool(toolName);
     }
     if (!tool) {
       return {

--- a/packages/backend/src/mcp-server/mcp-server.service.spec.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.spec.ts
@@ -76,14 +76,19 @@ describe('McpServerService.jsonSchemaToZod', () => {
     expect(() => schema.parse({ mode: 'unknown' })).toThrow();
   });
 
-  it('coerces date-time strings to Date instances', () => {
+  // Was 'coerces date-time strings to Date instances'. That is exactly what
+  // broke the shared /mcp: a ZodDate cannot be serialised back to JSON Schema,
+  // and the endpoint advertises its tools by doing precisely that. See the
+  // dedicated describe block below.
+  it('leaves a date-time string as a string', () => {
     const schema = makeSchema({
       type: 'object',
       properties: { from: { type: 'string', format: 'date-time' } },
       required: ['from'],
     });
     const parsed: any = schema.parse({ from: '2026-05-12T09:00:00Z' });
-    expect(parsed.from).toBeInstanceOf(Date);
+    expect(parsed.from).toBe('2026-05-12T09:00:00Z');
+    expect(parsed.from).not.toBeInstanceOf(Date);
   });
 
   it('marks non-required fields as optional', () => {
@@ -182,5 +187,52 @@ describe('McpServerService.loadAllTools paging', () => {
 
     expect(registered).toEqual([]);
     expect(calls).toHaveLength(1);
+  });
+});
+
+/**
+ * The global `/mcp` advertises its tools by serialising these zod schemas back
+ * to JSON Schema. A `ZodDate` has no representation there, so `z.coerce.date()`
+ * made `tools/list` fail for the whole workspace with
+ * `-32603 Date cannot be represented in JSON Schema` — 91 tools across 9
+ * workspaces on the cloud instance, which could not use the shared endpoint at
+ * all. Verified against production on 12 Sep 2026.
+ */
+describe('McpServerService.jsonSchemaToZod — dates stay serialisable', () => {
+  const dateSchema = (format: string) => ({
+    type: 'object',
+    properties: { since: { type: 'string', format } },
+    required: ['since'],
+  });
+
+  it.each(['date', 'date-time'])(
+    'keeps a %s parameter representable in JSON Schema',
+    (format) => {
+      const schema = makeSchema(dateSchema(format));
+      const field = (schema as any).shape.since;
+      expect(field._def.type ?? field._def.typeName).not.toMatch(/date/i);
+    },
+  );
+
+  it('accepts an ISO string and hands it on unchanged', () => {
+    const schema = makeSchema(dateSchema('date-time'));
+    expect(schema.parse({ since: '2026-09-12T08:00:00Z' })).toEqual({
+      since: '2026-09-12T08:00:00Z',
+    });
+  });
+
+  it('accepts a plain date', () => {
+    const schema = makeSchema(dateSchema('date'));
+    expect(schema.parse({ since: '2026-09-12' })).toEqual({ since: '2026-09-12' });
+  });
+
+  it('still honours an enum on a string', () => {
+    const schema = makeSchema({
+      type: 'object',
+      properties: { status: { type: 'string', enum: ['a', 'b'] } },
+      required: ['status'],
+    });
+    expect(schema.parse({ status: 'a' })).toEqual({ status: 'a' });
+    expect(() => schema.parse({ status: 'zzz' })).toThrow();
   });
 });

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -419,10 +419,21 @@ export class McpServerService implements OnModuleInit {
         case 'string':
           if (prop.enum) {
             zodType = z.enum(prop.enum as [string, ...string[]]);
-          } else if (prop.format === 'date-time' || prop.format === 'date') {
-            // Accept ISO date strings and Date-coercible inputs.
-            zodType = z.coerce.date();
           } else {
+            // A date stays a STRING. This used to be `z.coerce.date()`, which
+            // produces a ZodDate — and the global /mcp advertises its tools by
+            // serialising these zod schemas back to JSON Schema, where a Date
+            // has no representation. The serialiser threw, so `tools/list`
+            // failed for the WHOLE workspace with
+            // `-32603 Date cannot be represented in JSON Schema`, not just for
+            // the offending tool: 91 tools across 9 workspaces on the cloud
+            // instance, which could not use the shared endpoint at all.
+            //
+            // Nothing is lost. The value is on its way into a query string or a
+            // request body, so it has to end up as text regardless, and
+            // `format` is documentation for the caller either way. The
+            // per-server endpoint has always mapped strings this way
+            // (`jsonSchemaToZodShape`); the two paths now agree.
             zodType = z.string();
           }
           break;

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -260,6 +260,10 @@ export class McpServerService implements OnModuleInit {
         // merge that drops the option — is still not freely callable. Defence
         // in depth, not the only gate.
         const user = request?.user;
+        // Set when the caller's credential is pinned to one MCP server, so the
+        // executor resolves the tool in that server's scope rather than the
+        // whole organization's.
+        let serverConnectorIds: string[] | undefined;
         if (user?.sub) {
           // Global /mcp registry: there is no server-scoped org here, so the
           // caller's active org is the relevant one — same org used by
@@ -284,17 +288,22 @@ export class McpServerService implements OnModuleInit {
           }
 
           // Check MCP server scoping — if the API key is tied to a server,
-          // only allow tools from connectors assigned to that server
+          // only allow tools from connectors assigned to that server.
+          //
+          // The refusal used to sit inside `if (tool)`, so a name that matched
+          // NO connector on this server fell straight through the guard and was
+          // then resolved in a wider scope by the executor. Refuse on the
+          // absence, which is the case that mattered.
           if (user.mcpServerId) {
-            const allowedConnectorIds = await this.mcpServersService.getConnectorIds(user.mcpServerId);
-            const tool = this.toolRegistry.getTool(name, allowedConnectorIds);
-            if (tool) {
-              if (!allowedConnectorIds.includes(tool.connectorId)) {
-                return {
-                  content: [{ type: 'text' as const, text: JSON.stringify({ error: `Tool '${name}' is not available on this MCP server.` }) }],
-                  isError: true,
-                };
-              }
+            serverConnectorIds = await this.mcpServersService.getConnectorIds(
+              user.mcpServerId,
+            );
+            const tool = this.toolRegistry.getTool(name, serverConnectorIds);
+            if (!tool) {
+              return {
+                content: [{ type: 'text' as const, text: JSON.stringify({ error: `Tool '${name}' is not available on this MCP server.` }) }],
+                isError: true,
+              };
             }
           } else if (user.organizationId) {
             // Authenticated user without MCP-server scoping: the global
@@ -330,6 +339,7 @@ export class McpServerService implements OnModuleInit {
           authMethod: user?.authMethod || 'none',
           apiKeyName: user?.apiKeyName,
           mcpServerId: user?.mcpServerId,
+          connectorIds: serverConnectorIds,
         };
 
         return this.toolExecutor.executeTool(name, args, invocationContext);


### PR DESCRIPTION
> **Cross-tenant execution on the shared `/mcp` endpoint. Live on cloud right now.**

An authenticated user can execute **another tenant's connector**, with that tenant's stored credentials and base URL, by owning a tool of the same name.

## Reproduced on production

Two throwaway workspaces, each given their own Petstore connector with identical tool names but different base URLs. Both called `getinventory` on `/mcp`. `tool_invocations` says both executed a **third, unrelated customer's** connector:

| caller | their own connector | connector that actually ran | owner |
|---|---|---|---|
| Iso A | `petstore3.swagger.io` | `jsonplaceholder.typicode.com` | menglong35's Workspace |
| Iso B | `httpbin.org` | `jsonplaceholder.typicode.com` | menglong35's Workspace |

A third workspace with **no** connectors was correctly refused (*"It belongs to another workspace, or your MCP role does not grant it"*), and anonymous `POST /mcp` is 401 — so the name collision is the whole precondition, and it is trivial to arrange: you choose your own tool names.

### How much collides today

```
610   tool names shared by more than one organization
 76   organizations exposing the single most-shared name
37-38 organizations exposing each of the Etsy tools  ← OAuth tokens to real shops
```

## Cause

`DynamicMcpTools.executeTool`:

```ts
let tool = this.toolRegistry.getTool(toolName, context?.connectorIds);
if (!tool && context?.organizationId) {
  tool = this.toolRegistry.getToolForOrg(toolName, context.organizationId);
}
```

`connectorIds` is only set by `/mcp/:serverId`. On the global endpoint it is `undefined`, and `ToolRegistry.getTool` with no connector filter returns `candidates[0]` — whichever connector registered that name **first, in any organization**. Being truthy, it meant the org-scoped fallback never ran.

The intent was right and the comment above it said exactly the right thing. The order was inverted.

## Fix

The three scopes become mutually exclusive instead of a fallback chain:

| caller | scope |
|---|---|
| `/mcp/:serverId`, or an API key pinned to a server | that server's connectors, never wider |
| any JWT on the global `/mcp` | the caller's organization |
| neither — instance-level static credential, single-tenant self-hosted | unscoped, which is the correct answer there |

Nothing falls back to a wider scope when its own scope has no match; it refuses.

### A second, smaller hole in the same path

The server-pinned branch of the handler refused only `if (tool)`, so a name matching **no** connector on that server fell through the guard entirely and was then resolved in a wider scope by the executor. It now refuses on the absence, and passes the server's connector ids to the executor so the scope is actually *applied* rather than merely checked. Same organization, so not cross-tenant — but it defeated per-server scoping.

## What this is and is not

**Not** a data-read leak: the caller receives that connector's API response, not the other tenant's stored rows. Worse in one respect — with a write tool it acts **as them** against their own upstream system (CRM, ERP, shop).

The guards in `McpServerService`'s handler were never the hole. They check that the *caller's* organization has a tool of that name, which is why a collision was required; they never influenced which tool ran.

## Tests

Five regression tests pinning the resolution scope, including "runs MY connector, not the one that registered the name first" asserted on the base URL the engine was handed — the same way the production reproduction identified it. Full suite: 4048 passed, 238 suites.

Recommend merging and deploying ahead of anything else in flight.