### PR TITLE
Catalog fixes from the directory showcase: NINA/Nominatim/Bundesbank, connector update reload, marketplace auto-attach

### DIFF
--- a/packages/backend/src/adapters/adapters.controller.spec.ts
+++ b/packages/backend/src/adapters/adapters.controller.spec.ts
@@ -10,11 +10,17 @@ function buildController() {
   const licenseGuard = {
     checkCanCreateConnector: jest.fn().mockResolvedValue(undefined),
   };
+  const mcpServers = {
+    attachToDefaultServer: jest
+      .fn()
+      .mockResolvedValue({ id: 's1', name: 'Default' }),
+  };
   const controller = new AdaptersController(
     adaptersService as any,
     licenseGuard as any,
+    mcpServers as any,
   );
-  return { controller, adaptersService, licenseGuard };
+  return { controller, adaptersService, licenseGuard, mcpServers };
 }
 
 const req = (role: string) => ({
@@ -40,6 +46,24 @@ describe('AdaptersController role enforcement', () => {
       await controller.importAdapter(req(role), 'some-slug', {});
 
       expect(adaptersService.importAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('puts the imported connector on the default server and says which', async () => {
+      const { controller, mcpServers } = buildController();
+
+      const result = await controller.importAdapter(req('ADMIN'), 'some-slug', {});
+
+      expect(mcpServers.attachToDefaultServer).toHaveBeenCalledWith('u1', 'org1', 'c1');
+      expect(result.attachedToServer).toEqual({ id: 's1', name: 'Default' });
+    });
+
+    it('reports no server when there was none to attach to', async () => {
+      const { controller, mcpServers } = buildController();
+      mcpServers.attachToDefaultServer.mockResolvedValue(null);
+
+      const result = await controller.importAdapter(req('ADMIN'), 'some-slug', {});
+
+      expect(result.attachedToServer).toBeNull();
     });
   });
 });

--- a/packages/backend/src/adapters/adapters.controller.ts
+++ b/packages/backend/src/adapters/adapters.controller.ts
@@ -12,6 +12,7 @@ import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { AdaptersService } from './adapters.service';
 import { LicenseGuardService } from '../license/license-guard.service';
+import { McpServersService } from '../mcp-servers/mcp-servers.service';
 
 // Public endpoints (no auth required) — used by the marketing website
 @ApiTags('Adapters')
@@ -39,6 +40,7 @@ export class AdaptersController {
   constructor(
     private readonly adaptersService: AdaptersService,
     private readonly licenseGuard: LicenseGuardService,
+    private readonly mcpServers: McpServersService,
   ) {}
 
   @Get(':slug')
@@ -73,10 +75,19 @@ export class AdaptersController {
       req.user.organizationId,
       body?.credentials,
     );
+    // Same as a hand-made connector (connectors.controller): put it on a
+    // server straight away. A marketplace install that reaches no server is
+    // exactly the connector nobody's client ever sees.
+    const attachedTo = await this.mcpServers.attachToDefaultServer(
+      req.user.sub,
+      req.user.organizationId,
+      result.connectorId,
+    );
     return {
       message: `Adapter "${slug}" imported successfully with ${result.toolsCreated} tools.`,
       connectorId: result.connectorId,
       toolsCreated: result.toolsCreated,
+      attachedToServer: attachedTo ? { id: attachedTo.id, name: attachedTo.name } : null,
     };
   }
 }

