### PR TITLE
Five ways a connector could fail without saying why

### DIFF
--- a/packages/backend/src/adapters/adapters.service.spec.ts
+++ b/packages/backend/src/adapters/adapters.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { AdaptersService } from './adapters.service';
 
 /**
@@ -80,6 +81,90 @@ describe('AdaptersService placeholder resolution', () => {
       n: 42,
       b: true,
       nil: null,
+    });
+  });
+
+  /**
+   * baseUrl is the one place where keeping the placeholder is fatal rather
+   * than merely deferred: the connector gets created, looks fine in the UI,
+   * and every call dies in the SSRF guard against a literal `{{VAR}}` host.
+   */
+  describe('assertBaseUrlFullyResolved', () => {
+    // (slug, the adapter's template, the URL after substitution)
+    const assertResolved = (slug: string, template: string, resolved = template) =>
+      (service as any).assertBaseUrlFullyResolved(slug, template, resolved);
+
+    it('accepts a fully resolved URL', () => {
+      expect(() =>
+        assertResolved('weclapp', 'https://acme.weclapp.com/webapp/api/v1'),
+      ).not.toThrow();
+    });
+
+    it('rejects a bare placeholder and names the variable', () => {
+      expect(() => assertResolved('amazon-seller', '{{SPAPI_ENDPOINT}}')).toThrow(
+        BadRequestException,
+      );
+      expect(() => assertResolved('amazon-seller', '{{SPAPI_ENDPOINT}}')).toThrow(
+        /SPAPI_ENDPOINT is required to install "amazon-seller"/,
+      );
+    });
+
+    it('rejects a placeholder embedded in a path', () => {
+      expect(() =>
+        assertResolved('magento', '{{MAGENTO_BASE_URL}}/rest/default/V1'),
+      ).toThrow(/MAGENTO_BASE_URL/);
+    });
+
+    it('names every missing variable once, and reads as a plural', () => {
+      let message = '';
+      try {
+        assertResolved('x', 'https://{{A}}.example.com/{{B}}/{{A}}');
+      } catch (e) {
+        message = (e as Error).message;
+      }
+      expect(message).toContain('A and B are required');
+      expect(message).toContain('they form');
+    });
+
+    it('rejects a whole URL pasted into a fragment variable', () => {
+      // What actually happened to insightly in production: the pod name field
+      // got a full URL, the result parsed as a valid URL with host "api.https",
+      // and every call failed with "cannot resolve 'api.https'".
+      expect(() =>
+        assertResolved(
+          'insightly',
+          'https://api.{{INSIGHTLY_POD}}.insightly.com/v3.1',
+          'https://api.https://api.na1.insightly.com/v3.1.insightly.com/v3.1',
+        ),
+      ).toThrow(/looks like a full URL/);
+    });
+
+    it('leaves a correctly-filled templated URL alone', () => {
+      expect(() =>
+        assertResolved(
+          'insightly',
+          'https://api.{{INSIGHTLY_POD}}.insightly.com/v3.1',
+          'https://api.na1.insightly.com/v3.1',
+        ),
+      ).not.toThrow();
+    });
+
+    it('does not echo a resolved secret back in the message', () => {
+      // telegram-bot templates the bot token straight into the path, so the
+      // hint has to show the shape of the URL without the parts that resolved.
+      let message = '';
+      try {
+        assertResolved(
+          'telegram-bot',
+          'https://api.telegram.org/bot{{TELEGRAM_BOT_TOKEN}}/{{CHAT_ID}}',
+          'https://api.telegram.org/bot12345:SECRET/{{CHAT_ID}}',
+        );
+      } catch (e) {
+        message = (e as Error).message;
+      }
+      expect(message).toContain('CHAT_ID');
+      expect(message).not.toContain('SECRET');
+      expect(message).not.toContain('12345');
     });
   });
 });

--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../common/prisma.service';
 import { McpServerService } from '../mcp-server/mcp-server.service';
 import { encrypt } from '../common/crypto/encryption.util';
