### PR TITLE
feat(mcp): a Connections page, and a revoke that actually narrows

### DIFF
--- a/packages/backend/prisma/migrations/20260912092847_add_grant_revocation/migration.sql
+++ b/packages/backend/prisma/migrations/20260912092847_add_grant_revocation/migration.sql
@@ -1,0 +1,7 @@
+-- Revoking a connection must NARROW it. Deleting the grant row would mean "no
+-- grant", and no grant means the pre-grant behaviour — the caller's entire
+-- organization — so a delete would have widened access instead of removing it.
+-- The row is kept and stamped instead.
+
+-- AlterTable
+ALTER TABLE "mcp_connection_grants" ADD COLUMN     "revoked_at" TIMESTAMP(3);

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -639,6 +639,12 @@ model McpConnectionGrant {
   /// `mcp_server_configs` at resolution time and never trusted from here.
   serverIds String[] @map("server_ids")
 
+  /// Set when the user revoked this connection from the dashboard. The row is
+  /// KEPT rather than deleted, because deleting it means "no grant", and no
+  /// grant means the pre-grant behaviour — the caller's whole organization. A
+  /// revoke that widens access is the opposite of a revoke.
+  revokedAt DateTime? @map("revoked_at")
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/packages/backend/src/audit/security-event.service.ts
+++ b/packages/backend/src/audit/security-event.service.ts
@@ -21,6 +21,14 @@ export const SecurityEvents = {
   SCIM_DISABLED: 'SCIM_DISABLED',
   SCIM_TOKEN_ROTATED: 'SCIM_TOKEN_ROTATED',
 
+  // ── Connection grants: what a client may reach through the shared /mcp ──
+  /** A user chose what an OAuth client may reach, while authorizing it. */
+  MCP_GRANT_CREATED: 'MCP_GRANT_CREATED',
+  /** The choice was changed from the dashboard, without reconnecting. */
+  MCP_GRANT_CHANGED: 'MCP_GRANT_CHANGED',
+  /** The connection was revoked; it now reaches nothing. */
+  MCP_GRANT_REVOKED: 'MCP_GRANT_REVOKED',
+
   // ── Auth plane: who got in, and who failed to ───────────────────────────
   SSO_LOGIN_SUCCESS: 'SSO_LOGIN_SUCCESS',
   SSO_LOGIN_FAILED: 'SSO_LOGIN_FAILED',

--- a/packages/backend/src/auth/login.controller.spec.ts
+++ b/packages/backend/src/auth/login.controller.spec.ts
@@ -73,6 +73,11 @@ describe('LoginController', () => {
   >;
 
   let sso: { startMcp: jest.Mock };
+  let grants: {
+    grantServers: jest.Mock;
+    grantWholeOrganization: jest.Mock;
+    listSelectableTargets: jest.Mock;
+  };
 
   beforeEach(() => {
     authService = { comparePassword: jest.fn() };
@@ -80,6 +85,11 @@ describe('LoginController', () => {
     config = { get: jest.fn().mockReturnValue(undefined) };
     store = { getOAuthSession: jest.fn(), getClient: jest.fn() };
     sso = { startMcp: jest.fn() };
+    grants = {
+      grantServers: jest.fn().mockResolvedValue([]),
+      grantWholeOrganization: jest.fn().mockResolvedValue(true),
+      listSelectableTargets: jest.fn().mockResolvedValue([]),
+    };
 
     controller = new LoginController(
       authService as unknown as AuthService,
@@ -88,6 +98,7 @@ describe('LoginController', () => {
       store as unknown as PrismaOAuthStore,
       sso as unknown as SsoService,
       { mode: 'self-hosted', isCloud: () => false, isSelfHosted: () => true } as any,
+      grants as any,
     );
   });
 

--- a/packages/backend/src/auth/login.controller.ts
+++ b/packages/backend/src/auth/login.controller.ts
@@ -18,6 +18,14 @@ import { DeploymentService } from '../common/deployment.service';
 import { PrismaOAuthStore } from './prisma-oauth.store';
 import { SsoService } from '../identity-providers/sso.service';
 import { MCP_RESOURCE_COOKIE } from './resource-indicator.middleware';
+import { McpConnectionGrantService } from '../mcp-servers/mcp-connection-grant.service';
+
+/**
+ * Carries the VERIFIED identity across the second step of the authorize flow.
+ * Signed and httpOnly, so the server-selection submission cannot claim to be
+ * somebody else.
+ */
+const PENDING_GRANT_COOKIE = 'pending_grant';
 
 /**
  * Context describing the OAuth client that initiated the current authorize
@@ -26,6 +34,8 @@ import { MCP_RESOURCE_COOKIE } from './resource-indicator.middleware';
  * they submit their credentials.
  */
 interface ConsentContext {
+  /** The OAuth client a connection grant would be keyed on. */
+  clientId: string;
   clientName: string;
   redirectUri: string;
   redirectHost: string;
@@ -43,6 +53,7 @@ export class LoginController {
     private readonly oauthStore: PrismaOAuthStore,
     private readonly sso: SsoService,
     private readonly deployment: DeploymentService,
+    private readonly grants: McpConnectionGrantService,
   ) {}
 
   @Get('login')
@@ -214,9 +225,181 @@ export class LoginController {
     // The consent decision has been made — the single-use CSRF token is done.
     res.clearCookie('login_csrf');
 
+    // Between "who you are" and "what this client may reach". Returns true when
+    // it has taken over the response with the picker.
+    if (await this.maybeAskWhichServers(req, res, user.id)) return;
+
     // Derive callback URL from the request origin (works behind proxy/tunnel)
     const baseUrl = this.getBaseUrl(req);
     res.redirect(`${baseUrl}/callback`);
+  }
+
+  /**
+   * Decide what this client may reach, asking the user only when there is
+   * genuinely something to ask.
+   *
+   * Returns true when it has taken over the response — i.e. the picker is being
+   * shown and the OAuth flow is paused until the user submits it.
+   *
+   * The shape of the answer is dictated by what workspaces actually look like:
+   * 1318 of 1393 on the cloud instance have exactly one MCP server, and all but
+   * four users belong to a single workspace. Putting a screen in front of
+   * everyone to serve the remaining handful would add a step to the flow this
+   * whole piece of work exists to shorten, so a single candidate is granted
+   * silently and nothing is shown.
+   */
+  private async maybeAskWhichServers(
+    req: Request,
+    res: Response,
+    userId: string,
+  ): Promise<boolean> {
+    const consent = await this.loadConsentContext(req);
+    // Not an authorize flow — a bare visit to the login page. Nothing to grant.
+    if (!consent) return false;
+
+    // The client asked for one specific server via RFC 8707. It has already
+    // said what it wants; asking again would be noise. Still goes through
+    // grantServers, which drops an id this user cannot reach.
+    const requestedServerId = (req as Request & { signedCookies?: Record<string, unknown> })
+      .signedCookies?.[MCP_RESOURCE_COOKIE];
+    if (typeof requestedServerId === 'string' && requestedServerId) {
+      await this.grants.grantServers(consent.clientId, userId, [requestedServerId]);
+      return false;
+    }
+
+    const targets = await this.grants.listSelectableTargets(userId);
+    const servers = targets.flatMap((t) => t.servers);
+
+    // Nothing to choose between: one server, or one workspace whose servers are
+    // the only thing on offer. Grant it and carry on without a screen.
+    if (servers.length <= 1) {
+      if (servers.length === 1) {
+        await this.grants.grantServers(consent.clientId, userId, [servers[0].id]);
+      } else if (targets.length === 1) {
+        // No servers yet — grant the workspace, so a server created later is
+        // picked up without having to reconnect.
+        await this.grants.grantWholeOrganization(
+          consent.clientId,
+          userId,
+          targets[0].organizationId,
+        );
+      }
+      return false;
+    }
+
+    // More than one. Hold the verified identity in a signed, httpOnly cookie
+    // rather than a form field, so the submission cannot claim to be someone
+    // else, and issue a fresh CSRF token for the picker form.
+    const isSecure = this.isSecureRequest(req);
+    res.cookie(PENDING_GRANT_COOKIE, userId, {
+      httpOnly: true,
+      secure: isSecure,
+      maxAge: 10 * 60 * 1000,
+      sameSite: isSecure ? 'none' : 'lax',
+      signed: true,
+    });
+    const csrfToken = randomBytes(32).toString('base64url');
+    res.cookie('login_csrf', csrfToken, {
+      httpOnly: true,
+      secure: isSecure,
+      maxAge: 10 * 60 * 1000,
+      sameSite: isSecure ? 'none' : 'lax',
+      signed: true,
+    });
+
+    res.setHeader('Content-Type', 'text/html');
+    res.send(
+      this.renderServerPicker({
+        clientName: consent.clientName,
+        targets,
+        csrfToken,
+      }),
+    );
+    return true;
+  }
+
+  /**
+   * Second step of the authorize flow: which servers this client may reach.
+   *
+   * Nothing here is trusted. The identity comes from the signed cookie, not the
+   * form; and the ids that do come from the form go through `grantServers`,
+   * which resolves each one's owning organization from the database and drops
+   * anything this user is not a member of. A tampered submission can therefore
+   * only ever produce a NARROWER grant than the user was entitled to, never a
+   * wider one.
+   */
+  @Post('select-servers')
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  async handleServerSelection(
+    @Req() req: Request,
+    @Body() body: { servers?: string | string[]; workspace?: string; csrf?: string },
+    @Res() res: Response,
+  ) {
+    if (!this.verifyCsrf(req, body.csrf)) {
+      this.logger.warn('Rejected server selection with missing/invalid CSRF token');
+      res.clearCookie('login_csrf');
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Your session expired. Please try again.')}`,
+      );
+    }
+
+    const userId = (req as Request & { signedCookies?: Record<string, unknown> })
+      .signedCookies?.[PENDING_GRANT_COOKIE];
+    const consent = await this.loadConsentContext(req);
+    if (typeof userId !== 'string' || !userId || !consent) {
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Your session expired. Please sign in again.')}`,
+      );
+    }
+
+    const selected = Array.isArray(body.servers)
+      ? body.servers
+      : body.servers
+        ? [body.servers]
+        : [];
+
+    if (body.workspace) {
+      // "Everything in this workspace" — covers connectors not yet attached to
+      // any server. Refused outright if the user is not a member.
+      await this.grants.grantWholeOrganization(consent.clientId, userId, body.workspace);
+    } else if (selected.length > 0) {
+      const granted = await this.grants.grantServers(consent.clientId, userId, selected);
+      if (granted.length === 0) {
+        return res.redirect(
+          `/auth/login?error=${encodeURIComponent('None of the selected servers are available to you. Please try again.')}`,
+        );
+      }
+    } else {
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Choose at least one MCP server.')}`,
+      );
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true, name: true },
+    });
+    if (!user) {
+      return res.redirect(
+        `/auth/login?error=${encodeURIComponent('Your session expired. Please sign in again.')}`,
+      );
+    }
+
+    const encoded = Buffer.from(
+      JSON.stringify({ id: user.id, email: user.email, name: user.name, username: user.email }),
+    ).toString('base64url');
+    const isSecure = this.isSecureRequest(req);
+    res.cookie('login_user', encoded, {
+      httpOnly: true,
+      secure: isSecure,
+      maxAge: 60 * 1000,
+      sameSite: isSecure ? 'none' : 'lax',
+      signed: true,
+    });
+    res.clearCookie('login_csrf');
+    res.clearCookie(PENDING_GRANT_COOKIE);
+
+    res.redirect(`${this.getBaseUrl(req)}/callback`);
   }
 
   /**
@@ -249,6 +432,7 @@ export class LoginController {
         : "Access to your organization's MCP tools and connected servers.";
 
       return {
+        clientId: session.clientId,
         clientName: client?.client_name || session.clientId,
         redirectUri: session.redirectUri,
         redirectHost,
@@ -338,6 +522,94 @@ export class LoginController {
       this.logger.warn(`Could not load SSO providers: ${error?.message}`);
       return [];
     }
+  }
+
+  /**
+   * The second step: which MCP servers this client may reach.
+   *
+   * Only ever rendered when there is more than one candidate — see
+   * {@link maybeAskWhichServers}. Servers are grouped by workspace because that
+   * is how people think about them, and each workspace carries an "everything"
+   * option so connectors not yet attached to a server are still reachable.
+   */
+  private renderServerPicker(params: {
+    clientName: string;
+    targets: {
+      organizationId: string;
+      organizationName: string;
+      servers: { id: string; name: string; connectorCount: number }[];
+    }[];
+    csrfToken: string;
+  }): string {
+    const { clientName, targets, csrfToken } = params;
+
+    const groups = targets
+      .map((t) => {
+        const servers = t.servers
+          .map(
+            (srv) => `
+            <label class="row">
+              <input type="checkbox" name="servers" value="${this.escapeHtml(srv.id)}" />
+              <span class="row-name">${this.escapeHtml(srv.name)}</span>
+              <span class="row-meta">${srv.connectorCount} connector${srv.connectorCount === 1 ? '' : 's'}</span>
+            </label>`,
+          )
+          .join('');
+        const whole = `
+            <label class="row whole">
+              <input type="radio" name="workspace" value="${this.escapeHtml(t.organizationId)}" />
+              <span class="row-name">Everything in this workspace</span>
+              <span class="row-meta">including connectors not on a server</span>
+            </label>`;
+        return `
+        <fieldset>
+          <legend>${this.escapeHtml(t.organizationName)}</legend>
+          ${servers}${whole}
+        </fieldset>`;
+      })
+      .join('');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Choose what to connect</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+           background: #f5f6f8; margin: 0; padding: 40px 16px; color: #111; }
+    .card { max-width: 460px; margin: 0 auto; background: #fff; border-radius: 12px;
+            padding: 28px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+    h1 { font-size: 19px; margin: 0 0 6px; }
+    p.lead { color: #555; font-size: 14px; margin: 0 0 20px; }
+    .app { font-weight: 600; }
+    fieldset { border: 1px solid #e3e5e8; border-radius: 9px; margin: 0 0 14px; padding: 10px 12px 12px; }
+    legend { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: #6b7280; padding: 0 4px; }
+    .row { display: flex; align-items: center; gap: 10px; padding: 8px 4px; border-radius: 7px; cursor: pointer; }
+    .row:hover { background: #f7f8fa; }
+    .row-name { flex: 1; font-size: 14px; }
+    .row-meta { font-size: 12px; color: #8a8f98; }
+    .whole { border-top: 1px solid #eef0f2; margin-top: 6px; padding-top: 12px; }
+    button { width: 100%; padding: 11px; font-size: 15px; font-weight: 600; color: #fff;
+             background: #2563eb; border: 0; border-radius: 8px; cursor: pointer; margin-top: 6px; }
+    button:hover { background: #1d4ed8; }
+    .note { font-size: 12px; color: #8a8f98; margin-top: 14px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Choose what to connect</h1>
+    <p class="lead"><span class="app">${this.escapeHtml(clientName)}</span> will be able to use
+      the tools from whatever you pick here — and nothing else.</p>
+    <form method="POST" action="/auth/select-servers">
+      <input type="hidden" name="csrf" value="${this.escapeHtml(csrfToken)}" />
+      ${groups}
+      <button type="submit">Connect</button>
+    </form>
+    <p class="note">You can change this later from Settings, without reconnecting.</p>
+  </div>
+</body>
+</html>`;
   }
 
   private renderLoginPage(params: {

--- a/packages/backend/src/auth/oauth-body.util.ts
+++ b/packages/backend/src/auth/oauth-body.util.ts
@@ -1,0 +1,31 @@
+import { Request } from 'express';
+
+/**
+ * Reads an OAuth token-endpoint request body, tolerating both JSON and
+ * form-urlencoded clients.
+ *
+ * Shared by every middleware that pre-processes `POST /token`, so they agree on
+ * what the request said. `main.ts` installs `json()` and `urlencoded()` app-wide
+ * before Nest routing, so in practice `req.body` is already an object; the
+ * string branch covers a body parser that handed back the raw payload.
+ *
+ * SECURITY / CORRECTNESS: this must never read the raw stream. The upstream
+ * `@rekog/mcp-nest-auth` token controller has a `captureRawBody` fallback that
+ * re-reads the request when the content type is form-urlencoded and `req.body`
+ * is empty. A middleware that consumed the stream would leave that path waiting
+ * on data that never arrives, hanging the token endpoint.
+ */
+export function parseOAuthBody(req: Request): Record<string, any> {
+  if (req.body && typeof req.body === 'object') {
+    return req.body as Record<string, any>;
+  }
+  if (typeof req.body === 'string') {
+    const params = new URLSearchParams(req.body);
+    const result: Record<string, string> = {};
+    for (const [key, value] of params.entries()) {
+      result[key] = value;
+    }
+    return result;
+  }
+  return {};
+}

--- a/packages/backend/src/auth/refresh-token-revocation.middleware.spec.ts
+++ b/packages/backend/src/auth/refresh-token-revocation.middleware.spec.ts
@@ -1,0 +1,258 @@
+import { RefreshTokenRevocationMiddleware } from './refresh-token-revocation.middleware';
+
+describe('RefreshTokenRevocationMiddleware', () => {
+  const USER_ID = 'cmpzj8mm9007j1ymn5mo2y3eq';
+  const TOKEN = 'a.signed.refresh-token';
+
+  let middleware: RefreshTokenRevocationMiddleware;
+  let prisma: any;
+  let jwt: any;
+  let securityEvents: any;
+  let res: any;
+  let next: jest.Mock;
+
+  /** Seconds since epoch, the unit `iat` uses. */
+  const secs = (d: Date) => Math.floor(d.getTime() / 1000);
+
+  const req = (body: any, method = 'POST') => ({ method, body }) as any;
+
+  const refreshBody = (token: string | undefined = TOKEN) => ({
+    grant_type: 'refresh_token',
+    ...(token === undefined ? {} : { refresh_token: token }),
+  });
+
+  beforeEach(() => {
+    prisma = {
+      user: { findUnique: jest.fn() },
+      oAuthUserProfile: { findUnique: jest.fn().mockResolvedValue(null) },
+    };
+    jwt = { verifyAsync: jest.fn() };
+    securityEvents = { log: jest.fn().mockResolvedValue(undefined) };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      setHeader: jest.fn().mockReturnThis(),
+    };
+    next = jest.fn();
+    middleware = new RefreshTokenRevocationMiddleware(
+      prisma,
+      jwt,
+      securityEvents,
+    );
+  });
+
+  const expectPassthrough = () => {
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  };
+
+  const expectDenied = () => {
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid_grant',
+      error_description: 'This session was revoked. Please sign in again.',
+    });
+  };
+
+  // ── Pass-through: everything the upstream controller still owns ──────────
+
+  it('ignores non-POST requests', async () => {
+    await middleware.use(req(refreshBody(), 'GET'), res, next);
+    expectPassthrough();
+    expect(jwt.verifyAsync).not.toHaveBeenCalled();
+  });
+
+  it('ignores the authorization_code grant', async () => {
+    await middleware.use(req({ grant_type: 'authorization_code' }), res, next);
+    expectPassthrough();
+  });
+
+  it('does not interfere with the client_credentials grant', async () => {
+    // Guards the sibling middleware on the same route.
+    await middleware.use(req({ grant_type: 'client_credentials' }), res, next);
+    expectPassthrough();
+    expect(jwt.verifyAsync).not.toHaveBeenCalled();
+  });
+
+  it('leaves a missing refresh_token to upstream', async () => {
+    await middleware.use(req(refreshBody(undefined)), res, next);
+    expectPassthrough();
+  });
+
+  it('leaves an unverifiable token to upstream', async () => {
+    jwt.verifyAsync.mockRejectedValue(new Error('invalid signature'));
+    await middleware.use(req(refreshBody()), res, next);
+    expectPassthrough();
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('leaves an access token presented as a refresh token to upstream', async () => {
+    jwt.verifyAsync.mockResolvedValue({ sub: USER_ID, type: 'access' });
+    await middleware.use(req(refreshBody()), res, next);
+    expectPassthrough();
+  });
+
+  // ── The watermark ────────────────────────────────────────────────────────
+
+  it('allows the refresh when the user was never revoked', async () => {
+    jwt.verifyAsync.mockResolvedValue({ sub: USER_ID, type: 'refresh', iat: 1000 });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: null,
+    });
+    await middleware.use(req(refreshBody()), res, next);
+    expectPassthrough();
+  });
+
+  it('allows a token minted in the same second as the revocation', async () => {
+    // Mirrors isTokenRevoked, which compares at second granularity so a token
+    // issued moments after a password change is not rejected.
+    const cutover = new Date('2026-09-11T12:00:00.500Z');
+    jwt.verifyAsync.mockResolvedValue({
+      sub: USER_ID,
+      type: 'refresh',
+      iat: secs(cutover),
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: cutover,
+    });
+    await middleware.use(req(refreshBody()), res, next);
+    expectPassthrough();
+  });
+
+  it('refuses a token minted before the revocation', async () => {
+    // THE BUG: before this middleware the upstream refresh grant answered 200
+    // here and minted a token with a fresh iat, permanently above the watermark.
+    const cutover = new Date('2026-09-11T12:00:00Z');
+    jwt.verifyAsync.mockResolvedValue({
+      sub: USER_ID,
+      type: 'refresh',
+      iat: secs(cutover) - 1,
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: cutover,
+    });
+    await middleware.use(req(refreshBody()), res, next);
+    expectDenied();
+  });
+
+  it('marks the denial uncacheable', async () => {
+    const cutover = new Date('2026-09-11T12:00:00Z');
+    jwt.verifyAsync.mockResolvedValue({
+      sub: USER_ID,
+      type: 'refresh',
+      iat: secs(cutover) - 1,
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: cutover,
+    });
+    await middleware.use(req(refreshBody()), res, next);
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    expect(res.setHeader).toHaveBeenCalledWith('Pragma', 'no-cache');
+  });
+
+  it('refuses a token whose user no longer exists', async () => {
+    jwt.verifyAsync.mockResolvedValue({ sub: USER_ID, type: 'refresh', iat: 1000 });
+    prisma.user.findUnique.mockResolvedValue(null);
+    await middleware.use(req(refreshBody()), res, next);
+    expectDenied();
+  });
+
+  // ── Subject resolution (never by email) ──────────────────────────────────
+
+  it('refuses a legacy email-subject token with no recoverable profile', async () => {
+    jwt.verifyAsync.mockResolvedValue({
+      sub: 'victim@example.com',
+      type: 'refresh',
+      iat: 1000,
+    });
+    await middleware.use(req(refreshBody()), res, next);
+    expectDenied();
+    // An email must never become a lookup key.
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('resolves a legacy email-subject token through its profile id', async () => {
+    jwt.verifyAsync.mockResolvedValue({
+      sub: 'user@example.com',
+      user_profile_id: 'local:' + USER_ID,
+      type: 'refresh',
+      iat: 1000,
+    });
+    prisma.oAuthUserProfile.findUnique.mockResolvedValue({
+      externalId: USER_ID,
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: null,
+    });
+    await middleware.use(req(refreshBody()), res, next);
+    expectPassthrough();
+    expect(prisma.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: USER_ID } }),
+    );
+  });
+
+  // ── Body handling ────────────────────────────────────────────────────────
+
+  it('reads a form-urlencoded string body', async () => {
+    const cutover = new Date('2026-09-11T12:00:00Z');
+    jwt.verifyAsync.mockResolvedValue({
+      sub: USER_ID,
+      type: 'refresh',
+      iat: secs(cutover) - 1,
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: cutover,
+    });
+    await middleware.use(
+      req(`grant_type=refresh_token&refresh_token=${TOKEN}`),
+      res,
+      next,
+    );
+    expectDenied();
+  });
+
+  it('never reads the raw request stream', async () => {
+    // The upstream token controller has a captureRawBody fallback; consuming
+    // the stream here would hang it.
+    const on = jest.fn();
+    await middleware.use({ method: 'POST', body: refreshBody(), on } as any, res, next);
+    expect(on).not.toHaveBeenCalled();
+  });
+
+  // ── Audit ────────────────────────────────────────────────────────────────
+
+  it('audits a refusal once per subject within the flood window', async () => {
+    const cutover = new Date('2026-09-11T12:00:00Z');
+    jwt.verifyAsync.mockResolvedValue({
+      sub: USER_ID,
+      type: 'refresh',
+      iat: secs(cutover) - 1,
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      id: USER_ID,
+      sessionsValidFrom: cutover,
+    });
+
+    await middleware.use(req(refreshBody()), res, next);
+    await middleware.use(req(refreshBody()), res, next);
+
+    expect(securityEvents.log).toHaveBeenCalledTimes(1);
+    expect(securityEvents.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'TOKEN_REJECTED',
+        targetUserId: USER_ID,
+        metadata: expect.objectContaining({
+          grantType: 'refresh_token',
+          reason: 'revoked',
+        }),
+      }),
+    );
+  });
+});

--- a/packages/backend/src/auth/refresh-token-revocation.middleware.ts
+++ b/packages/backend/src/auth/refresh-token-revocation.middleware.ts
@@ -1,0 +1,151 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request, Response, NextFunction } from 'express';
+import { PrismaService } from '../common/prisma.service';
+import { SecurityEventService, SecurityEvents } from '../audit/security-event.service';
+import { isTokenRevoked } from './auth.service';
+import { parseOAuthBody } from './oauth-body.util';
+import { resolveUserIdFromTokenPayload } from './resolve-user-id.util';
+
+/**
+ * Makes `users.sessionsValidFrom` mean something on the OAuth refresh grant.
+ *
+ * THE BUG THIS EXISTS FOR. The watermark was enforced on two of the three paths
+ * that can present a user token — `JwtStrategy` for the dashboard API and
+ * `McpCombinedAuthGuard` for every MCP request — but `POST /token` belongs to
+ * `@rekog/mcp-nest-auth`, whose `handleRefreshTokenGrant` mints a new access
+ * token straight from the refresh token's claims and consults no user record at
+ * all. So a revoked client simply refreshed: the new token carried a fresh
+ * `iat`, which sat above the watermark, and `isTokenRevoked` said "fine". With
+ * a 30-day refresh lifetime, no rotation and no jti denylist, raising the
+ * watermark bought at most one access-token lifetime. Observed in production:
+ * a revoked user ran ERP queries 30 minutes later, with three `POST /token →
+ * 200` and no `/authorize` in between. The only way to actually cut them off
+ * was deleting every row from `oauth_clients`, which forces re-registration on
+ * every client of the instance. This middleware retires that workaround.
+ *
+ * SCOPE. It is a veto, not a second authenticator. Anything that is not a
+ * verifiable refresh token — wrong method, wrong grant, bad signature, wrong
+ * token type — falls through to `next()` so the upstream controller keeps
+ * owning those errors and the two can never disagree.
+ *
+ * UPSTREAM COUPLING. This depends on the refresh payload shape of
+ * @rekog/mcp-nest-auth (`sub`, `type: 'refresh'`, optional `user_profile_id`,
+ * HS256 with our JWT_SECRET — see its `jwt-token.service.ts` generateTokenPair
+ * and `mcp-oauth.controller.ts` handleRefreshTokenGrant). Re-verify both when
+ * bumping that dependency.
+ *
+ * Never reads the raw request stream — see the note on `parseOAuthBody`.
+ */
+@Injectable()
+export class RefreshTokenRevocationMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(RefreshTokenRevocationMiddleware.name);
+
+  /**
+   * Last audit write per subject. This middleware runs BEFORE ThrottlerGuard,
+   * so an unconforming client looping on a rejected refresh could otherwise
+   * write a security-event row per attempt. A conforming client cannot loop: it
+   * discards its tokens on `invalid_grant` before retrying.
+   */
+  private readonly lastLoggedAt = new Map<string, number>();
+  private static readonly AUDIT_WINDOW_MS = 60_000;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jwt: JwtService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    if (req.method !== 'POST') return next();
+
+    const body = parseOAuthBody(req);
+    if (body.grant_type !== 'refresh_token') return next();
+
+    const token = body.refresh_token;
+    // Missing parameter is upstream's error to report, not ours.
+    if (typeof token !== 'string' || !token) return next();
+
+    let payload: any;
+    try {
+      payload = await this.jwt.verifyAsync(token, { algorithms: ['HS256'] });
+    } catch {
+      // Malformed, expired or forged — upstream owns the response.
+      return next();
+    }
+
+    // Upstream checks this too; bailing keeps the error text in one place.
+    if (payload?.type !== 'refresh') return next();
+
+    const userId = await resolveUserIdFromTokenPayload(this.prisma, payload);
+    if (!userId) {
+      // Every refresh token originates from the authorization-code path, so one
+      // that verifies against our secret but cannot be attributed to a user is
+      // exactly the unrevocable session this middleware exists to eliminate.
+      // The cost of a false positive is one automatic re-authorization.
+      return this.deny(res, payload, undefined, 'unresolvable_subject');
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, sessionsValidFrom: true },
+    });
+    // A deleted account leaves no watermark to compare against.
+    if (!user) return this.deny(res, payload, userId, 'user_deleted');
+
+    if (isTokenRevoked(payload, user.sessionsValidFrom)) {
+      return this.deny(res, payload, userId, 'revoked');
+    }
+
+    // Deactivation is deliberately NOT checked here: it is per-membership, and
+    // `UserLifecycleService` stamps `sessionsValidFrom` in the same transaction,
+    // so the watermark above already covers it. Re-deriving org membership from
+    // the `resource` claim would duplicate what `getAllowedToolIds` enforces
+    // fail-closed on every request.
+    return next();
+  }
+
+  private deny(
+    res: Response,
+    payload: any,
+    userId: string | undefined,
+    reason: string,
+  ) {
+    this.audit(payload, userId, reason);
+
+    // 400 + `invalid_grant`, and the shape matters more than the status. The
+    // MCP client branches on the OAuth error CODE: given `invalid_grant` it
+    // discards its stored tokens and starts a fresh authorization, which is
+    // what we want and is structurally loop-free. Nest's default error body
+    // would arrive as code "Bad Request", which the client neither retries nor
+    // re-authorizes on — it just fails. And never 401: on the token endpoint
+    // that means client authentication failed, which makes clients throw away
+    // their dynamic registration too.
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Pragma', 'no-cache');
+    return res.status(400).json({
+      error: 'invalid_grant',
+      error_description: 'This session was revoked. Please sign in again.',
+    });
+  }
+
+  private audit(payload: any, userId: string | undefined, reason: string) {
+    const key = userId ?? `anon:${payload?.jti ?? 'unknown'}`;
+    const now = Date.now();
+    const last = this.lastLoggedAt.get(key);
+    if (last && now - last < RefreshTokenRevocationMiddleware.AUDIT_WINDOW_MS) {
+      return;
+    }
+    this.lastLoggedAt.set(key, now);
+
+    this.logger.warn(
+      `Refused refresh_token for ${userId ?? 'unresolvable subject'} (${reason})`,
+    );
+    void this.securityEvents.log({
+      event: SecurityEvents.TOKEN_REJECTED,
+      actorType: userId ? 'USER' : 'ANONYMOUS',
+      targetUserId: userId,
+      metadata: { path: '/token', grantType: 'refresh_token', reason },
+    });
+  }
+}

--- a/packages/backend/src/auth/resolve-user-id.util.ts
+++ b/packages/backend/src/auth/resolve-user-id.util.ts
@@ -1,0 +1,50 @@
+import { PrismaService } from '../common/prisma.service';
+
+/**
+ * Resolves the `users.id` cuid a token belongs to, WITHOUT ever trusting an
+ * email claim.
+ *
+ * Tokens minted after LocalOAuthProvider started mapping the profile `username`
+ * to the cuid carry it directly in `sub`.
+ *
+ * Tokens minted BEFORE that carry the user's email in `sub` — but they also
+ * carry `user_profile_id`, and `oauth_user_profiles.external_id` has always
+ * stored the cuid (PrismaOAuthStore.upsertUserProfile writes
+ * `externalId: profile.id`, and `profile.id` comes from the login cookie's
+ * `user.id`). So the cuid is recoverable from authoritative server state, keyed
+ * by an opaque identifier that is bound to the signed token.
+ *
+ * That is why no legacy email fallback is needed: previously-issued sessions
+ * keep working, and the mutable, IdP-supplied `email` claim never takes part in
+ * identity resolution.
+ *
+ * SECURITY: this logic must exist in exactly one place. It is the fix for the
+ * nOAuth class of bug — an email-keyed lookup would let anyone able to
+ * influence an IdP profile resolve to another organization's user. Both the
+ * MCP request guard and the refresh-grant middleware call in here; do not
+ * reimplement it at a third site.
+ */
+export async function resolveUserIdFromTokenPayload(
+  prisma: PrismaService,
+  payload: { sub?: string; user_profile_id?: string } | null | undefined,
+): Promise<string | undefined> {
+  const sub: string | undefined = payload?.sub;
+
+  // Modern tokens: `sub` is already the cuid. Emails are the only other shape
+  // we have ever put there, so an '@' is a reliable discriminator.
+  if (sub && !sub.includes('@')) return sub;
+
+  const profileId: string | undefined = payload?.user_profile_id;
+  if (profileId) {
+    const profile = await prisma.oAuthUserProfile.findUnique({
+      where: { profileId },
+      select: { externalId: true },
+    });
+    if (profile?.externalId) return profile.externalId;
+  }
+
+  // Legacy token with no recoverable profile → fail closed. Returning the email
+  // here would reintroduce the email-keyed lookup this function exists to
+  // remove.
+  return undefined;
+}

--- a/packages/backend/src/auth/server-picker.spec.ts
+++ b/packages/backend/src/auth/server-picker.spec.ts
@@ -1,0 +1,258 @@
+// `openid-client` is ESM-only and this suite reaches it transitively through
+// LoginController -> SsoService. Nothing here exercises the network half.
+jest.mock('openid-client', () => ({}));
+
+import { LoginController } from './login.controller';
+
+/**
+ * The second step of the authorize flow — which MCP servers a client may reach.
+ *
+ * Two things are being pinned here. The first is that it stays OUT of the way:
+ * 1318 of 1393 workspaces on the cloud instance have exactly one MCP server and
+ * all but four users belong to a single workspace, so a screen shown to
+ * everyone would add a step to the flow this work exists to shorten. The second
+ * is that nothing submitted by the browser is trusted with identity.
+ */
+function build(
+  opts: {
+    targets?: any[];
+    consent?: any;
+    requestedServerId?: string;
+  } = {},
+) {
+  const grants = {
+    grantServers: jest.fn().mockResolvedValue(['srv-1']),
+    grantWholeOrganization: jest.fn().mockResolvedValue(true),
+    listSelectableTargets: jest.fn().mockResolvedValue(opts.targets ?? []),
+  };
+  const store = {
+    getOAuthSession: jest.fn().mockResolvedValue(
+      opts.consent === null
+        ? null
+        : { clientId: 'client-1', redirectUri: 'https://claude.ai/cb', scope: 's' },
+    ),
+    getClient: jest.fn().mockResolvedValue({ client_name: 'Claude' }),
+  };
+  const controller = new LoginController(
+    { comparePassword: jest.fn() } as any,
+    { user: { findUnique: jest.fn() } } as any,
+    { get: jest.fn() } as any,
+    store as any,
+    { startMcp: jest.fn() } as any,
+    { isCloud: () => true } as any,
+    grants as any,
+  );
+
+  const req: any = {
+    cookies: { oauth_session: opts.consent === null ? undefined : 'sess-1' },
+    signedCookies: opts.requestedServerId
+      ? { mcp_resource: opts.requestedServerId }
+      : {},
+    headers: { host: 'cloud.anythingmcp.com' },
+  };
+  const res: any = {
+    cookie: jest.fn(),
+    setHeader: jest.fn(),
+    send: jest.fn(),
+    redirect: jest.fn(),
+    clearCookie: jest.fn(),
+  };
+  return { controller, grants, req, res };
+}
+
+const ask = (c: LoginController, req: any, res: any, userId = 'u1') =>
+  (c as any).maybeAskWhichServers(req, res, userId);
+
+const workspace = (id: string, name: string, servers: any[]) => ({
+  organizationId: id,
+  organizationName: name,
+  servers,
+});
+const server = (id: string, name: string, connectorCount = 1) => ({
+  id,
+  name,
+  connectorCount,
+});
+
+describe('choosing what a client may reach', () => {
+  it('shows nothing and grants the only server there is', async () => {
+    const { controller, grants, req, res } = build({
+      targets: [workspace('org-A', 'Acme', [server('srv-1', 'Default')])],
+    });
+
+    await expect(ask(controller, req, res)).resolves.toBe(false);
+
+    expect(grants.grantServers).toHaveBeenCalledWith('client-1', 'u1', ['srv-1']);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('asks once there is more than one server to choose between', async () => {
+    const { controller, grants, req, res } = build({
+      targets: [
+        workspace('org-A', 'Acme', [server('srv-1', 'ERP'), server('srv-2', 'CRM')]),
+      ],
+    });
+
+    await expect(ask(controller, req, res)).resolves.toBe(true);
+
+    expect(res.send).toHaveBeenCalled();
+    const html = res.send.mock.calls[0][0];
+    expect(html).toContain('ERP');
+    expect(html).toContain('CRM');
+    expect(html).toContain('Everything in this workspace');
+    // Nothing is granted until the user answers.
+    expect(grants.grantServers).not.toHaveBeenCalled();
+  });
+
+  it('asks a multi-workspace user even when each workspace has one server', async () => {
+    const { controller, req, res } = build({
+      targets: [
+        workspace('org-A', 'Acme', [server('srv-1', 'Default')]),
+        workspace('org-B', 'Globex', [server('srv-2', 'Default')]),
+      ],
+    });
+
+    await expect(ask(controller, req, res)).resolves.toBe(true);
+    const html = res.send.mock.calls[0][0];
+    expect(html).toContain('Acme');
+    expect(html).toContain('Globex');
+  });
+
+  // The client already said which server it wants via RFC 8707. Asking again
+  // would be noise — but it still goes through grantServers, which drops an id
+  // this user cannot reach.
+  it('honours a server the client named, without asking', async () => {
+    const { controller, grants, req, res } = build({
+      requestedServerId: 'srv-named',
+      targets: [
+        workspace('org-A', 'Acme', [server('srv-1', 'a'), server('srv-2', 'b')]),
+      ],
+    });
+
+    await expect(ask(controller, req, res)).resolves.toBe(false);
+
+    expect(grants.grantServers).toHaveBeenCalledWith('client-1', 'u1', ['srv-named']);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('grants the workspace when it has no servers yet, so one added later is picked up', async () => {
+    const { controller, grants, req, res } = build({
+      targets: [workspace('org-A', 'Acme', [])],
+    });
+
+    await expect(ask(controller, req, res)).resolves.toBe(false);
+
+    expect(grants.grantWholeOrganization).toHaveBeenCalledWith('client-1', 'u1', 'org-A');
+  });
+
+  it('does nothing at all outside an authorize flow', async () => {
+    const { controller, grants, req, res } = build({ consent: null });
+
+    await expect(ask(controller, req, res)).resolves.toBe(false);
+
+    expect(grants.grantServers).not.toHaveBeenCalled();
+    expect(grants.grantWholeOrganization).not.toHaveBeenCalled();
+  });
+
+  it('carries the verified identity in a signed cookie, never the form', async () => {
+    const { controller, req, res } = build({
+      targets: [
+        workspace('org-A', 'Acme', [server('srv-1', 'a'), server('srv-2', 'b')]),
+      ],
+    });
+
+    await ask(controller, req, res);
+
+    const pending = res.cookie.mock.calls.find((c: any[]) => c[0] === 'pending_grant');
+    expect(pending).toBeDefined();
+    expect(pending[1]).toBe('u1');
+    expect(pending[2]).toMatchObject({ httpOnly: true, signed: true });
+    // The rendered form must not carry the user id anywhere.
+    expect(res.send.mock.calls[0][0]).not.toContain('u1');
+  });
+
+  it('escapes a workspace name instead of interpolating it raw', async () => {
+    const { controller, req, res } = build({
+      targets: [
+        workspace('org-A', '<img src=x onerror=alert(1)>', [
+          server('srv-1', 'a'),
+          server('srv-2', 'b'),
+        ]),
+      ],
+    });
+
+    await ask(controller, req, res);
+    const html = res.send.mock.calls[0][0];
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img');
+  });
+});
+
+describe('submitting the selection', () => {
+  const submit = (c: LoginController, req: any, body: any, res: any) =>
+    (c as any).handleServerSelection(req, body, res);
+
+  function submitFixture(signed: Record<string, unknown>) {
+    const f = build({ targets: [] });
+    f.req.signedCookies = { login_csrf: 'tok', ...signed };
+    return f;
+  }
+
+  it('refuses without a matching CSRF token', async () => {
+    const { controller, grants, req, res } = submitFixture({ pending_grant: 'u1' });
+
+    await submit(controller, req, { servers: ['srv-1'], csrf: 'wrong' }, res);
+
+    expect(grants.grantServers).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining('error='));
+  });
+
+  it('refuses when the signed identity cookie is absent', async () => {
+    const { controller, grants, req, res } = submitFixture({});
+
+    await submit(controller, req, { servers: ['srv-1'], csrf: 'tok' }, res);
+
+    expect(grants.grantServers).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty selection rather than granting nothing silently', async () => {
+    const { controller, grants, req, res } = submitFixture({ pending_grant: 'u1' });
+
+    await submit(controller, req, { csrf: 'tok' }, res);
+
+    expect(grants.grantServers).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith(
+      expect.stringContaining('Choose%20at%20least%20one'),
+    );
+  });
+
+  // The ids come from the browser. grantServers resolves each one's owning
+  // organization and drops what this user cannot reach, so a tampered form can
+  // only ever produce a NARROWER grant — never a wider one.
+  it('sends the submitted ids straight to the validating write', async () => {
+    const { controller, grants, req, res } = submitFixture({ pending_grant: 'u1' });
+
+    await submit(
+      controller,
+      req,
+      { servers: ['srv-mine', 'srv-of-another-tenant'], csrf: 'tok' },
+      res,
+    );
+
+    expect(grants.grantServers).toHaveBeenCalledWith('client-1', 'u1', [
+      'srv-mine',
+      'srv-of-another-tenant',
+    ]);
+  });
+
+  it('stops when nothing in the selection validated', async () => {
+    const { controller, grants, req, res } = submitFixture({ pending_grant: 'u1' });
+    grants.grantServers.mockResolvedValue([]);
+
+    await submit(controller, req, { servers: ['srv-theirs'], csrf: 'tok' }, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      expect.stringContaining('None%20of%20the%20selected'),
+    );
+  });
+});

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.spec.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.spec.ts
@@ -19,7 +19,11 @@ import {
  */
 function build(
   overrides: {
-    grant?: { organizationId: string | null; serverIds: string[] } | null;
+    grant?: {
+      organizationId: string | null;
+      serverIds: string[];
+      revokedAt?: Date | null;
+    } | null;
     memberCount?: number;
     servers?: { id: string; organizationId: string }[];
   } = {},
@@ -29,10 +33,15 @@ function build(
     countMembers: [],
     upsert: [],
     del: [],
+    update: [],
   };
 
   const prisma: any = {
     mcpConnectionGrant: {
+      updateMany: jest.fn(async (args: any) => {
+        calls.update.push(args);
+        return { count: overrides.grant ? 1 : 0 };
+      }),
       findUnique: jest
         .fn()
         .mockResolvedValue(
@@ -150,6 +159,25 @@ describe('McpConnectionGrantService.resolve', () => {
       mode: 'servers',
       servers: [{ id: 'srv-mine', organizationId: 'org-A' }],
     });
+  });
+
+  it('shows nothing for a revoked connection, without re-reading its targets', async () => {
+    const { svc, calls } = build({
+      grant: {
+        organizationId: 'org-A',
+        serverIds: ['srv-1'],
+        revokedAt: new Date(),
+      },
+      memberCount: 1,
+      servers: [{ id: 'srv-1', organizationId: 'org-A' }],
+    });
+
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'none',
+    });
+    // Short-circuits: no point validating targets nobody may use.
+    expect(calls.findManyServers).toHaveLength(0);
+    expect(calls.countMembers).toHaveLength(0);
   });
 
   it('fails closed on a grant that is empty on both sides', async () => {
@@ -270,6 +298,7 @@ describe('McpConnectionGrantService writing a grant', () => {
     expect(calls.upsert[0].update).toEqual({
       organizationId: null,
       serverIds: ['srv-mine'],
+      revokedAt: null,
     });
   });
 
@@ -285,13 +314,35 @@ describe('McpConnectionGrantService writing a grant', () => {
     expect(calls.upsert).toHaveLength(0);
   });
 
-  it('revokes by (client, user) and tolerates a missing row', async () => {
-    const { svc, calls } = build();
-
-    await svc.revoke('client-1', 'user-1');
-
-    expect(calls.del[0].where).toEqual({
-      clientId_userId: { clientId: 'client-1', userId: 'user-1' },
+  // Deleting the row would read back as "no grant", which is the pre-grant
+  // behaviour — the caller's whole organization. A revoke that widens access is
+  // the opposite of a revoke.
+  it('stamps the row instead of deleting it', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: 'org-A', serverIds: [] },
     });
+
+    await expect(svc.revoke('client-1', 'user-1')).resolves.toBe(true);
+
+    expect(calls.del).toHaveLength(0);
+    expect(calls.update[0].where).toEqual({
+      clientId: 'client-1',
+      userId: 'user-1',
+      revokedAt: null,
+    });
+    expect(calls.update[0].data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('reports that there was nothing to revoke', async () => {
+    const { svc } = build({ grant: null });
+    await expect(svc.revoke('client-1', 'user-1')).resolves.toBe(false);
+  });
+
+  it('un-revokes when the user chooses again', async () => {
+    const { svc, calls } = build({ memberCount: 1 });
+
+    await svc.grantWholeOrganization('client-1', 'user-1', 'org-A');
+
+    expect(calls.upsert[0].update.revokedAt).toBeNull();
   });
 });

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
@@ -57,9 +57,14 @@ export class McpConnectionGrantService {
 
     const grant = await this.prisma.mcpConnectionGrant.findUnique({
       where: { clientId_userId: { clientId, userId } },
-      select: { organizationId: true, serverIds: true },
+      select: { organizationId: true, serverIds: true, revokedAt: true },
     });
     if (!grant) return null;
+
+    // Revoked from the dashboard. Not the same as absent: absent means the
+    // client was connected before grants existed and keeps the old behaviour,
+    // revoked means the user asked for this connection to stop seeing things.
+    if (grant.revokedAt) return { mode: 'none' };
 
     if (grant.organizationId) {
       const stillAMember = await this.isMember(userId, grant.organizationId);
@@ -120,11 +125,21 @@ export class McpConnectionGrantService {
     return valid.map((s) => s.id);
   }
 
-  /** Drop a client's grant. Idempotent. */
-  async revoke(clientId: string, userId: string): Promise<void> {
-    await this.prisma.mcpConnectionGrant
-      .delete({ where: { clientId_userId: { clientId, userId } } })
-      .catch(() => undefined);
+  /**
+   * Stop a client seeing anything, without deleting the row.
+   *
+   * Deleting would read back as "no grant", which is the pre-grant behaviour —
+   * the caller's whole organization. A revoke has to narrow, so it stamps
+   * `revokedAt` and leaves the rest in place; choosing again clears it.
+   *
+   * Returns false when there was nothing to revoke.
+   */
+  async revoke(clientId: string, userId: string): Promise<boolean> {
+    const { count } = await this.prisma.mcpConnectionGrant.updateMany({
+      where: { clientId, userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    return count > 0;
   }
 
   /**
@@ -187,6 +202,7 @@ export class McpConnectionGrantService {
         clientId: true,
         organizationId: true,
         serverIds: true,
+        revokedAt: true,
         createdAt: true,
         updatedAt: true,
       },
@@ -239,7 +255,9 @@ export class McpConnectionGrantService {
     await this.prisma.mcpConnectionGrant.upsert({
       where: { clientId_userId: { clientId, userId } },
       create: { clientId, userId, ...data },
-      update: data,
+      // Choosing again un-revokes: the user is explicitly saying what this
+      // client may reach, which is the opposite of having revoked it.
+      update: { ...data, revokedAt: null },
     });
   }
 }

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
@@ -127,6 +127,57 @@ export class McpConnectionGrantService {
       .catch(() => undefined);
   }
 
+  /**
+   * The workspaces this user belongs to and the MCP servers in each — what a
+   * picker may offer, and nothing else.
+   *
+   * Membership is the query, not a filter applied afterwards, for the same
+   * reason as {@link validateServers}: a workspace the user does not belong to
+   * cannot appear in the result at all, so it cannot be offered and then
+   * accidentally accepted.
+   */
+  async listSelectableTargets(userId: string): Promise<
+    {
+      organizationId: string;
+      organizationName: string;
+      servers: { id: string; name: string; connectorCount: number }[];
+    }[]
+  > {
+    if (!userId) return [];
+
+    const memberships = await this.prisma.organizationMember.findMany({
+      where: { userId, deactivatedAt: null },
+      select: {
+        organization: {
+          select: {
+            id: true,
+            name: true,
+            mcpServers: {
+              where: { isActive: true },
+              orderBy: { createdAt: 'asc' },
+              select: {
+                id: true,
+                name: true,
+                _count: { select: { connectors: true } },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { joinedAt: 'asc' },
+    });
+
+    return memberships.map((m) => ({
+      organizationId: m.organization.id,
+      organizationName: m.organization.name,
+      servers: m.organization.mcpServers.map((s) => ({
+        id: s.id,
+        name: s.name,
+        connectorCount: s._count.connectors,
+      })),
+    }));
+  }
+
   /** Everything this user has granted, for the dashboard's revoke list. */
   async listForUser(userId: string) {
     return this.prisma.mcpConnectionGrant.findMany({

--- a/packages/backend/src/mcp-servers/mcp-connections.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-connections.controller.ts
@@ -1,0 +1,173 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { McpConnectionGrantService } from './mcp-connection-grant.service';
+import { PrismaService } from '../common/prisma.service';
+import {
+  SecurityEventService,
+  SecurityEvents,
+} from '../audit/security-event.service';
+
+interface UpdateConnectionDto {
+  /** Grant a whole workspace. Mutually exclusive with `serverIds`. */
+  organizationId?: string;
+  /** Grant specific MCP servers. */
+  serverIds?: string[];
+}
+
+/**
+ * What each connected AI client may reach, and the ability to change it.
+ *
+ * This exists because a user cannot rely on their client to ask again. Claude
+ * holds an access token for a day and a refresh token for thirty, and reuses
+ * cached credentials aggressively — this deployment's own OAuth data shows a
+ * connector added months after the first authorization reusing the stored token
+ * without prompting. So "disconnect and reconnect" is not a dependable way to
+ * change what a connection sees. This is.
+ *
+ * Changes take effect on the connection's very next request: the grant is
+ * re-read, and re-validated, per request.
+ */
+@ApiTags('mcp-connections')
+@Controller('api/mcp-connections')
+@UseGuards(AuthGuard('jwt'))
+@ApiBearerAuth()
+export class McpConnectionsController {
+  constructor(
+    private readonly grants: McpConnectionGrantService,
+    private readonly prisma: PrismaService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'AI clients connected to the shared /mcp endpoint' })
+  async list(@Req() req: any) {
+    const userId = req.user.sub;
+    const grants = await this.grants.listForUser(userId);
+    if (grants.length === 0) return [];
+
+    // Names for the ids, resolved in two queries rather than per row.
+    const [clients, servers, organizations] = await Promise.all([
+      this.prisma.oAuthClient.findMany({
+        where: { clientId: { in: grants.map((g) => g.clientId) } },
+        select: { clientId: true, clientName: true },
+      }),
+      this.prisma.mcpServerConfig.findMany({
+        where: { id: { in: grants.flatMap((g) => g.serverIds) } },
+        select: { id: true, name: true, organizationId: true },
+      }),
+      this.prisma.organization.findMany({
+        where: {
+          id: {
+            in: grants
+              .map((g) => g.organizationId)
+              .filter((id): id is string => !!id),
+          },
+        },
+        select: { id: true, name: true },
+      }),
+    ]);
+
+    const clientName = new Map(clients.map((c) => [c.clientId, c.clientName]));
+    const serverById = new Map(servers.map((s) => [s.id, s]));
+    const orgName = new Map(organizations.map((o) => [o.id, o.name]));
+
+    return grants.map((g) => ({
+      clientId: g.clientId,
+      clientName: clientName.get(g.clientId) ?? g.clientId,
+      revoked: !!g.revokedAt,
+      // A server that has since been deleted simply drops out, rather than
+      // showing a dangling id.
+      servers: g.serverIds
+        .map((id) => serverById.get(id))
+        .filter((s): s is NonNullable<typeof s> => !!s)
+        .map((s) => ({ id: s.id, name: s.name })),
+      wholeWorkspace: g.organizationId
+        ? { id: g.organizationId, name: orgName.get(g.organizationId) ?? '' }
+        : null,
+      connectedAt: g.createdAt,
+      updatedAt: g.updatedAt,
+    }));
+  }
+
+  @Get('targets')
+  @ApiOperation({
+    summary: 'Workspaces and MCP servers this user can grant access to',
+  })
+  async targets(@Req() req: any) {
+    return this.grants.listSelectableTargets(req.user.sub);
+  }
+
+  @Put(':clientId')
+  @ApiOperation({ summary: 'Change what a connected client may reach' })
+  async update(
+    @Req() req: any,
+    @Param('clientId') clientId: string,
+    @Body() dto: UpdateConnectionDto,
+  ) {
+    const userId = req.user.sub;
+
+    // Both writes validate membership themselves and drop what this user
+    // cannot reach, so a request naming another tenant's workspace or server
+    // concedes nothing — it simply grants less than it asked for, or fails.
+    if (dto.organizationId) {
+      const ok = await this.grants.grantWholeOrganization(
+        clientId,
+        userId,
+        dto.organizationId,
+      );
+      if (!ok) return { ok: false, reason: 'not-a-member' };
+    } else if (dto.serverIds?.length) {
+      const granted = await this.grants.grantServers(
+        clientId,
+        userId,
+        dto.serverIds,
+      );
+      if (granted.length === 0) return { ok: false, reason: 'nothing-granted' };
+    } else {
+      return { ok: false, reason: 'empty-selection' };
+    }
+
+    await this.securityEvents.log({
+      event: SecurityEvents.MCP_GRANT_CHANGED,
+      actorType: 'USER',
+      actorUserId: userId,
+      organizationId: req.user.organizationId ?? null,
+      metadata: {
+        clientId,
+        organizationId: dto.organizationId,
+        serverIds: dto.serverIds,
+      },
+    });
+
+    return { ok: true };
+  }
+
+  @Delete(':clientId')
+  @ApiOperation({ summary: 'Revoke a connection — it then reaches nothing' })
+  async revoke(@Req() req: any, @Param('clientId') clientId: string) {
+    const userId = req.user.sub;
+    const revoked = await this.grants.revoke(clientId, userId);
+
+    if (revoked) {
+      await this.securityEvents.log({
+        event: SecurityEvents.MCP_GRANT_REVOKED,
+        actorType: 'USER',
+        actorUserId: userId,
+        organizationId: req.user.organizationId ?? null,
+        metadata: { clientId },
+      });
+    }
+
+    return { ok: revoked };
+  }
+}

--- a/packages/backend/src/mcp-servers/mcp-servers.module.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.module.ts
@@ -2,13 +2,15 @@ import { Module } from '@nestjs/common';
 import { McpServersService } from './mcp-servers.service';
 import { McpConnectionGrantService } from './mcp-connection-grant.service';
 import { McpServersController } from './mcp-servers.controller';
+import { McpConnectionsController } from './mcp-connections.controller';
 import { McpSessionManager } from './mcp-session.manager';
 import { LicenseModule } from '../license/license.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [LicenseModule],
+  imports: [LicenseModule, AuditModule],
   providers: [McpServersService, McpSessionManager, McpConnectionGrantService],
-  controllers: [McpServersController],
+  controllers: [McpServersController, McpConnectionsController],
   exports: [McpServersService, McpSessionManager, McpConnectionGrantService],
 })
 export class McpServersModule {}

--- a/packages/frontend/src/app/settings/connections/page.tsx
+++ b/packages/frontend/src/app/settings/connections/page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/lib/auth-context';
+import { mcpConnections } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+type Connection = Awaited<ReturnType<typeof mcpConnections.list>>[number];
+type Target = Awaited<ReturnType<typeof mcpConnections.targets>>[number];
+
+/**
+ * What each connected AI client can reach, and how to change it.
+ *
+ * This page exists because the client cannot be relied on to ask again. Claude
+ * holds an access token for a day and a refresh token for thirty, and reuses
+ * cached credentials — so disconnecting and reconnecting usually replays the
+ * stored token and lands on the previous choice without prompting. Changing it
+ * here takes effect on that connection's very next request instead.
+ */
+export default function ConnectionsPage() {
+  const { token } = useAuth();
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [targets, setTargets] = useState<Target[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draftServers, setDraftServers] = useState<string[]>([]);
+  const [draftWorkspace, setDraftWorkspace] = useState<string | null>(null);
+  const [msg, setMsg] = useState('');
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const [list, tg] = await Promise.all([
+        mcpConnections.list(token),
+        mcpConnections.targets(token),
+      ]);
+      setConnections(list);
+      setTargets(tg);
+    } catch (err: any) {
+      setMsg(err.message || 'Could not load connections');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const startEditing = (c: Connection) => {
+    setEditing(c.clientId);
+    setDraftServers(c.servers.map((s) => s.id));
+    setDraftWorkspace(c.wholeWorkspace?.id ?? null);
+    setMsg('');
+  };
+
+  const save = async (clientId: string) => {
+    if (!token) return;
+    const body = draftWorkspace
+      ? { organizationId: draftWorkspace }
+      : { serverIds: draftServers };
+    const res = await mcpConnections.update(clientId, body, token);
+    if (!res.ok) {
+      setMsg(
+        res.reason === 'empty-selection'
+          ? 'Choose at least one MCP server, or the whole workspace.'
+          : 'That selection is not available to you.',
+      );
+      return;
+    }
+    setEditing(null);
+    setMsg('Updated. It applies to this connection’s next request.');
+    load();
+  };
+
+  const revoke = async (c: Connection) => {
+    if (!token) return;
+    await mcpConnections.revoke(c.clientId, token);
+    setMsg(`${c.clientName} can no longer reach anything.`);
+    load();
+  };
+
+  if (loading) {
+    return <p className="text-[13px] text-[var(--text-3)]">Loading…</p>;
+  }
+
+  return (
+    <div>
+      <h2 className="mb-[3px] text-[15px] font-semibold text-[var(--text)]">
+        Connected AI clients
+      </h2>
+      <p className="mb-4 text-[13px] text-[var(--text-3)]">
+        What each client can reach through your shared MCP endpoint. Changes
+        apply on its next request — no need to reconnect.
+      </p>
+
+      {msg && (
+        <div className="mb-4 rounded-[9px] border border-[var(--border)] bg-[var(--surface-2)] p-3 text-[13px] text-[var(--text-2)]">
+          {msg}
+        </div>
+      )}
+
+      {connections.length === 0 ? (
+        <Card className="p-[22px]">
+          <p className="text-[13px] text-[var(--text-3)]">
+            Nothing is connected yet. Add your MCP endpoint in Claude, ChatGPT
+            or Cursor, and it will appear here once you authorize it.
+          </p>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {connections.map((c) => (
+            <Card key={c.clientId} className="p-[18px]">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[14px] font-semibold text-[var(--text)]">
+                      {c.clientName}
+                    </span>
+                    {c.revoked && <Badge tone="danger">Revoked</Badge>}
+                  </div>
+                  <p className="mt-[3px] text-[12px] text-[var(--text-3)]">
+                    {c.revoked
+                      ? 'Reaches nothing. Choose below to allow it again.'
+                      : c.wholeWorkspace
+                        ? `Everything in ${c.wholeWorkspace.name}`
+                        : c.servers.length > 0
+                          ? c.servers.map((s) => s.name).join(', ')
+                          : 'Nothing selected'}
+                  </p>
+                </div>
+                {editing !== c.clientId && (
+                  <div className="flex shrink-0 gap-2">
+                    <Button variant="secondary" onClick={() => startEditing(c)}>
+                      Change
+                    </Button>
+                    {!c.revoked && (
+                      <Button variant="danger" onClick={() => revoke(c)}>
+                        Revoke
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {editing === c.clientId && (
+                <div className="mt-4 border-t border-[var(--border)] pt-4">
+                  {targets.map((t) => (
+                    <fieldset key={t.organizationId} className="mb-3">
+                      <legend className="mb-1 text-[11px] uppercase tracking-wide text-[var(--text-3)]">
+                        {t.organizationName}
+                      </legend>
+                      {t.servers.map((srv) => (
+                        <label
+                          key={srv.id}
+                          className="flex cursor-pointer items-center gap-[10px] rounded-[7px] px-1 py-[6px] hover:bg-[var(--surface-2)]"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={
+                              !draftWorkspace && draftServers.includes(srv.id)
+                            }
+                            disabled={!!draftWorkspace}
+                            onChange={(e) =>
+                              setDraftServers((prev) =>
+                                e.target.checked
+                                  ? [...prev, srv.id]
+                                  : prev.filter((id) => id !== srv.id),
+                              )
+                            }
+                          />
+                          <span className="flex-1 text-[13px] text-[var(--text)]">
+                            {srv.name}
+                          </span>
+                          <span className="text-[12px] text-[var(--text-3)]">
+                            {srv.connectorCount} connector
+                            {srv.connectorCount === 1 ? '' : 's'}
+                          </span>
+                        </label>
+                      ))}
+                      <label className="mt-[6px] flex cursor-pointer items-center gap-[10px] rounded-[7px] border-t border-[var(--border)] px-1 pt-[10px] hover:bg-[var(--surface-2)]">
+                        <input
+                          type="checkbox"
+                          checked={draftWorkspace === t.organizationId}
+                          onChange={(e) =>
+                            setDraftWorkspace(
+                              e.target.checked ? t.organizationId : null,
+                            )
+                          }
+                        />
+                        <span className="flex-1 text-[13px] text-[var(--text)]">
+                          Everything in this workspace
+                        </span>
+                        <span className="text-[12px] text-[var(--text-3)]">
+                          including connectors not on a server
+                        </span>
+                      </label>
+                    </fieldset>
+                  ))}
+                  <div className="mt-2 flex gap-2">
+                    <Button onClick={() => save(c.clientId)}>Save</Button>
+                    <Button
+                      variant="secondary"
+                      onClick={() => setEditing(null)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -28,6 +28,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
     items: [
       { href: '/settings', label: 'Profile', description: 'Name, email, password', icon: GearIcon, exact: true },
+      { href: '/settings/connections', label: 'Connections', description: 'What each AI client can reach', icon: PlugIcon },
     ],
   },
   {
@@ -122,6 +123,17 @@ function GearIcon({ size = 16 }: { size?: number }) {
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
       <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function PlugIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 2v6" />
+      <path d="M15 2v6" />
+      <path d="M6 8h12v3a6 6 0 0 1-6 6 6 6 0 0 1-6-6V8z" />
+      <path d="M12 17v5" />
     </svg>
   );
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -181,6 +181,50 @@ export const organizations = {
     }>('/api/organizations/current', { method: 'DELETE', body: data, token }),
 };
 
+/**
+ * The AI clients connected to the shared `/mcp` endpoint, and what each may
+ * reach. Lives here rather than in the client itself because a client cannot be
+ * relied on to ask again — Claude holds a refresh token for 30 days and reuses
+ * cached credentials, so "disconnect and reconnect" does not reliably re-open
+ * the choice. Changes here take effect on the connection's next request.
+ */
+export const mcpConnections = {
+  list: (token: string) =>
+    request<
+      {
+        clientId: string;
+        clientName: string;
+        revoked: boolean;
+        servers: { id: string; name: string }[];
+        wholeWorkspace: { id: string; name: string } | null;
+        connectedAt: string;
+        updatedAt: string;
+      }[]
+    >('/api/mcp-connections', { token }),
+  targets: (token: string) =>
+    request<
+      {
+        organizationId: string;
+        organizationName: string;
+        servers: { id: string; name: string; connectorCount: number }[];
+      }[]
+    >('/api/mcp-connections/targets', { token }),
+  update: (
+    clientId: string,
+    body: { organizationId?: string; serverIds?: string[] },
+    token: string,
+  ) =>
+    request<{ ok: boolean; reason?: string }>(
+      `/api/mcp-connections/${clientId}`,
+      { method: 'PUT', body, token },
+    ),
+  revoke: (clientId: string, token: string) =>
+    request<{ ok: boolean }>(`/api/mcp-connections/${clientId}`, {
+      method: 'DELETE',
+      token,
+    }),
+};
+
 // Connectors
 export const connectors = {
   list: (token: string) =>


### PR DESCRIPTION
Completes the picker (#543): somewhere to change or withdraw what a connected client may reach — **without reconnecting**.

> Based on #543, which is based on `main`. Merge order: #542 → #543 → this.

## Why this is not optional

A user cannot rely on their client to ask again:

| | |
|---|---|
| access token | 1 day |
| refresh token | **30 days** |

Claude reuses cached credentials aggressively. This deployment's own OAuth data shows a connector added **months** after the first authorization reusing the stored token with no prompt. So *disconnect and reconnect* does not dependably re-open the choice — it usually replays the token and lands on the previous selection.

The dashboard does work, and immediately: the grant is re-read and re-validated on every request, so a change applies to that connection's very next call. No reconnect, no logout, no waiting.

## `revoke()` was wrong, and would have widened access

It deleted the grant row. A deleted row reads back as **"no grant"** — which means the pre-grant behaviour: the caller's **entire organization**. Pressing *Revoke* would have handed the client *more* than it had.

It now stamps `revokedAt` and keeps the row. `resolve()` answers `{ mode: 'none' }` for it, which stays distinct from the absent case:

| state | meaning |
|---|---|
| no row | connected before grants existed → previous behaviour |
| row, `revokedAt` set | **reaches nothing** |
| row, active | exactly what it names |

Choosing again clears the stamp, because saying what a client may reach is the opposite of having revoked it. The migration carries the reasoning so nobody re-introduces the delete.

## Verified in a browser

Local stack, two connected clients seeded as Claude and Cursor:

1. listed, each showing what it reaches (*CRM* / *Everything in Conn's Workspace*)
2. changed Claude from `CRM` to `CRM, ERP` → *"Updated. It applies to this connection's next request."*
3. revoked Cursor → badge **Revoked**, *"Reaches nothing. Choose below to allow it again."*

Database afterwards — note the revoked row is stamped, not gone:

```
 client_id  | whole_ws | n_srv | revoked
------------+----------+-------+---------
 claude-abc | f        |     2 | f
 cursor-xyz | t        |       | t
```

```
 event             | client
-------------------+------------
 MCP_GRANT_CHANGED | claude-abc
 MCP_GRANT_REVOKED | cursor-xyz
```

## Also here

Three audit events (`MCP_GRANT_CREATED` / `CHANGED` / `REVOKED`), and the API: list, selectable targets, change, revoke. Every write goes through `grantWholeOrganization` / `grantServers`, which validate membership themselves — so a request naming another tenant's workspace or server grants less than it asked for, never more.

## Still open

**Hard per-client token revocation.** Revoking here means the client sees nothing; it does not invalidate its token, so Claude stays "connected" with an empty tool list rather than being prompted to reconnect. Doing that properly needs a revocation marker on `oauth_clients` checked in the guard — `sessionsValidFrom` is account-wide and would sign the user out of the dashboard too. Worth a follow-up; not needed for the flow to be correct.

Suite: 4069 passed.