--- a/packages/backend/src/adapters/adapters.module.ts
+++ b/packages/backend/src/adapters/adapters.module.ts
@@ -6,9 +6,10 @@ import {
 import { AdaptersService } from './adapters.service';
 import { McpServerModule } from '../mcp-server/mcp-server.module';
 import { LicenseModule } from '../license/license.module';
+import { McpServersModule } from '../mcp-servers/mcp-servers.module';
 
 @Module({
-  imports: [McpServerModule, LicenseModule],
+  imports: [McpServerModule, LicenseModule, McpServersModule],
   controllers: [AdaptersPublicController, AdaptersController],
   providers: [AdaptersService],
 })

--- a/packages/backend/src/adapters/de/bundesbank.json
+++ b/packages/backend/src/adapters/de/bundesbank.json
@@ -16,7 +16,7 @@
   "tools": [
     {
       "name": "bundesbank_get_exchange_rates",
-      "description": "Get current and historical euro exchange rates from the Bundesbank. Returns daily exchange rates for major currencies (USD, GBP, CHF, JPY, etc.).",
+      "description": "Daily euro foreign exchange reference rates (ECB/Bundesbank) for one currency against EUR. Pass startPeriod to limit the range — the full history is very large.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -43,7 +43,8 @@
         "queryParams": {
           "startPeriod": "$startPeriod",
           "endPeriod": "$endPeriod",
-          "detail": "dataonly"
+          "detail": "dataonly",
+          "format": "json"
         },
         "headers": {
           "Accept": "application/json"
@@ -51,98 +52,83 @@
       }
     },
     {
-      "name": "bundesbank_get_interest_rates",
-      "description": "Get key interest rate data from the Bundesbank and ECB, including the main refinancing rate, deposit facility rate, and marginal lending rate.",
+      "name": "bundesbank_get_bund_yields",
+      "description": "Daily yield of German federal securities (Bunds) for a given residual maturity, from the Bundesbank term-structure statistics (BBSIS). Use as the risk-free EUR rate. Returns SDMX-JSON.",
       "parameters": {
         "type": "object",
         "properties": {
+          "maturityYears": {
+            "type": "string",
+            "description": "Residual maturity in years, two digits: 01, 02, 05, 10 or 30.",
+            "enum": [
+              "01",
+              "02",
+              "05",
+              "10",
+              "30"
+            ],
+            "default": "10"
+          },
           "startPeriod": {
             "type": "string",
-            "description": "Start date in YYYY-MM-DD format"
+            "description": "First period, e.g. 2026-01-01 (daily) or 2026-01 (monthly). Omit for the full history — can be large."
           },
           "endPeriod": {
             "type": "string",
-            "description": "End date in YYYY-MM-DD format"
-          }
-        }
-      },
-      "endpointMapping": {
-        "method": "GET",
-        "path": "/data/BBK01/SU0202",
-        "queryParams": {
-          "startPeriod": "$startPeriod",
-          "endPeriod": "$endPeriod",
-          "detail": "dataonly"
-        },
-        "headers": {
-          "Accept": "application/json"
-        }
-      }
-    },
-    {
-      "name": "bundesbank_search_statistics",
-      "description": "Search for available statistical series in the Bundesbank database by keyword. Returns matching time series with their IDs, titles, and metadata.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "query": {
-            "type": "string",
-            "description": "Search keyword (e.g. 'inflation', 'GDP', 'money supply', 'Geldmenge')"
-          },
-          "limit": {
-            "type": "number",
-            "description": "Maximum number of results to return (default: 10, max: 100)"
+            "description": "Last period, same format as startPeriod."
           }
         },
         "required": [
-          "query"
+          "maturityYears"
         ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/metadata/series",
+        "path": "/data/BBSIS/D.I.ZAR.ZI.EUR.S1311.B.A604.R{maturityYears}XX.R.A.A._Z._Z.A",
         "queryParams": {
-          "q": "$query",
-          "limit": "$limit"
-        },
-        "headers": {
-          "Accept": "application/json"
+          "startPeriod": "$startPeriod",
+          "endPeriod": "$endPeriod",
+          "detail": "dataonly",
+          "format": "json"
         }
       }
     },
     {
       "name": "bundesbank_get_timeseries",
-      "description": "Retrieve data for a specific Bundesbank time series by its ID. Use bundesbank_search_statistics first to find the series ID.",
+      "description": "Fetch any Bundesbank time series by SDMX dataflow and series key. Examples: flow BBEX3 + key D.USD.EUR.BB.AC.000 (EUR/USD reference rate, daily); flow BBSIS + key D.I.ZAR.ZI.EUR.S1311.B.A604.R10XX.R.A.A._Z._Z.A (10-year Bund yield, daily). Returns SDMX-JSON; observations are under data.dataSets[0].series.",
       "parameters": {
         "type": "object",
         "properties": {
-          "seriesId": {
+          "flow": {
             "type": "string",
-            "description": "The Bundesbank time series ID (e.g. 'BBEX3.D.USD.EUR.BB.AC.000')"
+            "description": "Dataflow id, e.g. BBEX3, BBSIS, BBAF3, BBFI1."
+          },
+          "key": {
+            "type": "string",
+            "description": "Dot-separated series key within the flow, e.g. D.USD.EUR.BB.AC.000."
           },
           "startPeriod": {
             "type": "string",
-            "description": "Start date in YYYY-MM-DD format"
+            "description": "First period, e.g. 2026-01-01 (daily) or 2026-01 (monthly). Omit for the full history — can be large."
           },
           "endPeriod": {
             "type": "string",
-            "description": "End date in YYYY-MM-DD format"
+            "description": "Last period, same format as startPeriod."
           }
         },
         "required": [
-          "seriesId"
+          "flow",
+          "key"
         ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/data/{seriesId}",
+        "path": "/data/{flow}/{key}",
         "queryParams": {
           "startPeriod": "$startPeriod",
           "endPeriod": "$endPeriod",
-          "detail": "dataonly"
-        },
-        "headers": {
-          "Accept": "application/json"
+          "detail": "dataonly",
+          "format": "json"
         }
       }
     }

--- a/packages/backend/src/adapters/de/nina-warnung.json
+++ b/packages/backend/src/adapters/de/nina-warnung.json
@@ -10,20 +10,37 @@
   "connector": {
     "name": "NINA Warnungen",
     "type": "REST",
-    "baseUrl": "https://nina.api.proxy.bund.dev/api31",
+    "baseUrl": "https://warnung.bund.de/api31",
     "authType": "NONE"
   },
   "tools": [
     {
-      "name": "nina_get_dashboard",
-      "description": "Get the current overview of all active emergency warnings across Germany. Returns a summary dashboard with warning counts and categories.",
+      "name": "nina_get_active_warnings",
+      "description": "All currently active warnings of one source, nationwide: mowas (civil protection / MoWaS), katwarn, biwapp, dwd (severe weather), lhp (flood), police. Each item has an id (pass it to nina_get_warning_detail), headline, severity, sent time and affected areas. An empty list means no active warning from that source.",
       "parameters": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "mowas",
+              "katwarn",
+              "biwapp",
+              "dwd",
+              "lhp",
+              "police"
+            ],
+            "description": "Warning source.",
+            "default": "mowas"
+          }
+        },
+        "required": [
+          "source"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
-        "path": "/dashboard/overview.json"
+        "path": "/{source}/mapData.json"
       }
     },
     {

--- a/packages/backend/src/adapters/intl/nominatim.json
+++ b/packages/backend/src/adapters/intl/nominatim.json
@@ -21,26 +21,57 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "q": { "type": "string", "description": "Free-text query, e.g. 'Brandenburg Gate, Berlin'." },
-          "format": { "type": "string", "description": "json (compact), jsonv2 (more fields), geojson. Default json." },
-          "addressdetails": { "type": "integer", "description": "1 = include parsed address components." },
-          "extratags": { "type": "integer", "description": "1 = include extra OSM tags." },
-          "namedetails": { "type": "integer", "description": "1 = include localized name variants." },
-          "limit": { "type": "integer", "description": "Max results (default 10, max 50)." },
-          "countrycodes": { "type": "string", "description": "Comma-separated ISO 3166-1 alpha-2 codes (e.g. 'de,fr')." },
-          "viewbox": { "type": "string", "description": "Bounding box 'left,top,right,bottom' (lng,lat) to bias." },
-          "bounded": { "type": "integer", "description": "If 1 with viewbox, restrict to box." },
-          "accept_language": { "type": "string", "description": "Localized output language (e.g. 'de', 'en-US')." },
-          "dedupe": { "type": "integer", "description": "1 = deduplicate (default)." }
+          "q": {
+            "type": "string",
+            "description": "Free-text query, e.g. 'Brandenburg Gate, Berlin'."
+          },
+          "addressdetails": {
+            "type": "integer",
+            "description": "1 = include parsed address components."
+          },
+          "extratags": {
+            "type": "integer",
+            "description": "1 = include extra OSM tags."
+          },
+          "namedetails": {
+            "type": "integer",
+            "description": "1 = include localized name variants."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Max results (default 10, max 50)."
+          },
+          "countrycodes": {
+            "type": "string",
+            "description": "Comma-separated ISO 3166-1 alpha-2 codes (e.g. 'de,fr')."
+          },
+          "viewbox": {
+            "type": "string",
+            "description": "Bounding box 'left,top,right,bottom' (lng,lat) to bias."
+          },
+          "bounded": {
+            "type": "integer",
+            "description": "If 1 with viewbox, restrict to box."
+          },
+          "accept_language": {
+            "type": "string",
+            "description": "Localized output language (e.g. 'de', 'en-US')."
+          },
+          "dedupe": {
+            "type": "integer",
+            "description": "1 = deduplicate (default)."
+          }
         },
