### PR TITLE
fix(mcp): tools/list on the shared /mcp shows the caller's own tool definitions

### DIFF
--- a/packages/backend/src/mcp-server/grant-visibility.spec.ts
+++ b/packages/backend/src/mcp-server/grant-visibility.spec.ts
@@ -194,4 +194,70 @@ describe('grant-scoped visibility on the shared /mcp', () => {
     // must not be handed it either.
     expect(user.grantedConnectorIds).toEqual(['conn-A1']);
   });
+
+  // The transport answers tools/list from the upstream registry, which keeps
+  // ONE entry per name for the whole deployment — the first tenant to register
+  // a name at boot defines what every other tenant is shown for it. The shared
+  // endpoint must answer from the caller's own entries instead.
+  describe('tools/list is built from the caller\'s own tool definitions', () => {
+    const shared = [
+      // org-B registered first and has the OLD shape of a catalog tool.
+      {
+        ...tool('t-b9', 'bundesbank_get_timeseries', 'org-B', 'conn-B1'),
+        description: 'old: by series ID',
+        parameters: { type: 'object', properties: { seriesId: { type: 'string' } }, required: ['seriesId'] },
+      },
+      {
+        ...tool('t-a9', 'bundesbank_get_timeseries', 'org-A', 'conn-A1'),
+        description: 'new: by dataflow and key',
+        parameters: { type: 'object', properties: { flow: { type: 'string' }, key: { type: 'string' } }, required: ['flow', 'key'] },
+        annotations: { readOnlyHint: true },
+        connectorConfig: { baseUrl: 'https://example.com', authType: 'NONE', envVars: { API_KEY: 'x' } },
+      },
+      tool('t-b1', 'gamma', 'org-B', 'conn-B1'),
+    ];
+
+    const controllerFor = () =>
+      new McpEndpointController(
+        { getConnectorIds: jest.fn(async () => []) } as any,
+        { getAllTools: () => shared, countByName: () => 1 } as any,
+        {} as any,
+        { getAllowedToolIds: jest.fn(async () => null) } as any,
+        {} as any,
+        {} as any,
+        { resolve: jest.fn().mockResolvedValue(null) } as any,
+      );
+
+    const listFor = async (user: any) => {
+      process.env.MCP_STREAMABLE_JSON_RESPONSE = 'true';
+      const req: any = { user, body: { jsonrpc: '2.0', id: 7, method: 'tools/list', params: {} } };
+      const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+      await controllerFor().handleGlobalPost(req, res);
+      return res.json.mock.calls[0]?.[0];
+    };
+
+    it('lists the caller\'s own schema, description and annotations for a shared name', async () => {
+      const out = await listFor({ sub: 'u1', organizationId: 'org-A', azp: 'c' });
+      expect(out.id).toBe(7);
+      expect(out.result.tools.map((t: any) => t.name)).toEqual(['bundesbank_get_timeseries']);
+      const t = out.result.tools[0];
+      expect(t.description).toBe('new: by dataflow and key');
+      expect(Object.keys(t.inputSchema.properties).sort()).toEqual(['flow', 'key']);
+      expect(t.annotations.readOnlyHint).toBe(true);
+    });
+
+    it('strips parameters that an env var already supplies', async () => {
+      const out = await listFor({ sub: 'u1', organizationId: 'org-A', azp: 'c' });
+      expect(out.result.tools[0].inputSchema.properties.API_KEY).toBeUndefined();
+    });
+
+    it('shows the other tenant its own version, and nothing of the first', async () => {
+      const out = await listFor({ sub: 'u2', organizationId: 'org-B', azp: 'c' });
+      const names = out.result.tools.map((t: any) => t.name).sort();
+      expect(names).toEqual(['bundesbank_get_timeseries', 'gamma']);
+      const t = out.result.tools.find((x: any) => x.name === 'bundesbank_get_timeseries');
+      expect(t.description).toBe('old: by series ID');
+      expect(Object.keys(t.inputSchema.properties)).toEqual(['seriesId']);
+    });
+  });
 });

