### PR TITLE
feat(mcp): a Connections page, and a revoke that actually narrows

### DIFF
--- a/packages/backend/prisma/migrations/20260912092847_add_grant_revocation/migration.sql
+++ b/packages/backend/prisma/migrations/20260912092847_add_grant_revocation/migration.sql
@@ -1,0 +1,7 @@
+-- Revoking a connection must NARROW it. Deleting the grant row would mean "no
+-- grant", and no grant means the pre-grant behaviour — the caller's entire
+-- organization — so a delete would have widened access instead of removing it.
+-- The row is kept and stamped instead.
+
+-- AlterTable
+ALTER TABLE "mcp_connection_grants" ADD COLUMN     "revoked_at" TIMESTAMP(3);

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -639,6 +639,12 @@ model McpConnectionGrant {
   /// `mcp_server_configs` at resolution time and never trusted from here.
   serverIds String[] @map("server_ids")
 
+  /// Set when the user revoked this connection from the dashboard. The row is
+  /// KEPT rather than deleted, because deleting it means "no grant", and no
+  /// grant means the pre-grant behaviour — the caller's whole organization. A
+  /// revoke that widens access is the opposite of a revoke.
+  revokedAt DateTime? @map("revoked_at")
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/packages/backend/src/audit/security-event.service.ts
+++ b/packages/backend/src/audit/security-event.service.ts
@@ -21,6 +21,14 @@ export const SecurityEvents = {
   SCIM_DISABLED: 'SCIM_DISABLED',
   SCIM_TOKEN_ROTATED: 'SCIM_TOKEN_ROTATED',
 
+  // ── Connection grants: what a client may reach through the shared /mcp ──
+  /** A user chose what an OAuth client may reach, while authorizing it. */
+  MCP_GRANT_CREATED: 'MCP_GRANT_CREATED',
+  /** The choice was changed from the dashboard, without reconnecting. */
+  MCP_GRANT_CHANGED: 'MCP_GRANT_CHANGED',
+  /** The connection was revoked; it now reaches nothing. */
+  MCP_GRANT_REVOKED: 'MCP_GRANT_REVOKED',
+
   // ── Auth plane: who got in, and who failed to ───────────────────────────
   SSO_LOGIN_SUCCESS: 'SSO_LOGIN_SUCCESS',
   SSO_LOGIN_FAILED: 'SSO_LOGIN_FAILED',

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.spec.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.spec.ts
@@ -19,7 +19,11 @@ import {
  */
 function build(
   overrides: {
-    grant?: { organizationId: string | null; serverIds: string[] } | null;
+    grant?: {
+      organizationId: string | null;
+      serverIds: string[];
+      revokedAt?: Date | null;
+    } | null;
     memberCount?: number;
     servers?: { id: string; organizationId: string }[];
   } = {},
@@ -29,10 +33,15 @@ function build(
     countMembers: [],
     upsert: [],
     del: [],
+    update: [],
   };
 
   const prisma: any = {
     mcpConnectionGrant: {
+      updateMany: jest.fn(async (args: any) => {
+        calls.update.push(args);
+        return { count: overrides.grant ? 1 : 0 };
+      }),
       findUnique: jest
         .fn()
         .mockResolvedValue(
@@ -150,6 +159,25 @@ describe('McpConnectionGrantService.resolve', () => {
       mode: 'servers',
       servers: [{ id: 'srv-mine', organizationId: 'org-A' }],
     });
+  });
+
+  it('shows nothing for a revoked connection, without re-reading its targets', async () => {
+    const { svc, calls } = build({
+      grant: {
+        organizationId: 'org-A',
+        serverIds: ['srv-1'],
+        revokedAt: new Date(),
+      },
+      memberCount: 1,
+      servers: [{ id: 'srv-1', organizationId: 'org-A' }],
+    });
+
+    await expect(svc.resolve('client-1', 'user-1')).resolves.toEqual({
+      mode: 'none',
+    });
+    // Short-circuits: no point validating targets nobody may use.
+    expect(calls.findManyServers).toHaveLength(0);
+    expect(calls.countMembers).toHaveLength(0);
   });
 
   it('fails closed on a grant that is empty on both sides', async () => {
@@ -270,6 +298,7 @@ describe('McpConnectionGrantService writing a grant', () => {
     expect(calls.upsert[0].update).toEqual({
       organizationId: null,
       serverIds: ['srv-mine'],
+      revokedAt: null,
     });
   });
 
@@ -285,13 +314,35 @@ describe('McpConnectionGrantService writing a grant', () => {
     expect(calls.upsert).toHaveLength(0);
   });
 
-  it('revokes by (client, user) and tolerates a missing row', async () => {
-    const { svc, calls } = build();
-
-    await svc.revoke('client-1', 'user-1');
-
-    expect(calls.del[0].where).toEqual({
-      clientId_userId: { clientId: 'client-1', userId: 'user-1' },
+  // Deleting the row would read back as "no grant", which is the pre-grant
+  // behaviour — the caller's whole organization. A revoke that widens access is
+  // the opposite of a revoke.
+  it('stamps the row instead of deleting it', async () => {
+    const { svc, calls } = build({
+      grant: { organizationId: 'org-A', serverIds: [] },
     });
+
+    await expect(svc.revoke('client-1', 'user-1')).resolves.toBe(true);
+
+    expect(calls.del).toHaveLength(0);
+    expect(calls.update[0].where).toEqual({
+      clientId: 'client-1',
+      userId: 'user-1',
+      revokedAt: null,
+    });
+    expect(calls.update[0].data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('reports that there was nothing to revoke', async () => {
+    const { svc } = build({ grant: null });
+    await expect(svc.revoke('client-1', 'user-1')).resolves.toBe(false);
+  });
+
+  it('un-revokes when the user chooses again', async () => {
+    const { svc, calls } = build({ memberCount: 1 });
+
+    await svc.grantWholeOrganization('client-1', 'user-1', 'org-A');
+
+    expect(calls.upsert[0].update.revokedAt).toBeNull();
   });
 });

--- a/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
+++ b/packages/backend/src/mcp-servers/mcp-connection-grant.service.ts
@@ -57,9 +57,14 @@ export class McpConnectionGrantService {
 
     const grant = await this.prisma.mcpConnectionGrant.findUnique({
       where: { clientId_userId: { clientId, userId } },
-      select: { organizationId: true, serverIds: true },
+      select: { organizationId: true, serverIds: true, revokedAt: true },
     });
     if (!grant) return null;
+
+    // Revoked from the dashboard. Not the same as absent: absent means the
+    // client was connected before grants existed and keeps the old behaviour,
+    // revoked means the user asked for this connection to stop seeing things.
+    if (grant.revokedAt) return { mode: 'none' };
 
     if (grant.organizationId) {
       const stillAMember = await this.isMember(userId, grant.organizationId);
@@ -120,11 +125,21 @@ export class McpConnectionGrantService {
     return valid.map((s) => s.id);
   }
 
-  /** Drop a client's grant. Idempotent. */
-  async revoke(clientId: string, userId: string): Promise<void> {
-    await this.prisma.mcpConnectionGrant
-      .delete({ where: { clientId_userId: { clientId, userId } } })
-      .catch(() => undefined);
+  /**
+   * Stop a client seeing anything, without deleting the row.
+   *
+   * Deleting would read back as "no grant", which is the pre-grant behaviour —
+   * the caller's whole organization. A revoke has to narrow, so it stamps
+   * `revokedAt` and leaves the rest in place; choosing again clears it.
+   *
+   * Returns false when there was nothing to revoke.
+   */
+  async revoke(clientId: string, userId: string): Promise<boolean> {
+    const { count } = await this.prisma.mcpConnectionGrant.updateMany({
+      where: { clientId, userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    return count > 0;
   }
 
   /**
@@ -187,6 +202,7 @@ export class McpConnectionGrantService {
         clientId: true,
         organizationId: true,
         serverIds: true,
+        revokedAt: true,
         createdAt: true,
         updatedAt: true,
       },
@@ -239,7 +255,9 @@ export class McpConnectionGrantService {
     await this.prisma.mcpConnectionGrant.upsert({
       where: { clientId_userId: { clientId, userId } },
       create: { clientId, userId, ...data },
-      update: data,
+      // Choosing again un-revokes: the user is explicitly saying what this
+      // client may reach, which is the opposite of having revoked it.
+      update: { ...data, revokedAt: null },
     });
   }
 }

--- a/packages/backend/src/mcp-servers/mcp-connections.controller.ts
+++ b/packages/backend/src/mcp-servers/mcp-connections.controller.ts
@@ -1,0 +1,173 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { McpConnectionGrantService } from './mcp-connection-grant.service';
+import { PrismaService } from '../common/prisma.service';
+import {
+  SecurityEventService,
+  SecurityEvents,
+} from '../audit/security-event.service';
+
+interface UpdateConnectionDto {
+  /** Grant a whole workspace. Mutually exclusive with `serverIds`. */
+  organizationId?: string;
+  /** Grant specific MCP servers. */
+  serverIds?: string[];
+}
+
+/**
+ * What each connected AI client may reach, and the ability to change it.
+ *
+ * This exists because a user cannot rely on their client to ask again. Claude
+ * holds an access token for a day and a refresh token for thirty, and reuses
+ * cached credentials aggressively — this deployment's own OAuth data shows a
+ * connector added months after the first authorization reusing the stored token
+ * without prompting. So "disconnect and reconnect" is not a dependable way to
+ * change what a connection sees. This is.
+ *
+ * Changes take effect on the connection's very next request: the grant is
+ * re-read, and re-validated, per request.
+ */
+@ApiTags('mcp-connections')
+@Controller('api/mcp-connections')
+@UseGuards(AuthGuard('jwt'))
+@ApiBearerAuth()
+export class McpConnectionsController {
+  constructor(
+    private readonly grants: McpConnectionGrantService,
+    private readonly prisma: PrismaService,
+    private readonly securityEvents: SecurityEventService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'AI clients connected to the shared /mcp endpoint' })
+  async list(@Req() req: any) {
+    const userId = req.user.sub;
+    const grants = await this.grants.listForUser(userId);
+    if (grants.length === 0) return [];
+
+    // Names for the ids, resolved in two queries rather than per row.
+    const [clients, servers, organizations] = await Promise.all([
+      this.prisma.oAuthClient.findMany({
+        where: { clientId: { in: grants.map((g) => g.clientId) } },
+        select: { clientId: true, clientName: true },
+      }),
+      this.prisma.mcpServerConfig.findMany({
+        where: { id: { in: grants.flatMap((g) => g.serverIds) } },
+        select: { id: true, name: true, organizationId: true },
+      }),
+      this.prisma.organization.findMany({
+        where: {
+          id: {
+            in: grants
+              .map((g) => g.organizationId)
+              .filter((id): id is string => !!id),
+          },
+        },
+        select: { id: true, name: true },
+      }),
+    ]);
+
+    const clientName = new Map(clients.map((c) => [c.clientId, c.clientName]));
+    const serverById = new Map(servers.map((s) => [s.id, s]));
+    const orgName = new Map(organizations.map((o) => [o.id, o.name]));
+
+    return grants.map((g) => ({
+      clientId: g.clientId,
+      clientName: clientName.get(g.clientId) ?? g.clientId,
+      revoked: !!g.revokedAt,
+      // A server that has since been deleted simply drops out, rather than
+      // showing a dangling id.
+      servers: g.serverIds
+        .map((id) => serverById.get(id))
+        .filter((s): s is NonNullable<typeof s> => !!s)
+        .map((s) => ({ id: s.id, name: s.name })),
+      wholeWorkspace: g.organizationId
+        ? { id: g.organizationId, name: orgName.get(g.organizationId) ?? '' }
+        : null,
+      connectedAt: g.createdAt,
+      updatedAt: g.updatedAt,
+    }));
+  }
+
+  @Get('targets')
+  @ApiOperation({
+    summary: 'Workspaces and MCP servers this user can grant access to',
+  })
+  async targets(@Req() req: any) {
+    return this.grants.listSelectableTargets(req.user.sub);
+  }
+
+  @Put(':clientId')
+  @ApiOperation({ summary: 'Change what a connected client may reach' })
+  async update(
+    @Req() req: any,
+    @Param('clientId') clientId: string,
+    @Body() dto: UpdateConnectionDto,
+  ) {
+    const userId = req.user.sub;
+
+    // Both writes validate membership themselves and drop what this user
+    // cannot reach, so a request naming another tenant's workspace or server
+    // concedes nothing — it simply grants less than it asked for, or fails.
+    if (dto.organizationId) {
+      const ok = await this.grants.grantWholeOrganization(
+        clientId,
+        userId,
+        dto.organizationId,
+      );
+      if (!ok) return { ok: false, reason: 'not-a-member' };
+    } else if (dto.serverIds?.length) {
+      const granted = await this.grants.grantServers(
+        clientId,
+        userId,
+        dto.serverIds,
+      );
+      if (granted.length === 0) return { ok: false, reason: 'nothing-granted' };
+    } else {
+      return { ok: false, reason: 'empty-selection' };
+    }
+
+    await this.securityEvents.log({
+      event: SecurityEvents.MCP_GRANT_CHANGED,
+      actorType: 'USER',
+      actorUserId: userId,
+      organizationId: req.user.organizationId ?? null,
+      metadata: {
+        clientId,
+        organizationId: dto.organizationId,
+        serverIds: dto.serverIds,
+      },
+    });
+
+    return { ok: true };
+  }
+
+  @Delete(':clientId')
+  @ApiOperation({ summary: 'Revoke a connection — it then reaches nothing' })
+  async revoke(@Req() req: any, @Param('clientId') clientId: string) {
+    const userId = req.user.sub;
+    const revoked = await this.grants.revoke(clientId, userId);
+
+    if (revoked) {
+      await this.securityEvents.log({
+        event: SecurityEvents.MCP_GRANT_REVOKED,
+        actorType: 'USER',
+        actorUserId: userId,
+        organizationId: req.user.organizationId ?? null,
+        metadata: { clientId },
+      });
+    }
+
+    return { ok: revoked };
+  }
+}

--- a/packages/backend/src/mcp-servers/mcp-servers.module.ts
+++ b/packages/backend/src/mcp-servers/mcp-servers.module.ts
@@ -2,13 +2,15 @@ import { Module } from '@nestjs/common';
 import { McpServersService } from './mcp-servers.service';
 import { McpConnectionGrantService } from './mcp-connection-grant.service';
 import { McpServersController } from './mcp-servers.controller';
+import { McpConnectionsController } from './mcp-connections.controller';
 import { McpSessionManager } from './mcp-session.manager';
 import { LicenseModule } from '../license/license.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [LicenseModule],
+  imports: [LicenseModule, AuditModule],
   providers: [McpServersService, McpSessionManager, McpConnectionGrantService],
-  controllers: [McpServersController],
+  controllers: [McpServersController, McpConnectionsController],
   exports: [McpServersService, McpSessionManager, McpConnectionGrantService],
 })
 export class McpServersModule {}

--- a/packages/frontend/src/app/settings/connections/page.tsx
+++ b/packages/frontend/src/app/settings/connections/page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/lib/auth-context';
+import { mcpConnections } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+type Connection = Awaited<ReturnType<typeof mcpConnections.list>>[number];
+type Target = Awaited<ReturnType<typeof mcpConnections.targets>>[number];
+
+/**
+ * What each connected AI client can reach, and how to change it.
+ *
+ * This page exists because the client cannot be relied on to ask again. Claude
+ * holds an access token for a day and a refresh token for thirty, and reuses
+ * cached credentials — so disconnecting and reconnecting usually replays the
+ * stored token and lands on the previous choice without prompting. Changing it
+ * here takes effect on that connection's very next request instead.
+ */
+export default function ConnectionsPage() {
+  const { token } = useAuth();
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [targets, setTargets] = useState<Target[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draftServers, setDraftServers] = useState<string[]>([]);
+  const [draftWorkspace, setDraftWorkspace] = useState<string | null>(null);
+  const [msg, setMsg] = useState('');
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const [list, tg] = await Promise.all([
+        mcpConnections.list(token),
+        mcpConnections.targets(token),
+      ]);
+      setConnections(list);
+      setTargets(tg);
+    } catch (err: any) {
+      setMsg(err.message || 'Could not load connections');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const startEditing = (c: Connection) => {
+    setEditing(c.clientId);
+    setDraftServers(c.servers.map((s) => s.id));
+    setDraftWorkspace(c.wholeWorkspace?.id ?? null);
+    setMsg('');
+  };
+
+  const save = async (clientId: string) => {
+    if (!token) return;
+    const body = draftWorkspace
+      ? { organizationId: draftWorkspace }
+      : { serverIds: draftServers };
+    const res = await mcpConnections.update(clientId, body, token);
+    if (!res.ok) {
+      setMsg(
+        res.reason === 'empty-selection'
+          ? 'Choose at least one MCP server, or the whole workspace.'
+          : 'That selection is not available to you.',
+      );
+      return;
+    }
+    setEditing(null);
+    setMsg('Updated. It applies to this connection’s next request.');
+    load();
+  };
+
+  const revoke = async (c: Connection) => {
+    if (!token) return;
+    await mcpConnections.revoke(c.clientId, token);
+    setMsg(`${c.clientName} can no longer reach anything.`);
+    load();
+  };
+
+  if (loading) {
+    return <p className="text-[13px] text-[var(--text-3)]">Loading…</p>;
+  }
+
+  return (
+    <div>
+      <h2 className="mb-[3px] text-[15px] font-semibold text-[var(--text)]">
+        Connected AI clients
+      </h2>
+      <p className="mb-4 text-[13px] text-[var(--text-3)]">
+        What each client can reach through your shared MCP endpoint. Changes
+        apply on its next request — no need to reconnect.
+      </p>
+
+      {msg && (
+        <div className="mb-4 rounded-[9px] border border-[var(--border)] bg-[var(--surface-2)] p-3 text-[13px] text-[var(--text-2)]">
+          {msg}
+        </div>
+      )}
+
+      {connections.length === 0 ? (
+        <Card className="p-[22px]">
+          <p className="text-[13px] text-[var(--text-3)]">
+            Nothing is connected yet. Add your MCP endpoint in Claude, ChatGPT
+            or Cursor, and it will appear here once you authorize it.
+          </p>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {connections.map((c) => (
+            <Card key={c.clientId} className="p-[18px]">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[14px] font-semibold text-[var(--text)]">
+                      {c.clientName}
+                    </span>
+                    {c.revoked && <Badge tone="danger">Revoked</Badge>}
+                  </div>
+                  <p className="mt-[3px] text-[12px] text-[var(--text-3)]">
+                    {c.revoked
+                      ? 'Reaches nothing. Choose below to allow it again.'
+                      : c.wholeWorkspace
+                        ? `Everything in ${c.wholeWorkspace.name}`
+                        : c.servers.length > 0
+                          ? c.servers.map((s) => s.name).join(', ')
+                          : 'Nothing selected'}
+                  </p>
+                </div>
+                {editing !== c.clientId && (
+                  <div className="flex shrink-0 gap-2">
+                    <Button variant="secondary" onClick={() => startEditing(c)}>
+                      Change
+                    </Button>
+                    {!c.revoked && (
+                      <Button variant="danger" onClick={() => revoke(c)}>
+                        Revoke
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {editing === c.clientId && (
+                <div className="mt-4 border-t border-[var(--border)] pt-4">
+                  {targets.map((t) => (
+                    <fieldset key={t.organizationId} className="mb-3">
+                      <legend className="mb-1 text-[11px] uppercase tracking-wide text-[var(--text-3)]">
+                        {t.organizationName}
+                      </legend>
+                      {t.servers.map((srv) => (
+                        <label
+                          key={srv.id}
+                          className="flex cursor-pointer items-center gap-[10px] rounded-[7px] px-1 py-[6px] hover:bg-[var(--surface-2)]"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={
+                              !draftWorkspace && draftServers.includes(srv.id)
+                            }
+                            disabled={!!draftWorkspace}
+                            onChange={(e) =>
+                              setDraftServers((prev) =>
+                                e.target.checked
+                                  ? [...prev, srv.id]
+                                  : prev.filter((id) => id !== srv.id),
+                              )
+                            }
+                          />
+                          <span className="flex-1 text-[13px] text-[var(--text)]">
+                            {srv.name}
+                          </span>
+                          <span className="text-[12px] text-[var(--text-3)]">
+                            {srv.connectorCount} connector
+                            {srv.connectorCount === 1 ? '' : 's'}
+                          </span>
+                        </label>
+                      ))}
+                      <label className="mt-[6px] flex cursor-pointer items-center gap-[10px] rounded-[7px] border-t border-[var(--border)] px-1 pt-[10px] hover:bg-[var(--surface-2)]">
+                        <input
+                          type="checkbox"
+                          checked={draftWorkspace === t.organizationId}
+                          onChange={(e) =>
+                            setDraftWorkspace(
+                              e.target.checked ? t.organizationId : null,
+                            )
+                          }
+                        />
+                        <span className="flex-1 text-[13px] text-[var(--text)]">
+                          Everything in this workspace
+                        </span>
+                        <span className="text-[12px] text-[var(--text-3)]">
+                          including connectors not on a server
+                        </span>
+                      </label>
+                    </fieldset>
+                  ))}
+                  <div className="mt-2 flex gap-2">
+                    <Button onClick={() => save(c.clientId)}>Save</Button>
+                    <Button
+                      variant="secondary"
+                      onClick={() => setEditing(null)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/settings/layout.tsx
+++ b/packages/frontend/src/app/settings/layout.tsx
@@ -28,6 +28,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
     items: [
       { href: '/settings', label: 'Profile', description: 'Name, email, password', icon: GearIcon, exact: true },
+      { href: '/settings/connections', label: 'Connections', description: 'What each AI client can reach', icon: PlugIcon },
     ],
   },
   {
@@ -122,6 +123,17 @@ function GearIcon({ size = 16 }: { size?: number }) {
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
       <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function PlugIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 2v6" />
+      <path d="M15 2v6" />
+      <path d="M6 8h12v3a6 6 0 0 1-6 6 6 6 0 0 1-6-6V8z" />
+      <path d="M12 17v5" />
     </svg>
   );
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -181,6 +181,50 @@ export const organizations = {
     }>('/api/organizations/current', { method: 'DELETE', body: data, token }),
 };
 
+/**
+ * The AI clients connected to the shared `/mcp` endpoint, and what each may
+ * reach. Lives here rather than in the client itself because a client cannot be
+ * relied on to ask again — Claude holds a refresh token for 30 days and reuses
+ * cached credentials, so "disconnect and reconnect" does not reliably re-open
+ * the choice. Changes here take effect on the connection's next request.
+ */
+export const mcpConnections = {
+  list: (token: string) =>
+    request<
+      {
+        clientId: string;
+        clientName: string;
+        revoked: boolean;
+        servers: { id: string; name: string }[];
+        wholeWorkspace: { id: string; name: string } | null;
+        connectedAt: string;
+        updatedAt: string;
+      }[]
+    >('/api/mcp-connections', { token }),
+  targets: (token: string) =>
+    request<
+      {
+        organizationId: string;
+        organizationName: string;
+        servers: { id: string; name: string; connectorCount: number }[];
+      }[]
+    >('/api/mcp-connections/targets', { token }),
+  update: (
+    clientId: string,
+    body: { organizationId?: string; serverIds?: string[] },
+    token: string,
+  ) =>
+    request<{ ok: boolean; reason?: string }>(
+      `/api/mcp-connections/${clientId}`,
+      { method: 'PUT', body, token },
+    ),
+  revoke: (clientId: string, token: string) =>
+    request<{ ok: boolean }>(`/api/mcp-connections/${clientId}`, {
+      method: 'DELETE',
+      token,
+    }),
+};
+
 // Connectors
 export const connectors = {
   list: (token: string) =>


### PR DESCRIPTION
Re-opened as a fresh PR: #544 was auto-closed when its base branch (the picker, #543) was merged and deleted. Same commit, now rebased onto `main`.

Completes the picker: somewhere to change or withdraw what a connected client may reach — **without reconnecting**.

## Why this is not optional

A user cannot rely on their client to ask again:

| | |
|---|---|
| access token | 1 day |
| refresh token | **30 days** |

Claude reuses cached credentials aggressively. This deployment's own OAuth data shows a connector added **months** after the first authorization reusing the stored token with no prompt. So *disconnect and reconnect* does not dependably re-open the choice — it usually replays the token and lands on the previous selection.

The dashboard does work, and immediately: the grant is re-read and re-validated on every request, so a change applies to that connection's very next call.

## `revoke()` was wrong, and would have widened access

It deleted the grant row. A deleted row reads back as **"no grant"** — which means the pre-grant behaviour: the caller's **entire organization**. Pressing *Revoke* would have handed the client *more* than it had.

It now stamps `revokedAt` and keeps the row:

| state | meaning |
|---|---|
| no row | connected before grants existed → previous behaviour |
| row, `revokedAt` set | **reaches nothing** |
| row, active | exactly what it names |

Choosing again clears the stamp. The migration carries the reasoning so nobody re-introduces the delete.

## Verified in a browser

Local stack, two connected clients seeded as Claude and Cursor:

1. listed, each showing what it reaches (*CRM* / *Everything in Conn's Workspace*)
2. changed Claude from `CRM` to `CRM, ERP` → *"Updated. It applies to this connection's next request."*
3. revoked Cursor → badge **Revoked**, *"Reaches nothing. Choose below to allow it again."*

Database afterwards — the revoked row is stamped, not gone:

```
 client_id  | whole_ws | n_srv | revoked        event             | client
------------+----------+-------+---------      -------------------+------------
 claude-abc | f        |     2 | f             MCP_GRANT_CHANGED  | claude-abc
 cursor-xyz | t        |       | t             MCP_GRANT_REVOKED  | cursor-xyz
```

## Also here

Three audit events (`MCP_GRANT_CREATED` / `CHANGED` / `REVOKED`), and the API: list, selectable targets, change, revoke. Every write goes through `grantWholeOrganization` / `grantServers`, which validate membership themselves — so a request naming another tenant's workspace or server grants less than it asked for, never more.

## Still open

**Hard per-client token revocation.** Revoking here means the client sees nothing; it does not invalidate its token, so Claude stays "connected" with an empty tool list rather than being prompted to reconnect. Doing that properly needs a revocation marker on `oauth_clients` checked in the guard — `sessionsValidFrom` is account-wide and would sign the user out of the dashboard too. Worth a follow-up; not needed for the flow to be correct.

Suite: 4079 passed.