-        "required": ["q"]
+        "required": [
+          "q"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/search",
         "queryParams": {
           "q": "$q",
-          "format": "$format",
+          "format": "jsonv2",
           "addressdetails": "$addressdetails",
           "extratags": "$extratags",
           "namedetails": "$namedetails",
@@ -51,7 +82,9 @@
           "accept-language": "$accept_language",
           "dedupe": "$dedupe"
         },
-        "headers": { "User-Agent": "AnythingMCP (https://anythingmcp.com)" }
+        "headers": {
+          "User-Agent": "AnythingMCP (https://anythingmcp.com)"
+        }
       }
     },
     {
@@ -60,14 +93,31 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "lat": { "type": "number", "description": "Latitude in decimal degrees." },
-          "lon": { "type": "number", "description": "Longitude in decimal degrees." },
-          "format": { "type": "string", "description": "json (compact), jsonv2, geojson." },
-          "zoom": { "type": "integer", "description": "Address detail level: 3 (country) → 18 (building). Default 18." },
-          "addressdetails": { "type": "integer", "description": "1 = parsed address parts." },
-          "accept_language": { "type": "string", "description": "Output language." }
+          "lat": {
+            "type": "number",
+            "description": "Latitude in decimal degrees."
+          },
+          "lon": {
+            "type": "number",
+            "description": "Longitude in decimal degrees."
+          },
+          "zoom": {
+            "type": "integer",
+            "description": "Address detail level: 3 (country) → 18 (building). Default 18."
+          },
+          "addressdetails": {
+            "type": "integer",
+            "description": "1 = parsed address parts."
+          },
+          "accept_language": {
+            "type": "string",
+            "description": "Output language."
+          }
         },
