### PR TITLE
feat(mcp): the shared /mcp serves what the user granted, and only that

### DIFF
--- a/packages/backend/src/mcp-server/grant-visibility.spec.ts
+++ b/packages/backend/src/mcp-server/grant-visibility.spec.ts
@@ -65,7 +65,10 @@ async function visible(controller: McpEndpointController, user: any) {
 }
 
 describe('grant-scoped visibility on the shared /mcp', () => {
-  const caller = () => ({ sub: 'u1', organizationId: 'org-A', client_id: 'client-1' });
+  // `azp` is what an ACCESS token actually carries. mcp-nest only writes
+  // `client_id` on the REFRESH token — reading that name alone found nothing on
+  // every request that matters, and the grant silently never applied.
+  const caller = () => ({ sub: 'u1', organizationId: 'org-A', azp: 'client-1' });
 
   // Every token issued before grants existed resolves to null. Their surface
   // must not move by a single tool.
@@ -156,6 +159,26 @@ describe('grant-scoped visibility on the shared /mcp', () => {
     const { names } = await visible(controller, caller());
 
     expect([...names!]).toEqual(['gamma']);
+  });
+
+  it('reads the client from `azp`, which is what an access token carries', async () => {
+    const controller = build({ mode: 'organization', organizationId: 'org-B' });
+
+    await visible(controller, { sub: 'u1', organizationId: 'org-A', azp: 'client-1' });
+
+    expect((controller as any).grants.resolve).toHaveBeenCalledWith('client-1', 'u1');
+  });
+
+  it('still accepts `client_id`, so a different token shape cannot break it quietly', async () => {
+    const controller = build({ mode: 'organization', organizationId: 'org-B' });
+
+    await visible(controller, {
+      sub: 'u1',
+      organizationId: 'org-A',
+      client_id: 'client-1',
+    });
+
+    expect((controller as any).grants.resolve).toHaveBeenCalledWith('client-1', 'u1');
   });
 
   it('confines the call path to exactly what it listed', async () => {

--- a/packages/backend/src/mcp-server/grant-visibility.spec.ts
+++ b/packages/backend/src/mcp-server/grant-visibility.spec.ts
@@ -1,0 +1,174 @@
+import { McpEndpointController } from './mcp-endpoint.controller';
+import { toolVisibilityRole } from './mcp-server.service';
+import type { RegisteredTool } from './tool-registry';
+
+/**
+ * What a connection grant narrows the shared `/mcp` down to.
+ *
+ * `attachVisibleTools` decides both halves of the answer: the names the
+ * transport will list, and the connector ids the call path is then confined to.
+ * The two must agree — a surface that lists less than it will execute is the
+ * shape the 12 Sep cross-tenant bug took.
+ */
+function tool(
+  id: string,
+  name: string,
+  organizationId: string,
+  connectorId: string,
+): RegisteredTool {
+  return {
+    id,
+    connectorId,
+    organizationId,
+    name,
+    description: name,
+    parameters: {},
+    connectorType: 'REST',
+    connectorConfig: { baseUrl: 'https://example.com', authType: 'NONE' },
+    endpointMapping: { method: 'GET', path: '/' },
+  };
+}
+
+const ALL = [
+  tool('t-a1', 'alpha', 'org-A', 'conn-A1'),
+  tool('t-a2', 'beta', 'org-A', 'conn-A2'),
+  tool('t-b1', 'gamma', 'org-B', 'conn-B1'),
+  tool('t-c1', 'delta', 'org-C', 'conn-C1'),
+];
+
+function build(
+  grant: unknown,
+  opts: { allowedByOrg?: Record<string, string[] | null>; connectorsByServer?: Record<string, string[]> } = {},
+) {
+  const controller = new McpEndpointController(
+    {
+      getConnectorIds: jest.fn(async (id: string) => opts.connectorsByServer?.[id] ?? []),
+    } as any,
+    { getAllTools: () => ALL } as any,
+    {} as any,
+    {
+      getAllowedToolIds: jest.fn(async (_sub: string, org: string) =>
+        opts.allowedByOrg ? (opts.allowedByOrg[org] ?? null) : null,
+      ),
+    } as any,
+    {} as any,
+    {} as any,
+    { resolve: jest.fn().mockResolvedValue(grant) } as any,
+  );
+  return controller;
+}
+
+async function visible(controller: McpEndpointController, user: any) {
+  const req: any = { user };
+  const names: Set<string> | null = await (controller as any).attachVisibleTools(req);
+  return { names, user: req.user };
+}
+
+describe('grant-scoped visibility on the shared /mcp', () => {
+  const caller = () => ({ sub: 'u1', organizationId: 'org-A', client_id: 'client-1' });
+
+  // Every token issued before grants existed resolves to null. Their surface
+  // must not move by a single tool.
+  it('falls back to the active organization when there is no grant', async () => {
+    const { names, user } = await visible(build(null), caller());
+
+    expect([...names!].sort()).toEqual(['alpha', 'beta']);
+    expect(user.grantedConnectorIds).toBeUndefined();
+  });
+
+  it('shows exactly the granted workspace, which need not be the active one', async () => {
+    const { names, user } = await visible(
+      build({ mode: 'organization', organizationId: 'org-B' }),
+      caller(),
+    );
+
+    expect([...names!]).toEqual(['gamma']);
+    expect(user.grantedConnectorIds).toEqual(['conn-B1']);
+  });
+
+  it('shows only the connectors of the granted servers', async () => {
+    const controller = build(
+      { mode: 'servers', servers: [{ id: 'srv-1', organizationId: 'org-A' }] },
+      { connectorsByServer: { 'srv-1': ['conn-A2'] } },
+    );
+
+    const { names, user } = await visible(controller, caller());
+
+    expect([...names!]).toEqual(['beta']);
+    expect(user.grantedConnectorIds).toEqual(['conn-A2']);
+  });
+
+  it('spans organizations when the grant does, and no further', async () => {
+    const controller = build(
+      {
+        mode: 'servers',
+        servers: [
+          { id: 'srv-a', organizationId: 'org-A' },
+          { id: 'srv-b', organizationId: 'org-B' },
+        ],
+      },
+      { connectorsByServer: { 'srv-a': ['conn-A1'], 'srv-b': ['conn-B1'] } },
+    );
+
+    const { names } = await visible(controller, caller());
+
+    expect([...names!].sort()).toEqual(['alpha', 'gamma']);
+    expect([...names!]).not.toContain('delta');
+  });
+
+  // A grant whose targets stopped validating is zero tools, never "everything".
+  it('shows nothing for a grant that no longer resolves', async () => {
+    const { names, user } = await visible(build({ mode: 'none' }), caller());
+
+    expect([...names!]).toEqual([]);
+    expect(user.grantedConnectorIds).toEqual([]);
+  });
+
+  it('plants a visibility role for every name it lists, and no other', async () => {
+    const { names, user } = await visible(
+      build({ mode: 'organization', organizationId: 'org-B' }),
+      caller(),
+    );
+
+    expect(user.roles).toContain(toolVisibilityRole('gamma'));
+    expect(user.roles).not.toContain(toolVisibilityRole('alpha'));
+    expect(names!.has('gamma')).toBe(true);
+  });
+
+  // Roles belong to the organization that owns the tool. Reading them from the
+  // caller's ACTIVE org would apply org-A's restrictions to org-B's tools.
+  it('reads roles from the organization that owns each tool', async () => {
+    const controller = build(
+      {
+        mode: 'servers',
+        servers: [
+          { id: 'srv-a', organizationId: 'org-A' },
+          { id: 'srv-b', organizationId: 'org-B' },
+        ],
+      },
+      {
+        connectorsByServer: { 'srv-a': ['conn-A1'], 'srv-b': ['conn-B1'] },
+        // Restricted in org-A, unrestricted in org-B.
+        allowedByOrg: { 'org-A': [], 'org-B': null },
+      },
+    );
+
+    const { names } = await visible(controller, caller());
+
+    expect([...names!]).toEqual(['gamma']);
+  });
+
+  it('confines the call path to exactly what it listed', async () => {
+    const controller = build(
+      { mode: 'servers', servers: [{ id: 'srv-1', organizationId: 'org-A' }] },
+      { connectorsByServer: { 'srv-1': ['conn-A1', 'conn-A2'] }, allowedByOrg: { 'org-A': ['t-a1'] } },
+    );
+
+    const { names, user } = await visible(controller, caller());
+
+    expect([...names!]).toEqual(['alpha']);
+    // conn-A2 was reachable but its tool is not role-allowed, so the call path
+    // must not be handed it either.
+    expect(user.grantedConnectorIds).toEqual(['conn-A1']);
+  });
+});

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.spec.ts
@@ -11,6 +11,7 @@ describe('McpEndpointController — tenant isolation', () => {
   let toolRegistry: any;
   let toolExecutor: any;
   let rolesService: any;
+  let grants: any;
 
   const SERVER = {
     id: 'srv-A',
@@ -50,6 +51,7 @@ describe('McpEndpointController — tenant isolation', () => {
       remove: jest.fn().mockResolvedValue(undefined),
       notifyToolsChanged: jest.fn().mockResolvedValue(undefined),
     };
+    grants = { resolve: jest.fn().mockResolvedValue(null) };
     controller = new McpEndpointController(
       mcpServersService,
       toolRegistry,
@@ -57,6 +59,7 @@ describe('McpEndpointController — tenant isolation', () => {
       rolesService,
       kgService as any,
       sessionManager as any,
+      grants as any,
     );
   });
 
@@ -206,6 +209,7 @@ describe('McpEndpointController — structuredContent', () => {
       { getAllowedToolIds: jest.fn() } as any,
       { lookup: jest.fn(), isEnabled: jest.fn(), captureIntentEnabled: jest.fn() } as any,
       { get: jest.fn(), add: jest.fn(), remove: jest.fn() } as any,
+      { resolve: jest.fn().mockResolvedValue(null) } as any,
     );
 
     const entries = (controller as any).planToolSet({

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -26,6 +26,25 @@ import { McpServersService } from '../mcp-servers/mcp-servers.service';
 import { McpSessionManager } from '../mcp-servers/mcp-session.manager';
 import { ToolRegistry, RegisteredTool } from './tool-registry';
 import { McpConnectionGrantService } from '../mcp-servers/mcp-connection-grant.service';
+
+/**
+ * The OAuth client an access token was issued to.
+ *
+ * @rekog/mcp-nest puts it under `azp` on the ACCESS token and under `client_id`
+ * on the REFRESH token — the two payloads in `generateTokenPair` genuinely
+ * differ. Reading `client_id` alone therefore found nothing on every request
+ * that matters, and a connection grant silently never applied. Caught only by
+ * decoding a token from a real authorize flow; no amount of mocking would have
+ * shown it. Both names are accepted so a future token shape cannot break this
+ * quietly again.
+ */
+function oauthClientId(user: {
+  azp?: unknown;
+  client_id?: unknown;
+}): string | undefined {
+  const value = user?.azp ?? user?.client_id;
+  return typeof value === 'string' && value ? value : undefined;
+}
 import { DynamicMcpTools } from './dynamic-mcp-tools';
 import { RolesService } from '../roles/roles.service';
 import { registerDemoTools } from './mcp-demo.tools';
@@ -187,7 +206,7 @@ export class McpEndpointController {
     // issued before grants existed — keep the previous answer. `{ mode: 'none' }`
     // means it HAS one and nothing in it validated any more, which is no tools.
     // Collapsing the two would turn a revoked membership into full access.
-    const grant = await this.grants.resolve(user.client_id, user.sub);
+    const grant = await this.grants.resolve(oauthClientId(user), user.sub);
 
     let reachable: RegisteredTool[];
     if (!grant) {

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -25,6 +25,7 @@ import { toolVisibilityRole } from './mcp-server.service';
 import { McpServersService } from '../mcp-servers/mcp-servers.service';
 import { McpSessionManager } from '../mcp-servers/mcp-session.manager';
 import { ToolRegistry, RegisteredTool } from './tool-registry';
+import { McpConnectionGrantService } from '../mcp-servers/mcp-connection-grant.service';
 import { DynamicMcpTools } from './dynamic-mcp-tools';
 import { RolesService } from '../roles/roles.service';
 import { registerDemoTools } from './mcp-demo.tools';
@@ -96,6 +97,7 @@ export class McpEndpointController {
     private readonly rolesService: RolesService,
     private readonly kgService: KgService,
     private readonly sessionManager: McpSessionManager,
+    private readonly grants: McpConnectionGrantService,
   ) {}
 
   // Streamable-HTTP response framing. Default: SSE-framed responses
@@ -156,8 +158,14 @@ export class McpEndpointController {
    * organization and refuses a mismatch. This closes the listing side.
    *
    * Two scopes are applied, in this order:
-   *   1. ORGANIZATION — only tools owned by the caller's active org.
-   *   2. ROLE — of those, only the ones the caller's MCP roles allow.
+   *   1. REACH — which connectors this connection may see at all. A connection
+   *      grant when the user chose one while authorizing the client (and only
+   *      the targets whose organization membership still validates); otherwise
+   *      the caller's active organization, unchanged, so tokens issued before
+   *      grants existed behave exactly as before.
+   *   2. ROLE — of those, only the ones the caller's MCP roles allow, read from
+   *      the organization that owns each tool rather than from whichever org
+   *      happens to be active. Under a grant those can differ.
    */
   private async attachVisibleTools(req: Request): Promise<Set<string> | null> {
     const user = (req as any).user;
@@ -175,21 +183,61 @@ export class McpEndpointController {
       return new Set<string>();
     }
 
-    const orgTools = this.toolRegistry
-      .getAllTools()
-      .filter((t) => t.organizationId === user.organizationId);
+    // `null` here means the client has no grant at all, which is every token
+    // issued before grants existed — keep the previous answer. `{ mode: 'none' }`
+    // means it HAS one and nothing in it validated any more, which is no tools.
+    // Collapsing the two would turn a revoked membership into full access.
+    const grant = await this.grants.resolve(user.client_id, user.sub);
 
-    const allowedToolIds = await this.rolesService.getAllowedToolIds(
-      user.sub,
-      user.organizationId,
-    );
+    let reachable: RegisteredTool[];
+    if (!grant) {
+      reachable = this.toolRegistry
+        .getAllTools()
+        .filter((t) => t.organizationId === user.organizationId);
+    } else if (grant.mode === 'organization') {
+      reachable = this.toolRegistry
+        .getAllTools()
+        .filter((t) => t.organizationId === grant.organizationId);
+    } else if (grant.mode === 'servers') {
+      const connectorIds = new Set(
+        (
+          await Promise.all(
+            grant.servers.map((srv) =>
+              this.mcpServersService.getConnectorIds(srv.id),
+            ),
+          )
+        ).flat(),
+      );
+      reachable = this.toolRegistry
+        .getAllTools()
+        .filter((t) => connectorIds.has(t.connectorId));
+    } else {
+      reachable = [];
+    }
 
-    // `null` means unrestricted — an ADMIN, or a user holding no MCP role at
-    // all. The organization scope still applies.
-    const visible =
-      allowedToolIds === null
-        ? orgTools
-        : orgTools.filter((t) => allowedToolIds.includes(t.id));
+    // Roles are per organization, and a grant may span more than one, so the
+    // allow-list is fetched once per organization actually in reach.
+    const allowedByOrg = new Map<string, string[] | null>();
+    for (const orgId of new Set(reachable.map((t) => t.organizationId))) {
+      allowedByOrg.set(
+        orgId,
+        await this.rolesService.getAllowedToolIds(user.sub, orgId),
+      );
+    }
+
+    // `null` from getAllowedToolIds means unrestricted — an ADMIN, or a user
+    // holding no MCP role at all. The reach scope still applies.
+    const visible = reachable.filter((t) => {
+      const allowed = allowedByOrg.get(t.organizationId);
+      return allowed === null || (allowed?.includes(t.id) ?? false);
+    });
+
+    // Handed to the call path so it resolves in exactly the scope that was
+    // listed here. Only set under a grant; without one the executor keeps
+    // using the caller's active organization, as before.
+    (user as { grantedConnectorIds?: string[] }).grantedConnectorIds = grant
+      ? [...new Set(visible.map((t) => t.connectorId))]
+      : undefined;
 
     const visibleNames = new Set(visible.map((t) => t.name));
     user.roles = [

--- a/packages/backend/src/mcp-server/mcp-server.service.ts
+++ b/packages/backend/src/mcp-server/mcp-server.service.ts
@@ -26,6 +26,19 @@ export function toolVisibilityRole(toolName: string): string {
   return `tool:${toolName}`;
 }
 
+/** The shape an MCP tool handler returns when it declines to run. */
+type ToolCallRefusal = {
+  content: { type: 'text'; text: string }[];
+  isError: true;
+};
+
+function refuse(error: string): ToolCallRefusal {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ error }) }],
+    isError: true,
+  };
+}
+
 @Injectable()
 export class McpServerService implements OnModuleInit {
   private readonly logger = new Logger(McpServerService.name);
@@ -260,76 +273,12 @@ export class McpServerService implements OnModuleInit {
         // merge that drops the option — is still not freely callable. Defence
         // in depth, not the only gate.
         const user = request?.user;
-        // Set when the caller's credential is pinned to one MCP server, so the
-        // executor resolves the tool in that server's scope rather than the
-        // whole organization's.
-        let serverConnectorIds: string[] | undefined;
-        if (user?.sub) {
-          // Global /mcp registry: there is no server-scoped org here, so the
-          // caller's active org is the relevant one — same org used by
-          // getToolForOrg below.
-          const allowedToolIds = await this.rolesService.getAllowedToolIds(
-            user.sub,
-            user.organizationId,
-          );
-          if (allowedToolIds !== null) {
-            // User has restricted access — check if this tool is allowed.
-            // Resolve by org first so we don't read the wrong org's tool
-            // when two orgs registered the same tool name.
-            const tool = user.organizationId
-              ? this.toolRegistry.getToolForOrg(name, user.organizationId)
-              : this.toolRegistry.getTool(name);
-            if (tool && !allowedToolIds.includes(tool.id)) {
-              return {
-                content: [{ type: 'text' as const, text: JSON.stringify({ error: `Access denied: you do not have permission to use '${name}'.` }) }],
-                isError: true,
-              };
-            }
-          }
 
-          // Check MCP server scoping — if the API key is tied to a server,
-          // only allow tools from connectors assigned to that server.
-          //
-          // The refusal used to sit inside `if (tool)`, so a name that matched
-          // NO connector on this server fell straight through the guard and was
-          // then resolved in a wider scope by the executor. Refuse on the
-          // absence, which is the case that mattered.
-          if (user.mcpServerId) {
-            serverConnectorIds = await this.mcpServersService.getConnectorIds(
-              user.mcpServerId,
-            );
-            const tool = this.toolRegistry.getTool(name, serverConnectorIds);
-            if (!tool) {
-              return {
-                content: [{ type: 'text' as const, text: JSON.stringify({ error: `Tool '${name}' is not available on this MCP server.` }) }],
-                isError: true,
-              };
-            }
-          } else if (user.organizationId) {
-            // Authenticated user without MCP-server scoping: the global
-            // /mcp endpoint must still refuse to invoke a same-named tool
-            // from a different organization. Reject if no tool exists for
-            // this org (an unscoped lookup would otherwise silently fall
-            // back to whichever org registered the name first).
-            const orgTool = this.toolRegistry.getToolForOrg(
-              name,
-              user.organizationId,
-            );
-            if (!orgTool) {
-              return {
-                content: [
-                  {
-                    type: 'text' as const,
-                    text: JSON.stringify({
-                      error: `Tool '${name}' is not available for your organization.`,
-                    }),
-                  },
-                ],
-                isError: true,
-              };
-            }
-          }
-        }
+        // Which connectors this call may reach, or a refusal. Everything that
+        // decides scope lives in one place so the branches cannot drift.
+        const scope = await this.resolveCallScope(user, name);
+        if ('error' in scope) return scope.error;
+        const serverConnectorIds = scope.connectorIds;
 
         // OAuth JWTs store email inside user_data, app JWTs have it top-level
         const invocationContext = {
@@ -345,6 +294,96 @@ export class McpServerService implements OnModuleInit {
         return this.toolExecutor.executeTool(name, args, invocationContext);
       },
     });
+  }
+
+  /**
+   * The connector scope a `tools/call` on the GLOBAL `/mcp` may use, or the
+   * refusal to send back instead.
+   *
+   * Three mutually exclusive cases, narrowest first. None of them widens when
+   * its own scope has no match — the whole point is that a miss is a refusal,
+   * not a reason to look somewhere bigger.
+   *
+   *  1. A CONNECTION GRANT. The user chose what this client may reach while
+   *     authorizing it; `attachVisibleTools` resolved it for this request,
+   *     re-checking organization membership. Narrower than the caller's active
+   *     organization — and possibly in a DIFFERENT one, when they belong to
+   *     several — so roles are read from the organization that owns the tool,
+   *     not from whichever org happens to be active.
+   *  2. A CREDENTIAL PINNED TO ONE SERVER (`user.mcpServerId`).
+   *  3. NO GRANT — every token issued before grants existed. Unchanged
+   *     behaviour: the caller's active organization.
+   *
+   * `undefined` connectorIds means "no connector filter", which the executor
+   * only honours for an instance-level static credential on a single-tenant
+   * box. An identified user always ends up with either a filter or a refusal.
+   */
+  private async resolveCallScope(
+    user: any,
+    name: string,
+  ): Promise<{ connectorIds?: string[] } | { error: ToolCallRefusal }> {
+    if (!user?.sub) return {};
+
+    const granted: string[] | undefined = user.grantedConnectorIds;
+    if (granted) {
+      const tool = this.toolRegistry.getTool(name, granted);
+      if (!tool) {
+        return { error: refuse(`Tool '${name}' is not available on this connection.`) };
+      }
+      const allowedToolIds = await this.rolesService.getAllowedToolIds(
+        user.sub,
+        tool.organizationId,
+      );
+      if (allowedToolIds !== null && !allowedToolIds.includes(tool.id)) {
+        return { error: refuse(`Access denied: you do not have permission to use '${name}'.`) };
+      }
+      return { connectorIds: granted };
+    }
+
+    // Role check, kept as a SECOND layer. The transport refuses a disallowed
+    // call before the handler runs, because `requiredRoles` gates `tools/call`
+    // as well as `tools/list`. This stays so that a tool registered without a
+    // visibility role — a future code path, a merge that drops the option — is
+    // still not freely callable. Defence in depth, not the only gate.
+    const allowedToolIds = await this.rolesService.getAllowedToolIds(
+      user.sub,
+      user.organizationId,
+    );
+    if (allowedToolIds !== null) {
+      // Resolve by org first so we don't read the wrong org's tool when two
+      // orgs registered the same tool name.
+      const tool = user.organizationId
+        ? this.toolRegistry.getToolForOrg(name, user.organizationId)
+        : this.toolRegistry.getTool(name);
+      if (tool && !allowedToolIds.includes(tool.id)) {
+        return { error: refuse(`Access denied: you do not have permission to use '${name}'.`) };
+      }
+    }
+
+    // The refusal used to sit inside `if (tool)`, so a name that matched NO
+    // connector on this server fell straight through the guard and was then
+    // resolved in a wider scope by the executor. Refuse on the absence, which
+    // is the case that mattered.
+    if (user.mcpServerId) {
+      const serverConnectorIds = await this.mcpServersService.getConnectorIds(
+        user.mcpServerId,
+      );
+      if (!this.toolRegistry.getTool(name, serverConnectorIds)) {
+        return { error: refuse(`Tool '${name}' is not available on this MCP server.`) };
+      }
+      return { connectorIds: serverConnectorIds };
+    }
+
+    if (user.organizationId) {
+      // The global endpoint must refuse a same-named tool from a different
+      // organization; an unscoped lookup would otherwise silently fall back to
+      // whichever org registered the name first.
+      if (!this.toolRegistry.getToolForOrg(name, user.organizationId)) {
+        return { error: refuse(`Tool '${name}' is not available for your organization.`) };
+      }
+    }
+
+    return {};
   }
 
   /**


### PR DESCRIPTION
PR 2 of the single-URL work. Wires in the grant model from #540, which until now was stored and never read.

## What the shared endpoint now answers

| grant | surface |
|---|---|
| **none** | the caller's active organization — exactly as before |
| whole workspace | that organization, which need not be the active one |
| chosen servers | the union of those servers' connectors |
| present, nothing validates | **no tools** |

The first row is the compatibility guarantee: every token issued before grants existed resolves to `null` and its surface does not move by a single tool. The last row is the fail-closed one — a target that stopped validating is zero tools, never "fall back to everything". `null` and `{ mode: 'none' }` stay distinct, and are separately tested.

## Two consequences of a grant spanning organizations

Both would have been wrong if left alone:

**Roles are read from the organization that owns each tool**, not from whichever org happens to be active. Otherwise org-A's restrictions get applied to org-B's tools, and a user restricted in one workspace silently loses tools in the other. The allow-list is fetched once per organization actually in reach.

**The listing hands its connector ids to the call path**, so `tools/call` resolves in exactly the scope that was listed. A surface that lists less than it will execute is precisely the shape the cross-tenant bug in #541 took — the two halves are no longer allowed to disagree. Note the test `confines the call path to exactly what it listed`: a connector that is reachable but whose tool is not role-allowed is not handed to the call path either.

## The call-scope decision moved

Out of the middle of the tool closure and into `resolveCallScope`, which returns either the connector filter to use or the refusal to send back. Three mutually exclusive cases, narrowest first — grant → server-pinned credential → active organization — none of which widens on a miss.

It was three nested conditionals sharing mutable state before, and the case that mattered (a name matching nothing in the caller's scope) fell through two of them. That is the second, smaller hole #541 had to patch; this removes the shape that allowed it.

## Not covered here

The picker UI is PR 3 — nothing writes a grant yet, so in practice this changes nothing in production until it lands. That is deliberate: this PR is the enforcement half, and it is the half worth reading carefully.

Full suite: 4061 passed, 239 suites.