@@ -70,6 +75,11 @@ export class AdaptersService {
 
     // Resolve {{VAR}} placeholders in baseUrl (e.g. weclapp tenant)
     const resolvedBaseUrl = this.resolveString(adapter.connector.baseUrl, credentials);
+    this.assertBaseUrlFullyResolved(
+      slug,
+      adapter.connector.baseUrl,
+      resolvedBaseUrl,
+    );
 
     // Resolve {{VAR}} placeholders in static connector headers (e.g. Harvest
     // requires a per-tenant Harvest-Account-Id header on every call).
@@ -152,6 +162,64 @@ export class AdaptersService {
   }
 
   /** Replace {{VAR}} placeholders in a string with credential values */
+  /**
+   * An unresolved placeholder in `baseUrl` produces a connector that cannot
+   * ever work. `resolveString` deliberately keeps the placeholder when a key
+   * is absent — right for `authConfig`, where an operator may fill a secret in
+   * later, but fatal here: every request then goes to a URL like
+   * `{{SPAPI_ENDPOINT}}/sellers/v1/...` and dies in the SSRF guard with a
+   * message that names neither the adapter nor the missing variable.
+   *
+   * Eleven live connectors were in exactly this state when the check was
+   * added — bitrix24, substack, amazon-seller, magento, wordpress,
+   * woocommerce, xentral, ghost, agilecrm, sap-concur and telegram-bot —
+   * and bitrix24 had already spent 97 tool calls on it. None of them could
+   * have succeeded once. Failing the import is the kinder outcome: the user
+   * is still on the form with the value in front of them.
+   */
+  private assertBaseUrlFullyResolved(
+    slug: string,
+    template: string,
+    resolved: string,
+  ): void {
+    const names = [
+      ...new Set([...resolved.matchAll(/\{\{(\w+)\}\}/g)].map((m) => m[1])),
+    ];
+
+    // A whole URL pasted into a variable that wanted one fragment. Insightly
+    // asks for a pod name to go in `https://api.{{INSIGHTLY_POD}}.insightly.com`;
+    // someone gave it `https://api.na1.insightly.com/v3.1`, which resolved to a
+    // host of `api.https` and failed every call with "cannot resolve
+    // 'api.https'". The URL is syntactically fine, so validateBaseUrl lets it
+    // through — only the template tells you the value was meant to be a part,
+    // not a whole.
+    if (names.length === 0) {
+      const placeholders = [
+        ...new Set([...template.matchAll(/\{\{(\w+)\}\}/g)].map((m) => m[1])),
+      ];
+      if (placeholders.length > 0 && resolved.split('://').length > 2) {
+        throw new BadRequestException(
+          `The value given for ${placeholders.join(' or ')} looks like a full ` +
+            `URL. "${slug}" builds the address as ` +
+            `${template.replace(/^https?:\/\//, '')}, so it needs just that ` +
+            `part — not another https:// inside it.`,
+        );
+      }
+      return;
+    }
+    const plural = names.length > 1;
+    // The hint shows the adapter's own template, never `resolved`. They differ
+    // precisely in the parts the user supplied, and those can be secrets —
+    // telegram-bot templates the bot token straight into the path, so echoing
+    // the resolved URL would put it in an error message and a server log.
+    throw new BadRequestException(
+      `${names.join(' and ')} ${plural ? 'are' : 'is'} required to install ` +
+        `"${slug}" — ${plural ? 'they form' : 'it forms'} part of the API ` +
+        `address (${template.replace(/^https?:\/\//, '')}), so the connector ` +
+        `cannot be created without ${plural ? 'them' : 'it'}.`,
+    );
+  }
+
   private resolveString(
     str: string,
     credentials?: Record<string, string>,

--- a/packages/backend/src/adapters/intl/buffer.json
+++ b/packages/backend/src/adapters/intl/buffer.json
@@ -11,7 +11,7 @@
   "connector": {
     "name": "Buffer GraphQL API",
     "type": "GRAPHQL",
-    "baseUrl": "https://graphql.buffer.com",
+    "baseUrl": "https://api.buffer.com/graphql",
     "authType": "BEARER_TOKEN",
     "authConfig": {
       "token": "{{BUFFER_ACCESS_TOKEN}}"

--- a/packages/backend/src/adapters/intl/buffer.live.spec.ts
+++ b/packages/backend/src/adapters/intl/buffer.live.spec.ts
@@ -3,8 +3,13 @@ const a = adapter as unknown as {
   connector: { baseUrl: string; type: string; authType: string };
 };
 describe('buffer adapter — static spec conformance', () => {
-  it('graphql.buffer.com base URL', () =>
-    expect(a.connector.baseUrl).toBe('https://graphql.buffer.com'));
+  // Was graphql.buffer.com, which has no DNS record at all — every call died
+  // in the SSRF guard with "cannot resolve 'graphql.buffer.com'". This test
+  // pinned the broken value, so it passed throughout. api.buffer.com/graphql
+  // answers with a well-formed GraphQL auth error, which is the shape the
+  // other GraphQL adapters point at.
+  it('api.buffer.com/graphql base URL', () =>
+    expect(a.connector.baseUrl).toBe('https://api.buffer.com/graphql'));
   it('GraphQL connector with Bearer auth', () => {
     expect(a.connector.type).toBe('GRAPHQL');
     expect(a.connector.authType).toBe('BEARER_TOKEN');

--- a/packages/backend/src/connectors/connectors.service.ts
+++ b/packages/backend/src/connectors/connectors.service.ts
@@ -401,8 +401,22 @@ export class ConnectorsService {
         ) }
       : params;
 
-    // Static response tools — return text immediately without engine dispatch
-    if (endpointMapping.method === 'static' && endpointMapping.staticResponse) {
+    // Static response tools — return text immediately without engine dispatch.
+    //
+    // The `method` alone decides this, not `method && staticResponse`. With the
+    // old `&&`, a static tool whose staticResponse was missing fell through to
+    // the engine below, which built a URL from an endpointMapping that has no
+    // `path` and died with "Cannot read properties of undefined (reading
+    // 'replace')" — a message naming neither the tool nor the real problem.
+    // api-football's af_analysis_playbook spent six weeks failing that way.
+    if (endpointMapping.method === 'static') {
+      if (!endpointMapping.staticResponse) {
+        throw new Error(
+          'This tool is configured to return a fixed text response, but that ' +
+            'response is empty. Set it under the tool\'s endpoint mapping, or ' +
+            'change the method to a real HTTP verb.',
+        );
+      }
       return { text: endpointMapping.staticResponse };
     }
 

--- a/packages/backend/src/connectors/engines/login-token.service.spec.ts
+++ b/packages/backend/src/connectors/engines/login-token.service.spec.ts
@@ -6,6 +6,7 @@ import {
   jsonPath,
   interpolateDeep,
   extractSetCookieValue,
+  extractLoginRefusal,
   LoginTokenAuthConfig,
 } from './login-token.service';
 import { encrypt } from '../../common/crypto/encryption.util';
@@ -259,7 +260,10 @@ describe('LoginTokenService', () => {
     expect(bundle.token).toBe('jwt-plain');
   });
 
-  it('throws a clear error when tokenJsonPath does not resolve', async () => {
+  it("surfaces the service's own refusal rather than our json path", async () => {
+    // This body is what a rejected sign-in actually looks like: HTTP 200, no
+    // token, and the reason in `errors`. Reporting the missing json path here
+    // describes our configuration and hides theirs.
     (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
       if (config.url.includes('/users/')) {
         return { data: { salt: bcrypt.genSaltSync(4) } };
@@ -268,7 +272,22 @@ describe('LoginTokenService', () => {
     });
 
     await expect(service.getToken(baseAuth, 'conn-8')).rejects.toThrow(
-      /token not found/,
+      /refused the login — bad creds/,
+    );
+  });
+
+  it('still names tokenJsonPath when the response explains nothing', async () => {
+    (mockedAxios as unknown as jest.Mock).mockImplementation(async (config: any) => {
+      if (config.url.includes('/users/')) {
+        return { data: { salt: bcrypt.genSaltSync(4) } };
+      }
+      // A 200 with a plausible-looking body and the token somewhere else:
+      // nothing to quote, so the json path is the most useful thing to say.
+      return { data: { data: { signIn: { currentUser: { slug: 'me' } } } } };
+    });
+
+    await expect(service.getToken(baseAuth, 'conn-9')).rejects.toThrow(
+      /token not found at "data.signIn.token"/,
     );
   });
 });
@@ -367,5 +386,55 @@ describe('LoginTokenService — tokenSource=cookie (SAP B1 pattern)', () => {
     await expect(service.getToken(cookieAuth, 'conn-x')).rejects.toThrow(
       /B1SESSION/,
     );
+  });
+});
+
+/**
+ * A login that is refused answers 200 with the reason in the body. Reporting
+ * "token not found at <our json path>" describes our own configuration and
+ * hides theirs, which is what thirteen Sorare failures looked like.
+ */
+describe('extractLoginRefusal', () => {
+  it('reads a GraphQL errors array nested under the mutation payload', () => {
+    expect(
+      extractLoginRefusal({
+        data: { signIn: { errors: [{ message: 'Invalid email or password' }] } },
+      }),
+    ).toBe('Invalid email or password');
+  });
+
+  it('reads a root-level GraphQL errors array', () => {
+    expect(
+      extractLoginRefusal({ errors: [{ message: 'Rate limited' }] }),
+    ).toBe('Rate limited');
+  });
+
+  it('joins several messages', () => {
+    expect(
+      extractLoginRefusal({ errors: [{ message: 'a' }, { message: 'b' }] }),
+    ).toBe('a; b');
+  });
+
+  it('reads plain-string error shapes', () => {
+    expect(extractLoginRefusal({ error_description: 'bad creds' })).toBe(
+      'bad creds',
+    );
+    expect(extractLoginRefusal({ error: 'unauthorized' })).toBe('unauthorized');
+    expect(extractLoginRefusal({ detail: { message: 'nope' } })).toBe('nope');
+  });
+
+  it('returns null when there is nothing to report', () => {
+    // The caller must then fall back to naming the json path — saying
+    // "the service refused the login — null" would be worse than either.
+    expect(extractLoginRefusal({ data: { signIn: { currentUser: {} } } })).toBeNull();
+    expect(extractLoginRefusal(null)).toBeNull();
+    expect(extractLoginRefusal('a string')).toBeNull();
+    expect(extractLoginRefusal({ errors: [] })).toBeNull();
+  });
+
+  it('survives a cyclic body without recursing forever', () => {
+    const body: Record<string, unknown> = { a: {} };
+    (body.a as Record<string, unknown>).self = body;
+    expect(extractLoginRefusal(body)).toBeNull();
   });
 });

--- a/packages/backend/src/connectors/engines/login-token.service.ts
+++ b/packages/backend/src/connectors/engines/login-token.service.ts
@@ -226,8 +226,17 @@ export class LoginTokenService {
     } else {
       token = jsonPath(response.data, authConfig.tokenJsonPath);
       if (!token || typeof token !== 'string') {
+        // Far and away the commonest reason the token is missing is that the
+        // login itself was refused — wrong password, 2FA, a locked account.
+        // The endpoint answers 200 and puts the reason in the body, so saying
+        // "token not found at data.signIn.jwtToken.token" describes our own
+        // JSON path and hides the vendor's explanation. Sorare accounted for
+        // thirteen failures reported that way.
+        const refusal = extractLoginRefusal(response.data);
         throw new Error(
-          `LOGIN_TOKEN: token not found at "${authConfig.tokenJsonPath}" in login response`,
+          refusal
+            ? `LOGIN_TOKEN: the service refused the login — ${refusal}`
+            : `LOGIN_TOKEN: token not found at "${authConfig.tokenJsonPath}" in login response`,
         );
       }
     }
@@ -517,4 +526,47 @@ export function interpolateDeep(
     return out;
   }
   return value;
+}
+
+/**
+ * Pull a human-readable refusal out of a login response that returned 200
+ * without a token. Covers the two shapes vendors actually use: a GraphQL-style
+ * `errors: [{ message }]` (at the root or nested under the mutation payload),
+ * and a flat `error` / `message` / `error_description` string.
+ */
+export function extractLoginRefusal(body: unknown): string | null {
+  const seen = new Set<unknown>();
+  const walk = (node: unknown, depth: number): string | null => {
+    if (!node || typeof node !== 'object' || depth > 4 || seen.has(node)) {
+      return null;
+    }
+    seen.add(node);
+    const obj = node as Record<string, unknown>;
+
+    const errors = obj.errors;
+    if (Array.isArray(errors) && errors.length > 0) {
+      const messages = errors
+        .map((e) =>
+          typeof e === 'string'
+            ? e
+            : typeof (e as Record<string, unknown>)?.message === 'string'
+              ? ((e as Record<string, unknown>).message as string)
+              : null,
+        )
+        .filter((m): m is string => !!m);
+      if (messages.length > 0) return messages.join('; ');
+    }
+
+    for (const key of ['error_description', 'error', 'message']) {
+      const v = obj[key];
+      if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+
+    for (const v of Object.values(obj)) {
+      const found = walk(v, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  };
+  return walk(body, 0);
 }

--- a/packages/backend/src/connectors/engines/rest.engine.ts
+++ b/packages/backend/src/connectors/engines/rest.engine.ts
@@ -46,7 +46,10 @@ export class RestEngine {
     },
     endpointMapping: {
       method: string;
-      path: string;
+      // Optional, because the stored mapping genuinely may not have one: a
+      // tool saved as `method: "static"` carries only its staticResponse.
+      // Declaring it required is what let an undefined path reach `.replace`.
+      path?: string;
       queryParams?: Record<string, unknown>;
       bodyMapping?: Record<string, unknown>;
       bodyTemplate?: string;
@@ -56,7 +59,20 @@ export class RestEngine {
     params: Record<string, unknown>,
   ): Promise<unknown> {
     // Interpolate path parameters: /users/{id} → /users/123
-    let path = endpointMapping.path;
+    //
+    // `path` is optional on the stored mapping — tools saved as `method:
+    // "static"` carry no path at all — so read it defensively. It used to be
+    // dereferenced straight away, and any mapping that reached here without
+    // one failed with "Cannot read properties of undefined (reading
+    // 'replace')": an error that points at this line rather than at the tool
+    // whose configuration is wrong.
+    let path = endpointMapping.path ?? '';
+    if (typeof path !== 'string') {
+      throw new Error(
+        `This tool's path is ${typeof path}, not a string. Check the tool's ` +
+          'endpoint mapping — it should be a path like /users/{id}.',
+      );
+    }
     for (const [key, value] of Object.entries(params)) {
       path = path.replace(`{${key}}`, String(value));
     }

--- a/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
+++ b/packages/backend/src/mcp-server/dynamic-mcp-tools.ts
@@ -570,8 +570,22 @@ export class DynamicMcpTools {
     params: Record<string, unknown>,
     extra?: { connectorConfig?: Record<string, unknown> },
   ): Promise<unknown> {
-    // Static response tools — return text immediately without engine dispatch
-    if (endpointMapping.method === 'static' && endpointMapping.staticResponse) {
+    // Static response tools — return text immediately without engine dispatch.
+    //
+    // The `method` alone decides this, not `method && staticResponse`. With the
+    // old `&&`, a static tool whose staticResponse was missing fell through to
+    // the engine below, which built a URL from an endpointMapping that has no
+    // `path` and died with "Cannot read properties of undefined (reading
+    // 'replace')" — a message naming neither the tool nor the real problem.
+    // api-football's af_analysis_playbook spent six weeks failing that way.
+    if (endpointMapping.method === 'static') {
+      if (!endpointMapping.staticResponse) {
+        throw new Error(
+          'This tool is configured to return a fixed text response, but that ' +
+            'response is empty. Set it under the tool\'s endpoint mapping, or ' +
+            'change the method to a real HTTP verb.',
+        );
+      }
       return { text: endpointMapping.staticResponse };
     }
 


### PR DESCRIPTION
## How these were found

Measured against the production database: **19,425 tool invocations, 1,359 failures, and sixteen connectors that have never completed a single call.**

Most of that is not fixable here — expired customer credentials (vinted, pinterest, trello, datev, teamviewer and eight more all return 401) and upstream blocking (reddit 403, etsy 520, magento 403). The five below are ours, and each one failed in a way that pointed at the wrong thing.

## 1. An unresolved `{{PLACEHOLDER}}` in `baseUrl` now fails the import

`resolveString` deliberately keeps a placeholder when the key is absent — correct for `authConfig`, where an operator may fill a secret in later. For `baseUrl` it produces a connector that is dead on arrival and looks fine in the UI.

**Eleven live connectors were in exactly this state:**

| slug | stored baseUrl | calls spent |
|---|---|---|
| bitrix24 | `{{BITRIX24_WEBHOOK_URL}}` | **97** |
| substack | `{{SUBSTACK_PUBLICATION_URL}}` | 2 |
| amazon-seller | `{{SPAPI_ENDPOINT}}` | 1 |
| xentral, ghost, agilecrm, sap-concur, magento, wordpress, woocommerce, telegram-bot | templated | 0 |

Not one could ever have succeeded. The failure read `SSRF guard: invalid URL '{{SPAPI_ENDPOINT}}/sellers/v1/marketplaceParticipations'` — naming neither the adapter nor the missing variable.

The new message quotes **the adapter's template, never the resolved URL**. The two differ precisely in what the user supplied, and `telegram-bot` templates its bot token straight into the path — echoing the resolved value would put a credential into an error message and a server log. There is a test for that.

## 2. A whole URL pasted into a fragment variable is rejected too

Insightly asks for a pod name to drop into `https://api.{{INSIGHTLY_POD}}.insightly.com/v3.1`. Someone pasted the full address. The result parses as a perfectly valid URL with a host of `api.https`, so `validateBaseUrl` waves it through, and every call failed with `cannot resolve 'api.https'`. Only the template knows the value was meant to be a part rather than a whole.

## 3. A static tool with no `staticResponse` no longer crashes somewhere else

The guard was `method === 'static' && staticResponse`. A static tool missing its response fell through to the REST engine, which built a URL from a mapping that has no `path` and died with `Cannot read properties of undefined (reading 'replace')` — an error pointing at `rest.engine.ts:61` rather than at the tool whose configuration is wrong. api-football's `af_analysis_playbook` spent six weeks failing that way.

The method alone now decides, and an empty response says so in its own words. Fixed in both execution paths (`connectors.service` and `dynamic-mcp-tools`).

## 4. `rest.engine` reads `endpointMapping.path` defensively

And the type now admits it is optional, which is what hid #3: a stored `static` mapping genuinely has no path, while the interface declared `path: string`.

## 5. `LOGIN_TOKEN` reports the service's refusal, not our JSON path

A rejected sign-in answers **200** with the reason in the body, so `token not found at "data.signIn.jwtToken.token"` described our configuration and hid theirs. Sorare accounted for thirteen failures reported that way.

`extractLoginRefusal` reads both shapes vendors actually use: a GraphQL `errors: [{ message }]` at any depth, and a flat `error` / `message` / `error_description`. It falls back to the JSON path when there is genuinely nothing to quote — `the service refused the login — null` would be worse than either.

## Also: buffer pointed at a hostname that does not exist

`graphql.buffer.com` has **no DNS record at all**; every call died in the SSRF guard. Its own spec asserted that value, so the test passed for as long as the connector was broken:

```ts
it('graphql.buffer.com base URL', () =>
  expect(a.connector.baseUrl).toBe('https://graphql.buffer.com'));
```

`api.buffer.com/graphql` answers with a well-formed GraphQL auth error and matches the shape every other GraphQL adapter uses.

## Diagnosed but not fixed here

- **deutsche-bahn** — the most-installed connector in the catalogue, 41% success. Reproduced live: `amcp-cloud-db-rest` calls `int.bahn.de` and gets a **520 from Cloudflare**. The block is on that container's own egress, so it is deploy configuration rather than an adapter change.
- **etsy** — 0 of 69, and it is **already routed through the web unblocker** (`useProxy` on all nine tools, `CONNECTOR_PROXY_URL` set, 64 of 69 calls recorded with `used_proxy = true`). The proxy itself is being refused: 520, and `421 Misdirected Request`, which smells like an SNI/Host mismatch. Needs someone who can see the proxy side.
- **vinted, pinterest, trello, datev, teamviewer, kenjo, salesflare, lemonsqueezy, immobilienscout24, mfr-fieldservice, youtube-data, coingecko, whatsapp-business** — 401s. Customer credentials, not code. #5 makes this class legible for LOGIN_TOKEN connectors; the OAuth2/API-key paths already surface the vendor body.

## Verification

`tsc --noEmit` clean, `eslint` clean on the nine touched files, **4,103 tests pass** (241 suites).