-        "required": ["lat", "lon"]
+        "required": [
+          "lat",
+          "lon"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
@@ -75,12 +125,14 @@
         "queryParams": {
           "lat": "$lat",
           "lon": "$lon",
-          "format": "$format",
+          "format": "jsonv2",
           "zoom": "$zoom",
           "addressdetails": "$addressdetails",
           "accept-language": "$accept_language"
         },
-        "headers": { "User-Agent": "AnythingMCP (https://anythingmcp.com)" }
+        "headers": {
+          "User-Agent": "AnythingMCP (https://anythingmcp.com)"
+        }
       }
     },
     {
@@ -89,23 +141,35 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "osm_ids": { "type": "string", "description": "Comma-separated OSM IDs prefixed with N/W/R, e.g. 'R146656,W104393803,N240109189'." },
-          "format": { "type": "string", "description": "json, jsonv2, geojson." },
-          "addressdetails": { "type": "integer", "description": "1 = address parts." },
-          "accept_language": { "type": "string", "description": "Output language." }
+          "osm_ids": {
+            "type": "string",
+            "description": "Comma-separated OSM IDs prefixed with N/W/R, e.g. 'R146656,W104393803,N240109189'."
+          },
+          "addressdetails": {
+            "type": "integer",
+            "description": "1 = address parts."
+          },
+          "accept_language": {
+            "type": "string",
+            "description": "Output language."
+          }
         },