--- a/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
+++ b/packages/backend/src/mcp-server/mcp-endpoint.controller.ts
@@ -148,6 +148,7 @@ export class McpEndpointController {
   async handleGlobalPost(@Req() req: Request, @Res() res: Response) {
     const visible = await this.attachVisibleTools(req);
     if (this.refuseHiddenToolCall(req, res, visible)) return;
+    if (this.answerToolsList(req, res, visible)) return;
     await mcpHttpTransport.httpHandlers.handlePost(req, res);
   }
 
@@ -258,6 +259,10 @@ export class McpEndpointController {
       ? [...new Set(visible.map((t) => t.connectorId))]
       : undefined;
 
+    // The full entries, not just the names: `answerToolsList` builds this
+    // caller's tools/list from them.
+    (req as { visibleTools?: RegisteredTool[] }).visibleTools = visible;
+
     const visibleNames = new Set(visible.map((t) => t.name));
     user.roles = [
       ...[...visibleNames].map(toolVisibilityRole),
@@ -311,6 +316,81 @@ export class McpEndpointController {
         message: `Tool '${name}' is not available to you. It belongs to another workspace, or your MCP role does not grant it.`,
       },
     });
+    return true;
+  }
+
+  /**
+   * Answers `tools/list` on the shared endpoint from THIS caller's tools.
+   *
+   * Left to the transport, the answer comes from the upstream registry, which
+   * holds one entry per NAME for the whole deployment: whichever connector
+   * registered a name first at boot supplies the description, input schema
+   * and annotations that every other tenant then sees for their own tool of
+   * that name. Seen live on 12 Sep: a workspace whose
+   * `bundesbank_get_timeseries` takes `flow` + `key` was listed with another
+   * tenant's `seriesId` version, and a read-only override on `vies_check_vat`
+   * showed up as a write tool. Claude calls what it was shown, so the call
+   * then fails against the real schema. It is also a disclosure: a tenant's
+   * customised description reaches whoever shares the name.
+   *
+   * Visibility was narrowed to this caller's connectors just above, so the
+   * definitions are taken from those very registry entries, shaped as the
+   * per-server endpoint shapes them (env-var parameters stripped, annotations
+   * derived plus overrides). Operator credentials (`visible === null`) keep
+   * the transport's answer, as everywhere else on this endpoint.
+   */
+  private answerToolsList(
+    req: Request,
+    res: Response,
+    visible: Set<string> | null,
+  ): boolean {
+    if (visible === null) return false;
+
+    const body = (req as any).body;
+    // Single requests only; a batch goes to the transport unchanged.
+    if (!body || Array.isArray(body) || body.method !== 'tools/list') return false;
+
+    const tools =
+      (req as { visibleTools?: RegisteredTool[] }).visibleTools ?? [];
+    const seen = new Set<string>();
+    const listed: Array<Record<string, unknown>> = [];
+    for (const tool of tools) {
+      // Two reachable connectors may expose the same name (a grant spanning
+      // two configs of one provider). One entry per name, like the per-server
+      // endpoint; the call path resolves within the same connector scope.
+      if (seen.has(tool.name)) continue;
+      seen.add(tool.name);
+
+      const schema = this.stripEnvVarParams(
+        (tool.parameters as Record<string, unknown>) ?? {},
+        tool.connectorConfig?.envVars,
+      );
+      listed.push({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: {
+          type: 'object',
+          ...schema,
+          properties: (schema.properties as Record<string, unknown>) ?? {},
+        },
+        annotations: deriveToolAnnotations(tool),
+      });
+    }
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: body.id ?? null,
+      result: { tools: listed },
+    };
+    // Same framing the transport would use for this deployment.
+    if (this.jsonResponseEnabled()) {
+      res.status(200).json(payload);
+    } else {
+      res.status(200);
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.end(`event: message\ndata: ${JSON.stringify(payload)}\n\n`);
+    }
     return true;
   }
 


### PR DESCRIPTION
Found while capturing the directory showcase through the shared `/mcp`.

**Bug.** `tools/list` on `/mcp` was answered by the transport from the upstream registry — one entry per tool *name* deployment-wide. The first connector to register a name at boot defined the description, input schema and annotations shown to every tenant for its own tool of that name. Which names are visible was already per caller (#542); what stands behind each name was not.

Observed live: `bundesbank_get_timeseries` (ours: `flow` + `key`) listed with another tenant's `seriesId` schema; Nominatim tools listed with a removed `format` parameter; the read-only override on `vies_check_vat` shown as a write tool. Claude calls what it is shown → the call fails against the real schema. Also a disclosure of customised descriptions across tenants.

**Fix.** `handleGlobalPost` answers single `tools/list` requests itself from the caller's visible `ToolRegistry` entries (stashed by `attachVisibleTools`), shaped like the per-server endpoint: env-var params stripped, `deriveToolAnnotations` (derived + overrides), one entry per name. Operator credentials (`visible === null`) and batch requests keep the transport path. Response framing follows `MCP_STREAMABLE_JSON_RESPONSE` like the transport.

**Tests.** `grant-visibility.spec.ts` +3: two orgs sharing a name each see their own description/schema/annotations; env-var params stripped; nothing of the other tenant. 27 green in the visibility suites; tsc + eslint clean.