### PR TITLE
Propose a base-URL fix instead of silently keeping a broken one

### DIFF
--- a/packages/backend/src/adapters/adapters.service.ts
+++ b/packages/backend/src/adapters/adapters.service.ts
@@ -122,6 +122,11 @@ export class AdaptersService {
           adapterSlug: slug,
           adapterVersion: adapter.version,
           instructionsBaseline: hashInstructions(adapter.instructions),
+          // What the catalog's baseUrl resolved to at install. Later, when the
+          // catalog moves, this is the only way to tell "we fixed a wrong
+          // hostname" from "the operator deliberately pointed this at their
+          // own region or sandbox" — the two look identical without it.
+          baseUrlBaseline: resolvedBaseUrl,
         },
       },
     });

--- a/packages/backend/src/connectors/catalog-resync.service.spec.ts
+++ b/packages/backend/src/connectors/catalog-resync.service.spec.ts
@@ -1,4 +1,4 @@
-import { CatalogResyncService } from './catalog-resync.service';
+import { CatalogResyncService, diffBaseUrl } from './catalog-resync.service';
 import { getAdapter } from '../adapters/catalog';
 import {
   computeAdapterVersion,
@@ -150,3 +150,197 @@ describe('CatalogResyncService.computeDiff', () => {
 function tools0Name(): string {
   return getAdapter(SLUG)!.tools[0].name;
 }
+
+
+/**
+ * Base URL drift.
+ *
+ * Correcting a hostname in the catalog does not reach connectors already
+ * installed — NINA kept calling nina.api.proxy.bund.dev, which has no DNS
+ * record, for a day after the catalog was fixed. The obvious repair, copying
+ * the catalog value over, would also have repointed the two connectors whose
+ * operators had deliberately chosen a different host: datadog at the us3
+ * region, DATEV at the sandbox. Hence a proposal rather than an overwrite.
+ */
+describe('diffBaseUrl', () => {
+  const CAT = 'https://warnung.bund.de/api31';
+
+  it('reports nothing when they agree', () => {
+    expect(diffBaseUrl(CAT, CAT, CAT)).toBeNull();
+  });
+
+  it('ignores a trailing slash', () => {
+    expect(diffBaseUrl(CAT, `${CAT}/`, CAT)).toBeNull();
+  });
+
+  it('never compares a templated catalog URL', () => {
+    // The connector holds the resolved form, so every templated adapter would
+    // otherwise report a change on every single diff.
+    expect(
+      diffBaseUrl(
+        'https://{{TENANT}}.weclapp.com/webapp/api/v1',
+        'https://acme.weclapp.com/webapp/api/v1',
+        null,
+      ),
+    ).toBeNull();
+  });
+
+  it('calls it catalog-moved when the connector still holds what it was given', () => {
+    const old = 'https://nina.api.proxy.bund.dev/api31';
+    expect(diffBaseUrl(CAT, old, old)).toEqual({
+      from: old,
+      to: CAT,
+      provenance: 'catalog-moved',
+    });
+  });
+
+  it('calls it user-edited when the operator moved it themselves', () => {
+    // datadog: installed against api.datadoghq.com, pointed at us3 on purpose.
+    const change = diffBaseUrl(
+      'https://api.datadoghq.com',
+      'https://api.us3.datadoghq.com',
+      'https://api.datadoghq.com',
+    );
+    expect(change?.provenance).toBe('user-edited');
+  });
+
+  it('calls it unknown when no baseline was recorded', () => {
+    // Everything installed before baseUrlBaseline existed. Indistinguishable,
+    // so it is shown and left to a human.
+    const change = diffBaseUrl(CAT, 'https://old.example.com', null);
+    expect(change?.provenance).toBe('unknown');
+  });
+});
+
+describe('CatalogResyncService.computeDiff — baseUrl', () => {
+  const NINA = 'nina-warnung';
+
+  function ninaConnector(baseUrl: string, baseline?: string | null) {
+    const adapter = getAdapter(NINA)!;
+    return {
+      id: 'c-nina',
+      name: adapter.connector.name,
+      baseUrl,
+      instructions: adapter.instructions ?? null,
+      config: {
+        adapterSlug: NINA,
+        adapterVersion: adapter.version,
+        instructionsBaseline: hashInstructions(adapter.instructions),
+        ...(baseline === undefined ? {} : { baseUrlBaseline: baseline }),
+      },
+      tools: adapter.tools.map((t: any, i: number) => ({
+        id: `t${i}`,
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+        endpointMapping: t.endpointMapping,
+        responseMapping: t.responseMapping ?? null,
+        useProxy: t.useProxy === true,
+        isEnabled: true,
+        deprecatedAt: null,
+      })),
+    };
+  }
+
+  it('is up to date when the base URL matches', async () => {
+    const adapter = getAdapter(NINA)!;
+    const svc = serviceFor(ninaConnector(adapter.connector.baseUrl));
+    const diff = await svc.computeDiff('c-nina');
+    expect(diff!.baseUrl).toBeNull();
+    expect(diff!.isUpToDate).toBe(true);
+  });
+
+  it('reports a drifted base URL and is no longer up to date', async () => {
+    const stale = 'https://nina.api.proxy.bund.dev/api31';
+    const svc = serviceFor(ninaConnector(stale, stale));
+    const diff = await svc.computeDiff('c-nina');
+    expect(diff!.baseUrl).toEqual({
+      from: stale,
+      to: getAdapter(NINA)!.connector.baseUrl,
+      provenance: 'catalog-moved',
+    });
+    expect(diff!.isUpToDate).toBe(false);
+  });
+
+  it('keeps a base-URL change out of the safe class', async () => {
+    // The boot-time reconciler applies safe-class diffs unattended. It must
+    // never be able to repoint a customer's connector at a different host.
+    const stale = 'https://nina.api.proxy.bund.dev/api31';
+    const svc = serviceFor(ninaConnector(stale, stale));
+    const diff = await svc.computeDiff('c-nina');
+    expect(diff!.isSafeClass).toBe(false);
+  });
+});
+
+describe('CatalogResyncService.resync — baseUrl is never applied unasked', () => {
+  const NINA = 'nina-warnung';
+  const STALE = 'https://nina.api.proxy.bund.dev/api31';
+
+  function setup() {
+    const adapter = getAdapter(NINA)!;
+    const connector = {
+      id: 'c-nina',
+      name: adapter.connector.name,
+      baseUrl: STALE,
+      instructions: adapter.instructions ?? null,
+      config: {
+        adapterSlug: NINA,
+        adapterVersion: adapter.version,
+        instructionsBaseline: hashInstructions(adapter.instructions),
+        baseUrlBaseline: STALE,
+      },
+      tools: adapter.tools.map((t: any, i: number) => ({
+        id: `t${i}`,
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+        endpointMapping: t.endpointMapping,
+        responseMapping: t.responseMapping ?? null,
+        useProxy: t.useProxy === true,
+        isEnabled: true,
+        deprecatedAt: null,
+      })),
+    };
+    const connectorUpdate = jest.fn().mockResolvedValue({});
+    const tx = {
+      connector: {
+        findUnique: jest.fn().mockResolvedValue(connector),
+        update: connectorUpdate,
+      },
+      mcpTool: {
+        update: jest.fn().mockResolvedValue({}),
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const prisma = {
+      connector: { findUnique: jest.fn().mockResolvedValue(connector) },
+      $transaction: jest.fn(async (cb: any) => cb(tx)),
+    } as any;
+    return { service: new CatalogResyncService(prisma), connectorUpdate, adapter };
+  }
+
+  it('leaves the base URL alone by default, even in full mode', async () => {
+    const { service, connectorUpdate } = setup();
+    const { applied } = await service.resync('c-nina', 'full');
+    expect(applied).toBe(true);
+    expect(connectorUpdate).toHaveBeenCalledTimes(1);
+    expect(connectorUpdate.mock.calls[0][0].data.baseUrl).toBeUndefined();
+  });
+
+  it('moves it when the caller explicitly asks, and re-baselines', async () => {
+    const { service, connectorUpdate, adapter } = setup();
+    await service.resync('c-nina', 'full', { applyBaseUrl: true });
+    const data = connectorUpdate.mock.calls[0][0].data;
+    expect(data.baseUrl).toBe(adapter.connector.baseUrl);
+    // Without re-baselining, the next diff would read our own fix as an
+    // operator edit and stop offering anything ever again.
+    expect(data.config.baseUrlBaseline).toBe(adapter.connector.baseUrl);
+  });
+
+  it('refuses in safe mode even when asked', async () => {
+    // Safe mode is what the unattended boot-time reconciler uses.
+    const { service, connectorUpdate } = setup();
+    await service.resync('c-nina', 'safe', { applyBaseUrl: true });
+    expect(connectorUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/connectors/catalog-resync.service.ts
+++ b/packages/backend/src/connectors/catalog-resync.service.ts
@@ -25,6 +25,29 @@ import {
 
 export type ToolChangeKind = 'safe' | 'structural';
 
+/**
+ * Where the connector's current baseUrl came from, which decides whether the
+ * catalog's value is an improvement or an unwanted overwrite.
+ *
+ *   catalog-moved — the connector still holds exactly what the catalog gave it
+ *                   at install, and the catalog has since changed. Our fix.
+ *   user-edited   — the operator changed it. Deliberate, and the reason we do
+ *                   not overwrite: of the five live connectors whose baseUrl
+ *                   differs from the catalog, datadog points at the us3 region
+ *                   and DATEV at the sandbox. Both work; both would break.
+ *   unknown       — installed before the baseline was recorded, so the two are
+ *                   indistinguishable. Shown, never applied without a say-so.
+ */
+export type BaseUrlProvenance = 'catalog-moved' | 'user-edited' | 'unknown';
+
+export interface BaseUrlChange {
+  /** What the connector calls today. */
+  from: string;
+  /** What the catalog says it should call. */
+  to: string;
+  provenance: BaseUrlProvenance;
+}
+
 export interface CatalogDiff {
   connectorId: string;
   slug: string;
@@ -35,6 +58,13 @@ export interface CatalogDiff {
   removed: string[];
   /** instructions changed upstream AND the user has not edited theirs. */
   instructionsRefreshable: boolean;
+  /**
+   * Set when the catalog's baseUrl differs from the connector's. Always a
+   * proposal: `resync` applies it only when explicitly asked, whatever the
+   * provenance says, because a base URL is the whole address of the API and
+   * getting it wrong takes every tool down at once.
+   */
+  baseUrl: BaseUrlChange | null;
   isUpToDate: boolean;
   /** Has changes, and every change is safe (no structural). */
   isSafeClass: boolean;
@@ -127,15 +157,26 @@ export class CatalogResyncService {
       baseline !== hashInstructions(connector.instructions);
     const instructionsRefreshable = instructionsChanged && !userEditedInstructions;
 
+    const baseUrl = diffBaseUrl(
+      adapter.connector.baseUrl,
+      connector.baseUrl,
+      typeof cfg.baseUrlBaseline === 'string' ? cfg.baseUrlBaseline : null,
+    );
+
     const isUpToDate =
       updated.length === 0 &&
       added.length === 0 &&
       removed.length === 0 &&
-      !instructionsRefreshable;
+      !instructionsRefreshable &&
+      baseUrl === null;
+    // A baseUrl change is never safe-class. The boot-time reconciler applies
+    // safe-class diffs on its own, and it must not be able to repoint a
+    // customer's connector at a different host while nobody is looking.
     const isSafeClass =
       !isUpToDate &&
       added.length === 0 &&
       removed.length === 0 &&
+      baseUrl === null &&
       updated.every((u) => u.kind === 'safe');
 
     return {
@@ -147,6 +188,7 @@ export class CatalogResyncService {
       added,
       removed,
       instructionsRefreshable,
+      baseUrl,
       isUpToDate,
       isSafeClass,
     };
@@ -159,11 +201,20 @@ export class CatalogResyncService {
    * including endpoint changes, new tools, and soft-deprecating removed tools.
    *
    * Always preserves responseMapping, role access, manual enable/disable and
-   * useProxy. Never touches auth/baseUrl/envVars/headers.
+   * useProxy. Never touches auth/envVars/headers.
+   *
+   * `opts.applyBaseUrl` is the one way a base URL can change, and it is
+   * deliberately not implied by `mode: 'full'`. Fixing a wrong hostname in the
+   * catalog does not reach connectors already installed — NINA kept calling a
+   * host with no DNS record for a day after the catalog was corrected — but
+   * the same overwrite would have repointed a DATEV connector from the
+   * sandbox it was deliberately set to. So the diff proposes and the caller
+   * decides, per connector.
    */
   async resync(
     connectorId: string,
     mode: 'safe' | 'full' = 'full',
+    opts: { applyBaseUrl?: boolean } = {},
   ): Promise<{ applied: boolean; diff: CatalogDiff; snapshot: unknown }> {
     const diff = await this.computeDiff(connectorId);
     if (!diff) {
@@ -203,6 +254,8 @@ export class CatalogResyncService {
           isEnabled: t.isEnabled,
         })),
         instructions: connector.instructions,
+        // Part of the pre-image since resync can now move it.
+        baseUrl: connector.baseUrl,
         config: connector.config,
       };
 
@@ -272,6 +325,11 @@ export class CatalogResyncService {
         newInstructions = adapter.instructions ?? null;
       }
 
+      // The base URL moves only when the caller asked for this specific
+      // change, and only in full mode.
+      const applyBaseUrl =
+        mode === 'full' && opts.applyBaseUrl === true && diff.baseUrl !== null;
+
       // Bump the stored version only when the connector is now fully in sync
       // with the catalog (full mode, or safe mode on a pure safe-class diff).
       const fullySynced = mode === 'full' || diff.isSafeClass;
@@ -280,6 +338,9 @@ export class CatalogResyncService {
         ...cfg,
         ...(fullySynced ? { adapterVersion: adapter.version } : {}),
         instructionsBaseline: hashInstructions(newInstructions),
+        // Re-baseline so the next diff reads this value as ours rather than
+        // as an operator edit.
+        ...(applyBaseUrl ? { baseUrlBaseline: diff.baseUrl!.to } : {}),
       };
 
       await tx.connector.update({
@@ -287,18 +348,62 @@ export class CatalogResyncService {
         data: {
           instructions: newInstructions,
           config: newConfig as any,
+          ...(applyBaseUrl ? { baseUrl: diff.baseUrl!.to } : {}),
         },
       });
 
-      return { snapshot, updatedCount, createdCount, deprecatedCount };
+      return {
+        snapshot,
+        updatedCount,
+        createdCount,
+        deprecatedCount,
+        baseUrlApplied: applyBaseUrl,
+      };
     });
 
     this.logger.log(
       `Re-synced connector ${connectorId} (${diff.slug}, mode=${mode}): ` +
         `${result.updatedCount} updated, ${result.createdCount} added, ` +
-        `${result.deprecatedCount} deprecated → ${adapter.version}`,
+        `${result.deprecatedCount} deprecated` +
+        (result.baseUrlApplied
+          ? `, baseUrl → ${diff.baseUrl!.to} (was ${diff.baseUrl!.from})`
+          : '') +
+        ` → ${adapter.version}`,
     );
 
     return { applied: true, diff, snapshot: result.snapshot };
   }
+}
+
+/**
+ * Compare the catalog's baseUrl with the connector's, and say which way to
+ * read the difference.
+ *
+ * A templated catalog value (`https://{{TENANT}}.weclapp.com`) is never
+ * comparable: the connector holds the resolved form, so every such adapter
+ * would report a change on every diff. Those return null.
+ */
+export function diffBaseUrl(
+  catalogBaseUrl: string,
+  connectorBaseUrl: string,
+  baseline: string | null,
+): BaseUrlChange | null {
+  if (catalogBaseUrl.includes('{{')) return null;
+  const from = (connectorBaseUrl ?? '').trim();
+  const to = (catalogBaseUrl ?? '').trim();
+  if (!to || normaliseUrl(from) === normaliseUrl(to)) return null;
+
+  const provenance: BaseUrlProvenance =
+    baseline === null
+      ? 'unknown'
+      : normaliseUrl(baseline) === normaliseUrl(from)
+        ? 'catalog-moved'
+        : 'user-edited';
+
+  return { from, to, provenance };
+}
+
+/** A trailing slash is not a difference worth telling anyone about. */
+function normaliseUrl(value: string): string {
+  return (value ?? '').trim().replace(/\/+$/, '');
 }

--- a/packages/backend/src/connectors/connectors.controller.ts
+++ b/packages/backend/src/connectors/connectors.controller.ts
@@ -1316,12 +1316,21 @@ export class ConnectorsController {
       'Re-sync a catalog-installed connector with the current catalog. ' +
       'Updates tool descriptions/parameters/endpoints from the catalog while ' +
       'preserving response customisations, role access and manual disables. ' +
-      'Never touches credentials, base URL or env vars.',
+      'Never touches credentials or env vars. The base URL moves only when ' +
+      'applyBaseUrl=true, and only when catalog-diff reported a change: a ' +
+      'different host takes every tool down at once, and the operator may ' +
+      'have pointed it at their own region or sandbox on purpose.',
   })
-  async resyncCatalog(@Req() req: any, @Param('id') id: string) {
+  async resyncCatalog(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Query('applyBaseUrl') applyBaseUrl?: string,
+  ) {
     const connector = await this.connectorsService.findById(id);
     this.assertCanWrite(connector, req);
-    const { applied, diff } = await this.catalogResync.resync(id, 'full');
+    const { applied, diff } = await this.catalogResync.resync(id, 'full', {
+      applyBaseUrl: applyBaseUrl === 'true',
+    });
     if (applied) {
       await this.mcpServer.reloadConnectorTools(id);
     }

--- a/packages/frontend/src/app/connectors/[id]/page.tsx
+++ b/packages/frontend/src/app/connectors/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
-import { connectors, tools, type ToolTestResult } from '@/lib/api';
+import { connectors, tools, type ToolTestResult, type CatalogDiff } from '@/lib/api';
 import { findDemoByTool } from '@/lib/demo-connectors';
 import { ToolEditor } from '@/components/tool-editor';
 import { McpAssignModal } from '@/components/mcp-assign-modal';
@@ -104,6 +104,13 @@ export default function ConnectorDetailPage() {
   // AI client would actually receive.
   const [testResponseView, setTestResponseView] = useState<'mapped' | 'raw'>('mapped');
 
+  // What the catalog has changed since this connector was installed.
+  const [catalogDiff, setCatalogDiff] = useState<CatalogDiff | null>(null);
+  const [applyingCatalog, setApplyingCatalog] = useState(false);
+  // Opt-in, and separate from the rest: the base URL is the whole address of
+  // the API, so it moves only when someone ticks this having read both values.
+  const [applyBaseUrl, setApplyBaseUrl] = useState(false);
+
   // Import modal
   const [showImport, setShowImport] = useState(false);
   const [importSource, setImportSource] = useState('openapi');
@@ -129,6 +136,12 @@ export default function ConnectorDetailPage() {
         .catch(() => setProxyAvailable(false));
       const c = await connectors.get(id, token);
       setConnector(c);
+      // Only catalog-installed connectors have anything to compare against;
+      // the endpoint answers catalogManaged:false for the rest.
+      connectors
+        .catalogDiff(id, token)
+        .then((d) => setCatalogDiff(d.catalogManaged && !d.isUpToDate ? d : null))
+        .catch(() => setCatalogDiff(null));
       setEditName(c.name);
       setEditBaseUrl(c.baseUrl);
       setEditHealthcheckPath(c.healthcheckPath || '');
@@ -348,6 +361,25 @@ export default function ConnectorDetailPage() {
       setMsg(`Import failed: ${err.message}`);
     } finally {
       setImporting(false);
+    }
+  };
+
+  const handleApplyCatalog = async () => {
+    if (!token) return;
+    setApplyingCatalog(true);
+    try {
+      const res = await connectors.resyncCatalog(id, token, { applyBaseUrl });
+      setMsg(
+        res.applied
+          ? `Updated from the catalog${applyBaseUrl && catalogDiff?.baseUrl ? `, base URL now ${catalogDiff.baseUrl.to}` : ''}.`
+          : 'Nothing to update.',
+      );
+      setApplyBaseUrl(false);
+      await fetchConnector();
+    } catch (err: any) {
+      setMsg(`Error: ${err.message}`);
+    } finally {
+      setApplyingCatalog(false);
     }
   };
 
@@ -667,6 +699,84 @@ export default function ConnectorDetailPage() {
                 </div>
               )}
           </div>
+        )}
+
+        {/* ── Catalog updates ─────────────────────────────────────
+            Tool definitions are copied into the connector at install, so a
+            later catalog fix never reaches it on its own. The base URL is
+            listed apart from the rest and ticked separately: correcting a
+            wrong hostname and overwriting a deliberate one look identical
+            from here, and getting it wrong takes every tool down at once. */}
+        {catalogDiff && (
+          <Card className="p-[22px]">
+            <div className="flex items-start justify-between gap-4 mb-3">
+              <div>
+                <h3 className="text-sm font-semibold">Catalog update available</h3>
+                <p className="text-xs text-muted-foreground mt-1">
+                  This connector was installed from{' '}
+                  <code>{catalogDiff.slug}</code>, which has changed since.
+                </p>
+              </div>
+              <Badge tone="neutral">{catalogDiff.catalogVersion?.slice(0, 7)}</Badge>
+            </div>
+
+            <ul className="text-sm space-y-1 mb-4">
+              {!!catalogDiff.updated?.length && (
+                <li>
+                  {catalogDiff.updated.length} tool
+                  {catalogDiff.updated.length === 1 ? '' : 's'} updated
+                  {catalogDiff.updated.some((u) => u.kind === 'structural') &&
+                    ' (including endpoint changes)'}
+                </li>
+              )}
+              {!!catalogDiff.added?.length && (
+                <li>{catalogDiff.added.length} new tool(s): {catalogDiff.added.join(', ')}</li>
+              )}
+              {!!catalogDiff.removed?.length && (
+                <li>
+                  {catalogDiff.removed.length} tool(s) no longer in the catalog:{' '}
+                  {catalogDiff.removed.join(', ')}
+                </li>
+              )}
+              {catalogDiff.instructionsRefreshable && <li>Instructions refreshed</li>}
+            </ul>
+
+            {catalogDiff.baseUrl && (
+              <div className="rounded-md border border-border p-3 mb-4">
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="mt-1"
+                    checked={applyBaseUrl}
+                    onChange={(e) => setApplyBaseUrl(e.target.checked)}
+                  />
+                  <span className="text-sm">
+                    <span className="font-medium">Also change the base URL</span>
+                    <span className="block text-xs text-muted-foreground mt-1 font-mono break-all">
+                      {catalogDiff.baseUrl.from} → {catalogDiff.baseUrl.to}
+                    </span>
+                    <span className="block text-xs text-muted-foreground mt-2">
+                      {catalogDiff.baseUrl.provenance === 'user-edited'
+                        ? 'This address was changed here, not by the catalog — a region, a sandbox or a self-hosted instance. Applying this will undo that.'
+                        : catalogDiff.baseUrl.provenance === 'catalog-moved'
+                          ? 'This connector still has the address the catalog gave it at install, and the catalog has since corrected it.'
+                          : 'Installed before we started recording the original address, so we cannot tell whether this was customised here. Check it before applying.'}
+                    </span>
+                  </span>
+                </label>
+              </div>
+            )}
+
+            <div className="flex items-center gap-3">
+              <Button onClick={handleApplyCatalog} disabled={applyingCatalog}>
+                {applyingCatalog ? 'Applying…' : 'Apply update'}
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                Credentials, response mappings, role access and manual
+                enable/disable are preserved.
+              </span>
+            </div>
+          </Card>
         )}
 
         {/* Connector Details */}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -226,6 +226,32 @@ export const mcpConnections = {
 };
 
 // Connectors
+
+export interface CatalogBaseUrlChange {
+  from: string;
+  to: string;
+  /**
+   * catalog-moved — the connector still holds what the catalog gave it.
+   * user-edited   — the operator changed it; do not overwrite silently.
+   * unknown       — installed before baselines were recorded.
+   */
+  provenance: 'catalog-moved' | 'user-edited' | 'unknown';
+}
+
+export interface CatalogDiff {
+  catalogManaged: boolean;
+  slug?: string;
+  catalogVersion?: string;
+  connectorVersion?: string | null;
+  updated?: Array<{ name: string; kind: 'safe' | 'structural' }>;
+  added?: string[];
+  removed?: string[];
+  instructionsRefreshable?: boolean;
+  baseUrl?: CatalogBaseUrlChange | null;
+  isUpToDate?: boolean;
+  isSafeClass?: boolean;
+}
+
 export const connectors = {
   list: (token: string) =>
     request<any[]>('/api/connectors', { token }),
@@ -243,6 +269,20 @@ export const connectors = {
     ),
   get: (id: string, token: string) =>
     request<any>(`/api/connectors/${id}`, { token }),
+  /**
+   * What the catalog has changed since this connector was installed. Tool
+   * descriptions, parameters and endpoints — and, separately, the base URL,
+   * which is reported but never applied by `resyncCatalog` unless asked:
+   * a different host takes every tool down at once, and the operator may have
+   * pointed it at their own region or sandbox on purpose.
+   */
+  catalogDiff: (id: string, token: string) =>
+    request<CatalogDiff>(`/api/connectors/${id}/catalog-diff`, { token }),
+  resyncCatalog: (id: string, token: string, opts?: { applyBaseUrl?: boolean }) =>
+    request<CatalogDiff & { applied: boolean }>(
+      `/api/connectors/${id}/resync-catalog${opts?.applyBaseUrl ? '?applyBaseUrl=true' : ''}`,
+      { method: 'POST', token },
+    ),
   update: (id: string, data: unknown, token: string) =>
     request(`/api/connectors/${id}`, { method: 'PUT', body: data, token }),
   /** Non-secret OAuth2 settings, for pre-filling the edit form. */


### PR DESCRIPTION
## The gap

Fixing an adapter in the catalog does not reach connectors already installed — `baseUrl` is snapshotted at import, and `resync` never touched it.

Two live consequences:

- **NINA** kept calling `nina.api.proxy.bund.dev`, a host with **no DNS record at all**, for a day after #549 corrected the catalog. Six failures, all `SSRF guard: cannot resolve`.
- **buffer**'s two connectors still point at `graphql.buffer.com`, which #548 fixed in the catalog. That fix helps new installs only.

## Why the obvious repair would have been wrong

Copying the catalog value over on re-sync is the one-line version. Measured against production first:

| slug | installed | catalog | verdict |
|---|---|---|---|
| buffer | `graphql.buffer.com` | `api.buffer.com/graphql` | **our mistake** |
| playtomic-public | `app.playtomic.io` | `api.app.playtomic.io` | **our mistake** |
| datadog | `api.us3.datadoghq.com` | `api.datadoghq.com` | deliberate — region |
| datev ×2 | sandbox endpoints | production endpoint | deliberate — sandbox |

Of five active drifted connectors, **three are deliberate operator choices that all work today**, and a blanket overwrite would have broken every one. So the diff proposes and the operator decides.

## How it tells them apart

Install now records `baseUrlBaseline` in `config`, alongside the existing `instructionsBaseline`. Without it, "we corrected a wrong hostname" and "the operator chose a different host" are indistinguishable.

`computeDiff` reports `baseUrl: { from, to, provenance }`:

- `catalog-moved` — the connector still holds exactly what the catalog gave it, and the catalog has since changed. Ours to fix.
- `user-edited` — the operator changed it. The UI says plainly that applying will undo that.
- `unknown` — installed before baselines existed. Shown, never assumed.

A **templated** catalog URL (`https://{{TENANT}}.weclapp.com`) is never compared: the connector holds the resolved form, so every such adapter would otherwise report a change on every single diff.

## Two guardrails

- **A baseUrl change is never safe-class.** The boot-time reconciler applies safe diffs unattended, and it must never be able to repoint a customer's connector while nobody is watching.
- **`mode: 'full'` does not imply it.** Only an explicit `applyBaseUrl` moves the address, and not even then in safe mode. A base URL is the whole address of the API — getting it wrong takes every tool down at once, unlike a tool description.

The pre-image snapshot now carries `baseUrl` too, since resync can move it.

## UI

This is the **first interface catalog re-sync has ever had** — the endpoints existed but nothing in the frontend called them. The connector page now shows what changed, with the base URL listed apart from the rest behind its own checkbox: both values side by side, and one line saying which reading applies to this connector.

## Verification

`tsc --noEmit` clean on both packages, `next build` clean, `eslint` clean (one pre-existing `exhaustive-deps` warning, unchanged — verified against the branch point).

**4,116 backend tests pass**, 16 of them new: the provenance matrix, the templated-URL exclusion, the safe-class exclusion, and three that assert the address does not move unless asked — including that safe mode refuses even when it is.