-        "required": ["osm_ids"]
+        "required": [
+          "osm_ids"
+        ]
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/lookup",
         "queryParams": {
           "osm_ids": "$osm_ids",
-          "format": "$format",
+          "format": "jsonv2",
           "addressdetails": "$addressdetails",
           "accept-language": "$accept_language"
         },
-        "headers": { "User-Agent": "AnythingMCP (https://anythingmcp.com)" }
+        "headers": {
+          "User-Agent": "AnythingMCP (https://anythingmcp.com)"
+        }
       }
     },
     {
@@ -113,15 +177,18 @@
       "description": "Service status check. Returns 'OK' if Nominatim is up. Useful health check.",
       "parameters": {
         "type": "object",
-        "properties": {
-          "format": { "type": "string", "description": "text or json." }
-        }
+        "properties": {},
+        "required": []
       },
       "endpointMapping": {
         "method": "GET",
         "path": "/status",
-        "queryParams": { "format": "$format" },
-        "headers": { "User-Agent": "AnythingMCP (https://anythingmcp.com)" }
+        "queryParams": {
+          "format": "json"
+        },
+        "headers": {
+          "User-Agent": "AnythingMCP (https://anythingmcp.com)"
+        }
       }
     }
   ]

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -706,7 +706,13 @@ export class ConnectorsController {
     if (dto.baseUrl !== undefined) {
       this.assertUsableBaseUrl(dto.baseUrl, connector.type);
     }
-    return this.connectorsService.update(id, dto);
+    const updated = await this.connectorsService.update(id, dto);
+    // The registry keeps its own copy of the connector — base URL, headers,
+    // auth — and reads it on every call. Without this, a changed base URL
+    // showed in the form and was ignored by every tool until the next
+    // restart; the env-vars and tool routes already reload, this one did not.
+    await this.mcpServer.reloadConnectorTools(id);
+    return updated;
   }
 
   @Get(':id/oauth-config')


### PR DESCRIPTION
While assembling the reviewer-facing showcase for the Claude connectors directory I installed each open-data connector on a fresh workspace and called every tool through `/mcp`. Three adapters were broken and two platform gaps surfaced.

## Adapters
- **NINA** — `nina.api.proxy.bund.dev` no longer resolves (all 4 tools failed in the SSRF guard). Moved to `warnung.bund.de/api31`; `nina_get_dashboard` (proxy-only endpoint) becomes `nina_get_active_warnings(source)`.
- **Nominatim** — `format` was an optional caller param with no default → HTML/XML responses. Pinned to `jsonv2`, removed from schema.
- **Bundesbank** (29 workspaces; 3/4 tools 404) — `BBK01/SU0202` retired → `bundesbank_get_bund_yields` over BBSIS (01/02/05/10/30y, each verified 200); `get_timeseries` now takes `flow` + `key` (`/data/{flow}/{key}`); `search_statistics` removed (endpoint does not exist upstream); `format=json` everywhere.
  Existing installs pick this up via catalog resync (structural change → user action) — see `catalog-resync.service.ts`.

## Platform
- **`PUT /api/connectors/:id` never reloaded the tool registry** — a changed base URL was stored and echoed but ignored by every tool until restart. Reproduced live. Now reloads, as the env-vars and tool routes already did.
- **Marketplace import did not attach to the default server** (#539 only covered hand-made connectors). Now attaches and returns `attachedToServer`.

## Verification
- All 30 showcase tools (Bundesbank, OpenPLZ, VIES, GTIN, Hacker News, Nominatim, NINA) return successfully through `/mcp` on production with these tool definitions applied to that workspace by hand.
- `src/adapters` specs (2,397 assertions incl. catalog validation) green; `adapters.controller.spec` +2; tsc + eslint clean.

## Follow-ups (not in this PR)
- Website guides still list `bundesbank_get_interest_rates` / `bundesbank_search_statistics` (5 guide files × locales).
- Deutsche Bahn: 0/17 successful calls in 21 days — `int.bahn.de` departures/journeys return 520 through the proxy (locations work). Needs a different route than the current proxy.
- Google Books (`gtin_lookup_book`): 429 direct from the droplet, 520 via proxy — needs an API key.