### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anythingmcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Self-hosted MCP gateway for REST, SOAP/WSDL, GraphQL and SQL — turn any API into MCP tools for Claude, ChatGPT, Gemini, Copilot and Cursor. 30+ pre-built adapters, on-prem audit log, OAuth2/RBAC. Open source (AGPL-3.0).",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AnythingMCP — NestJS Backend + Dynamic MCP Server",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anythingmcp/frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AnythingMCP — Next.js Admin UI",
   "private": true,
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Patch release for the Claude connectors directory prerequisites.

- #547 — protected-resource metadata at `/.well-known/oauth-protected-resource/mcp`, `error="invalid_token"` on 401 when a token was presented, generated tool names capped at 64 characters (hash tail), real favicon + PNG icons.
- #549 — NINA/Nominatim/Bundesbank adapter fixes; `PUT /api/connectors/:id` reloads the tool registry; marketplace import attaches to the default server.